### PR TITLE
add date and time formatting methods to localize service

### DIFF
--- a/src/Android/Services/LocalizeService.cs
+++ b/src/Android/Services/LocalizeService.cs
@@ -98,5 +98,15 @@ namespace Bit.Droid.Services
             Console.WriteLine(".NET Fallback Language/Locale:" + netLanguage + " (application-specific)");
             return netLanguage;
         }
+
+        public string GetLocaleShortDate(DateTime? date)
+        {
+            return date?.ToShortDateString() ?? string.Empty;
+        }
+
+        public string GetLocaleShortTime(DateTime? time)
+        {
+            return time?.ToShortTimeString() ?? string.Empty;
+        }
     }
 }

--- a/src/App/Abstractions/ILocalizeService.cs
+++ b/src/App/Abstractions/ILocalizeService.cs
@@ -1,9 +1,22 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 
 namespace Bit.App.Abstractions
 {
     public interface ILocalizeService
     {
         CultureInfo GetCurrentCultureInfo();
+
+        /// <summary>
+        /// Format date using device locale.
+        /// Needed for iOS as it provides locales unsupported in .Net
+        /// </summary>
+        string GetLocaleShortDate(DateTime? date);
+
+        /// <summary>
+        /// Format time using device locale.
+        /// Needed for iOS as it provides locales unsupported in .Net
+        /// </summary>
+        string GetLocaleShortTime(DateTime? time);
     }
 }

--- a/src/App/Pages/Send/SendsPage.xaml
+++ b/src/App/Pages/Send/SendsPage.xaml
@@ -17,7 +17,6 @@
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <u:DateTimeConverter x:Key="dateTime" />
             <ToolbarItem Text="{u:I18n Close}" Clicked="Close_Clicked" Order="Primary" Priority="-1"
                          x:Name="_closeItem" x:Key="closeItem" />
             <StackLayout

--- a/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
+++ b/src/App/Pages/Settings/SettingsPage/SettingsPageViewModel.cs
@@ -26,6 +26,7 @@ namespace Bit.App.Pages
         private readonly ISyncService _syncService;
         private readonly IBiometricService _biometricService;
         private readonly IPolicyService _policyService;
+        private readonly ILocalizeService _localizeService;
 
         private const int CustomVaultTimeoutValue = -100;
 
@@ -72,6 +73,7 @@ namespace Bit.App.Pages
             _syncService = ServiceContainer.Resolve<ISyncService>("syncService");
             _biometricService = ServiceContainer.Resolve<IBiometricService>("biometricService");
             _policyService = ServiceContainer.Resolve<IPolicyService>("policyService");
+            _localizeService = ServiceContainer.Resolve<ILocalizeService>("localizeService");
 
             GroupedItems = new ExtendedObservableCollection<SettingsPageListGroup>();
             PageTitle = AppResources.Settings;
@@ -86,8 +88,9 @@ namespace Bit.App.Pages
             if (lastSync != null)
             {
                 lastSync = lastSync.Value.ToLocalTime();
-                _lastSyncDate = string.Format("{0} {1}", lastSync.Value.ToShortDateString(),
-                    lastSync.Value.ToShortTimeString());
+                _lastSyncDate = string.Format("{0} {1}",
+                    _localizeService.GetLocaleShortDate(lastSync.Value),
+                    _localizeService.GetLocaleShortTime(lastSync.Value));
             }
 
             if (await _policyService.PolicyAppliesToUser(PolicyType.MaximumVaultTimeout))

--- a/src/App/Pages/Settings/SyncPageViewModel.cs
+++ b/src/App/Pages/Settings/SyncPageViewModel.cs
@@ -14,6 +14,7 @@ namespace Bit.App.Pages
         private readonly IPlatformUtilsService _platformUtilsService;
         private readonly IStorageService _storageService;
         private readonly ISyncService _syncService;
+        private readonly ILocalizeService _localizeService;
 
         private string _lastSync = "--";
         private bool _inited;
@@ -25,6 +26,7 @@ namespace Bit.App.Pages
             _platformUtilsService = ServiceContainer.Resolve<IPlatformUtilsService>("platformUtilsService");
             _storageService = ServiceContainer.Resolve<IStorageService>("storageService");
             _syncService = ServiceContainer.Resolve<ISyncService>("syncService");
+            _localizeService = ServiceContainer.Resolve<ILocalizeService>("localizeService");
 
             PageTitle = AppResources.Sync;
         }
@@ -68,7 +70,9 @@ namespace Bit.App.Pages
             if (last != null)
             {
                 var localDate = last.Value.ToLocalTime();
-                LastSync = string.Format("{0} {1}", localDate.ToShortDateString(), localDate.ToShortTimeString());
+                LastSync = string.Format("{0} {1}",
+                    _localizeService.GetLocaleShortDate(localDate),
+                    _localizeService.GetLocaleShortTime(localDate));
             }
             else
             {

--- a/src/App/Pages/Vault/CiphersPage.xaml
+++ b/src/App/Pages/Vault/CiphersPage.xaml
@@ -17,7 +17,6 @@
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <u:DateTimeConverter x:Key="dateTime" />
             <ToolbarItem Text="{u:I18n Close}" Clicked="Close_Clicked" Order="Primary" Priority="-1"
                          x:Name="_closeItem" x:Key="closeItem" />
             <StackLayout

--- a/src/App/Pages/Vault/ViewPageViewModel.cs
+++ b/src/App/Pages/Vault/ViewPageViewModel.cs
@@ -25,6 +25,7 @@ namespace Bit.App.Pages
         private readonly IMessagingService _messagingService;
         private readonly IEventService _eventService;
         private readonly IPasswordRepromptService _passwordRepromptService;
+        private readonly ILocalizeService _localizeService;
         private CipherView _cipher;
         private List<ViewPageFieldViewModel> _fields;
         private bool _canAccessPremium;
@@ -52,6 +53,7 @@ namespace Bit.App.Pages
             _messagingService = ServiceContainer.Resolve<IMessagingService>("messagingService");
             _eventService = ServiceContainer.Resolve<IEventService>("eventService");
             _passwordRepromptService = ServiceContainer.Resolve<IPasswordRepromptService>("passwordRepromptService");
+            _localizeService = ServiceContainer.Resolve<ILocalizeService>("localizeService");
             CopyCommand = new Command<string>((id) => CopyAsync(id, null));
             CopyUriCommand = new Command<LoginUriView>(CopyUri);
             CopyFieldCommand = new Command<FieldView>(CopyField);
@@ -152,8 +154,8 @@ namespace Bit.App.Pages
                 fs.Spans.Add(new Span
                 {
                     Text = string.Format(" {0} {1}",
-                        Cipher.RevisionDate.ToLocalTime().ToShortDateString(),
-                        Cipher.RevisionDate.ToLocalTime().ToShortTimeString())
+                        _localizeService.GetLocaleShortDate(Cipher.RevisionDate.ToLocalTime()),
+                        _localizeService.GetLocaleShortTime(Cipher.RevisionDate.ToLocalTime()))
                 });
                 return fs;
             }
@@ -171,8 +173,8 @@ namespace Bit.App.Pages
                 fs.Spans.Add(new Span
                 {
                     Text = string.Format(" {0} {1}",
-                        Cipher.PasswordRevisionDisplayDate?.ToLocalTime().ToShortDateString(),
-                        Cipher.PasswordRevisionDisplayDate?.ToLocalTime().ToShortTimeString())
+                        _localizeService.GetLocaleShortDate(Cipher.PasswordRevisionDisplayDate?.ToLocalTime()),
+                        _localizeService.GetLocaleShortTime(Cipher.PasswordRevisionDisplayDate?.ToLocalTime()))
                 });
                 return fs;
             }

--- a/src/App/Utilities/DateTimeConverter.cs
+++ b/src/App/Utilities/DateTimeConverter.cs
@@ -1,10 +1,19 @@
 ﻿using System;
+using Bit.App.Abstractions;
+using Bit.Core.Utilities;
 using Xamarin.Forms;
 
 namespace Bit.App.Utilities
 {
     public class DateTimeConverter : IValueConverter
     {
+        private readonly ILocalizeService _localizeService;
+
+        public DateTimeConverter()
+        {
+            _localizeService = ServiceContainer.Resolve<ILocalizeService>("localizeService");
+        }
+
         public object Convert(object value, Type targetType, object parameter,
             System.Globalization.CultureInfo culture)
         {
@@ -17,7 +26,9 @@ namespace Bit.App.Utilities
                 return string.Empty;
             }
             var d = ((DateTime)value).ToLocalTime();
-            return string.Format("{0} {1}", d.ToShortDateString(), d.ToShortTimeString());
+            return string.Format("{0} {1}",
+                _localizeService.GetLocaleShortDate(d),
+                _localizeService.GetLocaleShortTime(d));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter,

--- a/src/iOS.Core/Services/LocalizeService.cs
+++ b/src/iOS.Core/Services/LocalizeService.cs
@@ -100,5 +100,25 @@ namespace Bit.iOS.Core.Services
             Console.WriteLine(".NET Fallback Language/Locale:" + netLanguage + " (application-specific)");
             return netLanguage;
         }
+
+        public string GetLocaleShortDate(DateTime? date)
+        {
+            using (var df = new NSDateFormatter())
+            {
+                df.Locale = NSLocale.CurrentLocale;
+                df.DateStyle = NSDateFormatterStyle.Short;
+                return df.StringFor((NSDate)date);
+            }
+        }
+
+        public string GetLocaleShortTime(DateTime? time)
+        {
+            using (var df = new NSDateFormatter())
+            {
+                df.Locale = NSLocale.CurrentLocale;
+                df.TimeStyle = NSDateFormatterStyle.Short;
+                return df.StringFor((NSDate)time);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Apple supports many language-locale combinations that .Net is lacking. If a user is "en-FR" for example, we default that to "en" to set the `CultureInfo` object used in localization. 

Date formatting in .Net uses this `CultureInfo` object to decide how to show dates and times. Since we default unsupported locales to just "en", users noticed dates didn't appear in their chosen region format.

This change introduces date and time formatting methods to `LocalizationService` so we can use Apple APIs instead of the .Net ones relying on `CultureInfo`. Android formatting will still use the .Net ones.

Closes bitwarden/desktop#640

Asana Task: https://app.asana.com/0/1169444489336079/1199535628242243/f

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Abstractions/ILocalizeService.cs:** Added date and time formatting methods
* **src/Android/Services/LocalizeService.cs:** Implemented date and time formatting using .Net
* **src/iOS.Core/Services/LocalizeService.cs:** Implemented date and time formatting using Apple APIs
* **SettingsPageViewModel.cs:** Added date and time formatting using LocalizeService
* **SyncPageViewModel.cs:** Added date and time formatting using LocalizeService
* **ViewPageViewModel.cs:** Added date and time formatting using LocalizeService
* **DateTimeConverter.cs:** Added date and time formatting using LocalizeService
* **SendsPage.xaml:** Removed unnecessary call to DateTimeConverter
* **CiphersPage.xaml:** Removed unnecessary call to DateTimeConverter


## Screenshots
<!--Required for any UI changes. Delete if not applicable-->
iPhone set to en-fr, unsupported in .Net
![Screen Shot 2021-10-28 at 10 43 40 AM](https://user-images.githubusercontent.com/24985544/139280226-3e4de3ae-dc62-4eb6-b5e6-15c58a32663b.png)

Bitwarden still formats correctly
![Screen Shot 2021-10-28 at 10 45 34 AM](https://user-images.githubusercontent.com/24985544/139280290-037cc68e-4b71-44be-8002-2dfefa6695c8.png)


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

- iOS testing of unsupported language-locale in .Net, examples are en-fr, en-es, fr-ir
- Regression testing to ensure current behavior still works


## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
