### PR TITLE
fix for crash on startup when policies are non-existent

### DIFF
--- a/src/Core/Services/PolicyService.cs
+++ b/src/Core/Services/PolicyService.cs
@@ -201,6 +201,10 @@ namespace Bit.Core.Services
         public async Task<bool> PolicyAppliesToUser(PolicyType policyType, Func<Policy, bool> policyFilter)
         {
             var policies = await GetAll(policyType);
+            if (policies == null)
+            {
+                return false;
+            }
             var organizations = await _userService.GetAllOrganizationAsync();
 
             IEnumerable<Policy> filteredPolicies;


### PR DESCRIPTION
The Android app performs a check for vault timeout on startup, which leads into a policy check for the user.  If no policies exist it would throw.  This adds a null check to that flow.

This will be picked to `rc`