### PR TITLE
remove numeric restriction on card number field

### DIFF
--- a/src/App/Pages/Vault/AddEditPage.xaml
+++ b/src/App/Pages/Vault/AddEditPage.xaml
@@ -241,7 +241,6 @@
                             StyleClass="box-value"
                             Grid.Row="1"
                             Grid.Column="0"
-                            Keyboard="Numeric"
                             IsPassword="{Binding ShowCardNumber, Converter={StaticResource inverseBool}}"
                             IsSpellCheckEnabled="False"
                             IsTextPredictionEnabled="False" />


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Remove numeric restriction on card number field that was originally removed [here](https://github.com/bitwarden/mobile/pull/1097) but inadvertently restored [here](https://github.com/bitwarden/mobile/pull/1365)

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **AddEditPage.xaml:** Removed `Keyboard="Numeric"` to allow the full keyboard to be used


## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Create or modify a card and observe the keyboard type shown when the card number field is focused

## Before you submit
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
