### PR TITLE
Introduce FIDO 2 user verification to add edit item

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -39,10 +39,12 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialo
 import com.x8bit.bitwarden.ui.platform.components.dialog.LoadingDialogState
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.composition.LocalBiometricsManager
 import com.x8bit.bitwarden.ui.platform.composition.LocalExitManager
 import com.x8bit.bitwarden.ui.platform.composition.LocalFido2CompletionManager
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
 import com.x8bit.bitwarden.ui.platform.composition.LocalPermissionsManager
+import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricsManager
 import com.x8bit.bitwarden.ui.platform.manager.exit.ExitManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
@@ -52,6 +54,7 @@ import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCardTyp
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCommonHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditIdentityTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditLoginTypeHandlers
+import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditUserVerificationHandlers
 
 /**
  * Top level composable for the vault add item screen.
@@ -67,6 +70,7 @@ fun VaultAddEditScreen(
     intentManager: IntentManager = LocalIntentManager.current,
     exitManager: ExitManager = LocalExitManager.current,
     fido2CompletionManager: Fido2CompletionManager = LocalFido2CompletionManager.current,
+    biometricsManager: BiometricsManager = LocalBiometricsManager.current,
     onNavigateToManualCodeEntryScreen: () -> Unit,
     onNavigateToGeneratorModal: (GeneratorMode.Modal) -> Unit,
     onNavigateToAttachments: (cipherId: String) -> Unit,
@@ -75,6 +79,9 @@ fun VaultAddEditScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val resources = context.resources
+    val userVerificationHandlers = remember(viewModel) {
+        VaultAddEditUserVerificationHandlers.create(viewModel = viewModel)
+    }
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -115,6 +122,27 @@ fun VaultAddEditScreen(
             is VaultAddEditEvent.CompleteFido2Registration -> {
                 fido2CompletionManager.completeFido2Registration(event.result)
             }
+
+            is VaultAddEditEvent.Fido2UserVerification -> {
+                when {
+                    biometricsManager.isUserVerificationSupported -> {
+                        biometricsManager.promptUserVerification(
+                            onSuccess = userVerificationHandlers.onUserVerificationSuccess,
+                            onCancel = userVerificationHandlers.onUserVerificationCancelled,
+                            onError = userVerificationHandlers.onUserVerificationFail,
+                            onLockOut = userVerificationHandlers.onUserVerificationLockOut,
+                        )
+                    }
+
+                    event.isRequired -> {
+                        viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationFail)
+                    }
+
+                    else -> {
+                        viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationSuccess)
+                    }
+                }
+            }
         }
     }
 
@@ -147,6 +175,9 @@ fun VaultAddEditScreen(
         },
         onAutofillDismissRequest = remember(viewModel) {
             { viewModel.trySendAction(VaultAddEditAction.Common.InitialAutofillDialogDismissed) }
+        },
+        onFido2ErrorDismiss = remember(viewModel) {
+            { viewModel.trySendAction(VaultAddEditAction.Common.Fido2ErrorDialogDismissed) }
         },
     )
 
@@ -281,6 +312,7 @@ private fun VaultAddEditItemDialogs(
     dialogState: VaultAddEditState.DialogState?,
     onDismissRequest: () -> Unit,
     onAutofillDismissRequest: () -> Unit,
+    onFido2ErrorDismiss: () -> Unit,
 ) {
     when (dialogState) {
         is VaultAddEditState.DialogState.Loading -> {
@@ -306,6 +338,16 @@ private fun VaultAddEditItemDialogs(
                     message = R.string.bitwarden_autofill_service_alert2.asText(),
                 ),
                 onDismissRequest = onAutofillDismissRequest,
+            )
+        }
+
+        is VaultAddEditState.DialogState.Fido2Error -> {
+            BitwardenBasicDialog(
+                visibilityState = BasicDialogState.Shown(
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = dialogState.message,
+                ),
+                onDismissRequest = onFido2ErrorDismiss,
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -8,6 +8,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
@@ -254,6 +255,26 @@ class VaultAddEditViewModel @Inject constructor(
             is VaultAddEditAction.Common.HiddenFieldVisibilityChange -> {
                 handleHiddenFieldVisibilityChange(action)
             }
+
+            VaultAddEditAction.Common.UserVerificationSuccess -> {
+                handleUserVerificationSuccess()
+            }
+
+            VaultAddEditAction.Common.UserVerificationLockOut -> {
+                handleUserVerificationLockOut()
+            }
+
+            VaultAddEditAction.Common.UserVerificationFail -> {
+                handleUserVerificationFail()
+            }
+
+            VaultAddEditAction.Common.UserVerificationCancelled -> {
+                handleUserVerificationCancelled()
+            }
+
+            VaultAddEditAction.Common.Fido2ErrorDialogDismissed -> {
+                handleFido2ErrorDialogDismissed()
+            }
         }
     }
 
@@ -373,21 +394,45 @@ class VaultAddEditViewModel @Inject constructor(
         request: Fido2CredentialRequest,
         content: VaultAddEditState.ViewState.Content,
     ) {
+        val createOptions = fido2CredentialManager
+            .getPasskeyCreateOptionsOrNull(request.requestJson)
+            ?: run {
+                showFido2ErrorDialog()
+                return
+            }
+
+        when (createOptions.authenticatorSelection.userVerification) {
+            UserVerificationRequirement.DISCOURAGED -> {
+                registerFido2CredentialToCipher(request, content.toCipherView())
+            }
+
+            UserVerificationRequirement.PREFERRED -> {
+                sendEvent(VaultAddEditEvent.Fido2UserVerification(isRequired = false))
+            }
+
+            UserVerificationRequirement.REQUIRED,
+            null,
+            -> {
+                sendEvent(VaultAddEditEvent.Fido2UserVerification(isRequired = true))
+            }
+        }
+    }
+
+    private fun registerFido2CredentialToCipher(
+        request: Fido2CredentialRequest,
+        cipherView: CipherView,
+    ) {
         viewModelScope.launch {
-            val activeUserId = authRepository.activeUserId
+            val userId = authRepository.activeUserId
                 ?: run {
-                    sendAction(
-                        VaultAddEditAction.Internal.Fido2RegisterCredentialResultReceive(
-                            result = Fido2RegisterCredentialResult.Error,
-                        ),
-                    )
+                    showFido2ErrorDialog()
                     return@launch
                 }
             val result: Fido2RegisterCredentialResult =
                 fido2CredentialManager.registerFido2Credential(
-                    userId = activeUserId,
+                    userId = userId,
                     fido2CredentialRequest = request,
-                    selectedCipherView = content.toCipherView(),
+                    selectedCipherView = cipherView,
                 )
             sendAction(
                 VaultAddEditAction.Internal.Fido2RegisterCredentialResultReceive(result),
@@ -458,6 +503,46 @@ class VaultAddEditViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    private fun handleUserVerificationLockOut() {
+        showFido2ErrorDialog()
+    }
+
+    private fun handleUserVerificationSuccess() {
+        specialCircumstanceManager.specialCircumstance
+            ?.toFido2RequestOrNull()
+            ?.let { request ->
+                onContent { content ->
+                    registerFido2CredentialToCipher(
+                        request = request,
+                        cipherView = content.toCipherView(),
+                    )
+                }
+            }
+            ?: showFido2ErrorDialog()
+    }
+
+    private fun handleUserVerificationFail() {
+        showFido2ErrorDialog()
+    }
+
+    private fun handleFido2ErrorDialogDismissed() {
+        clearDialogState()
+        sendEvent(
+            VaultAddEditEvent.CompleteFido2Registration(
+                result = Fido2RegisterCredentialResult.Error,
+            ),
+        )
+    }
+
+    private fun handleUserVerificationCancelled() {
+        clearDialogState()
+        sendEvent(
+            VaultAddEditEvent.CompleteFido2Registration(
+                result = Fido2RegisterCredentialResult.Cancelled,
+            ),
+        )
     }
 
     private fun handleAddNewCustomFieldClick(
@@ -1376,6 +1461,17 @@ class VaultAddEditViewModel @Inject constructor(
         mutableStateFlow.update { it.copy(dialog = null) }
     }
 
+    private fun showFido2ErrorDialog() {
+        mutableStateFlow.update {
+            it.copy(
+                dialog = VaultAddEditState.DialogState.Fido2Error(
+                    message = R.string.passkey_operation_failed_because_user_could_not_be_verified
+                        .asText(),
+                ),
+            )
+        }
+    }
+
     private fun showGenericErrorDialog(
         message: Text = R.string.generic_error_message.asText(),
     ) {
@@ -1922,6 +2018,12 @@ data class VaultAddEditState(
          */
         @Parcelize
         data object InitialAutofillPrompt : DialogState()
+
+        /**
+         * Displays a FIDO 2 operation error dialog to the user.
+         */
+        @Parcelize
+        data class Fido2Error(val message: Text) : DialogState()
     }
 }
 
@@ -1992,10 +2094,19 @@ sealed class VaultAddEditEvent {
     /**
      * Complete the current FIDO 2 credential registration process.
      *
-     * @property result the result of FIDO 2 credential creation.
+     * @property result the result of FIDO 2 credential registration.
      */
     data class CompleteFido2Registration(
         val result: Fido2RegisterCredentialResult,
+    ) : VaultAddEditEvent()
+
+    /**
+     * Perform user verification for a FIDO 2 credential operation.
+     *
+     * @param isRequired When `false`, user verification can be bypassed if it is not supported.
+     */
+    data class Fido2UserVerification(
+        val isRequired: Boolean,
     ) : VaultAddEditEvent()
 }
 
@@ -2143,6 +2254,32 @@ sealed class VaultAddEditAction {
          * @property isVisible the new visibility state of the hidden field.
          */
         data class HiddenFieldVisibilityChange(val isVisible: Boolean) : Common()
+
+        /**
+         * The user has too many failed verification attempts for FIDO operations and can no longer
+         * use biometric verification for some time.
+         */
+        data object UserVerificationLockOut : Common()
+
+        /**
+         * The user has failed biometric verification for FIDO 2 operations.
+         */
+        data object UserVerificationFail : Common()
+
+        /**
+         * The user has successfully verified themself using biometrics.
+         */
+        data object UserVerificationSuccess : Common()
+
+        /**
+         * The user has cancelled biometric user verification.
+         */
+        data object UserVerificationCancelled : Common()
+
+        /**
+         * The user has dismissed the FIDO 2 credential error dialog.
+         */
+        data object Fido2ErrorDialogDismissed : Common()
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditUserVerificationHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditUserVerificationHandlers.kt
@@ -1,0 +1,48 @@
+package com.x8bit.bitwarden.ui.vault.feature.addedit.handlers
+
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditAction
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditViewModel
+
+/**
+ * A collection of handler functions specifically tailored for managing action within the context of
+ * biometric user verification.
+ *
+ * @property onUserVerificationSuccess Handles the action when biometric verification is
+ * successful.
+ * @property onUserVerificationFail Handles the action when biometric verification fails.
+ * @property onUserVerificationLockOut Handles the action when too many failed verification attempts
+ * locks out the user for a period of time.
+ */
+data class VaultAddEditUserVerificationHandlers(
+    val onUserVerificationSuccess: () -> Unit,
+    val onUserVerificationLockOut: () -> Unit,
+    val onUserVerificationFail: () -> Unit,
+    val onUserVerificationCancelled: () -> Unit,
+) {
+    companion object {
+
+        /**
+         * Creates an instance of [VaultAddEditUserVerificationHandlers] by binding actions
+         * to the provided [VaultAddEditViewModel].
+         */
+        fun create(
+            viewModel: VaultAddEditViewModel,
+        ): VaultAddEditUserVerificationHandlers =
+            VaultAddEditUserVerificationHandlers(
+                onUserVerificationSuccess = {
+                    viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationSuccess)
+                },
+                onUserVerificationFail = {
+                    viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationLockOut)
+                },
+                onUserVerificationLockOut = {
+                    viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationFail)
+                },
+                onUserVerificationCancelled = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.Common.UserVerificationCancelled,
+                    )
+                },
+            )
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -15,9 +15,11 @@ import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
+import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
@@ -684,7 +686,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in add mode during fido2, SaveClick should show dialog, register credential, show toast once an item is saved, and emit ExitApp`() =
+    fun `in add mode during fido2 registration, SaveClick should show saving dialog, and request user verification when required`() =
         runTest {
             val fido2CredentialRequest = Fido2CredentialRequest(
                 userId = "mockUserId",
@@ -697,7 +699,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 SpecialCircumstance.Fido2Save(
                     fido2CredentialRequest = fido2CredentialRequest,
                 )
-            val stateWithDialog = createVaultAddItemState(
+            val stateWithSavingDialog = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 dialogState = VaultAddEditState.DialogState.Loading(
                     R.string.saving.asText(),
@@ -708,25 +710,32 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
                 .copy(shouldExitOnSave = true)
 
-            val stateWithName = createVaultAddItemState(
+            val stateWithNewLogin = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
             )
                 .copy(shouldExitOnSave = true)
+
             mutableVaultDataFlow.value = DataState.Loaded(
-                createVaultData(),
+                data = createVaultData(),
             )
+
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
-                    state = stateWithName,
+                    state = stateWithNewLogin,
                     vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 ),
             )
             val mockCreateResult = Fido2RegisterCredentialResult.Success(
                 registrationResponse = "mockRegistrationResponse",
             )
+            val mockCreateOptions = createMockPublicKeyCredentialCreationOptions(
+                number = 1,
+                userVerificationRequirement = UserVerificationRequirement.REQUIRED,
+            )
+
             coEvery {
                 fido2CredentialManager.registerFido2Credential(
                     userId = "mockUserId",
@@ -734,6 +743,11 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CredentialRequest = fido2CredentialRequest,
                 )
             } returns mockCreateResult
+            every {
+                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                    requestJson = fido2CredentialRequest.requestJson,
+                )
+            } returns mockCreateOptions
             every { authRepository.activeUserId } returns "mockUserId"
 
             turbineScope {
@@ -742,101 +756,98 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
                 viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
+                assertEquals(stateWithNewLogin, stateTurbine.awaitItem())
+                assertEquals(stateWithSavingDialog, stateTurbine.awaitItem())
+                assertEquals(
+                    VaultAddEditEvent.Fido2UserVerification(isRequired = true),
+                    eventTurbine.awaitItem(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in add mode during fido2, SaveClick should show saving dialog, remove it once item is saved, skip user verification when not required, and emit ExitApp`() =
+        runTest {
+            val mockUserId = "mockUserId"
+            val fido2CredentialRequest = Fido2CredentialRequest(
+                userId = mockUserId,
+                requestJson = "mockRequestJson",
+                packageName = "mockPackageName",
+                signingInfo = mockk<SigningInfo>(),
+                origin = null,
+            )
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2Save(
+                    fido2CredentialRequest = fido2CredentialRequest,
+                )
+            val stateWithSavingDialog = createVaultAddItemState(
+                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                dialogState = VaultAddEditState.DialogState.Loading(
+                    R.string.saving.asText(),
+                ),
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                ),
+            )
+                .copy(shouldExitOnSave = true)
+
+            val stateWithName = createVaultAddItemState(
+                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                ),
+            )
+                .copy(shouldExitOnSave = true)
+
+            mutableVaultDataFlow.value = DataState.Loaded(
+                createVaultData(),
+            )
+            val viewModel = createAddVaultItemViewModel(
+                createSavedStateHandleWithState(
+                    state = stateWithName,
+                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                ),
+            )
+            val mockCreateResult = Fido2RegisterCredentialResult.Success("mockResponse")
+            val mockCreateOptions = createMockPublicKeyCredentialCreationOptions(
+                number = 1,
+                userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
+            )
+            coEvery {
+                fido2CredentialManager.registerFido2Credential(
+                    userId = mockUserId,
+                    selectedCipherView = any(),
+                    fido2CredentialRequest = fido2CredentialRequest,
+                )
+            } returns mockCreateResult
+            every {
+                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                    requestJson = fido2CredentialRequest.requestJson,
+                )
+            } returns mockCreateOptions
+            every { authRepository.activeUserId } returns mockUserId
+
+            turbineScope {
+                val stateTurbine = viewModel.stateFlow.testIn(backgroundScope)
+                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
+
+                viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
+
                 assertEquals(stateWithName, stateTurbine.awaitItem())
-                assertEquals(stateWithDialog, stateTurbine.awaitItem())
+                assertEquals(stateWithSavingDialog, stateTurbine.awaitItem())
                 assertEquals(
                     VaultAddEditEvent.ShowToast(R.string.item_updated.asText()),
                     eventTurbine.awaitItem(),
                 )
+                assertEquals(stateWithName, stateTurbine.awaitItem())
                 assertEquals(
-                    VaultAddEditEvent.CompleteFido2Registration(result = mockCreateResult),
+                    VaultAddEditEvent.CompleteFido2Registration(mockCreateResult),
                     eventTurbine.awaitItem(),
                 )
-                assertEquals(stateWithName, stateTurbine.awaitItem())
-
                 coVerify(exactly = 1) {
                     fido2CredentialManager.registerFido2Credential(
-                        userId = "mockUserId",
-                        fido2CredentialRequest = fido2CredentialRequest,
-                        selectedCipherView = any(),
-                    )
-                }
-            }
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `in add mode during fido2, SaveClick should show dialog, register credential, show toast on error, and emit ExitApp when result is Error`() =
-        runTest {
-            val fido2CredentialRequest = Fido2CredentialRequest(
-                userId = "mockUserId",
-                requestJson = "mockRequestJson",
-                packageName = "mockPackageName",
-                signingInfo = mockk<SigningInfo>(),
-                origin = null,
-            )
-            specialCircumstanceManager.specialCircumstance =
-                SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
-                )
-            val stateWithDialog = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
-                dialogState = VaultAddEditState.DialogState.Loading(
-                    R.string.saving.asText(),
-                ),
-                commonContentViewState = createCommonContentViewState(
-                    name = "mockName-1",
-                ),
-            )
-                .copy(shouldExitOnSave = true)
-
-            val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
-                commonContentViewState = createCommonContentViewState(
-                    name = "mockName-1",
-                ),
-            )
-                .copy(shouldExitOnSave = true)
-            mutableVaultDataFlow.value = DataState.Loaded(
-                createVaultData(),
-            )
-            val viewModel = createAddVaultItemViewModel(
-                createSavedStateHandleWithState(
-                    state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
-                ),
-            )
-            val mockCreateResult = Fido2RegisterCredentialResult.Error
-            coEvery {
-                fido2CredentialManager.registerFido2Credential(
-                    userId = "mockUserId",
-                    selectedCipherView = any(),
-                    fido2CredentialRequest = fido2CredentialRequest,
-                )
-            } returns mockCreateResult
-            every { authRepository.activeUserId } returns "mockUserId"
-
-            turbineScope {
-                val stateTurbine = viewModel.stateFlow.testIn(backgroundScope)
-                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
-
-                viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
-
-                assertEquals(stateWithName, stateTurbine.awaitItem())
-                assertEquals(stateWithDialog, stateTurbine.awaitItem())
-                assertEquals(
-                    VaultAddEditEvent.ShowToast(R.string.an_error_has_occurred.asText()),
-                    eventTurbine.awaitItem(),
-                )
-                assertEquals(
-                    VaultAddEditEvent.CompleteFido2Registration(result = mockCreateResult),
-                    eventTurbine.awaitItem(),
-                )
-                assertEquals(stateWithName, stateTurbine.awaitItem())
-
-                coVerify(exactly = 1) {
-                    fido2CredentialManager.registerFido2Credential(
-                        userId = "mockUserId",
+                        userId = mockUserId,
                         selectedCipherView = any(),
                         fido2CredentialRequest = fido2CredentialRequest,
                     )
@@ -846,10 +857,11 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in add mode during fido2, SaveClick should show saving dialog, register credential, dismiss dialog, show toast on error, and emit ExitApp when activeUserId is null`() =
+    fun `in add mode during fido2, SaveClick should show fido2 error dialog when create options are null`() =
         runTest {
+            val mockUserId = "mockUserId"
             val fido2CredentialRequest = Fido2CredentialRequest(
-                userId = "mockUserId",
+                userId = mockUserId,
                 requestJson = "mockRequestJson",
                 packageName = "mockPackageName",
                 signingInfo = mockk<SigningInfo>(),
@@ -859,17 +871,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 SpecialCircumstance.Fido2Save(
                     fido2CredentialRequest = fido2CredentialRequest,
                 )
-            val stateWithDialog = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
-                dialogState = VaultAddEditState.DialogState.Loading(
-                    R.string.saving.asText(),
-                ),
-                commonContentViewState = createCommonContentViewState(
-                    name = "mockName-1",
-                ),
-            )
-                .copy(shouldExitOnSave = true)
-
             val stateWithName = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
@@ -877,6 +878,13 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 ),
             )
                 .copy(shouldExitOnSave = true)
+
+            every {
+                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                    requestJson = fido2CredentialRequest.requestJson,
+                )
+            } returns null
+
             mutableVaultDataFlow.value = DataState.Loaded(
                 createVaultData(),
             )
@@ -886,41 +894,121 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 ),
             )
-            val mockCreateResult = Fido2RegisterCredentialResult.Error
-            coEvery {
-                fido2CredentialManager.registerFido2Credential(
-                    userId = "mockUserId",
-                    selectedCipherView = any(),
+
+            viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
+
+            assertEquals(
+                VaultAddEditState.DialogState.Fido2Error(
+                    message = R.string.passkey_operation_failed_because_user_could_not_be_verified
+                        .asText(),
+                ),
+                viewModel.stateFlow.value.dialog,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in add mode during fido2, SaveClick should emit fido user verification as optional when verification is PREFERRED`() =
+        runTest {
+            val mockUserId = "mockUserId"
+            val fido2CredentialRequest = Fido2CredentialRequest(
+                userId = mockUserId,
+                requestJson = "mockRequestJson",
+                packageName = "mockPackageName",
+                signingInfo = mockk<SigningInfo>(),
+                origin = null,
+            )
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2Save(
                     fido2CredentialRequest = fido2CredentialRequest,
                 )
-            } returns mockCreateResult
-            every { authRepository.activeUserId } returns null
+            val stateWithName = createVaultAddItemState(
+                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                ),
+            )
+                .copy(shouldExitOnSave = true)
+
+            every {
+                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                    requestJson = fido2CredentialRequest.requestJson,
+                )
+            } returns createMockPublicKeyCredentialCreationOptions(
+                number = 1,
+                userVerificationRequirement = UserVerificationRequirement.PREFERRED,
+            )
+            mutableVaultDataFlow.value = DataState.Loaded(
+                createVaultData(),
+            )
+            val viewModel = createAddVaultItemViewModel(
+                createSavedStateHandleWithState(
+                    state = stateWithName,
+                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                ),
+            )
+
+            viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
             turbineScope {
-                val stateTurbine = viewModel.stateFlow.testIn(backgroundScope)
                 val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
-
-                viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
-
-                assertEquals(stateWithName, stateTurbine.awaitItem())
-                assertEquals(stateWithDialog, stateTurbine.awaitItem())
                 assertEquals(
-                    VaultAddEditEvent.ShowToast(R.string.an_error_has_occurred.asText()),
+                    VaultAddEditEvent.Fido2UserVerification(isRequired = false),
                     eventTurbine.awaitItem(),
                 )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in add mode during fido2, SaveClick should emit fido user verification as required when request user verification option is REQUIRED`() =
+        runTest {
+            val mockUserId = "mockUserId"
+            val fido2CredentialRequest = Fido2CredentialRequest(
+                userId = mockUserId,
+                requestJson = "mockRequestJson",
+                packageName = "mockPackageName",
+                signingInfo = mockk<SigningInfo>(),
+                origin = null,
+            )
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2Save(
+                    fido2CredentialRequest = fido2CredentialRequest,
+                )
+            val stateWithName = createVaultAddItemState(
+                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                ),
+            )
+                .copy(shouldExitOnSave = true)
+
+            every {
+                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                    requestJson = fido2CredentialRequest.requestJson,
+                )
+            } returns createMockPublicKeyCredentialCreationOptions(
+                number = 1,
+                userVerificationRequirement = UserVerificationRequirement.REQUIRED,
+            )
+            mutableVaultDataFlow.value = DataState.Loaded(
+                createVaultData(),
+            )
+            val viewModel = createAddVaultItemViewModel(
+                createSavedStateHandleWithState(
+                    state = stateWithName,
+                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                ),
+            )
+
+            viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
+
+            turbineScope {
+                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
                 assertEquals(
-                    VaultAddEditEvent.CompleteFido2Registration(result = mockCreateResult),
+                    VaultAddEditEvent.Fido2UserVerification(isRequired = true),
                     eventTurbine.awaitItem(),
                 )
-                assertEquals(stateWithName, stateTurbine.awaitItem())
-
-                coVerify(exactly = 0) {
-                    fido2CredentialManager.registerFido2Credential(
-                        userId = "mockUserId",
-                        selectedCipherView = any(),
-                        fido2CredentialRequest = fido2CredentialRequest,
-                    )
-                }
             }
         }
 
@@ -1286,6 +1374,34 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             assertEquals(null, awaitItem().dialog)
         }
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `DismissFido2ErrorDialogClick should clear the dialog state then complete FIDO 2 create`() =
+        runTest {
+            val errorState = createVaultAddItemState(
+                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                dialogState = VaultAddEditState.DialogState.Fido2Error(
+                    message = R.string.passkey_operation_failed_because_user_could_not_be_verified.asText(),
+                ),
+            )
+            val viewModel = createAddVaultItemViewModel(
+                createSavedStateHandleWithState(
+                    state = errorState,
+                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                ),
+            )
+            viewModel.trySendAction(VaultAddEditAction.Common.Fido2ErrorDialogDismissed)
+            viewModel.eventFlow.test {
+                assertNull(viewModel.stateFlow.value.dialog)
+                assertEquals(
+                    VaultAddEditEvent.CompleteFido2Registration(
+                        result = Fido2RegisterCredentialResult.Error,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
 
     @Test
     fun `TypeOptionSelect LOGIN should switch to LoginItem`() = runTest {
@@ -2254,15 +2370,15 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
             viewModel = VaultAddEditViewModel(
                 savedStateHandle = secureNotesInitialSavedStateHandle,
-                clipboardManager = clipboardManager,
-                vaultRepository = vaultRepository,
-                generatorRepository = generatorRepository,
-                specialCircumstanceManager = specialCircumstanceManager,
-                policyManager = policyManager,
-                resourceManager = resourceManager,
                 authRepository = authRepository,
+                clipboardManager = clipboardManager,
+                policyManager = policyManager,
+                vaultRepository = vaultRepository,
                 fido2CredentialManager = fido2CredentialManager,
+                generatorRepository = generatorRepository,
                 settingsRepository = settingsRepository,
+                specialCircumstanceManager = specialCircumstanceManager,
+                resourceManager = resourceManager,
                 clock = fixedClock,
                 organizationEventManager = organizationEventManager,
             )
@@ -2750,6 +2866,273 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
             assertEquals(expectedState, viewModel.stateFlow.value)
         }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `UserVerificationLockout should display Fido2ErrorDialog`() {
+            viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationLockOut)
+
+            assertEquals(
+                VaultAddEditState.DialogState.Fido2Error(
+                    message = R.string.passkey_operation_failed_because_user_could_not_be_verified.asText(),
+                ),
+                viewModel.stateFlow.value.dialog,
+            )
+        }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `UserVerificationCancelled should clear dialog state and emit CompleteFido2Create with cancelled result`() =
+            runTest {
+                viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationCancelled)
+
+                assertNull(viewModel.stateFlow.value.dialog)
+                viewModel.eventFlow.test {
+                    assertEquals(
+                        VaultAddEditEvent.CompleteFido2Registration(
+                            result = Fido2RegisterCredentialResult.Cancelled,
+                        ),
+                        awaitItem(),
+                    )
+                }
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `UserVerificationFail should display Fido2ErrorDialog`() {
+            viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationFail)
+
+            assertEquals(
+                VaultAddEditState.DialogState.Fido2Error(
+                    message = R.string.passkey_operation_failed_because_user_could_not_be_verified.asText(),
+                ),
+                viewModel.stateFlow.value.dialog,
+            )
+        }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `UserVerificationSuccess should display Fido2ErrorDialog when SpecialCircumstance is null`() =
+            runTest {
+                specialCircumstanceManager.specialCircumstance = null
+                coEvery {
+                    fido2CredentialManager.registerFido2Credential(
+                        any(),
+                        any(),
+                        any(),
+                    )
+                } returns Fido2RegisterCredentialResult.Success(
+                    registrationResponse = "mockResponse",
+                )
+
+                viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationSuccess)
+
+                assertEquals(
+                    VaultAddEditState.DialogState.Fido2Error(
+                        message = R.string.passkey_operation_failed_because_user_could_not_be_verified.asText(),
+                    ),
+                    viewModel.stateFlow.value.dialog,
+                )
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `UserVerificationSuccess should display Fido2ErrorDialog when Fido2Request is null`() =
+            runTest {
+                specialCircumstanceManager.specialCircumstance =
+                    SpecialCircumstance.AutofillSave(
+                        AutofillSaveItem.Login(
+                            username = "mockUsername",
+                            password = "mockPassword",
+                            uri = "mockUri",
+                        ),
+                    )
+                coEvery {
+                    fido2CredentialManager.registerFido2Credential(
+                        any(),
+                        any(),
+                        any(),
+                    )
+                } returns Fido2RegisterCredentialResult.Success(
+                    registrationResponse = "mockResponse",
+                )
+
+                viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationSuccess)
+
+                assertEquals(
+                    VaultAddEditState.DialogState.Fido2Error(
+                        message = R.string.passkey_operation_failed_because_user_could_not_be_verified.asText(),
+                    ),
+                    viewModel.stateFlow.value.dialog,
+                )
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `UserVerificationSuccess should display Fido2ErrorDialog when activeUserId is null`() {
+            every { authRepository.activeUserId } returns null
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2Save(createMockFido2CredentialRequest(number = 1))
+
+            viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationSuccess)
+
+            assertEquals(
+                VaultAddEditState.DialogState.Fido2Error(
+                    message = R.string.passkey_operation_failed_because_user_could_not_be_verified
+                        .asText(),
+                ),
+                viewModel.stateFlow.value.dialog,
+            )
+        }
+
+        @Test
+        fun `UserVerificationSuccess should register FIDO 2 credential`() =
+            runTest {
+                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockResult = Fido2RegisterCredentialResult.Success(
+                    registrationResponse = "mockResponse",
+                )
+                specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
+                    fido2CredentialRequest = mockRequest,
+                )
+                every { authRepository.activeUserId } returns "activeUserId"
+                coEvery {
+                    fido2CredentialManager.registerFido2Credential(
+                        any(),
+                        any(),
+                        any(),
+                    )
+                } returns mockResult
+
+                viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationSuccess)
+
+                coVerify {
+                    fido2CredentialManager.registerFido2Credential(
+                        userId = any(),
+                        fido2CredentialRequest = mockRequest,
+                        selectedCipherView = any(),
+                    )
+                }
+
+                viewModel.eventFlow.test {
+                    assertEquals(
+                        VaultAddEditEvent.ShowToast(R.string.item_updated.asText()),
+                        awaitItem(),
+                    )
+                    assertEquals(
+                        VaultAddEditEvent.CompleteFido2Registration(mockResult),
+                        awaitItem(),
+                    )
+                }
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `Fido2RegisterCredentialResult Error should show toast and emit CompleteFido2Registration result`() =
+            runTest {
+                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockResult = Fido2RegisterCredentialResult.Error
+                specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
+                    fido2CredentialRequest = mockRequest,
+                )
+                every { authRepository.activeUserId } returns "activeUserId"
+                coEvery {
+                    fido2CredentialManager.registerFido2Credential(
+                        any(),
+                        any(),
+                        any(),
+                    )
+                } returns mockResult
+
+                viewModel.trySendAction(
+                    VaultAddEditAction.Internal.Fido2RegisterCredentialResultReceive(
+                        mockResult,
+                    ),
+                )
+
+                viewModel.eventFlow.test {
+                    assertEquals(
+                        VaultAddEditEvent.ShowToast(R.string.an_error_has_occurred.asText()),
+                        awaitItem(),
+                    )
+
+                    assertEquals(
+                        VaultAddEditEvent.CompleteFido2Registration(mockResult),
+                        awaitItem(),
+                    )
+                }
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `Fido2RegisterCredentialResult Success should show toast and emit CompleteFido2Registration result`() =
+            runTest {
+                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockResult = Fido2RegisterCredentialResult.Success(
+                    registrationResponse = "mockResponse",
+                )
+                specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
+                    fido2CredentialRequest = mockRequest,
+                )
+                every { authRepository.activeUserId } returns "activeUserId"
+                coEvery {
+                    fido2CredentialManager.registerFido2Credential(
+                        any(),
+                        any(),
+                        any(),
+                    )
+                } returns mockResult
+
+                viewModel.trySendAction(
+                    VaultAddEditAction.Internal.Fido2RegisterCredentialResultReceive(
+                        mockResult,
+                    ),
+                )
+
+                viewModel.eventFlow.test {
+                    assertEquals(
+                        VaultAddEditEvent.ShowToast(R.string.item_updated.asText()),
+                        awaitItem(),
+                    )
+
+                    assertEquals(
+                        VaultAddEditEvent.CompleteFido2Registration(mockResult),
+                        awaitItem(),
+                    )
+                }
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `Fido2RegisterCredentialResult Cancelled should emit CompleteFido2Registration result`() =
+            runTest {
+                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockResult = Fido2RegisterCredentialResult.Cancelled
+                specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
+                    fido2CredentialRequest = mockRequest,
+                )
+                every { authRepository.activeUserId } returns "activeUserId"
+                coEvery {
+                    fido2CredentialManager.registerFido2Credential(
+                        any(),
+                        any(),
+                        any(),
+                    )
+                } returns mockResult
+
+                viewModel.trySendAction(
+                    VaultAddEditAction.Internal.Fido2RegisterCredentialResultReceive(
+                        mockResult,
+                    ),
+                )
+
+                viewModel.eventFlow.test {
+                    assertEquals(
+                        VaultAddEditEvent.CompleteFido2Registration(mockResult),
+                        awaitItem(),
+                    )
+                }
+            }
     }
     //region Helper functions
 
@@ -2859,15 +3242,15 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     ): VaultAddEditViewModel =
         VaultAddEditViewModel(
             savedStateHandle = savedStateHandle,
-            clipboardManager = bitwardenClipboardManager,
-            vaultRepository = vaultRepo,
-            generatorRepository = generatorRepo,
-            specialCircumstanceManager = specialCircumstanceManager,
-            policyManager = policyManager,
-            resourceManager = bitwardenResourceManager,
-            fido2CredentialManager = fido2CredentialManager,
             authRepository = authRepository,
+            clipboardManager = bitwardenClipboardManager,
+            policyManager = policyManager,
+            vaultRepository = vaultRepo,
+            fido2CredentialManager = fido2CredentialManager,
+            generatorRepository = generatorRepo,
             settingsRepository = settingsRepository,
+            specialCircumstanceManager = specialCircumstanceManager,
+            resourceManager = bitwardenResourceManager,
             clock = clock,
             organizationEventManager = organizationEventManager,
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PublicKeyCredentialCreationOptionsTestHelpers.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PublicKeyCredentialCreationOptionsTestHelpers.kt
@@ -6,31 +6,34 @@ import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKe
  * Returns a mock FIDO 2 [PublicKeyCredentialCreationOptions] object to simulate a credential
  * creation request.
  */
-fun createMockPublicKeyCredentialCreationOptions(number: Int) =
-    PublicKeyCredentialCreationOptions(
-        authenticatorSelection = PublicKeyCredentialCreationOptions
-            .AuthenticatorSelectionCriteria(),
-        challenge = "mockPublicKeyCredentialCreationOptionsChallenge-$number",
-        excludeCredentials = listOf(
-            PublicKeyCredentialCreationOptions.PublicKeyCredentialDescriptor(
-                type = "mockPublicKeyCredentialDescriptorType-$number",
-                id = "mockPublicKeyCredentialDescriptorId-$number",
-                transports = listOf("mockPublicKeyCredentialDescriptorTransports-$number"),
-            ),
+@Suppress("MaxLineLength")
+fun createMockPublicKeyCredentialCreationOptions(
+    number: Int,
+    userVerificationRequirement: PublicKeyCredentialCreationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement? = null,
+) = PublicKeyCredentialCreationOptions(
+    authenticatorSelection = PublicKeyCredentialCreationOptions
+        .AuthenticatorSelectionCriteria(userVerification = userVerificationRequirement),
+    challenge = "mockPublicKeyCredentialCreationOptionsChallenge-$number",
+    excludeCredentials = listOf(
+        PublicKeyCredentialCreationOptions.PublicKeyCredentialDescriptor(
+            type = "mockPublicKeyCredentialDescriptorType-$number",
+            id = "mockPublicKeyCredentialDescriptorId-$number",
+            transports = listOf("mockPublicKeyCredentialDescriptorTransports-$number"),
         ),
-        pubKeyCredParams = listOf(
-            PublicKeyCredentialCreationOptions.PublicKeyCredentialParameters(
-                type = "PublicKeyCredentialParametersType-$number",
-                alg = number.toLong(),
-            ),
+    ),
+    pubKeyCredParams = listOf(
+        PublicKeyCredentialCreationOptions.PublicKeyCredentialParameters(
+            type = "PublicKeyCredentialParametersType-$number",
+            alg = number.toLong(),
         ),
-        relyingParty = PublicKeyCredentialCreationOptions.PublicKeyCredentialRpEntity(
-            name = "mockPublicKeyCredentialRpEntityName-$number",
-            id = "mockPublicKeyCredentialRpEntity-$number",
-        ),
-        user = PublicKeyCredentialCreationOptions.PublicKeyCredentialUserEntity(
-            name = "mockPublicKeyCredentialUserEntityName-$number",
-            id = "mockPublicKeyCredentialUserEntityId-$number",
-            displayName = "mockPublicKeyCredentialUserEntityDisplayName-$number",
-        ),
-    )
+    ),
+    relyingParty = PublicKeyCredentialCreationOptions.PublicKeyCredentialRpEntity(
+        name = "mockPublicKeyCredentialRpEntityName-$number",
+        id = "mockPublicKeyCredentialRpEntity-$number",
+    ),
+    user = PublicKeyCredentialCreationOptions.PublicKeyCredentialUserEntity(
+        name = "mockPublicKeyCredentialUserEntityName-$number",
+        id = "mockPublicKeyCredentialUserEntityId-$number",
+        displayName = "mockPublicKeyCredentialUserEntityDisplayName-$number",
+    ),
+)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8137

## 📔 Objective

When adding a credential to a new cipher or an existing cipher from teh Add Edit screen, perform user verification using biometrics or device credentials (password, pattern, or PIN) if the relying party indicates it is preferred or discouraged. If user verification cannot be performed on the device, when required, it is treated as a verification failure.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
