### PR TITLE
BIT-2442: check type before extracting autofill text

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensions.kt
@@ -26,7 +26,12 @@ fun AutofillValue.extractMonthValue(
 /**
  * Extract a text value from this [AutofillValue].
  */
-fun AutofillValue.extractTextValue(): String? = this
-    .textValue
-    .takeIf { it.isNotBlank() }
-    ?.toString()
+fun AutofillValue.extractTextValue(): String? =
+    if (this.isText) {
+        this
+            .textValue
+            .takeIf { it.isNotBlank() }
+            ?.toString()
+    } else {
+        null
+    }

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensionsTest.kt
@@ -79,6 +79,7 @@ class AutofillValueExtensionsTest {
     fun `extractTextValue should return textValue when not blank`() {
         // Setup
         val autofillValue: AutofillValue = mockk {
+            every { isText } returns true
             every { textValue } returns TEXT_VALUE
         }
 
@@ -93,7 +94,22 @@ class AutofillValueExtensionsTest {
     fun `extractTextValue should return null when not blank`() {
         // Setup
         val autofillValue: AutofillValue = mockk {
+            every { isText } returns true
             every { textValue } returns "   "
+        }
+
+        // Test
+        val actual = autofillValue.extractTextValue()
+
+        // Verify
+        assertNull(actual)
+    }
+
+    @Test
+    fun `extractTextValue should return null when not text`() {
+        // Setup
+        val autofillValue: AutofillValue = mockk {
+            every { isText } returns false
         }
 
         // Test


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2442](https://livefront.atlassian.net/browse/BIT-2442)

## 📔 Objective

This PR adds a check to avoid an exception when attempting to parse autofill data as text.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
