### PR TITLE
BIT-2433: Filter trash from search results

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
@@ -102,15 +102,18 @@ private fun CipherView.filterBySearchType(
     searchTypeData: SearchTypeData.Vault,
 ): Boolean =
     when (searchTypeData) {
-        SearchTypeData.Vault.All -> true
-        is SearchTypeData.Vault.Cards -> type == CipherType.CARD
-        is SearchTypeData.Vault.Collection -> searchTypeData.collectionId in this.collectionIds
-        is SearchTypeData.Vault.Folder -> folderId == searchTypeData.folderId
-        SearchTypeData.Vault.NoFolder -> folderId == null
-        is SearchTypeData.Vault.Identities -> type == CipherType.IDENTITY
-        is SearchTypeData.Vault.Logins -> type == CipherType.LOGIN
-        is SearchTypeData.Vault.SecureNotes -> type == CipherType.SECURE_NOTE
-        is SearchTypeData.Vault.VerificationCodes -> login?.totp != null
+        SearchTypeData.Vault.All -> deletedDate == null
+        is SearchTypeData.Vault.Cards -> type == CipherType.CARD && deletedDate == null
+        is SearchTypeData.Vault.Collection -> {
+            searchTypeData.collectionId in this.collectionIds && deletedDate == null
+        }
+
+        is SearchTypeData.Vault.Folder -> folderId == searchTypeData.folderId && deletedDate == null
+        SearchTypeData.Vault.NoFolder -> folderId == null && deletedDate == null
+        is SearchTypeData.Vault.Identities -> type == CipherType.IDENTITY && deletedDate == null
+        is SearchTypeData.Vault.Logins -> type == CipherType.LOGIN && deletedDate == null
+        is SearchTypeData.Vault.SecureNotes -> type == CipherType.SECURE_NOTE && deletedDate == null
+        is SearchTypeData.Vault.VerificationCodes -> login?.totp != null && deletedDate == null
         is SearchTypeData.Vault.Trash -> deletedDate != null
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
@@ -257,6 +257,32 @@ class SearchTypeDataExtensionsTest {
         assertEquals(listOf(match1, match2), result)
     }
 
+    @Test
+    fun `CipherViews filterAndOrganize should return list without deleted items`() {
+        val match1 = createMockCipherView(number = 1, isDeleted = true).copy(name = "match1")
+        val match2 = createMockCipherView(number = 2).copy(name = "match2")
+        val match3 = createMockCipherView(number = 3, isDeleted = true).copy(name = "match3")
+        val ciphers = listOf(match1, match2, match3)
+        val result = ciphers.filterAndOrganize(
+            searchTypeData = SearchTypeData.Vault.Logins,
+            searchTerm = "match",
+        )
+        assertEquals(listOf(match2), result)
+    }
+
+    @Test
+    fun `CipherViews filterAndOrganize should return list with only deleted items`() {
+        val match1 = createMockCipherView(number = 1, isDeleted = true).copy(name = "match1")
+        val match2 = createMockCipherView(number = 2).copy(name = "match2")
+        val match3 = createMockCipherView(number = 3, isDeleted = true).copy(name = "match3")
+        val ciphers = listOf(match1, match2, match3)
+        val result = ciphers.filterAndOrganize(
+            searchTypeData = SearchTypeData.Vault.Trash,
+            searchTerm = "match",
+        )
+        assertEquals(listOf(match1, match3), result)
+    }
+
     @Suppress("MaxLineLength")
     @Test
     fun `CipherViews toViewState should return empty state with no message when search term is blank`() {


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2433](https://livefront.atlassian.net/browse/BIT-2433)

## 📔 Objective

This PR filters any deleted items from the search unless you are explicitly searching the trash.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
