### PR TITLE
Add ability to log non-fatal errors

### DIFF
--- a/app/src/fdroid/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManagerImpl.kt
+++ b/app/src/fdroid/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManagerImpl.kt
@@ -11,4 +11,6 @@ class CrashLogsManagerImpl(
     legacyAppCenterMigrator: LegacyAppCenterMigrator,
 ) : CrashLogsManager {
     override var isEnabled: Boolean = true
+
+    override fun trackNonFatalException(e: Exception) = Unit
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManager.kt
@@ -9,4 +9,9 @@ interface CrashLogsManager {
      * Gets or sets whether the collection of crash logs is enabled.
      */
     var isEnabled: Boolean
+
+    /**
+     * Tracks an exception if logs are enabled.
+     */
+    fun trackNonFatalException(e: Exception)
 }

--- a/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManagerImpl.kt
+++ b/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManagerImpl.kt
@@ -22,6 +22,12 @@ class CrashLogsManagerImpl(
             Firebase.crashlytics.setCrashlyticsCollectionEnabled(value)
         }
 
+    override fun trackNonFatalException(e: Exception) {
+        if (settingsRepository.isCrashLoggingEnabled) {
+            Firebase.crashlytics.recordException(e)
+        }
+    }
+
     init {
         legacyAppCenterMigrator.migrateIfNecessary()
         isEnabled = settingsRepository.isCrashLoggingEnabled


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Add functionality to allow us to track errors that do not result in a crash. This new functionality respects whether the user has opted out of crashing logging and does not function for FDroid users.

This errors will be displayed in Crashlytics but they will be listed as `Non-fatals` instead of the `Crashes` you normally see.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
