### PR TITLE
Introduce utility function for clearing VaultAddEdit dialog state

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -452,16 +452,12 @@ class VaultAddEditViewModel @Inject constructor(
     }
 
     private fun handleDismissDialog() {
-        mutableStateFlow.update {
-            it.copy(dialog = null)
-        }
+        clearDialogState()
     }
 
     private fun handleInitialAutofillDialogDismissed() {
         settingsRepository.initialAutofillDialogShown = true
-        mutableStateFlow.update {
-            it.copy(dialog = null)
-        }
+        clearDialogState()
     }
 
     private fun handleHiddenFieldVisibilityChange(
@@ -1147,9 +1143,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleCreateCipherResultReceive(
         action: VaultAddEditAction.Internal.CreateCipherResultReceive,
     ) {
-        mutableStateFlow.update {
-            it.copy(dialog = null)
-        }
+        clearDialogState()
 
         when (action.createCipherResult) {
             is CreateCipherResult.Error -> {
@@ -1184,7 +1178,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleUpdateCipherResultReceive(
         action: VaultAddEditAction.Internal.UpdateCipherResultReceive,
     ) {
-        mutableStateFlow.update { it.copy(dialog = null) }
+        clearDialogState()
         when (val result = action.updateCipherResult) {
             is UpdateCipherResult.Error -> {
                 mutableStateFlow.update {
@@ -1222,7 +1216,7 @@ class VaultAddEditViewModel @Inject constructor(
             }
 
             DeleteCipherResult.Success -> {
-                mutableStateFlow.update { it.copy(dialog = null) }
+                clearDialogState()
                 sendEvent(
                     VaultAddEditEvent.ShowToast(
                         message = R.string.item_soft_deleted.asText(),
@@ -1392,7 +1386,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleFido2RegisterCredentialResultReceive(
         action: VaultAddEditAction.Internal.Fido2RegisterCredentialResultReceive,
     ) {
-        mutableStateFlow.update { it.copy(dialog = null) }
+        clearDialogState()
         when (action.result) {
             is Fido2CreateCredentialResult.Error -> {
                 sendEvent(VaultAddEditEvent.ShowToast(R.string.an_error_has_occurred.asText()))
@@ -1408,6 +1402,10 @@ class VaultAddEditViewModel @Inject constructor(
     //endregion Internal Type Handlers
 
     //region Utility Functions
+
+    private fun clearDialogState() {
+        mutableStateFlow.update { it.copy(dialog = null) }
+    }
 
     private inline fun onContent(
         crossinline block: (VaultAddEditState.ViewState.Content) -> Unit,


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

Define a utility function for clearing the VaultAddEdit dialog state.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
