### PR TITLE
Add ssoToken to limit lifetime of SSO redirect

### DIFF
--- a/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
+++ b/src/App/Pages/Accounts/LoginSsoPageViewModel.cs
@@ -81,10 +81,12 @@ namespace Bit.App.Pages
             }
 
             await _deviceActionService.ShowLoadingAsync(AppResources.LoggingIn);
+            string ssoToken;
 
             try
             {
-                await _apiService.PreValidateSso(OrgIdentifier);
+                var response = await _apiService.PreValidateSso(OrgIdentifier);
+                ssoToken = response.Token;
             }
             catch (ApiException e)
             {
@@ -112,7 +114,8 @@ namespace Bit.App.Pages
                       "response_type=code&scope=api%20offline_access&" +
                       "state=" + state + "&code_challenge=" + codeChallenge + "&" +
                       "code_challenge_method=S256&response_mode=query&" +
-                      "domain_hint=" + Uri.EscapeDataString(OrgIdentifier);
+                      "domain_hint=" + Uri.EscapeDataString(OrgIdentifier) + "&" +
+                      "ssoToken=" + Uri.EscapeDataString(ssoToken);
 
             WebAuthenticatorResult authResult = null;
             try

--- a/src/Core/Abstractions/IApiService.cs
+++ b/src/Core/Abstractions/IApiService.cs
@@ -44,7 +44,7 @@ namespace Bit.Core.Abstractions
         Task PutDeleteCipherAsync(string id);
         Task<CipherResponse> PutRestoreCipherAsync(string id);
         Task RefreshIdentityTokenAsync();
-        Task<object> PreValidateSso(string identifier);
+        Task<SsoPrevalidateResponse> PreValidateSso(string identifier);
         Task<TResponse> SendAsync<TRequest, TResponse>(HttpMethod method, string path,
             TRequest body, bool authed, bool hasResponse, bool logoutOnUnauthorized = true);
         void SetUrls(EnvironmentUrls urls);

--- a/src/Core/Models/Response/SsoPrevalidateResponse.cs
+++ b/src/Core/Models/Response/SsoPrevalidateResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace Bit.Core.Models.Response
+{
+    public class SsoPrevalidateResponse
+    {
+        public string Token { get; set; }
+    }
+}

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -547,7 +547,7 @@ namespace Bit.Core.Services
             return accessToken;
         }
 
-        public async Task<object> PreValidateSso(string identifier)
+        public async Task<SsoPrevalidateResponse> PreValidateSso(string identifier)
         {
             var path = "/account/prevalidate?domainHint=" + WebUtility.UrlEncode(identifier);
             using (var requestMessage = new HttpRequestMessage())
@@ -571,7 +571,8 @@ namespace Bit.Core.Services
                     var error = await HandleErrorAsync(response, false, true);
                     throw new ApiException(error);
                 }
-                return null;
+                var responseJsonString = await response.Content.ReadAsStringAsync();
+                return JsonConvert.DeserializeObject<SsoPrevalidateResponse>(responseJsonString);
             }
         }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Mobile implementation of bitwarden/jslib#780. Adds an expiring token to SSO page redirects.




## Before you submit
- [x] I have checked for formatting errors (`dotnet tool run dotnet-format --check`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
