### PR TITLE
Clean up environment urls

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/interceptor/BaseUrlInterceptors.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/interceptor/BaseUrlInterceptors.kt
@@ -1,8 +1,9 @@
 package com.x8bit.bitwarden.data.platform.datasource.network.interceptor
 
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
+import com.x8bit.bitwarden.data.platform.repository.util.baseApiUrl
+import com.x8bit.bitwarden.data.platform.repository.util.baseEventsUrl
 import com.x8bit.bitwarden.data.platform.repository.util.baseIdentityUrl
-import com.x8bit.bitwarden.ui.platform.base.util.orNullIfBlank
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -39,24 +40,8 @@ class BaseUrlInterceptors @Inject constructor() {
 
     private fun updateBaseUrls(environment: Environment) {
         val environmentUrlData = environment.environmentUrlData
-        val baseUrl = environmentUrlData.base.trim()
-
-        // Determine the required base URLs
-        val apiUrl: String
-        val eventsUrl: String
-        if (baseUrl.isNotEmpty()) {
-            apiUrl = "$baseUrl/api"
-            eventsUrl = "$baseUrl/events"
-        } else {
-            apiUrl =
-                environmentUrlData.api.orNullIfBlank() ?: "https://api.bitwarden.com"
-            eventsUrl =
-                environmentUrlData.events.orNullIfBlank() ?: "https://events.bitwarden.com"
-        }
-
-        // Update the base URLs
-        apiInterceptor.baseUrl = apiUrl
+        apiInterceptor.baseUrl = environmentUrlData.baseApiUrl
         identityInterceptor.baseUrl = environmentUrlData.baseIdentityUrl
-        eventsInterceptor.baseUrl = eventsUrl
+        eventsInterceptor.baseUrl = environmentUrlData.baseEventsUrl
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/util/EnvironmentUrlsDataJsonExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/util/EnvironmentUrlsDataJsonExtensionsTest.kt
@@ -8,20 +8,68 @@ import org.junit.jupiter.api.Test
 
 class EnvironmentUrlsDataJsonExtensionsTest {
     @Test
+    fun `baseApiUrl should return base if it is present`() {
+        assertEquals(
+            "base/api",
+            DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA.baseApiUrl,
+        )
+    }
+
+    @Test
+    fun `baseApiUrl should return api value if base is empty`() {
+        assertEquals(
+            "api",
+            DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA.copy(base = "").baseApiUrl,
+        )
+    }
+
+    @Test
+    fun `baseApiUrl should return default url if base is empty and api is null`() {
+        assertEquals(
+            "https://api.bitwarden.com",
+            DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA.copy(base = "", api = null).baseApiUrl,
+        )
+    }
+
+    @Test
+    fun `baseEventsUrl should return base if it is present`() {
+        assertEquals(
+            "base/events",
+            DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA.baseEventsUrl,
+        )
+    }
+
+    @Test
+    fun `baseEventsUrl should return events value if base is empty`() {
+        assertEquals(
+            "events",
+            DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA.copy(base = "").baseEventsUrl,
+        )
+    }
+
+    @Test
+    fun `baseEventsUrl should return default url if base is empty and events is null`() {
+        assertEquals(
+            "https://events.bitwarden.com",
+            DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA.copy(base = "", events = null).baseEventsUrl,
+        )
+    }
+
+    @Test
     fun `baseIdentityUrl should return identity if value is present`() {
         assertEquals(
-            DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA.baseIdentityUrl,
             "identity",
+            DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA.baseIdentityUrl,
         )
     }
 
     @Test
     fun `baseIdentityUrl should return base value if identity is null`() {
         assertEquals(
+            "base/identity",
             DEFAULT_CUSTOM_ENVIRONMENT_URL_DATA
                 .copy(identity = null)
                 .baseIdentityUrl,
-            "base/identity",
         )
     }
 
@@ -242,7 +290,7 @@ class EnvironmentUrlsDataJsonExtensionsTest {
 
     @Test
     fun `toIconBaseurl should return default url if base is empty and icon is null`() {
-        val expectedUrl = "https://icons.bitwarden.net/"
+        val expectedUrl = "https://icons.bitwarden.net"
 
         assertEquals(
             expectedUrl,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR cleans up the environment urls to create a more consistent way of retrieving the appropriate URLs.

Additionally, the urls are now sanitized for `/` to ensure that custom urls with trailing forward slashes work correctly.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
