### PR TITLE
BIT-2439: Handle invalid patterns when processing regular expression matching

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ciphermatching/CipherMatchingManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ciphermatching/CipherMatchingManagerImpl.kt
@@ -9,12 +9,12 @@ import com.x8bit.bitwarden.data.platform.util.getDomainOrNull
 import com.x8bit.bitwarden.data.platform.util.getHostWithPortOrNull
 import com.x8bit.bitwarden.data.platform.util.getWebHostFromAndroidUriOrNull
 import com.x8bit.bitwarden.data.platform.util.isAndroidApp
+import com.x8bit.bitwarden.data.platform.util.regexOrNull
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.util.toSdkUriMatchType
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
-import kotlin.text.Regex
 import kotlin.text.RegexOption
 import kotlin.text.isNullOrBlank
 import kotlin.text.lowercase
@@ -212,8 +212,9 @@ private fun LoginUriView.checkForMatch(
             UriMatchType.NEVER -> MatchResult.NONE
 
             UriMatchType.REGULAR_EXPRESSION -> {
-                val pattern = Regex(loginViewUri, RegexOption.IGNORE_CASE)
-                exactIfTrue(matchUri.matches(pattern))
+                regexOrNull(loginViewUri, RegexOption.IGNORE_CASE)
+                    ?.let { exactIfTrue(matchUri.matches(it)) }
+                    ?: MatchResult.NONE
             }
 
             UriMatchType.STARTS_WITH -> exactIfTrue(matchUri.startsWith(loginViewUri))

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/RegexUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/RegexUtils.kt
@@ -1,0 +1,16 @@
+package com.x8bit.bitwarden.data.platform.util
+
+import java.util.regex.PatternSyntaxException
+
+/**
+ * Attempts to create a [Regex] and returns `null` if the [pattern] is not valid.
+ */
+fun regexOrNull(
+    pattern: String,
+    option: RegexOption,
+): Regex? =
+    try {
+        Regex(pattern, option)
+    } catch (e: PatternSyntaxException) {
+        null
+    }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/util/RegexUtilsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/util/RegexUtilsTest.kt
@@ -1,0 +1,18 @@
+package com.x8bit.bitwarden.data.platform.util
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class RegexUtilsTest {
+
+    @Test
+    fun `regexOrNull should return nonnull when pattern is valid`() {
+        assertNotNull(regexOrNull(pattern = ".*/", option = RegexOption.IGNORE_CASE))
+    }
+
+    @Test
+    fun `regexOrNull should return null when pattern is invalid`() {
+        assertNull(regexOrNull(pattern = ".*\\", option = RegexOption.IGNORE_CASE))
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2439](https://livefront.atlassian.net/browse/BIT-2439)

## 📔 Objective

This PR fixes a crash that can happen when a user enters a regular expression that is not a valid pattern.

```
Fatal Exception: java.util.regex.PatternSyntaxException: Unrecognized backslash escape sequence in pattern near index 4
.*\maj\-soul\.com.*
    ^
       at com.android.icu.util.regex.PatternNative.compileImpl(PatternNative.java)
       at com.android.icu.util.regex.PatternNative.<init>(PatternNative.java:53)
       at com.android.icu.util.regex.PatternNative.create(PatternNative.java:49)
       at java.util.regex.Pattern.compile(Pattern.java:3533)
       at java.util.regex.Pattern.<init>(Pattern.java:1419)
       at java.util.regex.Pattern.compile(Pattern.java:947)
       at kotlin.text.Regex.<init>(Regex.kt:91)
       at com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManagerImplKt.checkForMatch(CipherMatchingManagerImpl.kt:215)
       at com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManagerImplKt.checkForCipherMatch(CipherMatchingManagerImpl.kt:158)
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
