### PR TITLE
Use random ints for request codes to ensure no overlap

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
@@ -18,7 +18,7 @@ import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.autofill.model.AutofillTotpCopyData
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.data.platform.util.getSafeParcelableExtra
-import java.util.UUID
+import kotlin.random.Random
 
 private const val AUTOFILL_SAVE_ITEM_DATA_KEY = "autofill-save-item-data"
 private const val AUTOFILL_SELECTION_DATA_KEY = "autofill-selection-data"
@@ -67,7 +67,7 @@ fun createTotpCopyIntentSender(
     return PendingIntent
         .getActivity(
             context,
-            UUID.randomUUID().hashCode(),
+            Random.nextInt(),
             intent,
             PendingIntent.FLAG_CANCEL_CURRENT.toPendingIntentMutabilityFlag(),
         )
@@ -93,7 +93,7 @@ fun createAutofillSavedItemIntentSender(
     return PendingIntent
         .getActivity(
             autofillAppInfo.context,
-            0,
+            Random.nextInt(),
             intent,
             PendingIntent.FLAG_CANCEL_CURRENT.toPendingIntentMutabilityFlag(),
         )

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/FilledDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/FilledDataExtensions.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.autofill.model.FilledData
 import com.x8bit.bitwarden.data.autofill.model.FilledItem
 import com.x8bit.bitwarden.ui.autofill.buildVaultItemAutofillRemoteViews
 import com.x8bit.bitwarden.ui.autofill.util.createVaultItemInlinePresentationOrNull
+import kotlin.random.Random
 
 /**
  * Returns all the possible [AutofillId]s that were potentially fillable for the given [FilledData].
@@ -43,7 +44,7 @@ fun FilledData.buildVaultItemDataset(
     val pendingIntent = PendingIntent
         .getActivity(
             autofillAppInfo.context,
-            0,
+            Random.nextInt(),
             intent,
             PendingIntent.FLAG_CANCEL_CURRENT.toPendingIntentMutabilityFlag(),
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/nfc/NfcManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/nfc/NfcManagerImpl.kt
@@ -8,6 +8,7 @@ import android.nfc.NfcAdapter
 import com.x8bit.bitwarden.AuthCallbackActivity
 import com.x8bit.bitwarden.data.autofill.util.toPendingIntentMutabilityFlag
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
+import kotlin.random.Random
 
 /**
  * The default implementation of the [NfcManager].
@@ -26,7 +27,7 @@ class NfcManagerImpl(
             activity,
             PendingIntent.getActivity(
                 activity,
-                1,
+                Random.nextInt(),
                 Intent(activity, AuthCallbackActivity::class.java).addFlags(
                     Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP,
                 ),


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates a bunch of pending intents to use a random request code in order to avoid collisions.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
