### PR TITLE
PM-8534 update the active account after a "soft logout"

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -34,37 +34,19 @@ class UserLogoutManagerImpl(
     private val mainScope = CoroutineScope(dispatcherManager.main)
 
     override fun logout(userId: String, isExpired: Boolean) {
-        val currentUserState = authDiskSource.userState ?: return
+        if (authDiskSource.userState == null) return
 
         if (isExpired) {
             showToast(message = R.string.login_expired)
         }
 
-        // Remove the active user from the accounts map
-        val updatedAccounts = currentUserState
-            .accounts
-            .filterKeys { it != userId }
+        val ableToSwitchToNewAccount = switchUserIfAvailable(
+            currentUserId = userId,
+            isExpired = isExpired,
+            removeCurrentUserFromAccounts = true,
+        )
 
-        // Check if there is a new active user
-        if (updatedAccounts.isNotEmpty()) {
-            if (userId == currentUserState.activeUserId && !isExpired) {
-                showToast(message = R.string.account_switched_automatically)
-            }
-
-            // If we logged out a non-active user, we want to leave the active user unchanged.
-            // If we logged out the active user, we want to set the active user to the first one
-            // in the list.
-            val updatedActiveUserId = currentUserState
-                .activeUserId
-                .takeUnless { it == userId }
-                ?: updatedAccounts.entries.first().key
-
-            // Update the user information and emit an updated token
-            authDiskSource.userState = currentUserState.copy(
-                activeUserId = updatedActiveUserId,
-                accounts = updatedAccounts,
-            )
-        } else {
+        if (!ableToSwitchToNewAccount) {
             // Update the user information and log out
             authDiskSource.userState = null
         }
@@ -81,6 +63,8 @@ class UserLogoutManagerImpl(
         // Save any data that will still need to be retained after otherwise clearing all dat
         val vaultTimeoutInMinutes = settingsDiskSource.getVaultTimeoutInMinutes(userId = userId)
         val vaultTimeoutAction = settingsDiskSource.getVaultTimeoutAction(userId = userId)
+
+        switchUserIfAvailable(currentUserId = userId, removeCurrentUserFromAccounts = false)
 
         clearData(userId = userId)
 
@@ -111,5 +95,47 @@ class UserLogoutManagerImpl(
 
     private fun showToast(@StringRes message: Int) {
         mainScope.launch { Toast.makeText(context, message, Toast.LENGTH_SHORT).show() }
+    }
+
+    private fun switchUserIfAvailable(
+        currentUserId: String,
+        removeCurrentUserFromAccounts: Boolean,
+        isExpired: Boolean = false,
+    ): Boolean {
+        val currentUserState = authDiskSource.userState ?: return false
+
+        val currentAccountsMap = currentUserState.accounts
+
+        // Remove the active user from the accounts map
+        val updatedAccounts = currentAccountsMap
+            .filterKeys { it != currentUserId }
+
+        // Check if there is a new active user
+        return if (updatedAccounts.isNotEmpty()) {
+            if (currentUserId == currentUserState.activeUserId && !isExpired) {
+                showToast(message = R.string.account_switched_automatically)
+            }
+
+            // If we logged out a non-active user, we want to leave the active user unchanged.
+            // If we logged out the active user, we want to set the active user to the first one
+            // in the list.
+            val updatedActiveUserId = currentUserState
+                .activeUserId
+                .takeUnless { it == currentUserId }
+                ?: updatedAccounts.entries.first().key
+
+            // Update the user information and emit an updated token
+            authDiskSource.userState = currentUserState.copy(
+                activeUserId = updatedActiveUserId,
+                accounts = if (removeCurrentUserFromAccounts) {
+                    updatedAccounts
+                } else {
+                    currentAccountsMap
+                },
+            )
+            true
+        } else {
+            false
+        }
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -34,7 +34,7 @@ class UserLogoutManagerImpl(
     private val mainScope = CoroutineScope(dispatcherManager.main)
 
     override fun logout(userId: String, isExpired: Boolean) {
-        if (authDiskSource.userState == null) return
+        authDiskSource.userState ?: return
 
         if (isExpired) {
             showToast(message = R.string.login_expired)

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensions.kt
@@ -49,4 +49,4 @@ fun CipherView.toAutofillCipherProvider(): AutofillCipherProvider =
  * Returns true when the cipher is not deleted and contains at least one FIDO 2 credential.
  */
 val CipherView.isActiveWithFido2Credentials: Boolean
-    get() = deletedDate == null && login?.fido2Credentials.isNullOrEmpty().not()
+    get() = deletedDate == null && !(login?.fido2Credentials.isNullOrEmpty())

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -438,7 +438,7 @@ class VaultLockManagerImpl(
     ) {
         val accounts = authDiskSource.userAccountTokens
         // Check if the user is already logged out. If this is the case no need to check timeout.
-        if (accounts.find { it.userId == userId }?.isLoggedIn?.not() == true) {
+        if ((accounts.find { it.userId == userId }?.isLoggedIn) == false) {
             return
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -437,7 +437,12 @@ class VaultLockManagerImpl(
         isAppRestart: Boolean = false,
     ) {
         val accounts = authDiskSource.userAccountTokens
-        // Check if the user is already logged out. If this is the case no need to check timeout.
+        /**
+         * Check if the user is already logged out. If this is the case no need to check timeout.
+         * This is required in the case that an account has been "soft logged out" and has an
+         * immediate time interval time out. Without this check it would be automatically switch
+         * the active user back to an authenticated user if one exists.
+         */
         if ((accounts.find { it.userId == userId }?.isLoggedIn) == false) {
             return
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -216,7 +216,8 @@ class LandingViewModel @Inject constructor(
      */
     private fun handleActiveAccountChange(activeAccount: UserState.Account) {
         val activeUserNotLoggedIn = activeAccount.isLoggedIn.not()
-        if (activeUserNotLoggedIn) {
+        val noPendingAdditions = authRepository.hasPendingAccountAddition.not()
+        if (activeUserNotLoggedIn && noPendingAdditions) {
             trySendAction(LandingAction.EmailInputChanged(activeAccount.email))
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -82,7 +82,7 @@ class LandingViewModel @Inject constructor(
         authRepository
             .userStateFlow
             .map { userState ->
-                userState?.activeAccount?.let(this::mapToInternalActionOrNull)
+                userState?.activeAccount?.let(::mapToInternalActionOrNull)
             }
             .onEach { action ->
                 action?.let(::handleAction)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -103,7 +103,7 @@ class LandingViewModel @Inject constructor(
             LandingAction.CreateAccountClick -> handleCreateAccountClicked()
             is LandingAction.DialogDismiss -> handleDialogDismiss()
             is LandingAction.RememberMeToggle -> handleRememberMeToggled(action)
-            is LandingAction.EmailInputChanged -> handleEmailInputUpdated(action.input)
+            is LandingAction.EmailInputChanged -> handleEmailInputChanged(action)
             is LandingAction.EnvironmentTypeSelect -> handleEnvironmentTypeSelect(action)
             is LandingAction.Internal -> handleInternalActions(action)
         }
@@ -111,7 +111,7 @@ class LandingViewModel @Inject constructor(
 
     private fun handleInternalActions(action: LandingAction.Internal) {
         when (action) {
-            is LandingAction.Internal.UpdateEmailState -> handleEmailInputUpdated(action.emailInput)
+            is LandingAction.Internal.UpdateEmailState -> handleInternalEmailStateUpdate(action)
             is LandingAction.Internal.UpdatedEnvironmentReceive -> {
                 handleUpdatedEnvironmentReceive(action)
             }
@@ -136,7 +136,15 @@ class LandingViewModel @Inject constructor(
         authRepository.switchAccount(userId = action.accountSummary.userId)
     }
 
-    private fun handleEmailInputUpdated(updatedInput: String) {
+    private fun handleEmailInputChanged(action: LandingAction.EmailInputChanged) {
+        updateEmailInput(action.input)
+    }
+
+    private fun handleInternalEmailStateUpdate(action: LandingAction.Internal.UpdateEmailState) {
+        updateEmailInput(action.emailInput)
+    }
+
+    private fun updateEmailInput(updatedInput: String) {
         mutableStateFlow.update {
             it.copy(
                 emailInput = updatedInput,
@@ -224,8 +232,8 @@ class LandingViewModel @Inject constructor(
     private fun mapToInternalActionOrNull(
         activeAccount: UserState.Account,
     ): LandingAction.Internal.UpdateEmailState? {
-        val activeUserNotLoggedIn = activeAccount.isLoggedIn.not()
-        val noPendingAdditions = authRepository.hasPendingAccountAddition.not()
+        val activeUserNotLoggedIn = !activeAccount.isLoggedIn
+        val noPendingAdditions = !authRepository.hasPendingAccountAddition
         return LandingAction.Internal.UpdateEmailState(activeAccount.email)
             .takeIf { activeUserNotLoggedIn && noPendingAdditions }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.auth.manager
 
 import android.content.Context
 import android.widget.Toast
+import androidx.annotation.StringRes
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
@@ -92,17 +93,7 @@ class UserLogoutManagerTest {
     @Suppress("MaxLineLength")
     @Test
     fun `logout for multiple accounts should clear data associated with the given user and change to the new active user`() {
-        mockkStatic(Toast::class)
-
-        every {
-            Toast
-                .makeText(
-                    context,
-                    R.string.account_switched_automatically,
-                    Toast.LENGTH_SHORT,
-                )
-                .show()
-        } just runs
+        mockToast(R.string.account_switched_automatically)
 
         val userId = USER_ID_1
         every { authDiskSource.userState } returns MULTI_USER_STATE
@@ -132,17 +123,8 @@ class UserLogoutManagerTest {
         val vaultTimeoutInMinutes = 360
         val vaultTimeoutAction = VaultTimeoutAction.LOGOUT
 
-        mockkStatic(Toast::class)
+        mockToast(R.string.account_switched_automatically)
 
-        every {
-            Toast
-                .makeText(
-                    context,
-                    R.string.account_switched_automatically,
-                    Toast.LENGTH_SHORT,
-                )
-                .show()
-        } just runs
         every { authDiskSource.userState } returns MULTI_USER_STATE
         every {
             settingsDiskSource.getVaultTimeoutInMinutes(userId = userId)
@@ -177,17 +159,8 @@ class UserLogoutManagerTest {
         val vaultTimeoutInMinutes = 360
         val vaultTimeoutAction = VaultTimeoutAction.LOGOUT
 
-        mockkStatic(Toast::class)
+        mockToast(R.string.account_switched_automatically)
 
-        every {
-            Toast
-                .makeText(
-                    context,
-                    R.string.account_switched_automatically,
-                    Toast.LENGTH_SHORT,
-                )
-                .show()
-        } just runs
         every { authDiskSource.userState } returns MULTI_USER_STATE
         every {
             settingsDiskSource.getVaultTimeoutInMinutes(userId = userId)
@@ -215,6 +188,15 @@ class UserLogoutManagerTest {
         coVerify {
             vaultDiskSource.deleteVaultData(userId = userId)
         }
+    }
+
+    private fun mockToast(@StringRes res: Int) {
+        mockkStatic(Toast::class)
+        every {
+            Toast
+                .makeText(context, res, Toast.LENGTH_SHORT)
+                .show()
+        } just runs
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -185,6 +185,7 @@ class VaultLockManagerTest {
     @Suppress("MaxLineLength")
     @Test
     fun `app coming into foreground for the first time for OnAppRestart timeout should clear existing times and lock vaults if necessary`() {
+        setAccountTokens()
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         mutableVaultTimeoutActionStateFlow.value = VaultTimeoutAction.LOCK
         mutableVaultTimeoutStateFlow.value = VaultTimeout.OnAppRestart
@@ -209,6 +210,7 @@ class VaultLockManagerTest {
     @Suppress("MaxLineLength")
     @Test
     fun `app coming into foreground for the first time for other timeout should clear existing times and lock vaults if necessary`() {
+        setAccountTokens()
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         mutableVaultTimeoutActionStateFlow.value = VaultTimeoutAction.LOCK
         mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
@@ -233,6 +235,7 @@ class VaultLockManagerTest {
     @Suppress("MaxLineLength")
     @Test
     fun `app coming into foreground for the first time for non-Never timeout should clear existing times and perform timeout action`() {
+        setAccountTokens()
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         mutableVaultTimeoutActionStateFlow.value = VaultTimeoutAction.LOCK
         mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
@@ -256,7 +259,49 @@ class VaultLockManagerTest {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `Verify Checking for timeout should take place for a user who is an logged in state`() {
+        setAccountTokens()
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        mutableVaultTimeoutActionStateFlow.value = VaultTimeoutAction.LOGOUT
+        mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
+
+        fakeAppForegroundManager.appForegroundState = AppForegroundState.BACKGROUNDED
+        fakeAuthDiskSource.storeLastActiveTimeMillis(
+            userId = USER_ID,
+            lastActiveTimeMillis = 123L,
+        )
+        verifyUnlockedVaultBlocking(userId = USER_ID)
+        assertTrue(vaultLockManager.isVaultUnlocked(USER_ID))
+
+        fakeAppForegroundManager.appForegroundState = AppForegroundState.FOREGROUNDED
+
+        verify(exactly = 1) { settingsRepository.getVaultTimeoutActionStateFlow(USER_ID) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Verify Checking for timeout should not take place for a user who is already in the soft logged out state`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        mutableVaultTimeoutActionStateFlow.value = VaultTimeoutAction.LOGOUT
+        mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
+
+        fakeAppForegroundManager.appForegroundState = AppForegroundState.BACKGROUNDED
+        fakeAuthDiskSource.storeLastActiveTimeMillis(
+            userId = USER_ID,
+            lastActiveTimeMillis = 123L,
+        )
+        verifyUnlockedVaultBlocking(userId = USER_ID)
+        assertTrue(vaultLockManager.isVaultUnlocked(USER_ID))
+
+        fakeAppForegroundManager.appForegroundState = AppForegroundState.FOREGROUNDED
+
+        verify(exactly = 0) { settingsRepository.getVaultTimeoutActionStateFlow(USER_ID) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `app coming into foreground subsequent times should perform timeout action if necessary and not clear existing times`() {
+        setAccountTokens()
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
         // Start in a foregrounded state
@@ -362,6 +407,7 @@ class VaultLockManagerTest {
     @Test
     fun `switching users should perform lock actions for each user if necessary and reset their last active times`() {
         val userId2 = "mockId-2"
+        setAccountTokens(listOf(USER_ID, userId2))
         fakeAuthDiskSource.userState = UserStateJson(
             activeUserId = USER_ID,
             accounts = mapOf(
@@ -1506,6 +1552,16 @@ class VaultLockManagerTest {
 
     private fun verifyUnlockedVaultBlocking(userId: String) {
         runBlocking { verifyUnlockedVault(userId = userId) }
+    }
+
+    // region helper functions
+    private fun setAccountTokens(userIds: List<String> = listOf(USER_ID)) {
+        userIds.forEach { userId ->
+            fakeAuthDiskSource.storeAccountTokens(
+                userId,
+                accountTokens = AccountTokensJson("access-$userId", "refresh-$userId")
+            )
+        }
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -259,7 +259,7 @@ class VaultLockManagerTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `Verify Checking for timeout should take place for a user who is an logged in state`() {
+    fun `Verify Checking for timeout should take place for a user with logged in state`() {
         setAccountTokens()
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         mutableVaultTimeoutActionStateFlow.value = VaultTimeoutAction.LOGOUT

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -1559,7 +1559,7 @@ class VaultLockManagerTest {
         userIds.forEach { userId ->
             fakeAuthDiskSource.storeAccountTokens(
                 userId,
-                accountTokens = AccountTokensJson("access-$userId", "refresh-$userId")
+                accountTokens = AccountTokensJson("access-$userId", "refresh-$userId"),
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.test
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
@@ -397,6 +398,38 @@ class LandingViewModelTest : BaseViewModelTest() {
                 awaitItem(),
             )
         }
+    }
+
+    @Test
+    fun `Active Logged Out user causes email field to prepopulate`() = runTest {
+        val expectedEmail = "frodo@hobbit.on"
+        val userId = "1"
+
+        val userAccount: UserState.Account = UserState.Account(
+            userId = userId,
+            name = null,
+            email = expectedEmail,
+            avatarColorHex = "lorem",
+            environment = Environment.Us,
+            isPremium = false,
+            isLoggedIn = false,
+            isVaultUnlocked = false,
+            needsPasswordReset = false,
+            needsMasterPassword = false,
+            trustedDevice = null,
+            organizations = listOf(),
+            isBiometricsEnabled = false,
+            vaultUnlockType = VaultUnlockType.MASTER_PASSWORD,
+        )
+
+        val userState = UserState(
+            activeUserId = userId,
+            accounts = listOf(userAccount),
+        )
+
+        val viewModel = createViewModel(userState = userState)
+
+        assertEquals(expectedEmail, viewModel.stateFlow.value.emailInput)
     }
 
     //region Helper methods

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
@@ -22,6 +22,7 @@ import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class LandingViewModelTest : BaseViewModelTest() {
@@ -463,7 +464,7 @@ class LandingViewModelTest : BaseViewModelTest() {
 
         val viewModel = createViewModel(userState = userState)
 
-        assert(viewModel.stateFlow.value.emailInput.isEmpty())
+        assertTrue(viewModel.stateFlow.value.emailInput.isEmpty())
     }
 
     //region Helper methods

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
@@ -432,6 +432,40 @@ class LandingViewModelTest : BaseViewModelTest() {
         assertEquals(expectedEmail, viewModel.stateFlow.value.emailInput)
     }
 
+    @Test
+    fun `Email input will not change based on active user when adding new account`() = runTest {
+        val expectedEmail = "frodo@hobbit.on"
+        val userId = "1"
+
+        val userAccount: UserState.Account = UserState.Account(
+            userId = userId,
+            name = null,
+            email = expectedEmail,
+            avatarColorHex = "lorem",
+            environment = Environment.Us,
+            isPremium = false,
+            isLoggedIn = false,
+            isVaultUnlocked = false,
+            needsPasswordReset = false,
+            needsMasterPassword = false,
+            trustedDevice = null,
+            organizations = listOf(),
+            isBiometricsEnabled = false,
+            vaultUnlockType = VaultUnlockType.MASTER_PASSWORD,
+        )
+
+        val userState = UserState(
+            activeUserId = userId,
+            accounts = listOf(userAccount),
+        )
+
+        every { authRepository.hasPendingAccountAddition } returns true
+
+        val viewModel = createViewModel(userState = userState)
+
+        assert(viewModel.stateFlow.value.emailInput.isEmpty())
+    }
+
     //region Helper methods
 
     private fun createViewModel(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-8534
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
If more than one accounts are available and one has `LOGOUT` as the session timeout action, the app should switch to the next active account. Additionally added pre-populating the email input if ending up on the Landing screen when switching to the "soft" logged out account.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/d1496bde-244e-4d63-ac49-9541c26d4df1


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
