### PR TITLE
Fix HTML labels colors issue (#1516)

### DIFF
--- a/src/App/Pages/Generator/GeneratorHistoryPage.xaml
+++ b/src/App/Pages/Generator/GeneratorHistoryPage.xaml
@@ -68,8 +68,7 @@
                         <controls:MonoLabel LineBreakMode="CharacterWrap"
                             Grid.Column="0"
                             Grid.Row="0"
-                            StyleClass="list-title, list-title-platform"
-                            TextType="Html"
+                            StyleClass="list-title, list-title-platform, text-html"
                             Text="{Binding Password, Mode=OneWay, Converter={StaticResource coloredPassword}}" />
                         <Label LineBreakMode="TailTruncation"
                             Grid.Column="0"

--- a/src/App/Pages/Generator/GeneratorPage.xaml
+++ b/src/App/Pages/Generator/GeneratorPage.xaml
@@ -63,10 +63,9 @@
                     </Frame>
                 </Grid>
                 <controls:MonoLabel
+                    StyleClass="text-lg, text-html"
                     Text="{Binding ColoredPassword, Mode=OneWay}"
-                    TextType="Html"
                     Margin="0, 20"
-                    StyleClass="text-lg"
                     HorizontalTextAlignment="Center"
                     HorizontalOptions="CenterAndExpand"
                     LineBreakMode="CharacterWrap" />

--- a/src/App/Pages/Vault/PasswordHistoryPage.xaml
+++ b/src/App/Pages/Vault/PasswordHistoryPage.xaml
@@ -59,8 +59,7 @@
                         <controls:MonoLabel LineBreakMode="CharacterWrap"
                             Grid.Column="0"
                             Grid.Row="0"
-                            StyleClass="list-title, list-title-platform"
-                            TextType="Html"
+                            StyleClass="list-title, list-title-platform, text-html"
                             Text="{Binding Password, Mode=OneWay, Converter={StaticResource coloredPassword}}" />
                         <Label LineBreakMode="TailTruncation"
                             Grid.Column="0"

--- a/src/App/Pages/Vault/ViewPage.xaml
+++ b/src/App/Pages/Vault/ViewPage.xaml
@@ -120,8 +120,7 @@
                                     IsVisible="{Binding ShowPassword, Converter={StaticResource inverseBool}}" />
                                 <controls:MonoLabel
                                     Text="{Binding ColoredPassword, Mode=OneWay}"
-                                    TextType="Html"
-                                    StyleClass="box-value"
+                                    StyleClass="box-value, text-html"
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     LineBreakMode="CharacterWrap"

--- a/src/App/Styles/Base.xaml
+++ b/src/App/Styles/Base.xaml
@@ -59,6 +59,14 @@
         <Setter Property="FontAttributes"
                 Value="Bold" />
     </Style>
+    <Style TargetType="Label"
+           Class="text-html"
+           ApplyToDerivedTypes="True">
+        <Setter Property="TextColor"
+                Value="Default" />
+        <Setter Property="TextType"
+                Value="Html" />
+    </Style>
 
     <!-- Pages -->
     <Style TargetType="TabbedPage"


### PR DESCRIPTION
Fixed HTMl labels colors issue that was not taking the html style color correctly.

This was because [Xamarin Forms expect](https://github.com/xamarin/Xamarin.Forms/blob/cd675ae32b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs#L569) that the Label color be the Default one and the Base styles were overriding that.

So I created a new style `text-html` that sets the TextColor to Default and the TextType to Html.
