### PR TITLE
Add password reprompt for card number and code

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
@@ -75,13 +75,15 @@ fun VaultItemCardContent(
                 )
             }
         }
-        cardState.number?.let { number ->
+        cardState.number?.let { numberData ->
             item {
                 Spacer(modifier = Modifier.height(8.dp))
                 BitwardenPasswordFieldWithActions(
                     label = stringResource(id = R.string.number),
-                    value = number,
+                    value = numberData.number,
                     onValueChange = {},
+                    showPassword = numberData.isVisible,
+                    showPasswordChange = vaultCardItemTypeHandlers.onShowNumberClick,
                     readOnly = true,
                     singleLine = false,
                     actions = {
@@ -137,13 +139,15 @@ fun VaultItemCardContent(
             }
         }
 
-        cardState.securityCode?.let { securityCode ->
+        cardState.securityCode?.let { securityCodeData ->
             item {
                 Spacer(modifier = Modifier.height(8.dp))
                 BitwardenPasswordFieldWithActions(
                     label = stringResource(id = R.string.security_code),
-                    value = securityCode,
+                    value = securityCodeData.code,
                     onValueChange = {},
+                    showPassword = securityCodeData.isVisible,
+                    showPasswordChange = vaultCardItemTypeHandlers.onShowSecurityCodeClick,
                     readOnly = true,
                     singleLine = false,
                     actions = {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/handlers/VaultCardItemTypeHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/handlers/VaultCardItemTypeHandlers.kt
@@ -10,6 +10,8 @@ import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemViewModel
 data class VaultCardItemTypeHandlers(
     val onCopyNumberClick: () -> Unit,
     val onCopySecurityCodeClick: () -> Unit,
+    val onShowNumberClick: (Boolean) -> Unit,
+    val onShowSecurityCodeClick: (Boolean) -> Unit,
 ) {
     companion object {
 
@@ -23,6 +25,14 @@ data class VaultCardItemTypeHandlers(
                 },
                 onCopySecurityCodeClick = {
                     viewModel.trySendAction(VaultItemAction.ItemType.Card.CopySecurityCodeClick)
+                },
+                onShowNumberClick = {
+                    viewModel.trySendAction(
+                        VaultItemAction.ItemType.Card.NumberVisibilityClick(it),
+                    )
+                },
+                onShowSecurityCodeClick = {
+                    viewModel.trySendAction(VaultItemAction.ItemType.Card.CodeVisibilityClick(it))
                 },
             )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensions.kt
@@ -115,10 +115,20 @@ fun CipherView.toViewState(
             CipherType.CARD -> {
                 VaultItemState.ViewState.Content.ItemType.Card(
                     cardholderName = card?.cardholderName,
-                    number = card?.number,
+                    number = card?.number?.let {
+                        VaultItemState.ViewState.Content.ItemType.Card.NumberData(
+                            number = it,
+                            isVisible = false,
+                        )
+                    },
                     brand = card?.cardBrand,
                     expiration = card?.expiration,
-                    securityCode = card?.code,
+                    securityCode = card?.code?.let {
+                        VaultItemState.ViewState.Content.ItemType.Card.CodeData(
+                            code = it,
+                            isVisible = false,
+                        )
+                    },
                 )
             }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -1837,14 +1837,17 @@ class VaultItemScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `in card state the number should be displayed according to state`() {
+    fun `in card state, on show number click should send NumberVisibilityClick`() {
         composeTestRule.assertScrollableNodeDoesNotExist("Number")
 
         mutableStateFlow.update {
             it.copy(
                 viewState = EMPTY_CARD_VIEW_STATE.copy(
                     type = EMPTY_CARD_TYPE.copy(
-                        number = "number",
+                        number = VaultItemState.ViewState.Content.ItemType.Card.NumberData(
+                            number = "number",
+                            isVisible = false,
+                        ),
                     ),
                 ),
             )
@@ -1861,6 +1864,54 @@ class VaultItemScreenTest : BaseComposeTest() {
             .onNodeWithContentDescription("Show")
             .assertIsDisplayed()
             .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(
+                VaultItemAction.ItemType.Card.NumberVisibilityClick(isVisible = true),
+            )
+        }
+    }
+
+    @Test
+    fun `in card state the number should be displayed according to state`() {
+        composeTestRule.assertScrollableNodeDoesNotExist("Number")
+
+        mutableStateFlow.update {
+            it.copy(
+                viewState = EMPTY_CARD_VIEW_STATE.copy(
+                    type = EMPTY_CARD_TYPE.copy(
+                        number = VaultItemState.ViewState.Content.ItemType.Card.NumberData(
+                            number = "number",
+                            isVisible = false,
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTextAfterScroll("Number")
+            .assertTextEquals("Number", "••••••")
+            .assertIsEnabled()
+        composeTestRule
+            .onNodeWithContentDescription("Copy number")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("Show")
+            .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(
+                viewState = EMPTY_CARD_VIEW_STATE.copy(
+                    type = EMPTY_CARD_TYPE.copy(
+                        number = VaultItemState.ViewState.Content.ItemType.Card.NumberData(
+                            number = "number",
+                            isVisible = true,
+                        ),
+                    ),
+                ),
+            )
+        }
 
         composeTestRule
             .onNodeWithText("Number")
@@ -1881,7 +1932,10 @@ class VaultItemScreenTest : BaseComposeTest() {
             currentState.copy(
                 viewState = EMPTY_CARD_VIEW_STATE.copy(
                     type = EMPTY_CARD_TYPE.copy(
-                        number = number,
+                        number = VaultItemState.ViewState.Content.ItemType.Card.NumberData(
+                            number = number,
+                            isVisible = false,
+                        ),
                         expiration = "test",
                     ),
                 ),
@@ -1927,14 +1981,17 @@ class VaultItemScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `in card state the security code should be displayed according to state`() {
+    fun `in card state, on show code click should send CodeVisibilityClick`() {
         composeTestRule.assertScrollableNodeDoesNotExist("Security code")
 
         mutableStateFlow.update {
             it.copy(
                 viewState = EMPTY_CARD_VIEW_STATE.copy(
                     type = EMPTY_CARD_TYPE.copy(
-                        securityCode = "123",
+                        securityCode = VaultItemState.ViewState.Content.ItemType.Card.CodeData(
+                            code = "123",
+                            isVisible = false,
+                        ),
                     ),
                 ),
             )
@@ -1953,6 +2010,55 @@ class VaultItemScreenTest : BaseComposeTest() {
             .assertIsDisplayed()
             .performClick()
 
+        verify(exactly = 1) {
+            viewModel.trySendAction(
+                VaultItemAction.ItemType.Card.CodeVisibilityClick(isVisible = true),
+            )
+        }
+    }
+
+    @Test
+    fun `in card state the security code should be displayed according to state`() {
+        composeTestRule.assertScrollableNodeDoesNotExist("Security code")
+
+        mutableStateFlow.update {
+            it.copy(
+                viewState = EMPTY_CARD_VIEW_STATE.copy(
+                    type = EMPTY_CARD_TYPE.copy(
+                        securityCode = VaultItemState.ViewState.Content.ItemType.Card.CodeData(
+                            code = "123",
+                            isVisible = false,
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithTextAfterScroll("Security code")
+            .assertTextEquals("Security code", "•••")
+            .assertIsEnabled()
+        composeTestRule
+            .onNodeWithContentDescription("Copy security code")
+            .assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithContentDescription("Show")
+            .onLast()
+            .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(
+                viewState = EMPTY_CARD_VIEW_STATE.copy(
+                    type = EMPTY_CARD_TYPE.copy(
+                        securityCode = VaultItemState.ViewState.Content.ItemType.Card.CodeData(
+                            code = "123",
+                            isVisible = true,
+                        ),
+                    ),
+                ),
+            )
+        }
+
         composeTestRule
             .onNodeWithText("Security code")
             .assertTextEquals("Security code", "123")
@@ -1967,12 +2073,15 @@ class VaultItemScreenTest : BaseComposeTest() {
 
     @Test
     fun `in card state, on copy security code click should send CopySecurityCodeClick`() {
-        val number = "1234"
+        val code = "1234"
         mutableStateFlow.update { currentState ->
             currentState.copy(
                 viewState = EMPTY_CARD_VIEW_STATE.copy(
                     type = EMPTY_CARD_TYPE.copy(
-                        securityCode = number,
+                        securityCode = VaultItemState.ViewState.Content.ItemType.Card.CodeData(
+                            code = code,
+                            isVisible = false,
+                        ),
                     ),
                 ),
             )
@@ -2167,10 +2276,16 @@ private val DEFAULT_IDENTITY: VaultItemState.ViewState.Content.ItemType.Identity
 private val DEFAULT_CARD: VaultItemState.ViewState.Content.ItemType.Card =
     VaultItemState.ViewState.Content.ItemType.Card(
         cardholderName = "the cardholder name",
-        number = "the number",
+        number = VaultItemState.ViewState.Content.ItemType.Card.NumberData(
+            number = "the number",
+            isVisible = false,
+        ),
         brand = VaultCardBrand.VISA,
         expiration = "the expiration",
-        securityCode = "the security code",
+        securityCode = VaultItemState.ViewState.Content.ItemType.Card.CodeData(
+            code = "the security code",
+            isVisible = false,
+        ),
     )
 
 private val EMPTY_COMMON: VaultItemState.ViewState.Content.Common =
@@ -2212,10 +2327,16 @@ private val EMPTY_IDENTITY_TYPE: VaultItemState.ViewState.Content.ItemType.Ident
 private val EMPTY_CARD_TYPE: VaultItemState.ViewState.Content.ItemType.Card =
     VaultItemState.ViewState.Content.ItemType.Card(
         cardholderName = "",
-        number = "",
+        number = VaultItemState.ViewState.Content.ItemType.Card.NumberData(
+            number = "",
+            isVisible = false,
+        ),
         brand = VaultCardBrand.SELECT,
         expiration = "",
-        securityCode = "",
+        securityCode = VaultItemState.ViewState.Content.ItemType.Card.CodeData(
+            code = "",
+            isVisible = false,
+        ),
     )
 
 private val EMPTY_LOGIN_VIEW_STATE: VaultItemState.ViewState.Content =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -1925,7 +1925,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     cardState.copy(
                         dialog = VaultItemState.DialogState.MasterPasswordDialog(
                             action = PasswordRepromptAction.CopyClick(
-                                value = requireNotNull(DEFAULT_CARD_TYPE.number),
+                                value = requireNotNull(DEFAULT_CARD_TYPE.number).number,
                             ),
                         ),
                     ),
@@ -1973,6 +1973,81 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         }
 
         @Test
+        fun `on NumberVisibilityClick should show password dialog when re-prompt is required`() =
+            runTest {
+                val cardState = DEFAULT_STATE.copy(viewState = CARD_VIEW_STATE)
+                val mockCipherView = mockk<CipherView> {
+                    every {
+                        toViewState(
+                            isPremiumUser = true,
+                            hasMasterPassword = true,
+                            totpCodeItemData = null,
+                        )
+                    } returns CARD_VIEW_STATE
+                }
+                mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
+                mutableAuthCodeItemFlow.value = DataState.Loaded(data = null)
+
+                assertEquals(cardState, viewModel.stateFlow.value)
+                viewModel.trySendAction(
+                    VaultItemAction.ItemType.Card.NumberVisibilityClick(isVisible = true),
+                )
+                assertEquals(
+                    cardState.copy(
+                        dialog = VaultItemState.DialogState.MasterPasswordDialog(
+                            action = PasswordRepromptAction.ViewNumberClick(isVisible = true),
+                        ),
+                    ),
+                    viewModel.stateFlow.value,
+                )
+
+                verify(exactly = 1) {
+                    mockCipherView.toViewState(
+                        isPremiumUser = true,
+                        hasMasterPassword = true,
+                        totpCodeItemData = null,
+                    )
+                }
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `on NumberVisibilityClick should call trackEvent on the OrganizationEventManager and update the ViewState when re-prompt is not required`() {
+            val mockCipherView = mockk<CipherView> {
+                every {
+                    toViewState(
+                        isPremiumUser = true,
+                        hasMasterPassword = true,
+                        totpCodeItemData = null,
+                    )
+                } returns createViewState(
+                    common = DEFAULT_COMMON.copy(requiresReprompt = false),
+                    type = DEFAULT_CARD_TYPE,
+                )
+            }
+            every { clipboardManager.setText(text = "12345436") } just runs
+            mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
+            mutableAuthCodeItemFlow.value = DataState.Loaded(data = null)
+
+            viewModel.trySendAction(
+                VaultItemAction.ItemType.Card.NumberVisibilityClick(isVisible = true),
+            )
+
+            verify(exactly = 1) {
+                organizationEventManager.trackEvent(
+                    event = OrganizationEvent.CipherClientToggledCardNumberVisible(
+                        cipherId = VAULT_ITEM_ID,
+                    ),
+                )
+                mockCipherView.toViewState(
+                    isPremiumUser = true,
+                    hasMasterPassword = true,
+                    totpCodeItemData = null,
+                )
+            }
+        }
+
+        @Test
         fun `on CopySecurityCodeClick should show password dialog when re-prompt is required`() =
             runTest {
                 val cardState = DEFAULT_STATE.copy(viewState = CARD_VIEW_STATE)
@@ -1994,7 +2069,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     cardState.copy(
                         dialog = VaultItemState.DialogState.MasterPasswordDialog(
                             action = PasswordRepromptAction.CopyClick(
-                                value = requireNotNull(DEFAULT_CARD_TYPE.securityCode),
+                                value = requireNotNull(DEFAULT_CARD_TYPE.securityCode).code,
                             ),
                         ),
                     ),
@@ -2033,6 +2108,81 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
             verify(exactly = 1) {
                 clipboardManager.setText(text = "987")
+                mockCipherView.toViewState(
+                    isPremiumUser = true,
+                    hasMasterPassword = true,
+                    totpCodeItemData = null,
+                )
+            }
+        }
+
+        @Test
+        fun `on CodeVisibilityClick should show password dialog when re-prompt is required`() =
+            runTest {
+                val cardState = DEFAULT_STATE.copy(viewState = CARD_VIEW_STATE)
+                val mockCipherView = mockk<CipherView> {
+                    every {
+                        toViewState(
+                            isPremiumUser = true,
+                            hasMasterPassword = true,
+                            totpCodeItemData = null,
+                        )
+                    } returns CARD_VIEW_STATE
+                }
+                mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
+                mutableAuthCodeItemFlow.value = DataState.Loaded(data = null)
+
+                assertEquals(cardState, viewModel.stateFlow.value)
+                viewModel.trySendAction(
+                    VaultItemAction.ItemType.Card.CodeVisibilityClick(isVisible = true),
+                )
+                assertEquals(
+                    cardState.copy(
+                        dialog = VaultItemState.DialogState.MasterPasswordDialog(
+                            action = PasswordRepromptAction.ViewCodeClick(isVisible = true),
+                        ),
+                    ),
+                    viewModel.stateFlow.value,
+                )
+
+                verify(exactly = 1) {
+                    mockCipherView.toViewState(
+                        isPremiumUser = true,
+                        hasMasterPassword = true,
+                        totpCodeItemData = null,
+                    )
+                }
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `on CodeVisibilityClick should call trackEvent on the OrganizationEventManager and update the ViewState when re-prompt is not required`() {
+            val mockCipherView = mockk<CipherView> {
+                every {
+                    toViewState(
+                        isPremiumUser = true,
+                        hasMasterPassword = true,
+                        totpCodeItemData = null,
+                    )
+                } returns createViewState(
+                    common = DEFAULT_COMMON.copy(requiresReprompt = false),
+                    type = DEFAULT_CARD_TYPE,
+                )
+            }
+            every { clipboardManager.setText(text = "987") } just runs
+            mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
+            mutableAuthCodeItemFlow.value = DataState.Loaded(data = null)
+
+            viewModel.trySendAction(
+                VaultItemAction.ItemType.Card.CodeVisibilityClick(isVisible = true),
+            )
+
+            verify(exactly = 1) {
+                organizationEventManager.trackEvent(
+                    event = OrganizationEvent.CipherClientToggledCardCodeVisible(
+                        cipherId = VAULT_ITEM_ID,
+                    ),
+                )
                 mockCipherView.toViewState(
                     isPremiumUser = true,
                     hasMasterPassword = true,
@@ -2313,10 +2463,16 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         private val DEFAULT_CARD_TYPE: VaultItemState.ViewState.Content.ItemType.Card =
             VaultItemState.ViewState.Content.ItemType.Card(
                 cardholderName = "mockName",
-                number = "12345436",
+                number = VaultItemState.ViewState.Content.ItemType.Card.NumberData(
+                    number = "12345436",
+                    isVisible = false,
+                ),
                 brand = VaultCardBrand.VISA,
                 expiration = "03/2027",
-                securityCode = "987",
+                securityCode = VaultItemState.ViewState.Content.ItemType.Card.CodeData(
+                    code = "987",
+                    isVisible = false,
+                ),
             )
 
         private val DEFAULT_COMMON: VaultItemState.ViewState.Content.Common =


### PR DESCRIPTION
## 🎟️ Tracking

[PM-7607](https://bitwarden.atlassian.net/browse/PM-7607)

## 📔 Objective

This PR adds the master password re-prompt for the card cipher code and number.

## 📸 Screenshots

| Before | After
| --- | --- |
| <video src="https://github.com/bitwarden/android/assets/125928928/a0793022-19bf-4276-b5af-4fe8164dd7ad" width="300" /> | <video src="https://github.com/bitwarden/android/assets/125928928/edfe4bce-be78-43d0-a094-ea050d4a2fcd" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-7607]: https://bitwarden.atlassian.net/browse/PM-7607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ