### PR TITLE
[1578] Bitwarden app crashes when selecting show password button

### DIFF
--- a/src/App/Pages/Accounts/LockPageViewModel.cs
+++ b/src/App/Pages/Accounts/LockPageViewModel.cs
@@ -318,7 +318,7 @@ namespace Bit.App.Pages
             var page = (Page as LockPage);
             var entry = PinLock ? page.PinEntry : page.MasterPasswordEntry;
             entry.Focus();
-            entry.CursorPosition = PinLock ? Pin.Length : MasterPassword.Length;
+            entry.CursorPosition = PinLock ? Pin?.Length ?? 0 : MasterPassword?.Length ?? 0;
         }
 
         public async Task PromptBiometricAsync()

--- a/src/App/Pages/Accounts/LoginPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginPageViewModel.cs
@@ -187,7 +187,7 @@ namespace Bit.App.Pages
             ShowPassword = !ShowPassword;
             var entry = (Page as LoginPage).MasterPasswordEntry;
             entry.Focus();
-            entry.CursorPosition = MasterPassword.Length;
+            entry.CursorPosition = MasterPassword?.Length ?? 0;
         }
     }
 }

--- a/src/App/Pages/Accounts/RegisterPageViewModel.cs
+++ b/src/App/Pages/Accounts/RegisterPageViewModel.cs
@@ -203,7 +203,7 @@ namespace Bit.App.Pages
             ShowPassword = !ShowPassword;
             var entry = (Page as RegisterPage).MasterPasswordEntry;
             entry.Focus();
-            entry.CursorPosition = MasterPassword.Length;
+            entry.CursorPosition = MasterPassword?.Length ?? 0;
         }
 
         public void ToggleConfirmPassword()
@@ -211,7 +211,7 @@ namespace Bit.App.Pages
             ShowPassword = !ShowPassword;
             var entry = (Page as RegisterPage).ConfirmMasterPasswordEntry;
             entry.Focus();
-            entry.CursorPosition = ConfirmMasterPassword.Length;
+            entry.CursorPosition = ConfirmMasterPassword?.Length ?? 0;
         }
     }
 }


### PR DESCRIPTION
Pressing the show password button caused 'null reference exception' when the password or PIN was not filled.

https://github.com/bitwarden/mobile/issues/1578