### PR TITLE
Hide inline autofill option when not supported

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -133,19 +133,23 @@ fun AutoFillScreen(
                     .testTag("AutofillServicesSwitch")
                     .padding(horizontal = 16.dp),
             )
-            BitwardenWideSwitch(
-                label = stringResource(id = R.string.inline_autofill),
-                description = stringResource(id = R.string.use_inline_autofill_explanation_long),
-                isChecked = state.isUseInlineAutoFillEnabled,
-                onCheckedChange = remember(viewModel) {
-                    { viewModel.trySendAction(AutoFillAction.UseInlineAutofillClick(it)) }
-                },
-                enabled = state.canInteractWithInlineAutofillToggle,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("InlineAutofillSwitch")
-                    .padding(horizontal = 16.dp),
-            )
+            if (state.showInlineAutofillOption) {
+                BitwardenWideSwitch(
+                    label = stringResource(id = R.string.inline_autofill),
+                    description = stringResource(
+                        id = R.string.use_inline_autofill_explanation_long,
+                    ),
+                    isChecked = state.isUseInlineAutoFillEnabled,
+                    onCheckedChange = remember(viewModel) {
+                        { viewModel.trySendAction(AutoFillAction.UseInlineAutofillClick(it)) }
+                    },
+                    enabled = state.canInteractWithInlineAutofillToggle,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("InlineAutofillSwitch")
+                        .padding(horizontal = 16.dp),
+                )
+            }
             Spacer(modifier = Modifier.height(16.dp))
             BitwardenListHeaderText(
                 label = stringResource(id = R.string.additional_options),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -1,10 +1,12 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.autofill
 
+import android.os.Build
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,6 +34,7 @@ class AutoFillViewModel @Inject constructor(
             isAutoFillServicesEnabled = settingsRepository.isAutofillEnabledStateFlow.value,
             isCopyTotpAutomaticallyEnabled = !settingsRepository.isAutoCopyTotpDisabled,
             isUseInlineAutoFillEnabled = settingsRepository.isInlineAutofillEnabled,
+            showInlineAutofillOption = !isBuildVersionBelow(Build.VERSION_CODES.R),
             defaultUriMatchType = settingsRepository.defaultUriMatchType,
         ),
 ) {
@@ -121,6 +124,7 @@ data class AutoFillState(
     val isAutoFillServicesEnabled: Boolean,
     val isCopyTotpAutomaticallyEnabled: Boolean,
     val isUseInlineAutoFillEnabled: Boolean,
+    val showInlineAutofillOption: Boolean,
     val defaultUriMatchType: UriMatchType,
 ) : Parcelable {
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -188,6 +188,24 @@ class AutoFillScreenTest : BaseComposeTest() {
     }
 
     @Test
+    fun `use inline autofill should be displayed according to state`() {
+        mutableStateFlow.update {
+            it.copy(showInlineAutofillOption = true)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Use inline autofill")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(showInlineAutofillOption = false)
+        }
+
+        composeTestRule.onNodeWithText(text = "Use inline autofill").assertDoesNotExist()
+    }
+
+    @Test
     fun `on copy TOTP automatically toggle should send CopyTotpAutomaticallyClick`() {
         composeTestRule
             .onNodeWithText("Copy TOTP automatically")
@@ -337,5 +355,6 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     isAutoFillServicesEnabled = false,
     isCopyTotpAutomaticallyEnabled = false,
     isUseInlineAutoFillEnabled = false,
+    showInlineAutofillOption = true,
     defaultUriMatchType = UriMatchType.DOMAIN,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -1,18 +1,24 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.autofill
 
+import android.os.Build
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class AutoFillViewModelTest : BaseViewModelTest() {
@@ -31,6 +37,17 @@ class AutoFillViewModelTest : BaseViewModelTest() {
         every { disableAutofill() } just runs
     }
 
+    @BeforeEach
+    fun setup() {
+        mockkStatic(::isBuildVersionBelow)
+        every { isBuildVersionBelow(Build.VERSION_CODES.R) } returns true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(::isBuildVersionBelow)
+    }
+
     @Test
     fun `initial state should be correct when not set`() {
         val viewModel = createViewModel(state = null)
@@ -46,6 +63,16 @@ class AutoFillViewModelTest : BaseViewModelTest() {
         )
         val viewModel = createViewModel(state = state)
         assertEquals(state, viewModel.stateFlow.value)
+    }
+
+    @Test
+    fun `showInlineAutofillOption should be true when the build version is not below R`() {
+        every { isBuildVersionBelow(Build.VERSION_CODES.R) } returns false
+        val viewModel = createViewModel(state = null)
+        assertEquals(
+            DEFAULT_STATE.copy(showInlineAutofillOption = true),
+            viewModel.stateFlow.value,
+        )
     }
 
     @Test
@@ -183,5 +210,6 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     isAutoFillServicesEnabled = false,
     isCopyTotpAutomaticallyEnabled = false,
     isUseInlineAutoFillEnabled = true,
+    showInlineAutofillOption = false,
     defaultUriMatchType = UriMatchType.DOMAIN,
 )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR hides the inline autofill option in the UI when the device OS does not support it.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/7de227c7-98e7-48e4-b191-f49593c75815" width="300" /> | <img src="https://github.com/user-attachments/assets/8824581e-c900-44c1-8ec7-8dbd8f1b94df" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
