### PR TITLE
Introduce utility function for displaying VaultAddEdit error message

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -326,7 +326,9 @@ class VaultAddEditViewModel @Inject constructor(
             content.common.selectedOwnerId != null &&
             content.common.selectedOwner?.collections?.all { !it.isSelected } == true
         ) {
-            showGenericErrorDialog(R.string.select_one_collection.asText())
+            showGenericErrorDialog(
+                message = R.string.select_one_collection.asText()
+            )
             return@onContent
         }
 
@@ -1181,7 +1183,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleDeleteCipherReceive(action: VaultAddEditAction.Internal.DeleteCipherReceive) {
         when (action.result) {
             DeleteCipherResult.Error -> {
-                showGenericErrorDialog()
+                showErrorDialog(message = R.string.generic_error_message.asText())
             }
 
             DeleteCipherResult.Success -> {
@@ -1300,7 +1302,10 @@ class VaultAddEditViewModel @Inject constructor(
             }
 
             TotpCodeResult.CodeScanningError -> {
-                showGenericErrorDialog(R.string.authenticator_key_read_error.asText())
+                showErrorDialog(
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.authenticator_key_read_error.asText(),
+                )
             }
         }
     }
@@ -1340,7 +1345,7 @@ class VaultAddEditViewModel @Inject constructor(
                 }
             }
         }
-        showGenericErrorDialog(message = message)
+        showErrorDialog(message = message)
     }
 
     private fun handleFido2RegisterCredentialResultReceive(
@@ -1367,11 +1372,20 @@ class VaultAddEditViewModel @Inject constructor(
         mutableStateFlow.update { it.copy(dialog = null) }
     }
 
-    private fun showGenericErrorDialog(message: Text = R.string.generic_error_message.asText()) {
+    private fun showGenericErrorDialog(
+        message: Text = R.string.generic_error_message.asText(),
+    ) {
+        showErrorDialog(
+            title = R.string.an_error_has_occurred.asText(),
+            message = message,
+        )
+    }
+
+    private fun showErrorDialog(title: Text? = null, message: Text) {
         mutableStateFlow.update {
             it.copy(
                 dialog = VaultAddEditState.DialogState.Generic(
-                    title = R.string.an_error_has_occurred.asText(),
+                    title = title,
                     message = message,
                 ),
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -318,28 +318,15 @@ class VaultAddEditViewModel @Inject constructor(
     @Suppress("LongMethod")
     private fun handleSaveClick() = onContent { content ->
         if (content.common.name.isBlank()) {
-            mutableStateFlow.update {
-                it.copy(
-                    dialog = VaultAddEditState.DialogState.Generic(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.validation_field_required
-                            .asText(R.string.name.asText()),
-                    ),
-                )
-            }
+            showGenericErrorDialog(
+                message = R.string.validation_field_required.asText(R.string.name.asText()),
+            )
             return@onContent
         } else if (
             content.common.selectedOwnerId != null &&
             content.common.selectedOwner?.collections?.all { !it.isSelected } == true
         ) {
-            mutableStateFlow.update {
-                it.copy(
-                    dialog = VaultAddEditState.DialogState.Generic(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.select_one_collection.asText(),
-                    ),
-                )
-            }
+            showGenericErrorDialog(R.string.select_one_collection.asText())
             return@onContent
         }
 
@@ -1147,14 +1134,7 @@ class VaultAddEditViewModel @Inject constructor(
 
         when (action.createCipherResult) {
             is CreateCipherResult.Error -> {
-                mutableStateFlow.update {
-                    it.copy(
-                        dialog = VaultAddEditState.DialogState.Generic(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.generic_error_message.asText(),
-                        ),
-                    )
-                }
+                showGenericErrorDialog()
             }
 
             is CreateCipherResult.Success -> {
@@ -1181,17 +1161,12 @@ class VaultAddEditViewModel @Inject constructor(
         clearDialogState()
         when (val result = action.updateCipherResult) {
             is UpdateCipherResult.Error -> {
-                mutableStateFlow.update {
-                    it.copy(
-                        dialog = VaultAddEditState.DialogState.Generic(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = result
-                                .errorMessage
-                                ?.asText()
-                                ?: R.string.generic_error_message.asText(),
-                        ),
-                    )
-                }
+                showGenericErrorDialog(
+                    message = result
+                        .errorMessage
+                        ?.asText()
+                        ?: R.string.generic_error_message.asText(),
+                )
             }
 
             is UpdateCipherResult.Success -> {
@@ -1206,13 +1181,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleDeleteCipherReceive(action: VaultAddEditAction.Internal.DeleteCipherReceive) {
         when (action.result) {
             DeleteCipherResult.Error -> {
-                mutableStateFlow.update {
-                    it.copy(
-                        dialog = VaultAddEditState.DialogState.Generic(
-                            message = R.string.generic_error_message.asText(),
-                        ),
-                    )
-                }
+                showGenericErrorDialog()
             }
 
             DeleteCipherResult.Success -> {
@@ -1331,14 +1300,7 @@ class VaultAddEditViewModel @Inject constructor(
             }
 
             TotpCodeResult.CodeScanningError -> {
-                mutableStateFlow.update {
-                    it.copy(
-                        dialog = VaultAddEditState.DialogState.Generic(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.authenticator_key_read_error.asText(),
-                        ),
-                    )
-                }
+                showGenericErrorDialog(R.string.authenticator_key_read_error.asText())
             }
         }
     }
@@ -1378,9 +1340,7 @@ class VaultAddEditViewModel @Inject constructor(
                 }
             }
         }
-        mutableStateFlow.update {
-            it.copy(dialog = VaultAddEditState.DialogState.Generic(message = message))
-        }
+        showGenericErrorDialog(message = message)
     }
 
     private fun handleFido2RegisterCredentialResultReceive(
@@ -1405,6 +1365,17 @@ class VaultAddEditViewModel @Inject constructor(
 
     private fun clearDialogState() {
         mutableStateFlow.update { it.copy(dialog = null) }
+    }
+
+    private fun showGenericErrorDialog(message: Text = R.string.generic_error_message.asText()) {
+        mutableStateFlow.update {
+            it.copy(
+                dialog = VaultAddEditState.DialogState.Generic(
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = message,
+                ),
+            )
+        }
     }
 
     private inline fun onContent(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -327,7 +327,7 @@ class VaultAddEditViewModel @Inject constructor(
             content.common.selectedOwner?.collections?.all { !it.isSelected } == true
         ) {
             showGenericErrorDialog(
-                message = R.string.select_one_collection.asText()
+                message = R.string.select_one_collection.asText(),
             )
             return@onContent
         }


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

Define a utility function for displaying VaultAddEdit error messages.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
