### PR TITLE
Release branch constraint on build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,37 @@ jobs:
         run: cloc --vcs git --exclude-dir Resources,store,test,Properties --include-lang C#,XAML
 
 
+  setup:
+    name: Setup
+    runs-on: ubuntu-20.04
+    outputs:
+      rc_branch_exists: ${{ steps.branch-check.outputs.rc_branch_exists }}
+      release_branch_exists: ${{ steps.branch-check.outputs.release_branch_exists }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
+
+      - name: Check if special branches exist
+        id: branch-check
+        run: |
+          if [[ $(git ls-remote --heads origin rc) ]]; then
+            echo "::set-output name=rc_branch_exists::1"
+          else
+            echo "::set-output name=rc_branch_exists::0"
+          fi
+
+          if [[ $(git ls-remote --heads origin release) ]]; then
+            echo "::set-output name=release_branch_exists::1"
+          else
+            echo "::set-output name=release_branch_exists::0"
+          fi
+        shell: bash
+
+
   android:
     name: Android
     runs-on: windows-2019
+    needs: setup
     steps:
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@c26a08ba26249b81327e26f6ef381897b6a8754d  # v1
@@ -148,26 +176,12 @@ jobs:
           path: ./com.x8bit.bitwarden.apk
           if-no-files-found: error
 
-      - name: Check if special branches exists
-        id: branch-check
-        run: |
-          if [[ $(git ls-remote --heads origin rc) ]]; then
-            echo "::set-output name=rc_branch_exists::1"
-          else
-            echo "::set-output name=rc_branch_exists::0"
-          fi
-
-          if [[ $(git ls-remote --heads origin release) ]]; then
-            echo "::set-output name=release_branch_exists::1"
-          else
-            echo "::set-output name=release_branch_exists::0"
-          fi
-        shell: bash
-
       - name: Deploy to Play Store
         if: |
-            (github.ref == 'refs/heads/master' && steps.branch-check.outputs.rc_branch_exists == 0 && steps.branch-check.outputs.release_branch_exists == 0)
-            || (github.ref == 'refs/heads/rc' && steps.branch-check.outputs.release_branch_exists == 0)
+            (github.ref == 'refs/heads/master'
+              && needs.setup.outputs.rc_branch_exists == 0
+              && needs.setup.outputs.release_branch_exists == 0)
+            || (github.ref == 'refs/heads/rc' && needs.setup.outputs.release_branch_exists == 0)
             || github.ref == 'refs/heads/release'
         run: |
           PUBLISHER_PATH="$GITHUB_WORKSPACE/store/google/Publisher/bin/Release/netcoreapp2.0/Publisher.dll"
@@ -339,6 +353,7 @@ jobs:
   ios:
     name: Apple iOS
     runs-on: macos-11
+    needs: setup
     steps:
       - name: Print environment
         run: |
@@ -455,26 +470,12 @@ jobs:
           path: ./bitwarden-export/Bitwarden.ipa
           if-no-files-found: error
 
-      - name: Check if special branches exists
-        id: branch-check
-        run: |
-          if [[ $(git ls-remote --heads origin rc) ]]; then
-            echo "::set-output name=rc_branch_exists::1"
-          else
-            echo "::set-output name=rc_branch_exists::0"
-          fi
-
-          if [[ $(git ls-remote --heads origin release) ]]; then
-            echo "::set-output name=release_branch_exists::1"
-          else
-            echo "::set-output name=release_branch_exists::0"
-          fi
-        shell: bash
-
       - name: Deploy to App Store
         if: |
-            (github.ref == 'refs/heads/master' && steps.branch-check.outputs.rc_branch_exists == 0 && steps.branch-check.outputs.release_branch_exists == 0)
-            || (github.ref == 'refs/heads/rc' && steps.branch-check.outputs.release_branch_exists == 0)
+            (github.ref == 'refs/heads/master'
+              && needs.setup.outputs.rc_branch_exists == 0
+              && needs.setup.outputs.release_branch_exists == 0)
+            || (github.ref == 'refs/heads/rc' && needs.setup.outputs.release_branch_exists == 0)
             || github.ref == 'refs/heads/release'
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}


### PR DESCRIPTION
## Summary

Forgot to add the branch constraint to the deploy steps in the build workflow. This PR handles the special cases needed to deploy `master`, `rc`, and `release` to the internal track to the Android and Apple stores.