### PR TITLE
Update NotificationPayload to handle null values

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
@@ -153,7 +153,14 @@ class PushManagerImpl @Inject constructor(
             -> {
                 val payload: NotificationPayload.SyncCipherNotification =
                     json.decodeFromString(notification.payload)
-                if (!isLoggedIn(userId) || !payload.userMatchesNotification(userId)) return
+                @Suppress("ComplexCondition")
+                if (payload.id == null ||
+                    payload.revisionDate == null ||
+                    !isLoggedIn(userId) ||
+                    !payload.userMatchesNotification(userId)
+                ) {
+                    return
+                }
                 mutableSyncCipherUpsertSharedFlow.tryEmit(
                     SyncCipherUpsertData(
                         cipherId = payload.id,
@@ -170,7 +177,12 @@ class PushManagerImpl @Inject constructor(
             -> {
                 val payload: NotificationPayload.SyncCipherNotification =
                     json.decodeFromString(notification.payload)
-                if (!isLoggedIn(userId) || !payload.userMatchesNotification(userId)) return
+                if (payload.id == null ||
+                    !isLoggedIn(userId) ||
+                    !payload.userMatchesNotification(userId)
+                ) {
+                    return
+                }
                 mutableSyncCipherDeleteSharedFlow.tryEmit(
                     SyncCipherDeleteData(payload.id),
                 )
@@ -291,8 +303,8 @@ class PushManagerImpl @Inject constructor(
             .fold(
                 onSuccess = {
                     pushDiskSource.storeLastPushTokenRegistrationDate(
-                        userId,
-                        ZonedDateTime.ofInstant(clock.instant(), ZoneOffset.UTC),
+                        userId = userId,
+                        registrationDate = ZonedDateTime.ofInstant(clock.instant(), ZoneOffset.UTC),
                     )
                     pushDiskSource.storeCurrentPushToken(
                         userId = userId,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
@@ -20,12 +20,12 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class SyncCipherNotification(
-        @SerialName("Id") val id: String,
+        @SerialName("Id") val id: String?,
         @SerialName("UserId") override val userId: String?,
         @SerialName("OrganizationId") val organizationId: String?,
         @SerialName("CollectionIds") val collectionIds: List<String>?,
         @Contextual
-        @SerialName("RevisionDate") val revisionDate: ZonedDateTime,
+        @SerialName("RevisionDate") val revisionDate: ZonedDateTime?,
     ) : NotificationPayload()
 
     /**


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR resolves a crash found in Crashlytics:

```
    Fatal Exception: kotlinx.serialization.MissingFieldException: Fields [Id, RevisionDate] are required for type with serial name 'com.x8bit.bitwarden.data.platform.manager.model.NotificationPayload.SyncCipherNotification', but they were missing at path: $
       at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:95)
       at kotlinx.serialization.json.Json.decodeFromString(Json.kt:165)
       at com.x8bit.bitwarden.data.platform.manager.PushManagerImpl.onMessageReceived(PushManagerImpl.kt:347)
       at com.x8bit.bitwarden.data.platform.manager.PushManagerImpl.onMessageReceived(PushManagerImpl.kt:125)
       at com.x8bit.bitwarden.data.push.BitwardenFirebaseMessagingService.onMessageReceived(BitwardenFirebaseMessagingService.kt:23)
       at com.google.firebase.messaging.FirebaseMessagingService.dispatchMessage(FirebaseMessagingService.java:243)
       at com.google.firebase.messaging.FirebaseMessagingService.passMessageIntentToSdk(FirebaseMessagingService.java:193)
       at com.google.firebase.messaging.FirebaseMessagingService.handleMessageIntent(FirebaseMessagingService.java:179)
       at com.google.firebase.messaging.FirebaseMessagingService.handleIntent(FirebaseMessagingService.java:168)
       at com.google.firebase.messaging.EnhancedIntentService.lambda$processIntent$0$com-google-firebase-messaging-EnhancedIntentService(EnhancedIntentService.java:82)
       at com.google.firebase.messaging.EnhancedIntentService$$ExternalSyntheticLambda1.run(D8$$SyntheticClass)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at com.google.android.gms.common.util.concurrent.zza.run(com.google.android.gms:play-services-basement@@18.3.0:2)
       at java.lang.Thread.run(Thread.java:1012)
        
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
