### PR TITLE
BIT-2443: Fix crash caused by extra blank spaces in name

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/AccountSummaryExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/AccountSummaryExtensions.kt
@@ -18,7 +18,7 @@ import java.util.Locale
  */
 val AccountSummary.initials: String
     get() {
-        val names = this.name.orEmpty().split(" ")
+        val names = this.name.orEmpty().split(" ").filter { it.isNotBlank() }
         return if (names.size >= 2) {
             names
                 .take(2)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/AccountSummaryExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/AccountSummaryExtensionsTest.kt
@@ -12,11 +12,11 @@ class AccountSummaryExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `initials should return the starting letters of the first two words for a multi-word name`() {
+    fun `initials should return the starting letters of the first two words for a multi-word name and ignore any extra spaces`() {
         assertEquals(
             "FS",
             mockk<AccountSummary> {
-                every { name } returns "First Second Third"
+                every { name } returns "First   Second Third"
             }
                 .initials,
         )


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2443](https://livefront.atlassian.net/browse/BIT-2443)

## 📔 Objective

This PR fixes a crash when parsing initials that have extra blank spaces in them.

Stacktrace:
```
   Fatal Exception: java.util.NoSuchElementException: Char sequence is empty.
       at kotlin.text.StringsKt___StringsKt.first(_Strings.kt:76)
       at com.x8bit.bitwarden.ui.vault.feature.vault.util.AccountSummaryExtensionsKt._get_initials_$lambda$0(AccountSummaryExtensions.kt:25)
       at com.x8bit.bitwarden.ui.vault.feature.vault.util.AccountSummaryExtensionsKt.$r8$lambda$75K7JSwE63qgrtaNuTKqE1qCJyM()
       at com.x8bit.bitwarden.ui.vault.feature.vault.util.AccountSummaryExtensionsKt$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass)
       at kotlin.text.StringsKt__AppendableKt.appendElement(Appendable.kt:84)
       ...
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
