### PR TITLE
Add logic to find missing username fields

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/model/AutofillView.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/model/AutofillView.kt
@@ -86,4 +86,11 @@ sealed class AutofillView {
             override val data: Data,
         ) : Login()
     }
+
+    /**
+     * A view that is an input field but does not correspond to any known autofill field.
+     */
+    data class Unused(
+        override val data: Data,
+    ) : AutofillView()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensions.kt
@@ -112,7 +112,7 @@ private fun AssistStructure.ViewNode.buildAutofillView(
     autofillOptions: List<String>,
     autofillViewData: AutofillView.Data,
     supportedHint: String?,
-): AutofillView? = when {
+): AutofillView = when {
     supportedHint == View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH -> {
         val monthValue = this
             .autofillValue
@@ -156,7 +156,11 @@ private fun AssistStructure.ViewNode.buildAutofillView(
         )
     }
 
-    else -> null
+    else -> {
+        AutofillView.Unused(
+            data = autofillViewData,
+        )
+    }
 }
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
@@ -230,15 +230,18 @@ class ViewNodeExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `toAutofillView should return null when hint is not supported, is an inputField, and isn't a username or password`() {
+    fun `toAutofillView should return only unused field when hint is not supported, is an inputField, and isn't a username or password`() {
         // Setup
         setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Unused(
+            data = autofillViewData,
+        )
 
         // Test
         val actual = viewNode.toAutofillView()
 
         // Verify
-        assertNull(actual)
+        assertEquals(expected, actual)
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds logic to find a username field for autofill by assuming any `Unused` field directly in front of the password field is the username field.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
