### PR TITLE
workaround for xamarin.android issue with Android 11 emulator debugging

### DIFF
--- a/src/Android/Android.csproj
+++ b/src/Android/Android.csproj
@@ -31,6 +31,8 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <AndroidSupportedAbis />
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>


### PR DESCRIPTION
There is currently an issue with `Xamarin.Android` being unable to install to the Android 11 emulator due to the new limitations on external storage access:  https://github.com/xamarin/xamarin-android/issues/4996

The provided workaround keeps us rolling until they finish their rewrite of the fast deployment mechanism.