### PR TITLE
BIT-2431 add condition to only update labelTextWidth on initial layout

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -611,8 +612,10 @@ private fun PasswordLengthSliderItem(
                 Text(
                     text = stringResource(id = R.string.length),
                     modifier = Modifier
-                        .onGloballyPositioned {
-                            labelTextWidth = it.size.width.toDp(density)
+                        .onGloballyPositioned { layoutCoordinates ->
+                            if (labelTextWidth == Dp.Unspecified) {
+                                labelTextWidth = layoutCoordinates.size.width.toDp(density)
+                            }
                         },
                 )
             },
@@ -636,7 +639,7 @@ private fun PasswordLengthSliderItem(
                 }
                 .testTag("PasswordLengthLabel")
                 .wrapContentWidth()
-                .width(labelTextWidth + 16.dp + 16.dp),
+                .width(labelTextWidth + 32.dp),
         )
 
         Slider(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -596,6 +596,20 @@ private fun PasswordLengthSliderItem(
     val density = LocalDensity.current
     val sliderRange = minValue.toFloat()..maxValue.toFloat()
 
+    val lengthLabel: @Composable () -> Unit = remember {
+        {
+            Text(
+                text = stringResource(id = R.string.length),
+                modifier = Modifier
+                    .onGloballyPositioned { layoutCoordinates ->
+                        if (labelTextWidth == Dp.Unspecified) {
+                            labelTextWidth = layoutCoordinates.size.width.toDp(density)
+                        }
+                    },
+            )
+        }
+    }
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -607,17 +621,7 @@ private fun PasswordLengthSliderItem(
             value = sliderValue.toString(),
             readOnly = true,
             onValueChange = { },
-            label = {
-                Text(
-                    text = stringResource(id = R.string.length),
-                    modifier = Modifier
-                        .onGloballyPositioned { layoutCoordinates ->
-                            if (labelTextWidth == Dp.Unspecified) {
-                                labelTextWidth = layoutCoordinates.size.width.toDp(density)
-                            }
-                        },
-                )
-            },
+            label = lengthLabel,
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -642,7 +642,8 @@ private fun PasswordLengthSliderItem(
                 }
                 .testTag("PasswordLengthLabel")
                 .wrapContentWidth()
-                .width(labelTextWidth + 32.dp),
+                // We want the width to be no wider than the label + 16dp on either side
+                .width(16.dp + labelTextWidth + 16.dp),
         )
 
         Slider(


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-2431](https://livefront.atlassian.net/browse/BIT-2431)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Fix bug where the password length field would shrink when the screen display size is zoomed all the way out. 
- able to repro original issue on Pixel 6 Pro (OS 14)
- unable to repro on Samsung device

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/bitwarden/android/assets/149429124/732a4de5-a8ce-4f4d-ab6d-d2b039f4bdc6


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
