### PR TITLE
[PM-8137] Introduce FIDO 2 user verification tracking

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
@@ -12,6 +12,12 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 interface Fido2CredentialManager {
 
     /**
+     * Returns true when the user has performed an explicit verification action. E.g., biometric
+     * verification, device credential verification, or vault unlock.
+     */
+    var isUserVerified: Boolean
+
+    /**
      * Attempt to validate the RP and origin of the provided [fido2CredentialRequest].
      */
     suspend fun validateOrigin(

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
@@ -39,6 +39,8 @@ class Fido2CredentialManagerImpl(
 ) : Fido2CredentialManager,
     Fido2CredentialStore by fido2CredentialStore {
 
+    override var isUserVerified: Boolean = false
+
     override suspend fun registerFido2Credential(
         userId: String,
         fido2CredentialRequest: Fido2CredentialRequest,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8137

## 📔 Objective

During FIDO 2 operations, Fido2CredentialManager will track whether the user has performed an action that explicitly verifies their identity.

`Fido2CredentialManager.isUserVerified` can be read to determine if the user is verified. It can also be modified any time a verification action completes. User verification actions include, but not limited to, biometric authentication, device credential entry, or vault unlock.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
