### PR TITLE
[PM-8016] Push string resources to Crowdin

### DIFF
--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -7,7 +7,6 @@ on:
       - "main"
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  JAVA_VERSION: 17
 
 jobs:
   crowdin-push:

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - "main"
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   crowdin-push:

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -1,0 +1,43 @@
+name: Crowdin Push
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  JAVA_VERSION: 17
+
+jobs:
+  crowdin-push:
+    name: Crowdin Push
+    runs-on: ubuntu-22.04
+    env:
+      _CROWDIN_PROJECT_ID: "269690"
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Log in to Azure
+        uses: Azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
+        with:
+          creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@2bd1450c2cdb2a8ac886232b8589696f22794229 # v0.2.0
+        with:
+          keyvault: "bitwarden-ci"
+          secrets: "crowdin-api-token"
+
+      - name: Upload sources
+        uses: crowdin/github-action@67705afb6985401459cd143d5f5f00c9dc212f23 # v1.20.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
+        with:
+          config: crowdin.yml
+          crowdin_branch_name: main
+          upload_sources: true
+          upload_translations: false

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,9 @@
+project_id_env: _CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_API_TOKEN
+preserve_hierarchy: true
+base_path: "app/src/main"
+files:
+  - source: "/res/values/strings.xml"
+    translation: "/res/values-%android_code%/%original_file_name%"
+    update_option: update_as_unapproved
+    type: android


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8016

## 📔 Objective

Upload source strings to Crowdin on push events to `main`. 

When uploading, directory hierarchy is preserved to decouple Android source files from other platforms.

Target destination for Android string source files is `res/values/strings.xml`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
