### PR TITLE
Fix a screen capture bug that clears the setting when the app language changes

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
@@ -66,6 +66,7 @@ class MainActivity : AppCompatActivity() {
         }
         setContent {
             val state by mainViewModel.stateFlow.collectAsStateWithLifecycle()
+            updateScreenCapture(isScreenCaptureAllowed = state.isScreenCaptureAllowed)
             LocalManagerProvider {
                 BitwardenTheme(theme = state.theme) {
                     RootNavScreen(
@@ -97,15 +98,8 @@ class MainActivity : AppCompatActivity() {
             .eventFlow
             .onEach { event ->
                 when (event) {
-                    is MainEvent.CompleteAutofill -> {
-                        handleCompleteAutofill(event)
-                    }
-
+                    is MainEvent.CompleteAutofill -> handleCompleteAutofill(event)
                     MainEvent.Recreate -> handleRecreate()
-
-                    is MainEvent.ScreenCaptureSettingChange -> {
-                        handleScreenCaptureSettingChange(event)
-                    }
                 }
             }
             .launchIn(lifecycleScope)
@@ -118,15 +112,15 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
-    private fun handleScreenCaptureSettingChange(event: MainEvent.ScreenCaptureSettingChange) {
-        if (event.isAllowed) {
+    private fun handleRecreate() {
+        recreate()
+    }
+
+    private fun updateScreenCapture(isScreenCaptureAllowed: Boolean) {
+        if (isScreenCaptureAllowed) {
             window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
         } else {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
-    }
-
-    private fun handleRecreate() {
-        recreate()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -50,8 +50,9 @@ class MainViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<MainState, MainEvent, MainAction>(
-    MainState(
+    initialState = MainState(
         theme = settingsRepository.appTheme,
+        isScreenCaptureAllowed = settingsRepository.isScreenCaptureAllowed,
     ),
 ) {
     private var specialCircumstance: SpecialCircumstance?
@@ -81,9 +82,8 @@ class MainViewModel @Inject constructor(
 
         settingsRepository
             .isScreenCaptureAllowedStateFlow
-            .onEach { isAllowed ->
-                sendEvent(MainEvent.ScreenCaptureSettingChange(isAllowed))
-            }
+            .map { MainAction.Internal.ScreenCaptureUpdate(it) }
+            .onEach(::trySendAction)
             .launchIn(viewModelScope)
 
         authRepository
@@ -124,6 +124,7 @@ class MainViewModel @Inject constructor(
             }
 
             is MainAction.Internal.CurrentUserStateChange -> handleCurrentUserStateChange()
+            is MainAction.Internal.ScreenCaptureUpdate -> handleScreenCaptureUpdate(action)
             is MainAction.Internal.ThemeUpdate -> handleAppThemeUpdated(action)
             is MainAction.Internal.VaultUnlockStateChange -> handleVaultUnlockStateChange()
             is MainAction.ReceiveFirstIntent -> handleFirstIntentReceived(action)
@@ -139,6 +140,10 @@ class MainViewModel @Inject constructor(
 
     private fun handleCurrentUserStateChange() {
         recreateUiAndGarbageCollect()
+    }
+
+    private fun handleScreenCaptureUpdate(action: MainAction.Internal.ScreenCaptureUpdate) {
+        mutableStateFlow.update { it.copy(isScreenCaptureAllowed = action.isScreenCaptureEnabled) }
     }
 
     private fun handleAppThemeUpdated(action: MainAction.Internal.ThemeUpdate) {
@@ -249,6 +254,7 @@ class MainViewModel @Inject constructor(
 @Parcelize
 data class MainState(
     val theme: AppTheme,
+    val isScreenCaptureAllowed: Boolean,
 ) : Parcelable
 
 /**
@@ -282,6 +288,13 @@ sealed class MainAction {
         data object CurrentUserStateChange : Internal()
 
         /**
+         * Indicates that the screen capture state has changed.
+         */
+        data class ScreenCaptureUpdate(
+            val isScreenCaptureEnabled: Boolean,
+        ) : Internal()
+
+        /**
          * Indicates that the app theme has changed.
          */
         data class ThemeUpdate(
@@ -304,11 +317,6 @@ sealed class MainEvent {
      * process is ready to complete.
      */
     data class CompleteAutofill(val cipherView: CipherView) : MainEvent()
-
-    /**
-     * Event indicating a change in the screen capture setting.
-     */
-    data class ScreenCaptureSettingChange(val isAllowed: Boolean) : MainEvent()
 
     /**
      * Event indicating that the UI should recreate itself.


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes a bug that clears the screen capture state on the activity whenever language changes (whenever it recomposes).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
