### PR TITLE
BIT-2437: Add mitigation logic for bad encryption key

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1626,7 +1626,8 @@ class AuthRepositoryImpl(
             // The value for the organization keys here will typically be null. We can separately
             // unlock the vault for organization data after receiving the sync response if this
             // data is currently absent. These keys may be present during certain multi-phase login
-            // processes.
+            // processes or if we needed to delete the user's token due to an encrypted data
+            // corruption issue and they are forced to log back in.
             organizationKeys = authDiskSource.getOrganizationKeys(userId = userId),
         )
     }

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -4,15 +4,27 @@
         domain="sharedpref"
         path="." />
     <exclude
+        domain="device_sharedpref"
+        path="." />
+    <exclude
         domain="file"
         path="." />
     <exclude
+        domain="device_file"
+        path="." />
+    <exclude
         domain="database"
+        path="." />
+    <exclude
+        domain="device_database"
         path="." />
     <exclude
         domain="external"
         path="." />
     <exclude
         domain="root"
+        path="." />
+    <exclude
+        domain="device_root"
         path="." />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,16 +5,28 @@
             domain="sharedpref"
             path="." />
         <exclude
+            domain="device_sharedpref"
+            path="." />
+        <exclude
             domain="file"
             path="." />
         <exclude
+            domain="device_file"
+            path="." />
+        <exclude
             domain="database"
+            path="." />
+        <exclude
+            domain="device_database"
             path="." />
         <exclude
             domain="external"
             path="." />
         <exclude
             domain="root"
+            path="." />
+        <exclude
+            domain="device_root"
             path="." />
     </cloud-backup>
     <device-transfer>
@@ -22,16 +34,28 @@
             domain="sharedpref"
             path="." />
         <exclude
+            domain="device_sharedpref"
+            path="." />
+        <exclude
             domain="file"
             path="." />
         <exclude
+            domain="device_file"
+            path="." />
+        <exclude
             domain="database"
+            path="." />
+        <exclude
+            domain="device_database"
             path="." />
         <exclude
             domain="external"
             path="." />
         <exclude
             domain="root"
+            path="." />
+        <exclude
+            domain="device_root"
             path="." />
     </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2437](https://livefront.atlassian.net/browse/BIT-2437)

## 📔 Objective

This PR attempt to mitigate a crash that occurs when trying to instantiate encrypted shared preferences.

This problem cannot be reproduced easily but has been tracked [here](https://issuetracker.google.com/issues/176215143).
The logic in this PR _mitigates_ the issue but does not _solve_ it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
