### PR TITLE
Corrected spelling mistake of change_master_password

### DIFF
--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -95,7 +95,7 @@
   <string name="bitwarden_autofill_accessibility_service_description">Verwende den Bitwarden Dienst in den Bedienungshilfen um deine Zugangsdaten automatisch einzufügen.</string>
   <string name="change_email">E-Mail-Adresse ändern</string>
   <string name="change_email_confirmation">Du kannst deine E-Mail Adresse im Bitwarden.com Web-Tresor ändern. Möchtest du die Seite jetzt öffnen?</string>
-  <string name="change_master_password">Master-Password ändern</string>
+  <string name="change_master_password">Master-Passwort ändern</string>
   <string name="close">Schließen</string>
   <string name="continue_text">Fortsetzen</string>
   <string name="create_account">Konto erstellen</string>


### PR DESCRIPTION
## 🎟️ Tracking

Found a spelling mistake during testing of the android beta app.

## 📔 Objective

Corrected spelling mistake of the german value of the key "change_master_password"

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
