### PR TITLE
fix padding between sync button and last sync timestamp

### DIFF
--- a/src/App/Pages/Settings/SyncPage.xaml
+++ b/src/App/Pages/Settings/SyncPage.xaml
@@ -35,7 +35,7 @@
             </StackLayout>
             <StackLayout StyleClass="box">
                 <Button Text="{u:I18n SyncVaultNow}" Clicked="Sync_Clicked"></Button>
-                <Label StyleClass="text-muted, text-sm" HorizontalTextAlignment="Center">
+                <Label StyleClass="text-muted, text-sm" HorizontalTextAlignment="Center" Margin="0,10">
                     <Label.FormattedText>
                         <FormattedString>
                             <Span Text="{u:I18n LastSync}" />


### PR DESCRIPTION
Timestamp label no longer touching the sync button.

![image](https://user-images.githubusercontent.com/59324545/136616768-05fc23ca-d1d6-4f64-ac05-bfcefb66180b.png)
