### PR TITLE
trackEvent should not suspend

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/event/OrganizationEventManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/event/OrganizationEventManager.kt
@@ -9,5 +9,5 @@ interface OrganizationEventManager {
     /**
      * Tracks a specific event to be uploaded at a different time.
      */
-    suspend fun trackEvent(eventType: OrganizationEventType, cipherId: String? = null)
+    fun trackEvent(eventType: OrganizationEventType, cipherId: String? = null)
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the `suspend` keyword for the trackEvent function of the `OrganizationEventManager`. this simplifies the interface and allows us to manage the process within out own scope.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
