### PR TITLE
[BIT-2140] Add strings for typeform and export vault

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,9 @@ android {
         unitTests.isIncludeAndroidResources = true
         unitTests.isReturnDefaultValues = true
     }
+    lint {
+        disable.add("MissingTranslation")
+    }
 }
 
 kotlin {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/util/TwoFactorAuthMethodExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/util/TwoFactorAuthMethodExtensions.kt
@@ -39,7 +39,7 @@ fun TwoFactorAuthMethod.description(email: String): Text = when (this) {
     }
 
     TwoFactorAuthMethod.EMAIL -> R.string.enter_verification_code_email.asText(email)
-    TwoFactorAuthMethod.WEB_AUTH -> R.string.continue_to_complete_web_authn_verfication.asText()
+    TwoFactorAuthMethod.WEB_AUTH -> R.string.continue_to_complete_web_authn_verification.asText()
     TwoFactorAuthMethod.YUBI_KEY -> R.string.yubi_key_instruction.asText()
     else -> "".asText()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -913,4 +913,16 @@ Do you want to switch to this account?</string>
   <string name="passkey_operation_failed_because_of_missing_asset_links">Passkey operation failed because of missing asset links</string>
   <string name="passkey_operation_failed_because_app_not_found_in_asset_links">Passkey operation failed because app not found in asset links</string>
   <string name="passkey_operation_failed_because_app_could_not_be_verified">Passkey operation failed because app could not be verified</string>
+  <string name="confirm_file_password">Confirm file password</string>
+  <string name="continue_to_give_feedback">Continue to Give Feedback?</string>
+  <string name="continue_to_provide_feedback">Select continue to give feedback on the new app!</string>
+  <string name="file_password">File password</string>
+  <string name="give_feedback">Give Feedback</string>
+  <string name="password_protected">Password Protected</string>
+  <string name="password_used_to_export">This password will be used to export and import this file</string>
+  <string name="autofill_suggestion">Autofill suggestion</string>
+  <string name="continue_to_complete_web_authn_verification">Continue to complete WebAuthn verification.</string>
+  <string name="launch_web_authn">Launch WebAuthn</string>
+  <string name="there_was_an_error_starting_web_authn_two_factor_authentication">There was an error starting WebAuthn two factor authentication</string>
+  <string name="self_hosted_server_url">Self-hosted server URL</string>
 </resources>

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -6,17 +6,4 @@
     <string name="duo_org_title" translatable="false">Duo (%1$s)</string>
     <string name="json_extension" translatable="false">.json</string>
     <string name="json_extension_formatted" translatable="false">.json (%1$s)</string>
-    <!-- TODO BIT-2140: Update typeform and vault export strings -->
-    <string name="confirm_file_password" translatable="false">Confirm file password</string>
-    <string name="continue_to_give_feedback" translatable="false">Continue to Give Feedback?</string>
-    <string name="continue_to_provide_feedback" translatable="false">Select continue to give feedback on the new app!</string>
-    <string name="file_password" translatable="false">File password</string>
-    <string name="give_feedback" translatable="false">Give Feedback</string>
-    <string name="password_protected" translatable="false">Password Protected</string>
-    <string name="password_used_to_export" translatable="false">This password will be used to export and import this file</string>
-    <string name="autofill_suggestion" translatable="false">Autofill suggestion</string>
-    <string name="continue_to_complete_web_authn_verfication" translatable="false">Continue to complete WebAuthn verification.</string>
-    <string name="launch_web_authn" translatable="false">Launch WebAuthn</string>
-    <string name="there_was_an_error_starting_web_authn_two_factor_authentication" translatable="false">There was an error starting WebAuthn two factor authentication</string>
-    <string name="self_hosted_server_url" translatable="false">Self-hosted server URL</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/util/TwoFactorAuthMethodExtensionTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/util/TwoFactorAuthMethodExtensionTest.kt
@@ -49,7 +49,7 @@ class TwoFactorAuthMethodExtensionTest {
                     .concat(" ".asText())
                     .concat(R.string.follow_the_steps_from_duo_to_finish_logging_in.asText()),
             TwoFactorAuthMethod.WEB_AUTH to
-                R.string.continue_to_complete_web_authn_verfication.asText(),
+                R.string.continue_to_complete_web_authn_verification.asText(),
             TwoFactorAuthMethod.RECOVERY_CODE to "".asText(),
         )
             .forEach { (type, title) ->


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BIT-2140

## 📔 Objective

Move newly added strings related to feedback typeform and vault export to the primary strings resource file so they are tracked by Crowdin.

"MissingTranslation" lint check is disabled to allow source strings to be added without initial translations.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
