### PR TITLE
Update no network errors to be consistent and have a space inbetween concatenated text

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -610,7 +610,10 @@ class SearchViewModel @Inject constructor(
                         viewState = SearchState.ViewState.Error(
                             message = R.string.internet_connection_required_title
                                 .asText()
-                                .concat(R.string.internet_connection_required_message.asText()),
+                                .concat(
+                                    " ".asText(),
+                                    R.string.internet_connection_required_message.asText(),
+                                ),
                         ),
                         dialogState = null,
                     )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersViewModel.kt
@@ -97,7 +97,10 @@ class FoldersViewModel @Inject constructor(
                         viewState = FoldersState.ViewState.Error(
                             message = R.string.internet_connection_required_title
                                 .asText()
-                                .concat(R.string.internet_connection_required_message.asText()),
+                                .concat(
+                                    " ".asText(),
+                                    R.string.internet_connection_required_message.asText(),
+                                ),
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModel.kt
@@ -208,7 +208,10 @@ class FolderAddEditViewModel @Inject constructor(
                         viewState = FolderAddEditState.ViewState.Error(
                             message = R.string.internet_connection_required_title
                                 .asText()
-                                .concat(R.string.internet_connection_required_message.asText()),
+                                .concat(
+                                    " ".asText(),
+                                    R.string.internet_connection_required_message.asText(),
+                                ),
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -164,6 +164,7 @@ class SendViewModel @Inject constructor(
         }
     }
 
+    @Suppress("LongMethod")
     private fun handleSendDataReceive(action: SendAction.Internal.SendDataReceive) {
         when (val dataState = action.sendDataState) {
             is DataState.Error -> {
@@ -205,7 +206,10 @@ class SendViewModel @Inject constructor(
                         viewState = SendState.ViewState.Error(
                             message = R.string.internet_connection_required_title
                                 .asText()
-                                .concat(R.string.internet_connection_required_message.asText()),
+                                .concat(
+                                    " ".asText(),
+                                    R.string.internet_connection_required_message.asText(),
+                                ),
                         ),
                         dialogState = null,
                     )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
@@ -343,7 +343,10 @@ class AddSendViewModel @Inject constructor(
                         viewState = AddSendState.ViewState.Error(
                             message = R.string.internet_connection_required_title
                                 .asText()
-                                .concat(R.string.internet_connection_required_message.asText()),
+                                .concat(
+                                    " ".asText(),
+                                    R.string.internet_connection_required_message.asText(),
+                                ),
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1236,7 +1236,10 @@ class VaultAddEditViewModel @Inject constructor(
                         viewState = VaultAddEditState.ViewState.Error(
                             message = R.string.internet_connection_required_title
                                 .asText()
-                                .concat(R.string.internet_connection_required_message.asText()),
+                                .concat(
+                                    " ".asText(),
+                                    R.string.internet_connection_required_message.asText(),
+                                ),
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
@@ -239,8 +239,10 @@ class AttachmentsViewModel @Inject constructor(
                     viewState = AttachmentsState.ViewState.Error(
                         message = R.string.internet_connection_required_title
                             .asText()
-                            .concat("\n".asText())
-                            .concat(R.string.internet_connection_required_message.asText()),
+                            .concat(
+                                " ".asText(),
+                                R.string.internet_connection_required_message.asText(),
+                            ),
                     ),
                 )
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -735,7 +735,10 @@ class VaultItemListingViewModel @Inject constructor(
                     viewState = VaultItemListingState.ViewState.Error(
                         message = R.string.internet_connection_required_title
                             .asText()
-                            .concat(R.string.internet_connection_required_message.asText()),
+                            .concat(
+                                " ".asText(),
+                                R.string.internet_connection_required_message.asText(),
+                            ),
                     ),
                     dialogState = null,
                 )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModel.kt
@@ -221,7 +221,10 @@ class VaultMoveToOrganizationViewModel @Inject constructor(
                     dialogState = VaultMoveToOrganizationState.DialogState.Error(
                         message = R.string.internet_connection_required_title
                             .asText()
-                            .concat(R.string.internet_connection_required_message.asText()),
+                            .concat(
+                                " ".asText(),
+                                R.string.internet_connection_required_message.asText(),
+                            ),
                     ),
                 )
             } else {
@@ -229,7 +232,10 @@ class VaultMoveToOrganizationViewModel @Inject constructor(
                     viewState = VaultMoveToOrganizationState.ViewState.Error(
                         message = R.string.internet_connection_required_title
                             .asText()
-                            .concat(R.string.internet_connection_required_message.asText()),
+                            .concat(
+                                " ".asText(),
+                                R.string.internet_connection_required_message.asText(),
+                            ),
                     ),
                     dialogState = null,
                 )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
@@ -219,7 +219,10 @@ class VerificationCodeViewModel @Inject constructor(
                     viewState = VerificationCodeState.ViewState.Error(
                         message = R.string.internet_connection_required_title
                             .asText()
-                            .concat(R.string.internet_connection_required_message.asText()),
+                            .concat(
+                                " ".asText(),
+                                R.string.internet_connection_required_message.asText(),
+                            ),
                     ),
                     dialogState = null,
                 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -1154,7 +1154,10 @@ class SearchViewModelTest : BaseViewModelTest() {
                 viewState = SearchState.ViewState.Error(
                     message = R.string.internet_connection_required_title
                         .asText()
-                        .concat(R.string.internet_connection_required_message.asText()),
+                        .concat(
+                            " ".asText(),
+                            R.string.internet_connection_required_message.asText(),
+                        ),
                 ),
             ),
             viewModel.stateFlow.value,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersViewModelTest.kt
@@ -129,7 +129,10 @@ class FoldersViewModelTest : BaseViewModelTest() {
                 viewState = FoldersState.ViewState.Error(
                     R.string.internet_connection_required_title
                         .asText()
-                        .concat(R.string.internet_connection_required_message.asText()),
+                        .concat(
+                            " ".asText(),
+                            R.string.internet_connection_required_message.asText(),
+                        ),
                 ),
             ),
             viewModel.stateFlow.value,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModelTest.kt
@@ -572,7 +572,10 @@ class FolderAddEditViewModelTest : BaseViewModelTest() {
                 viewState = FolderAddEditState.ViewState.Error(
                     R.string.internet_connection_required_title
                         .asText()
-                        .concat(R.string.internet_connection_required_message.asText()),
+                        .concat(
+                            " ".asText(),
+                            R.string.internet_connection_required_message.asText(),
+                        ),
                 ),
             ),
             viewModel.stateFlow.value,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
@@ -389,7 +389,10 @@ class SendViewModelTest : BaseViewModelTest() {
                     viewState = SendState.ViewState.Error(
                         message = R.string.internet_connection_required_title
                             .asText()
-                            .concat(R.string.internet_connection_required_message.asText()),
+                            .concat(
+                                " ".asText(),
+                                R.string.internet_connection_required_message.asText(),
+                            ),
                     ),
                     dialogState = null,
                 ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
@@ -480,8 +480,10 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                 viewState = AttachmentsState.ViewState.Error(
                     message = R.string.internet_connection_required_title
                         .asText()
-                        .concat("\n".asText())
-                        .concat(R.string.internet_connection_required_message.asText()),
+                        .concat(
+                            " ".asText(),
+                            R.string.internet_connection_required_message.asText(),
+                        ),
                 ),
             ),
             viewModel.stateFlow.value,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -1333,7 +1333,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 viewState = VaultItemListingState.ViewState.Error(
                     message = R.string.internet_connection_required_title
                         .asText()
-                        .concat(R.string.internet_connection_required_message.asText()),
+                        .concat(
+                            " ".asText(),
+                            R.string.internet_connection_required_message.asText(),
+                        ),
                 ),
             ),
             viewModel.stateFlow.value,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModelTest.kt
@@ -224,7 +224,10 @@ class VaultMoveToOrganizationViewModelTest : BaseViewModelTest() {
                     viewState = VaultMoveToOrganizationState.ViewState.Error(
                         message = R.string.internet_connection_required_title
                             .asText()
-                            .concat(R.string.internet_connection_required_message.asText()),
+                            .concat(
+                                " ".asText(),
+                                R.string.internet_connection_required_message.asText(),
+                            ),
                     ),
                 ),
                 awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModelTest.kt
@@ -325,7 +325,10 @@ class VerificationCodeViewModelTest : BaseViewModelTest() {
                 viewState = VerificationCodeState.ViewState.Error(
                     message = R.string.internet_connection_required_title
                         .asText()
-                        .concat(R.string.internet_connection_required_message.asText()),
+                        .concat(
+                            " ".asText(),
+                            R.string.internet_connection_required_message.asText(),
+                        ),
                 ),
             ),
             viewModel.stateFlow.value,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the way we concatenate no network errors in the app. In many cases, we were not adding a space between the two strings which caused them to run into each other. Some spots used newline to separate the two strings and those have also been updated to maintain consistency throughout the app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
