### PR TITLE
[PM-9020] Fix production server URLs to use the correct ones

### DIFF
--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -58,7 +58,7 @@ namespace Bit.Core.Services
         public void SetUrls(EnvironmentUrlData urls)
         {
             UrlsSet = true;
-            if (!string.IsNullOrWhiteSpace(urls.Base))
+            if (urls?.Region == Enums.Region.SelfHosted && !string.IsNullOrWhiteSpace(urls.Base))
             {
                 ApiBaseUrl = urls.Base + "/api";
                 IdentityBaseUrl = urls.Base + "/identity";


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
US and EU production servers should not be using base url + api or identity suffixes, only SelfHosted ones.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **ApiService:** Add a constrain when setting urls to use the logic of BaseUrl + Suffix only when in SelfHosted region.


## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team
