### PR TITLE
Add organization event tracking

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/builder/FillResponseBuilderImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/builder/FillResponseBuilderImpl.kt
@@ -76,15 +76,13 @@ class FillResponseBuilderImpl : FillResponseBuilder {
  */
 private fun FilledPartition.toAuthIntentSenderOrNull(
     autofillAppInfo: AutofillAppInfo,
-): IntentSender? {
-    val isTotpEnabled = this.autofillCipher.isTotpEnabled
-    val cipherId = this.autofillCipher.cipherId
-    return if (isTotpEnabled && cipherId != null) {
-        createTotpCopyIntentSender(
-            cipherId = cipherId,
-            context = autofillAppInfo.context,
-        )
-    } else {
-        null
-    }
-}
+): IntentSender? =
+    autofillCipher
+        .cipherId
+        ?.let { cipherId ->
+            // We always do this even if there is no TOTP code because we want to log the events
+            createTotpCopyIntentSender(
+                cipherId = cipherId,
+                context = autofillAppInfo.context,
+            )
+        }

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
+import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import dagger.Module
@@ -59,6 +60,7 @@ object AutofillModule {
         dispatcherManager: DispatcherManager,
         settingsRepository: SettingsRepository,
         vaultRepository: VaultRepository,
+        organizationEventManager: OrganizationEventManager,
     ): AutofillCompletionManager =
         AutofillCompletionManagerImpl(
             authRepository = authRepository,
@@ -67,6 +69,7 @@ object AutofillModule {
             dispatcherManager = dispatcherManager,
             settingsRepository = settingsRepository,
             vaultRepository = vaultRepository,
+            organizationEventManager = organizationEventManager,
         )
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/manager/AutofillCompletionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/manager/AutofillCompletionManagerImpl.kt
@@ -18,6 +18,8 @@ import com.x8bit.bitwarden.data.autofill.util.toAutofillAppInfo
 import com.x8bit.bitwarden.data.autofill.util.toAutofillCipherProvider
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
+import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
+import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
@@ -37,6 +39,7 @@ class AutofillCompletionManagerImpl(
         { createSingleItemFilledDataBuilder(cipherView = it) },
     private val settingsRepository: SettingsRepository,
     private val vaultRepository: VaultRepository,
+    private val organizationEventManager: OrganizationEventManager,
 ) : AutofillCompletionManager {
     private val mainScope = CoroutineScope(dispatcherManager.main)
 
@@ -85,6 +88,11 @@ class AutofillCompletionManagerImpl(
             )
             val resultIntent = createAutofillSelectionResultIntent(dataset)
             activity.setResultAndFinish(resultIntent = resultIntent)
+            cipherView.id?.let {
+                organizationEventManager.trackEvent(
+                    event = OrganizationEvent.CipherClientAutoFilled(cipherId = it),
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -12,6 +12,8 @@ import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
+import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSelectionDataOrNull
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -65,6 +67,7 @@ class SearchViewModel @Inject constructor(
     private val clipboardManager: BitwardenClipboardManager,
     private val policyManager: PolicyManager,
     private val autofillSelectionManager: AutofillSelectionManager,
+    private val organizationEventManager: OrganizationEventManager,
     private val vaultRepo: VaultRepository,
     private val authRepo: AuthRepository,
     environmentRepo: EnvironmentRepository,
@@ -343,12 +346,18 @@ class SearchViewModel @Inject constructor(
         action: ListingItemOverflowAction.VaultAction.CopyPasswordClick,
     ) {
         clipboardManager.setText(action.password)
+        organizationEventManager.trackEvent(
+            event = OrganizationEvent.CipherClientCopiedPassword(cipherId = action.cipherId),
+        )
     }
 
     private fun handleCopySecurityCodeClick(
         action: ListingItemOverflowAction.VaultAction.CopySecurityCodeClick,
     ) {
         clipboardManager.setText(action.securityCode)
+        organizationEventManager.trackEvent(
+            event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = action.cipherId),
+        )
     }
 
     private fun handleCopyUsernameClick(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -12,6 +12,8 @@ import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
+import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSaveItemOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSelectionDataOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toFido2RequestOrNull
@@ -88,6 +90,7 @@ class VaultAddEditViewModel @Inject constructor(
     private val specialCircumstanceManager: SpecialCircumstanceManager,
     private val resourceManager: ResourceManager,
     private val clock: Clock,
+    private val organizationEventManager: OrganizationEventManager,
 ) : BaseViewModel<VaultAddEditState, VaultAddEditEvent, VaultAddEditAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
@@ -159,6 +162,11 @@ class VaultAddEditViewModel @Inject constructor(
     //region Initialization and Overrides
 
     init {
+        onEdit {
+            organizationEventManager.trackEvent(
+                event = OrganizationEvent.CipherClientViewed(cipherId = it.vaultItemId),
+            )
+        }
         vaultRepository
             .vaultDataStateFlow
             .takeUntilLoaded()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -17,6 +17,8 @@ import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
+import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -82,6 +84,7 @@ class VaultItemListingViewModel @Inject constructor(
     private val specialCircumstanceManager: SpecialCircumstanceManager,
     private val policyManager: PolicyManager,
     private val fido2CredentialManager: Fido2CredentialManager,
+    private val organizationEventManager: OrganizationEventManager,
 ) : BaseViewModel<VaultItemListingState, VaultItemListingEvent, VaultItemListingsAction>(
     initialState = run {
         val userState = requireNotNull(authRepository.userStateFlow.value)
@@ -342,12 +345,18 @@ class VaultItemListingViewModel @Inject constructor(
         action: ListingItemOverflowAction.VaultAction.CopyPasswordClick,
     ) {
         clipboardManager.setText(action.password)
+        organizationEventManager.trackEvent(
+            event = OrganizationEvent.CipherClientCopiedPassword(cipherId = action.cipherId),
+        )
     }
 
     private fun handleCopySecurityCodeClick(
         action: ListingItemOverflowAction.VaultAction.CopySecurityCodeClick,
     ) {
         clipboardManager.setText(action.securityCode)
+        organizationEventManager.trackEvent(
+            event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = action.cipherId),
+        )
     }
 
     private fun handleCopyTotpClick(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
@@ -105,6 +105,7 @@ sealed class ListingItemOverflowAction : Parcelable {
          */
         @Parcelize
         data class CopyPasswordClick(
+            val cipherId: String,
             val password: String,
             override val requiresPasswordReprompt: Boolean,
         ) : VaultAction() {
@@ -137,6 +138,7 @@ sealed class ListingItemOverflowAction : Parcelable {
         @Parcelize
         data class CopySecurityCodeClick(
             val securityCode: String,
+            val cipherId: String,
             override val requiresPasswordReprompt: Boolean,
         ) : VaultAction() {
             override val title: Text get() = R.string.copy_security_code.asText()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
@@ -28,6 +28,7 @@ fun CipherView.toOverflowActions(
                 this.login?.password
                     ?.let {
                         ListingItemOverflowAction.VaultAction.CopyPasswordClick(
+                            cipherId = cipherId,
                             password = it,
                             requiresPasswordReprompt = hasMasterPassword,
                         )
@@ -45,6 +46,7 @@ fun CipherView.toOverflowActions(
                 this.card?.code?.let {
                     ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
                         securityCode = it,
+                        cipherId = cipherId,
                         requiresPasswordReprompt = hasMasterPassword,
                     )
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -10,6 +10,8 @@ import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
+import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.DataState
 import com.x8bit.bitwarden.data.platform.repository.util.baseIconUrl
@@ -52,11 +54,12 @@ import javax.inject.Inject
 /**
  * Manages [VaultState], handles [VaultAction], and launches [VaultEvent] for the [VaultScreen].
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class VaultViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val clipboardManager: BitwardenClipboardManager,
+    private val organizationEventManager: OrganizationEventManager,
     private val clock: Clock,
     private val policyManager: PolicyManager,
     private val settingsRepository: SettingsRepository,
@@ -364,12 +367,18 @@ class VaultViewModel @Inject constructor(
         action: ListingItemOverflowAction.VaultAction.CopyPasswordClick,
     ) {
         clipboardManager.setText(action.password)
+        organizationEventManager.trackEvent(
+            event = OrganizationEvent.CipherClientCopiedPassword(cipherId = action.cipherId),
+        )
     }
 
     private fun handleCopySecurityCodeClick(
         action: ListingItemOverflowAction.VaultAction.CopySecurityCodeClick,
     ) {
         clipboardManager.setText(action.securityCode)
+        organizationEventManager.trackEvent(
+            event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = action.cipherId),
+        )
     }
 
     private fun handleCopyTotpClick(

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/builder/FillResponseBuilderTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/builder/FillResponseBuilderTest.kt
@@ -45,15 +45,9 @@ class FillResponseBuilderTest {
     )
     private val autofillCipherValid: AutofillCipher = mockk {
         every { cipherId } returns CIPHER_ID
-        every { isTotpEnabled } returns true
     }
     private val autofillCipherNoId: AutofillCipher = mockk {
         every { cipherId } returns null
-        every { isTotpEnabled } returns true
-    }
-    private val autofillCipherTotpDisabled: AutofillCipher = mockk {
-        every { cipherId } returns CIPHER_ID
-        every { isTotpEnabled } returns false
     }
     private val filledPartitionOne: FilledPartition = mockk {
         every { this@mockk.filledItems } returns listOf(mockk())
@@ -65,10 +59,6 @@ class FillResponseBuilderTest {
     private val filledPartitionThree: FilledPartition = mockk {
         every { this@mockk.filledItems } returns listOf(mockk())
         every { this@mockk.autofillCipher } returns autofillCipherNoId
-    }
-    private val filledPartitionFour: FilledPartition = mockk {
-        every { this@mockk.filledItems } returns listOf(mockk())
-        every { this@mockk.autofillCipher } returns autofillCipherTotpDisabled
     }
     private val saveInfo: SaveInfo = mockk()
 
@@ -141,7 +131,6 @@ class FillResponseBuilderTest {
             filledPartitionOne,
             filledPartitionTwo,
             filledPartitionThree,
-            filledPartitionFour,
         )
         val filledData = FilledData(
             filledPartitions = filledPartitions,
@@ -171,12 +160,6 @@ class FillResponseBuilderTest {
         } returns dataset
         every {
             filledPartitionThree.buildDataset(
-                authIntentSender = null,
-                autofillAppInfo = appInfo,
-            )
-        } returns dataset
-        every {
-            filledPartitionFour.buildDataset(
                 authIntentSender = null,
                 autofillAppInfo = appInfo,
             )
@@ -219,10 +202,6 @@ class FillResponseBuilderTest {
                 authIntentSender = null,
                 autofillAppInfo = appInfo,
             )
-            filledPartitionFour.buildDataset(
-                authIntentSender = null,
-                autofillAppInfo = appInfo,
-            )
             filledData.buildVaultItemDataset(
                 autofillAppInfo = appInfo,
             )
@@ -233,7 +212,7 @@ class FillResponseBuilderTest {
             )
             anyConstructed<FillResponse.Builder>().setSaveInfo(saveInfo)
         }
-        verify(exactly = 3) {
+        verify(exactly = 2) {
             anyConstructed<FillResponse.Builder>().addDataset(dataset)
         }
     }
@@ -252,7 +231,6 @@ class FillResponseBuilderTest {
             filledPartitionOne,
             filledPartitionTwo,
             filledPartitionThree,
-            filledPartitionFour,
         )
         val filledData = FilledData(
             filledPartitions = filledPartitions,
@@ -282,12 +260,6 @@ class FillResponseBuilderTest {
         } returns dataset
         every {
             filledPartitionThree.buildDataset(
-                authIntentSender = null,
-                autofillAppInfo = appInfo,
-            )
-        } returns dataset
-        every {
-            filledPartitionFour.buildDataset(
                 authIntentSender = null,
                 autofillAppInfo = appInfo,
             )
@@ -327,10 +299,6 @@ class FillResponseBuilderTest {
                 authIntentSender = null,
                 autofillAppInfo = appInfo,
             )
-            filledPartitionFour.buildDataset(
-                authIntentSender = null,
-                autofillAppInfo = appInfo,
-            )
             filledData.buildVaultItemDataset(
                 autofillAppInfo = appInfo,
             )
@@ -340,7 +308,7 @@ class FillResponseBuilderTest {
                 ignoredAutofillIdTwo,
             )
         }
-        verify(exactly = 3) {
+        verify(exactly = 2) {
             anyConstructed<FillResponse.Builder>().addDataset(dataset)
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/manager/AutofillCompletionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/manager/AutofillCompletionManagerTest.kt
@@ -22,6 +22,8 @@ import com.x8bit.bitwarden.data.autofill.util.getAutofillAssistStructureOrNull
 import com.x8bit.bitwarden.data.autofill.util.toAutofillAppInfo
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
+import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
@@ -54,7 +56,9 @@ class AutofillCompletionManagerTest {
     }
     private val autofillAppInfo: AutofillAppInfo = mockk()
     private val autofillParser: AutofillParser = mockk()
-    private val cipherView: CipherView = mockk()
+    private val cipherView: CipherView = mockk {
+        every { id } returns "cipherId"
+    }
     private val clipboardManager: BitwardenClipboardManager = mockk {
         every { setText(any<String>()) } just runs
     }
@@ -70,6 +74,9 @@ class AutofillCompletionManagerTest {
         every { show() } just runs
     }
     private val vaultRepository: VaultRepository = mockk()
+    private val organizationEventManager = mockk<OrganizationEventManager> {
+        every { trackEvent(event = any()) } just runs
+    }
 
     private val autofillCompletionManager: AutofillCompletionManager =
         AutofillCompletionManagerImpl(
@@ -80,6 +87,7 @@ class AutofillCompletionManagerTest {
             filledDataBuilderProvider = { filledDataBuilder },
             settingsRepository = settingsRepository,
             vaultRepository = vaultRepository,
+            organizationEventManager = organizationEventManager,
         )
 
     @BeforeEach
@@ -290,6 +298,9 @@ class AutofillCompletionManagerTest {
                 Toast.LENGTH_LONG,
             )
             toast.show()
+            organizationEventManager.trackEvent(
+                event = OrganizationEvent.CipherClientAutoFilled(cipherId = "cipherId"),
+            )
         }
         coVerify {
             filledDataBuilder.build(autofillRequest = fillableRequest)
@@ -358,6 +369,9 @@ class AutofillCompletionManagerTest {
             )
             settingsRepository.isAutoCopyTotpDisabled
             createAutofillSelectionResultIntent(dataset = dataset)
+            organizationEventManager.trackEvent(
+                event = OrganizationEvent.CipherClientAutoFilled(cipherId = "cipherId"),
+            )
         }
         coVerify {
             filledDataBuilder.build(autofillRequest = fillableRequest)
@@ -421,6 +435,9 @@ class AutofillCompletionManagerTest {
             )
             settingsRepository.isAutoCopyTotpDisabled
             createAutofillSelectionResultIntent(dataset = dataset)
+            organizationEventManager.trackEvent(
+                event = OrganizationEvent.CipherClientAutoFilled(cipherId = "cipherId"),
+            )
         }
         coVerify {
             filledDataBuilder.build(autofillRequest = fillableRequest)
@@ -479,6 +496,9 @@ class AutofillCompletionManagerTest {
             )
             settingsRepository.isAutoCopyTotpDisabled
             createAutofillSelectionResultIntent(dataset = dataset)
+            organizationEventManager.trackEvent(
+                event = OrganizationEvent.CipherClientAutoFilled(cipherId = "cipherId"),
+            )
         }
         coVerify {
             filledDataBuilder.build(autofillRequest = fillableRequest)
@@ -537,6 +557,9 @@ class AutofillCompletionManagerTest {
             )
             settingsRepository.isAutoCopyTotpDisabled
             createAutofillSelectionResultIntent(dataset = dataset)
+            organizationEventManager.trackEvent(
+                event = OrganizationEvent.CipherClientAutoFilled(cipherId = "cipherId"),
+            )
         }
         coVerify {
             filledDataBuilder.build(autofillRequest = fillableRequest)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
@@ -581,6 +581,7 @@ class SearchScreenTest : BaseComposeTest() {
                     overflowAction = ListingItemOverflowAction.VaultAction.CopyPasswordClick(
                         password = "mockPassword-1",
                         requiresPasswordReprompt = true,
+                        cipherId = "mockId-1",
                     ),
                 ),
             )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
@@ -52,6 +52,7 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.CopyPasswordClick(
                         password = "mockPassword-$number",
                         requiresPasswordReprompt = true,
+                        cipherId = "mockId-$number",
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
                         totpCode = "mockTotp-$number",
@@ -136,6 +137,7 @@ fun createMockDisplayItemForCipher(
                     ),
                     ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
                         securityCode = "mockCode-$number",
+                        cipherId = "mockId-$number",
                         requiresPasswordReprompt = true,
                     ),
                 ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -23,6 +23,8 @@ import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
+import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.DataState
@@ -126,6 +128,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         SpecialCircumstanceManagerImpl()
 
     private val generatorRepository: GeneratorRepository = FakeGeneratorRepository()
+    private val organizationEventManager = mockk<OrganizationEventManager> {
+        every { trackEvent(event = any()) } just runs
+    }
 
     @BeforeEach
     fun setup() {
@@ -178,6 +183,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         )
         verify(exactly = 1) {
             vaultRepository.vaultDataStateFlow
+        }
+        verify(exactly = 0) {
+            organizationEventManager.trackEvent(event = any())
         }
     }
 
@@ -351,6 +359,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         )
         verify(exactly = 1) {
             vaultRepository.vaultDataStateFlow
+            organizationEventManager.trackEvent(
+                event = OrganizationEvent.CipherClientViewed(cipherId = DEFAULT_EDIT_ITEM_ID),
+            )
         }
     }
 
@@ -370,6 +381,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         )
         verify(exactly = 1) {
             vaultRepository.vaultDataStateFlow
+        }
+        verify(exactly = 0) {
+            organizationEventManager.trackEvent(event = any())
         }
     }
 
@@ -1934,6 +1948,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 fido2CredentialManager = fido2CredentialManager,
                 settingsRepository = settingsRepository,
                 clock = fixedClock,
+                organizationEventManager = organizationEventManager,
             )
         }
 
@@ -2514,6 +2529,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             authRepository = authRepository,
             settingsRepository = settingsRepository,
             clock = clock,
+            organizationEventManager = organizationEventManager,
         )
 
     private fun createVaultData(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -53,6 +53,7 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.CopyPasswordClick(
                         password = "mockPassword-$number",
                         requiresPasswordReprompt = true,
+                        cipherId = "mockId-$number",
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
                         totpCode = "mockTotp-$number",
@@ -139,6 +140,7 @@ fun createMockDisplayItemForCipher(
                     ),
                     ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
                         securityCode = "mockCode-$number",
+                        cipherId = "mockId-$number",
                         requiresPasswordReprompt = true,
                     ),
                 ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
@@ -44,6 +44,7 @@ class CipherViewExtensionsTest {
                 ListingItemOverflowAction.VaultAction.CopyPasswordClick(
                     password = password,
                     requiresPasswordReprompt = false,
+                    cipherId = id,
                 ),
                 ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode = totpCode),
                 ListingItemOverflowAction.VaultAction.LaunchClick(url = uri),
@@ -140,6 +141,7 @@ class CipherViewExtensionsTest {
                 ),
                 ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
                     securityCode = securityCode,
+                    cipherId = id,
                     requiresPasswordReprompt = true,
                 ),
             ),


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2419](https://livefront.atlassian.net/browse/BIT-2419)

## 📔 Objective

This PR adds most of the organization events to the app, a second PR will be coming shortly to get the last of them.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
