### PR TITLE
BIT-2446: Limit the number of inline autofill items that can be displayed

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
@@ -11,6 +11,22 @@ import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProvider
 import com.x8bit.bitwarden.data.autofill.util.buildFilledItemOrNull
 
 /**
+ * The maximum amount of filled partitions the user will see. Viewing the rest will require opening
+ * the vault.
+ *
+ * Note: The vault item is not included in this count.
+ */
+private const val MAX_FILLED_PARTITIONS_COUNT: Int = 20
+
+/**
+ * The maximum amount of inline suggestions the user will see. Viewing the rest will require
+ * opening the vault.
+ *
+ * Note: The vault item is not included in this count.
+ */
+private const val MAX_INLINE_SUGGESTION_COUNT: Int = 5
+
+/**
  * The default [FilledDataBuilder]. This converts parsed autofill data into filled data that is
  * ready to be loaded into an autofill response.
  */
@@ -21,7 +37,9 @@ class FilledDataBuilderImpl(
         val isVaultLocked = autofillCipherProvider.isVaultLocked()
 
         // Subtract one to make sure there is space for the vault item.
-        val maxCipherInlineSuggestionsCount = autofillRequest.maxInlineSuggestionsCount - 1
+        val maxCipherInlineSuggestionsCount = (autofillRequest.maxInlineSuggestionsCount - 1)
+            .coerceAtMost(maximumValue = MAX_INLINE_SUGGESTION_COUNT)
+
         // Track the number of inline suggestions that have been added.
         var inlineSuggestionsAdded = 0
 
@@ -76,7 +94,7 @@ class FilledDataBuilderImpl(
             ?.getOrLastOrNull(inlineSuggestionsAdded)
 
         return FilledData(
-            filledPartitions = filledPartitions,
+            filledPartitions = filledPartitions.take(n = MAX_FILLED_PARTITIONS_COUNT),
             ignoreAutofillIds = autofillRequest.ignoreAutofillIds,
             originalPartition = autofillRequest.partition,
             uri = autofillRequest.uri,


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2446](https://livefront.atlassian.net/browse/BIT-2446)

## 📔 Objective

This PR limits the number of inline autofill suggestions a user can see as well as the number of regular autofill suggestions a user can see. If the user has additional items, they can still view them by selecting the `My Vault` item.

The documentation for inline autofill suggests no more than 5 for performace reasons:
```
    /**
     * Max number of suggestions expected from the response. It must be a positive value.
     * Defaults to {@code SUGGESTION_COUNT_UNLIMITED} if not set.
     *
     * <p>In practice, it is recommended that the max suggestion count does not exceed <b>5</b>
     * for performance reasons.</p>
     */
```

We additionally want to avoid `TransactionTooLargeException`s that can occur when the fill response is too large. documentation can be found [here](https://developer.android.com/identity/autofill/autofill-services#advanced).

```
To prevent the Android system from throwing an exception in these scenarios, you can keep the FillResponse small by adding no more than 20 Dataset objects at a time.
```

An error from this has already appeared in the beta:
```
   Fatal Exception: java.lang.RuntimeException: android.os.TransactionTooLargeException: data parcel size 3444472 bytes
       at android.service.autofill.FillCallback.onSuccess(FillCallback.java:72)
       at com.x8bit.bitwarden.data.autofill.processor.AutofillProcessorImpl$process$1.invokeSuspend(AutofillProcessorImpl.kt:135)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:363)
       at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
       at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
       at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
       at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
