### PR TITLE
Add support for AutoCompleteTextView as an input field

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensions.kt
@@ -2,13 +2,9 @@ package com.x8bit.bitwarden.data.autofill.util
 
 import android.app.assist.AssistStructure
 import android.view.View
+import android.widget.EditText
 import com.x8bit.bitwarden.data.autofill.model.AutofillView
 import com.x8bit.bitwarden.ui.platform.base.util.orNullIfBlank
-
-/**
- * The class name of the android edit text field.
- */
-private const val ANDROID_EDIT_TEXT_CLASS_NAME: String = "android.widget.EditText"
 
 /**
  * The default web URI scheme.
@@ -59,7 +55,18 @@ private val SUPPORTED_VIEW_HINTS: List<String> = listOf(
  * Whether this [AssistStructure.ViewNode] represents an input field.
  */
 private val AssistStructure.ViewNode.isInputField: Boolean
-    get() = className == ANDROID_EDIT_TEXT_CLASS_NAME || htmlInfo.isInputField
+    get() {
+        val isEditText = className
+            ?.let {
+                try {
+                    Class.forName(it)
+                } catch (e: ClassNotFoundException) {
+                    null
+                }
+            }
+            ?.let { EditText::class.java.isAssignableFrom(it) } == true
+        return isEditText || htmlInfo.isInputField
+    }
 
 /**
  * Attempt to convert this [AssistStructure.ViewNode] into an [AutofillView]. If the view node

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
@@ -177,13 +177,32 @@ class ViewNodeExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `toAutofillView should return AutofillView Login Username when is android text field and is isUsernameField`() {
+    fun `toAutofillView should return AutofillView Login Username when is EditText and isUsernameField`() {
         // Setup
         val expected = AutofillView.Login.Username(
             data = autofillViewData,
         )
         setupUnsupportedInputFieldViewNode()
-        every { viewNode.className } returns ANDROID_EDIT_TEXT_CLASS_NAME
+        every { viewNode.className } returns "android.widget.EditText"
+        every { any<Int>().isPasswordInputType } returns false
+        every { any<Int>().isUsernameInputType } returns true
+
+        // Test
+        val actual = viewNode.toAutofillView()
+
+        // Verify
+        assertEquals(expected, actual)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toAutofillView should return AutofillView Login Username when is EditText subclass and isUsernameField`() {
+        // Setup
+        val expected = AutofillView.Login.Username(
+            data = autofillViewData,
+        )
+        setupUnsupportedInputFieldViewNode()
+        every { viewNode.className } returns "android.widget.AutoCompleteTextView"
         every { any<Int>().isPasswordInputType } returns false
         every { any<Int>().isUsernameInputType } returns true
 
@@ -532,7 +551,6 @@ private val AUTOFILL_OPTIONS_LIST: List<String> = listOf(
     AUTOFILL_OPTION_TWO,
 )
 private const val AUTOFILL_TYPE: Int = View.AUTOFILL_TYPE_LIST
-private const val ANDROID_EDIT_TEXT_CLASS_NAME: String = "android.widget.EditText"
 private val IGNORED_RAW_HINTS: List<String> = listOf(
     "search",
     "find",


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Update autofill to identify an `AutoCompleteTextView` as an input field. This allowed the username field to be found when logging in to the Linked In app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
