### PR TITLE
Refactor PublicKeyCredentialCreationOptions to match WebAuthn spec

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/datasource/network/model/PublicKeyCredentialCreationOptions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/datasource/network/model/PublicKeyCredentialCreationOptions.kt
@@ -30,7 +30,9 @@ data class PublicKeyCredentialCreationOptions(
         @SerialName("authenticatorAttachment")
         val authenticatorAttachment: AuthenticatorAttachment? = null,
         @SerialName("residentKey")
-        val residentKey: ResidentKeyRequirement? = null,
+        val residentKeyRequirement: ResidentKeyRequirement? = null,
+        @SerialName("userVerification")
+        val userVerification: UserVerificationRequirement? = null,
     ) {
         /**
          * Enum class representing the types of attachments associated with selection criteria.
@@ -50,13 +52,38 @@ data class PublicKeyCredentialCreationOptions(
         @Serializable
         enum class ResidentKeyRequirement {
             /**
-             * User verification is preferred during selection, if supported.
+             * Resident keys are preferred during selection, if supported.
              */
             @SerialName("preferred")
             PREFERRED,
 
             /**
-             * User verification is required during selection.
+             * Resident keys are required during selection.
+             */
+            @SerialName("required")
+            REQUIRED,
+        }
+
+        /**
+         * Enum class indicating the type of user verification requested by the relying party.
+         */
+        @Serializable
+        enum class UserVerificationRequirement {
+            /**
+             * User verification should not be performed.
+             */
+            @SerialName("discouraged")
+            DISCOURAGED,
+
+            /**
+             * User verification is preferred, if supported by the device or application.
+             */
+            @SerialName("preferred")
+            PREFERRED,
+
+            /**
+             * User verification is required. If is cannot be performed the registration process
+             * should be terminated.
              */
             @SerialName("required")
             REQUIRED,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8137

## 📔 Objective

Refactor PublicKeyCredentialCreationOptions so that it reflects the WebAuth object spec.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
