### PR TITLE
PM-9077: Ensure each PendingIntent for inline autofill uses unique requestCode

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
@@ -18,6 +18,7 @@ import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.autofill.model.AutofillTotpCopyData
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.data.platform.util.getSafeParcelableExtra
+import java.util.UUID
 
 private const val AUTOFILL_SAVE_ITEM_DATA_KEY = "autofill-save-item-data"
 private const val AUTOFILL_SELECTION_DATA_KEY = "autofill-selection-data"
@@ -57,19 +58,16 @@ fun createTotpCopyIntentSender(
         context,
         AutofillTotpCopyActivity::class.java,
     )
-        .apply {
-            putExtra(
-                AUTOFILL_BUNDLE_KEY,
-                bundleOf(
-                    AUTOFILL_TOTP_COPY_DATA_KEY to AutofillTotpCopyData(cipherId = cipherId),
-                ),
-            )
-        }
-
+        .putExtra(
+            AUTOFILL_BUNDLE_KEY,
+            bundleOf(
+                AUTOFILL_TOTP_COPY_DATA_KEY to AutofillTotpCopyData(cipherId = cipherId),
+            ),
+        )
     return PendingIntent
         .getActivity(
             context,
-            0,
+            UUID.randomUUID().hashCode(),
             intent,
             PendingIntent.FLAG_CANCEL_CURRENT.toPendingIntentMutabilityFlag(),
         )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9077](https://bitwarden.atlassian.net/browse/PM-9077)

## 📔 Objective

This PR addresses a bug in inline autofill where having multiple options that can be used to fill the same field causes the PendingIntents to not function at all. The request codes for the pending intents are now based on random UUIDs ensuing unique request codes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9077]: https://bitwarden.atlassian.net/browse/PM-9077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ