### PR TITLE
[PM-8405] Add Firefox Nightly to the FIDO2 allow list

### DIFF
--- a/src/App/Resources/Raw/fido2_privileged_allow_list.json
+++ b/src/App/Resources/Raw/fido2_privileged_allow_list.json
@@ -127,6 +127,18 @@
       {
         "type": "android",
         "info": {
+          "package_name": "org.mozilla.fenix",
+          "signatures": [
+            {
+              "build": "release",
+              "cert_fingerprint_sha256": "50:04:77:90:88:e7:f9:88:d5:bc:5c:c5:f8:79:8f:eb:f4:f8:cd:08:4a:1b:2a:46:ef:d4:c8:ee:4a:ea:f2:11"
+            }
+          ]
+        }
+      },
+      {
+        "type": "android",
+        "info": {
           "package_name": "org.mozilla.focus",
           "signatures": [
             {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The FIDO2 privileged allow list does not have Firefox Nightly on it, which [has supported third-party passkeys](https://bugzilla.mozilla.org/show_bug.cgi?id=1831137). When trying to complete the passkey sign-in flow, Bitwarden throws the `Passkey operation failed because browser is not privileged` error. This PR adds Firefox Nightly to the list.

The certificate fingerprint is extracted from the APK file listed in https://firefox-ci-tc.services.mozilla.com/tasks/index/gecko.v2.mozilla-central.latest.mobile/fenix-nightly and is identical to one published on https://play.google.com/store/apps/details?id=org.mozilla.fenix.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **src/App/Resources/Raw/fido2_privileged_allow_list.json:** Adds Firefox Nightly to the FIDO2 allow list

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
