### PR TITLE
[PM-2364] Fix settings inaccessible when language is set to Turkish

### DIFF
--- a/src/Core/Utilities/ServiceContainer.cs
+++ b/src/Core/Utilities/ServiceContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Threading.Tasks;
 using Bit.Core.Abstractions;
@@ -228,7 +229,7 @@ namespace Bit.Core.Utilities
                 // and lower case the 2nd one (index 1)
                 indexToLowerCase = 1;
             }
-            sb.Append(char.ToLower(typeName[indexToLowerCase]));
+            sb.Append(char.ToLower(typeName[indexToLowerCase], new CultureInfo("en-US")));
             sb.Append(typeName.Substring(++indexToLowerCase));
             return sb.ToString();
         }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes #2534

Users using Turkish language were unable to access the settings page.

This was caused by an exception when trying to resolve the `II18nService`. That is caused by the lower case of "I" being "ı" in Turkish language so the `GetServiceRegistrationName` is returning ı18nService instead of i18nService.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ServiceContainer.cs:** Set the `CultureInfo` to `en-US` on the `char.ToLower` to use the expected alphabet

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
