### PR TITLE
PM-9406: Add passkey management to autofill settings

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/row/BitwardenExternalLinkRow.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/row/BitwardenExternalLinkRow.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * @param text The label for the row as a [String].
  * @param onConfirmClick The callback when the confirm button of the dialog is clicked.
  * @param modifier The modifier to be applied to the layout.
+ * @param description An optional description label to be displayed below the [text].
  * @param withDivider Indicates if a divider should be drawn on the bottom of the row, defaults
  * to `true`.
  * @param dialogTitle The title of the dialog displayed when the user clicks this item.
@@ -37,6 +38,7 @@ fun BitwardenExternalLinkRow(
     text: String,
     onConfirmClick: () -> Unit,
     modifier: Modifier = Modifier,
+    description: String? = null,
     withDivider: Boolean = true,
     dialogTitle: String,
     dialogMessage: String,
@@ -46,6 +48,7 @@ fun BitwardenExternalLinkRow(
     var shouldShowDialog by rememberSaveable { mutableStateOf(false) }
     BitwardenTextRow(
         text = text,
+        description = description,
         onClick = { shouldShowDialog = true },
         modifier = modifier,
         withDivider = withDivider,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -38,6 +38,7 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenSelectionRow
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
+import com.x8bit.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenTextRow
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenWideSwitch
@@ -78,6 +79,10 @@ fun AutoFillScreen(
 
             AutoFillEvent.NavigateToBlockAutoFill -> {
                 onNavigateToBlockAutoFillScreen()
+            }
+
+            AutoFillEvent.NavigateToSettings -> {
+                intentManager.startCredentialManagerSettings(context)
             }
         }
     }
@@ -148,6 +153,22 @@ fun AutoFillScreen(
                         .fillMaxWidth()
                         .testTag("InlineAutofillSwitch")
                         .padding(horizontal = 16.dp),
+                )
+            }
+            if (state.showPasskeyManagementRow) {
+                BitwardenExternalLinkRow(
+                    text = stringResource(id = R.string.passkey_management),
+                    description = stringResource(
+                        id = R.string.passkey_management_explanation_long,
+                    ),
+                    onConfirmClick = remember(viewModel) {
+                        { viewModel.trySendAction(AutoFillAction.PasskeyManagementClick) }
+                    },
+                    dialogTitle = stringResource(id = R.string.continue_to_device_settings),
+                    dialogMessage = stringResource(
+                        id = R.string.set_bitwarden_as_passkey_manager_description,
+                    ),
+                    withDivider = false,
                 )
             }
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -35,6 +35,7 @@ class AutoFillViewModel @Inject constructor(
             isCopyTotpAutomaticallyEnabled = !settingsRepository.isAutoCopyTotpDisabled,
             isUseInlineAutoFillEnabled = settingsRepository.isInlineAutofillEnabled,
             showInlineAutofillOption = !isBuildVersionBelow(Build.VERSION_CODES.R),
+            showPasskeyManagementRow = !isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE),
             defaultUriMatchType = settingsRepository.defaultUriMatchType,
         ),
 ) {
@@ -61,6 +62,7 @@ class AutoFillViewModel @Inject constructor(
         is AutoFillAction.DefaultUriMatchTypeSelect -> handleDefaultUriMatchTypeSelect(action)
         AutoFillAction.BlockAutoFillClick -> handleBlockAutoFillClick()
         is AutoFillAction.UseInlineAutofillClick -> handleUseInlineAutofillClick(action)
+        AutoFillAction.PasskeyManagementClick -> handlePasskeyManagementClick()
         is AutoFillAction.Internal.AutofillEnabledUpdateReceive -> {
             handleAutofillEnabledUpdateReceive(action)
         }
@@ -95,6 +97,10 @@ class AutoFillViewModel @Inject constructor(
         mutableStateFlow.update { it.copy(isUseInlineAutoFillEnabled = action.isEnabled) }
     }
 
+    private fun handlePasskeyManagementClick() {
+        sendEvent(AutoFillEvent.NavigateToSettings)
+    }
+
     private fun handleDefaultUriMatchTypeSelect(action: AutoFillAction.DefaultUriMatchTypeSelect) {
         settingsRepository.defaultUriMatchType = action.defaultUriMatchType
         mutableStateFlow.update {
@@ -125,6 +131,7 @@ data class AutoFillState(
     val isCopyTotpAutomaticallyEnabled: Boolean,
     val isUseInlineAutoFillEnabled: Boolean,
     val showInlineAutofillOption: Boolean,
+    val showPasskeyManagementRow: Boolean,
     val defaultUriMatchType: UriMatchType,
 ) : Parcelable {
 
@@ -154,6 +161,11 @@ sealed class AutoFillEvent {
      * Navigate to block auto fill screen.
      */
     data object NavigateToBlockAutoFill : AutoFillEvent()
+
+    /**
+     * Navigate to device settings.
+     */
+    data object NavigateToSettings : AutoFillEvent()
 
     /**
      * Displays a toast with the given [Text].
@@ -211,6 +223,11 @@ sealed class AutoFillAction {
     data class UseInlineAutofillClick(
         val isEnabled: Boolean,
     ) : AutoFillAction()
+
+    /**
+     * User clicked passkey management button.
+     */
+    data object PasskeyManagementClick : AutoFillAction()
 
     /**
      * Internal actions.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.platform.manager.intent
 
 import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Parcelable
@@ -36,6 +37,11 @@ interface IntentManager {
      * Starts the application's settings activity.
      */
     fun startApplicationDetailsSettingsActivity()
+
+    /**
+     * Starts the credential manager settings.
+     */
+    fun startCredentialManagerSettings(context: Context)
 
     /**
      * Start an activity to view the given [uri] in an external browser.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.provider.MediaStore
 import android.provider.Settings
 import android.webkit.MimeTypeMap
@@ -19,6 +20,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.Composable
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import androidx.credentials.CredentialManager
 import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.util.toPendingIntentMutabilityFlag
@@ -115,6 +117,12 @@ class IntentManagerImpl(
         val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
         intent.data = Uri.parse("package:" + context.packageName)
         startActivity(intent = intent)
+    }
+
+    override fun startCredentialManagerSettings(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            CredentialManager.create(context).createSettingsPendingIntent().send()
+        }
     }
 
     override fun launchUri(uri: Uri) {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -20,7 +20,9 @@ import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.util.assertNoDialogExists
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -42,6 +44,7 @@ class AutoFillScreenTest : BaseComposeTest() {
     }
     private val intentManager: IntentManager = mockk {
         every { startSystemAutofillSettingsActivity() } answers { isSystemSettingsRequestSuccess }
+        every { startCredentialManagerSettings(any()) } just runs
     }
 
     @Before
@@ -92,6 +95,15 @@ class AutoFillScreenTest : BaseComposeTest() {
             .onAllNodesWithText("Ok")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun `on NavigateToSettings should attempt to navigate to credential manager settings`() {
+        mutableEventFlow.tryEmit(AutoFillEvent.NavigateToSettings)
+
+        verify { intentManager.startCredentialManagerSettings(any()) }
+
+        composeTestRule.assertNoDialogExists()
     }
 
     @Test
@@ -185,6 +197,33 @@ class AutoFillScreenTest : BaseComposeTest() {
             .performScrollTo()
             .assertIsOn()
             .assertIsNotEnabled()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on passkey management click should display confirmation dialog and confirm click should emit PasskeyManagementClick`() {
+        composeTestRule.onNode(isDialog()).assertDoesNotExist()
+        composeTestRule
+            .onNodeWithText("Passkey management")
+            .performClick()
+        composeTestRule.onNode(isDialog()).assertExists()
+        composeTestRule
+            .onAllNodesWithText("Continue")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+        composeTestRule.onNode(isDialog()).assertDoesNotExist()
+        verify { viewModel.trySendAction(AutoFillAction.PasskeyManagementClick) }
+    }
+
+    @Test
+    fun `passkey management row should not appear according to state`() {
+        mutableStateFlow.update {
+            it.copy(
+                showPasskeyManagementRow = false,
+            )
+        }
+        composeTestRule.onNode(isDialog()).assertDoesNotExist()
+        composeTestRule.onNodeWithText("Passkey management").assertDoesNotExist()
     }
 
     @Test
@@ -356,5 +395,6 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     isCopyTotpAutomaticallyEnabled = false,
     isUseInlineAutoFillEnabled = false,
     showInlineAutofillOption = true,
+    showPasskeyManagementRow = true,
     defaultUriMatchType = UriMatchType.DOMAIN,
 )


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-9406](https://bitwarden.atlassian.net/browse/PM-9406)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add the manage passkey row to the autofill settings for Android 14+ devices.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<video width="400px" src="https://github.com/bitwarden/android/assets/125921730/9745f6cf-ba88-4383-a73e-c5b432fa663b" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9406]: https://bitwarden.atlassian.net/browse/PM-9406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ