### PR TITLE
Fix for Android 5.x crash caused by new switch styling

### DIFF
--- a/src/Android/Renderers/CustomSwitchRenderer.cs
+++ b/src/Android/Renderers/CustomSwitchRenderer.cs
@@ -2,6 +2,7 @@
 using Android.Content;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
+using Android.OS;
 using AndroidX.Core.Content.Resources;
 using Bit.Droid.Renderers;
 using Bit.Droid.Utilities;
@@ -35,6 +36,12 @@ namespace Bit.Droid.Renderers
         
         private void UpdateColors()
         {
+            if (Build.VERSION.SdkInt <= BuildVersionCodes.LollipopMr1)
+            {
+                // Android 5.x doesn't support ThumbTintList, and using SwitchCompat on every version after 5.x
+                // doesn't apply tinting the way we want. Let 5.x to do its own thing here.
+                return;
+            }
             if (Control != null)
             {
                 var t = ResourcesCompat.GetDrawable(Resources, Resource.Drawable.switch_thumb, null);


### PR DESCRIPTION
Android 5.x `Switch` widget doesn't support `ThumbTintList`, and using `SwitchCompat` is yielding poor results on every version after 5.x.  We'll let 5.x to do its own thing here (see screenshot).  It's not fabulous, but it's better than the alternative.

This will be picked to `rc`.


![image](https://user-images.githubusercontent.com/59324545/137159555-b0685f81-c16d-4fb6-9743-00df2c53dce8.png)
