### PR TITLE
PM-8202 move dialog status to VM for restore item, add check for MP p…

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -328,6 +328,7 @@ private fun VaultItemDialogs(
                 onDismissRequest = onDismissRequest,
             )
         }
+
         VaultItemState.DialogState.RestoreItemDialog -> BitwardenTwoButtonDialog(
             title = stringResource(id = R.string.restore),
             message = stringResource(id = R.string.do_you_really_want_to_restore_cipher),
@@ -337,6 +338,7 @@ private fun VaultItemDialogs(
             onDismissClick = onDismissRequest,
             onDismissRequest = onDismissRequest,
         )
+
         null -> Unit
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -67,9 +67,6 @@ fun VaultItemScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val resources = context.resources
-    val confirmRestoreAction = remember(viewModel) {
-        { viewModel.trySendAction(VaultItemAction.Common.ConfirmRestoreClick) }
-    }
 
     val fileChooserLauncher = intentManager.getActivityResultLauncher { activityResult ->
         intentManager.getFileDataFromActivityResult(activityResult)
@@ -146,27 +143,12 @@ fun VaultItemScreen(
                 )
             }
         },
+        onConfirmRestoreAction = remember(viewModel) {
+            {
+                viewModel.trySendAction(VaultItemAction.Common.ConfirmRestoreClick)
+            }
+        },
     )
-
-    val dismissRestoreDialog = remember(viewModel) {
-        {
-            viewModel.trySendAction(VaultItemAction.Common.DismissRestoreDialog)
-        }
-    }
-
-    if (state.pendingRestoreCipher) {
-        BitwardenTwoButtonDialog(
-            title = stringResource(id = R.string.restore),
-            message = stringResource(id = R.string.do_you_really_want_to_restore_cipher),
-            confirmButtonText = stringResource(id = R.string.ok),
-            dismissButtonText = stringResource(id = R.string.cancel),
-            onConfirmClick = {
-                confirmRestoreAction()
-            },
-            onDismissClick = dismissRestoreDialog,
-            onDismissRequest = dismissRestoreDialog,
-        )
-    }
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
     BitwardenScaffold(
@@ -301,6 +283,7 @@ private fun VaultItemDialogs(
     onConfirmDeleteClick: () -> Unit,
     onSubmitMasterPassword: (masterPassword: String, action: PasswordRepromptAction) -> Unit,
     onConfirmCloneWithoutFido2Credential: () -> Unit,
+    onConfirmRestoreAction: () -> Unit,
 ) {
     when (dialog) {
         is VaultItemState.DialogState.Generic -> BitwardenBasicDialog(
@@ -345,7 +328,15 @@ private fun VaultItemDialogs(
                 onDismissRequest = onDismissRequest,
             )
         }
-
+        VaultItemState.DialogState.RestoreItemDialog -> BitwardenTwoButtonDialog(
+            title = stringResource(id = R.string.restore),
+            message = stringResource(id = R.string.do_you_really_want_to_restore_cipher),
+            confirmButtonText = stringResource(id = R.string.ok),
+            dismissButtonText = stringResource(id = R.string.cancel),
+            onConfirmClick = onConfirmRestoreAction,
+            onDismissClick = onDismissRequest,
+            onDismissRequest = onDismissRequest,
+        )
         null -> Unit
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -73,8 +73,6 @@ fun VaultItemScreen(
         { viewModel.trySendAction(VaultItemAction.Common.ConfirmRestoreClick) }
     }
 
-    var pendingRestoreCipher by rememberSaveable { mutableStateOf(false) }
-
     val fileChooserLauncher = intentManager.getActivityResultLauncher { activityResult ->
         intentManager.getFileDataFromActivityResult(activityResult)
             ?.let {
@@ -152,22 +150,23 @@ fun VaultItemScreen(
         },
     )
 
-    if (pendingRestoreCipher) {
+    val dismissRestoreDialog = remember(viewModel) {
+        {
+            viewModel.trySendAction(VaultItemAction.Common.DismissRestoreDialog)
+        }
+    }
+
+    if (state.pendingRestoreCipher) {
         BitwardenTwoButtonDialog(
             title = stringResource(id = R.string.restore),
             message = stringResource(id = R.string.do_you_really_want_to_restore_cipher),
             confirmButtonText = stringResource(id = R.string.ok),
             dismissButtonText = stringResource(id = R.string.cancel),
             onConfirmClick = {
-                pendingRestoreCipher = false
                 confirmRestoreAction()
             },
-            onDismissClick = {
-                pendingRestoreCipher = false
-            },
-            onDismissRequest = {
-                pendingRestoreCipher = false
-            },
+            onDismissClick = dismissRestoreDialog,
+            onDismissRequest = dismissRestoreDialog,
         )
     }
 
@@ -189,7 +188,11 @@ fun VaultItemScreen(
                     if (state.isCipherDeleted) {
                         BitwardenTextButton(
                             label = stringResource(id = R.string.restore),
-                            onClick = { pendingRestoreCipher = true },
+                            onClick = remember(viewModel) {
+                                {
+                                    viewModel.trySendAction(VaultItemAction.Common.RestoreVaultItemClick)
+                                }
+                            },
                             modifier = Modifier.testTag("RestoreButton"),
                         )
                     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -15,9 +15,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -190,7 +188,9 @@ fun VaultItemScreen(
                             label = stringResource(id = R.string.restore),
                             onClick = remember(viewModel) {
                                 {
-                                    viewModel.trySendAction(VaultItemAction.Common.RestoreVaultItemClick)
+                                    viewModel.trySendAction(
+                                        VaultItemAction.Common.RestoreVaultItemClick,
+                                    )
                                 }
                             },
                             modifier = Modifier.testTag("RestoreButton"),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -165,6 +165,7 @@ class VaultItemViewModel @Inject constructor(
             is VaultItemAction.Common.ConfirmCloneWithoutFido2CredentialClick -> {
                 handleConfirmCloneClick()
             }
+
             is VaultItemAction.Common.RestoreVaultItemClick -> handleRestoreItemClicked()
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -922,7 +922,7 @@ class VaultItemViewModel @Inject constructor(
         .data
         ?.cipher
         ?.toViewState(
-            previousState = state.viewState as? VaultItemState.ViewState.Content,
+            previousState = state.viewState.asContentOrNull(),
             isPremiumUser = account.isPremium,
             hasMasterPassword = account.hasMasterPassword,
             totpCodeItemData = this.data?.totpCodeItemData,
@@ -1068,8 +1068,8 @@ class VaultItemViewModel @Inject constructor(
             if (content.common.requiresReprompt) {
                 updateDialogState(
                     VaultItemState.DialogState.MasterPasswordDialog(
-                        action = PasswordRepromptAction.RestoreItemClick
-                    )
+                        action = PasswordRepromptAction.RestoreItemClick,
+                    ),
                 )
             } else {
                 updatePendingRestoreCipher(true)
@@ -1434,6 +1434,10 @@ data class VaultItemState(
             }
         }
 
+        /**
+         * Convenience function to keep the syntax a little cleaner when safe casting specifically
+         * for [Content]
+         */
         fun asContentOrNull(): Content? = this as? Content
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -967,7 +967,7 @@ class VaultItemScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `Restore dialog ok click should close the dialog and send ConfirmRestoreClick`() {
+    fun `Restore dialog ok click should send ConfirmRestoreClick`() {
         mutableStateFlow.update {
             it.copy(
                 viewState = DEFAULT_IDENTITY_VIEW_STATE
@@ -1000,7 +1000,7 @@ class VaultItemScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `Restore dialog cancel click should close the dialog and send DismissDialogClick`() {
+    fun `Restore dialog cancel click should send DismissDialogClick`() {
         mutableStateFlow.update {
             it.copy(
                 viewState = DEFAULT_IDENTITY_VIEW_STATE

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -846,7 +846,7 @@ class VaultItemScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `Restore click should send show restore confirmation dialog`() {
+    fun `Clicking Restore should send RestoreVaultItemClick ViewModel action`() {
         mutableStateFlow.update {
             it.copy(
                 viewState = DEFAULT_IDENTITY_VIEW_STATE
@@ -866,6 +866,31 @@ class VaultItemScreenTest : BaseComposeTest() {
         composeTestRule
             .onNodeWithText("Restore")
             .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                VaultItemAction.Common.RestoreVaultItemClick
+            )
+        }
+    }
+
+    @Test
+    fun `Restore dialog should display correctly when dialog state changes`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_IDENTITY_VIEW_STATE
+                    .copy(
+                        common = DEFAULT_COMMON
+                            .copy(
+                                currentCipher = createMockCipherView(1).copy(
+                                    deletedDate = Instant.MIN,
+                                ),
+                            ),
+                    ),
+            )
+        }
+
+        composeTestRule.assertNoDialogExists()
 
         mutableStateFlow.update {
             it.copy(dialog = VaultItemState.DialogState.RestoreItemDialog)
@@ -893,7 +918,7 @@ class VaultItemScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `Restore dialog cancel click should hide restore confirmation menu`() {
+    fun `Restore dialog should hide restore confirmation menu if dialog state changes`() {
         mutableStateFlow.update {
             it.copy(
                 viewState = DEFAULT_IDENTITY_VIEW_STATE
@@ -909,10 +934,6 @@ class VaultItemScreenTest : BaseComposeTest() {
         }
 
         composeTestRule.assertNoDialogExists()
-
-        composeTestRule
-            .onNodeWithText("Restore")
-            .performClick()
 
         mutableStateFlow.update {
             it.copy(dialog = VaultItemState.DialogState.RestoreItemDialog)
@@ -937,7 +958,6 @@ class VaultItemScreenTest : BaseComposeTest() {
             .onAllNodesWithText("Cancel")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
-            .performClick()
 
         mutableStateFlow.update {
             it.copy(dialog = null)
@@ -964,28 +984,9 @@ class VaultItemScreenTest : BaseComposeTest() {
 
         composeTestRule.assertNoDialogExists()
 
-        composeTestRule
-            .onNodeWithText("Restore")
-            .performClick()
-
         mutableStateFlow.update {
             it.copy(dialog = VaultItemState.DialogState.RestoreItemDialog)
         }
-
-        composeTestRule
-            .onAllNodesWithText("Do you really want to restore this item?")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertIsDisplayed()
-
-        composeTestRule
-            .onAllNodesWithText("Restore")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertIsDisplayed()
-
-        composeTestRule
-            .onAllNodesWithText("Cancel")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertIsDisplayed()
 
         composeTestRule
             .onAllNodesWithText("Ok")
@@ -993,14 +994,41 @@ class VaultItemScreenTest : BaseComposeTest() {
             .assertIsDisplayed()
             .performClick()
 
+        verify {
+            viewModel.trySendAction(VaultItemAction.Common.ConfirmRestoreClick)
+        }
+    }
+
+    @Test
+    fun `Restore dialog cancel click should close the dialog and send DismissDialogClick`() {
         mutableStateFlow.update {
-            it.copy(dialog = null)
+            it.copy(
+                viewState = DEFAULT_IDENTITY_VIEW_STATE
+                    .copy(
+                        common = DEFAULT_COMMON
+                            .copy(
+                                currentCipher = createMockCipherView(1).copy(
+                                    deletedDate = Instant.MIN,
+                                ),
+                            ),
+                    ),
+            )
         }
 
         composeTestRule.assertNoDialogExists()
 
+        mutableStateFlow.update {
+            it.copy(dialog = VaultItemState.DialogState.RestoreItemDialog)
+        }
+
+        composeTestRule
+            .onAllNodesWithText("Cancel")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+            .performClick()
+
         verify {
-            viewModel.trySendAction(VaultItemAction.Common.ConfirmRestoreClick)
+            viewModel.trySendAction(VaultItemAction.Common.DismissDialogClick)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -868,7 +868,7 @@ class VaultItemScreenTest : BaseComposeTest() {
             .performClick()
 
         mutableStateFlow.update {
-            it.copy(pendingRestoreCipher = true)
+            it.copy(dialog = VaultItemState.DialogState.RestoreItemDialog)
         }
 
         composeTestRule
@@ -915,7 +915,7 @@ class VaultItemScreenTest : BaseComposeTest() {
             .performClick()
 
         mutableStateFlow.update {
-            it.copy(pendingRestoreCipher = true)
+            it.copy(dialog = VaultItemState.DialogState.RestoreItemDialog)
         }
 
         composeTestRule
@@ -940,7 +940,7 @@ class VaultItemScreenTest : BaseComposeTest() {
             .performClick()
 
         mutableStateFlow.update {
-            it.copy(pendingRestoreCipher = false)
+            it.copy(dialog = null)
         }
 
         composeTestRule.assertNoDialogExists()
@@ -969,7 +969,7 @@ class VaultItemScreenTest : BaseComposeTest() {
             .performClick()
 
         mutableStateFlow.update {
-            it.copy(pendingRestoreCipher = true)
+            it.copy(dialog = VaultItemState.DialogState.RestoreItemDialog)
         }
 
         composeTestRule
@@ -994,7 +994,7 @@ class VaultItemScreenTest : BaseComposeTest() {
             .performClick()
 
         mutableStateFlow.update {
-            it.copy(pendingRestoreCipher = false)
+            it.copy(dialog = null)
         }
 
         composeTestRule.assertNoDialogExists()
@@ -2211,7 +2211,6 @@ private val DEFAULT_STATE: VaultItemState = VaultItemState(
     vaultItemId = VAULT_ITEM_ID,
     viewState = VaultItemState.ViewState.Loading,
     dialog = null,
-    pendingRestoreCipher = false,
 )
 
 private val DEFAULT_COMMON: VaultItemState.ViewState.Content.Common =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -867,6 +867,10 @@ class VaultItemScreenTest : BaseComposeTest() {
             .onNodeWithText("Restore")
             .performClick()
 
+        mutableStateFlow.update {
+            it.copy(pendingRestoreCipher = true)
+        }
+
         composeTestRule
             .onAllNodesWithText("Do you really want to restore this item?")
             .filterToOne(hasAnyAncestor(isDialog()))
@@ -910,6 +914,10 @@ class VaultItemScreenTest : BaseComposeTest() {
             .onNodeWithText("Restore")
             .performClick()
 
+        mutableStateFlow.update {
+            it.copy(pendingRestoreCipher = true)
+        }
+
         composeTestRule
             .onAllNodesWithText("Do you really want to restore this item?")
             .filterToOne(hasAnyAncestor(isDialog()))
@@ -930,6 +938,10 @@ class VaultItemScreenTest : BaseComposeTest() {
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
             .performClick()
+
+        mutableStateFlow.update {
+            it.copy(pendingRestoreCipher = false)
+        }
 
         composeTestRule.assertNoDialogExists()
     }
@@ -956,6 +968,10 @@ class VaultItemScreenTest : BaseComposeTest() {
             .onNodeWithText("Restore")
             .performClick()
 
+        mutableStateFlow.update {
+            it.copy(pendingRestoreCipher = true)
+        }
+
         composeTestRule
             .onAllNodesWithText("Do you really want to restore this item?")
             .filterToOne(hasAnyAncestor(isDialog()))
@@ -976,6 +992,10 @@ class VaultItemScreenTest : BaseComposeTest() {
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
             .performClick()
+
+        mutableStateFlow.update {
+            it.copy(pendingRestoreCipher = false)
+        }
 
         composeTestRule.assertNoDialogExists()
 
@@ -2191,6 +2211,7 @@ private val DEFAULT_STATE: VaultItemState = VaultItemState(
     vaultItemId = VAULT_ITEM_ID,
     viewState = VaultItemState.ViewState.Loading,
     dialog = null,
+    pendingRestoreCipher = false,
 )
 
 private val DEFAULT_COMMON: VaultItemState.ViewState.Content.Common =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -450,15 +450,15 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                 // show dialog
                 viewModel.trySendAction(VaultItemAction.Common.RestoreVaultItemClick)
                 assertEquals(
-                    loginState.copy(pendingRestoreCipher = true),
+                    loginState.copy(dialog = VaultItemState.DialogState.RestoreItemDialog),
                     viewModel.stateFlow.value
                 )
 
                 // dismiss dialog
-                viewModel.trySendAction(VaultItemAction.Common.DismissRestoreDialog)
+                viewModel.trySendAction(VaultItemAction.Common.DismissDialogClick)
                 assertEquals(
                     // setting this to be explicit.
-                    loginState.copy(pendingRestoreCipher = false),
+                    loginState.copy(dialog = null),
                     viewModel.stateFlow.value
                 )
             }
@@ -2557,7 +2557,6 @@ class VaultItemViewModelTest : BaseViewModelTest() {
             vaultItemId = VAULT_ITEM_ID,
             viewState = VaultItemState.ViewState.Loading,
             dialog = null,
-            pendingRestoreCipher = false,
         )
 
         private val DEFAULT_USER_STATE: UserState = UserState(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -397,6 +397,73 @@ class VaultItemViewModelTest : BaseViewModelTest() {
             }
 
         @Test
+        fun `on RestoreItemClick should prompt for master password when required`() = runTest {
+            val mockCipherView = mockk<CipherView> {
+                every {
+                    toViewState(
+                        previousState = any(),
+                        isPremiumUser = true,
+                        hasMasterPassword = true,
+                        totpCodeItemData = createTotpCodeData(),
+                    )
+                } returns DEFAULT_VIEW_STATE
+            }
+            mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
+            mutableAuthCodeItemFlow.value = DataState.Loaded(data = createVerificationCodeItem())
+            val loginState = DEFAULT_STATE.copy(viewState = DEFAULT_VIEW_STATE)
+            val viewModel = createViewModel(state = loginState)
+            assertEquals(loginState, viewModel.stateFlow.value)
+
+            viewModel.trySendAction(VaultItemAction.Common.RestoreVaultItemClick)
+            assertEquals(
+                loginState.copy(
+                    dialog = VaultItemState.DialogState.MasterPasswordDialog(
+                        action = PasswordRepromptAction.RestoreItemClick,
+                    ),
+                ),
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `on RestoreItemClick when no need to prompt for master password updates pendingCipher state correctly`() =
+            runTest {
+                val viewState =
+                    DEFAULT_VIEW_STATE.copy(common = DEFAULT_COMMON.copy(requiresReprompt = false))
+                val mockCipherView = mockk<CipherView> {
+                    every {
+                        toViewState(
+                            previousState = any(),
+                            isPremiumUser = true,
+                            hasMasterPassword = true,
+                            totpCodeItemData = createTotpCodeData(),
+                        )
+                    } returns viewState
+                }
+                mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
+                mutableAuthCodeItemFlow.value =
+                    DataState.Loaded(data = createVerificationCodeItem())
+                val loginState = DEFAULT_STATE.copy(viewState = viewState)
+                val viewModel = createViewModel(state = loginState)
+                assertEquals(loginState, viewModel.stateFlow.value)
+
+                // show dialog
+                viewModel.trySendAction(VaultItemAction.Common.RestoreVaultItemClick)
+                assertEquals(
+                    loginState.copy(pendingRestoreCipher = true),
+                    viewModel.stateFlow.value
+                )
+
+                // dismiss dialog
+                viewModel.trySendAction(VaultItemAction.Common.DismissRestoreDialog)
+                assertEquals(
+                    // setting this to be explicit.
+                    loginState.copy(pendingRestoreCipher = false),
+                    viewModel.stateFlow.value
+                )
+            }
+
+        @Test
         @Suppress("MaxLineLength")
         fun `ConfirmRestoreClick with RestoreCipherResult Success should should ShowToast and NavigateBack`() =
             runTest {
@@ -2490,6 +2557,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
             vaultItemId = VAULT_ITEM_ID,
             viewState = VaultItemState.ViewState.Loading,
             dialog = null,
+            pendingRestoreCipher = false,
         )
 
         private val DEFAULT_USER_STATE: UserState = UserState(


### PR DESCRIPTION

## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-8202
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
If an item which requires re-prompt of the master password is restored, the user should be prompted to enter MP before given the option to restore.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
