### PR TITLE
fix for Captcha crashing on account creation

### DIFF
--- a/src/App/Pages/CaptchaProtectedViewModel.cs
+++ b/src/App/Pages/CaptchaProtectedViewModel.cs
@@ -27,7 +27,12 @@ namespace Bit.App.Pages
                 captchaRequiredText = AppResources.CaptchaRequired,
             });
 
-            var url = environmentService.GetWebVaultUrl() + "/captcha-mobile-connector.html?" + "data=" + data +
+            var url = environmentService.GetWebVaultUrl();
+            if (url == null)
+            {
+                url = "https://vault.bitwarden.com";
+            }
+            url += "/captcha-mobile-connector.html?" + "data=" + data +
                 "&parent=" + Uri.EscapeDataString(callbackUri) + "&v=1";
 
             WebAuthenticatorResult authResult = null;


### PR DESCRIPTION
# Overview
Bitwarden was crashing when a Captcha was requested on account creation because we had no loaded URLs in our `EnvironmentService`. This fix checks our `GetWebVaultUrl` call and returns our default URL if null.

This fix will be picked to `rc`

Closes #1574