### PR TITLE
Fix bug where JWT token clearing premium status

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/RefreshTokenResponseExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/RefreshTokenResponseExtensions.kt
@@ -24,7 +24,6 @@ fun RefreshTokenResponseJson.toUserStateJson(
             email = jwtTokenData.email,
             isEmailVerified = jwtTokenData.isEmailVerified,
             name = jwtTokenData.name,
-            hasPremium = jwtTokenData.hasPremium,
         ),
     )
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/RefreshTokenResponseJsonTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/RefreshTokenResponseJsonTest.kt
@@ -103,7 +103,6 @@ private val ACCOUNT_1_UPDATED = ACCOUNT_1.copy(
         email = JWT_TOKEN_DATA.email,
         isEmailVerified = JWT_TOKEN_DATA.isEmailVerified,
         name = JWT_TOKEN_DATA.name,
-        hasPremium = JWT_TOKEN_DATA.hasPremium,
     ),
 )
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR addresses an issue where the JWT `premium` status was returning false even when a user has premium. So we no longer use that value to update the premium status. The sync response is stilled used to update the premium state.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
