### PR TITLE
PM-9659: Do not show push notification permissions on FDroid

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.vault
 
 import android.Manifest
-import android.os.Build
+import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.scaleIn
@@ -125,7 +125,10 @@ fun VaultScreen(
         }
     }
     val vaultHandlers = remember(viewModel) { VaultHandlers.create(viewModel) }
-    VaultScreenPushNotifications(permissionsManager = permissionsManager)
+    VaultScreenPushNotifications(
+        hideNotificationsDialog = state.hideNotificationsDialog,
+        permissionsManager = permissionsManager,
+    )
     VaultScreenScaffold(
         state = state,
         pullToRefreshState = pullToRefreshState,
@@ -139,14 +142,17 @@ fun VaultScreen(
  */
 @Composable
 private fun VaultScreenPushNotifications(
+    hideNotificationsDialog: Boolean,
     permissionsManager: PermissionsManager,
 ) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+    if (hideNotificationsDialog) return
     val launcher = permissionsManager.getLauncher {
         // We do not actually care what the response is, we just need
         // to give the user a chance to give us the permission.
     }
     LaunchedEffect(key1 = Unit) {
+        @SuppressLint("InlinedApi")
+        // We check the version code as part of the 'hideNotificationsDialog' property.
         if (!permissionsManager.checkPermission(Manifest.permission.POST_NOTIFICATIONS)) {
             launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.vault.feature.vault
 
+import android.os.Build
 import android.os.Parcelable
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.viewModelScope
@@ -15,6 +16,8 @@ import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.DataState
 import com.x8bit.bitwarden.data.platform.repository.util.baseIconUrl
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
+import com.x8bit.bitwarden.data.platform.util.isFdroid
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
@@ -87,6 +90,7 @@ class VaultViewModel @Inject constructor(
             isPullToRefreshSettingEnabled = settingsRepository.getPullToRefreshEnabledFlow().value,
             baseIconUrl = userState.activeAccount.environment.environmentUrlData.baseIconUrl,
             hasMasterPassword = userState.activeAccount.hasMasterPassword,
+            hideNotificationsDialog = isBuildVersionBelow(Build.VERSION_CODES.TIRAMISU) || isFdroid,
         )
     },
 ) {
@@ -628,6 +632,7 @@ data class VaultState(
     private val isPullToRefreshSettingEnabled: Boolean,
     val baseIconUrl: String,
     val isIconLoadingDisabled: Boolean,
+    val hideNotificationsDialog: Boolean,
 ) : Parcelable {
 
     /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/manager/permissions/FakePermissionManager.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/manager/permissions/FakePermissionManager.kt
@@ -26,14 +26,20 @@ class FakePermissionManager : PermissionsManager {
     var getMultiplePermissionsResult: Map<String, Boolean> = emptyMap()
 
     /**
-     * * The value for whether a rationale should be shown to the user.
+     * The value for whether a rationale should be shown to the user.
      */
     var shouldShowRequestRationale: Boolean = false
+
+    /**
+     * Indicates that the [getLauncher] function has been called.
+     */
+    var hasGetLauncherBeenCalled: Boolean = false
 
     @Composable
     override fun getLauncher(
         onResult: (Boolean) -> Unit,
     ): ManagedActivityResultLauncher<String, Boolean> {
+        hasGetLauncherBeenCalled = true
         return mockk {
             every { launch(any()) } answers { onResult.invoke(getPermissionsResult) }
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -1129,6 +1129,14 @@ class VaultScreenTest : BaseComposeTest() {
             viewModel.trySendAction(VaultAction.TrashClick)
         }
     }
+
+    @Test
+    fun `permissionManager is invoked for notifications based on state`() {
+        assertFalse(permissionsManager.hasGetLauncherBeenCalled)
+        mutableStateFlow.update { it.copy(hideNotificationsDialog = false) }
+        composeTestRule.waitForIdle()
+        assertTrue(permissionsManager.hasGetLauncherBeenCalled)
+    }
 }
 
 private val ACTIVE_ACCOUNT_SUMMARY = AccountSummary(
@@ -1181,6 +1189,7 @@ private val DEFAULT_STATE: VaultState = VaultState(
     baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
     isIconLoadingDisabled = false,
     hasMasterPassword = true,
+    hideNotificationsDialog = true,
 )
 
 private val DEFAULT_CONTENT_VIEW_STATE: VaultState.ViewState.Content = VaultState.ViewState.Content(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1572,4 +1572,5 @@ private fun createMockVaultState(
         baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
         isIconLoadingDisabled = false,
         hasMasterPassword = true,
+        hideNotificationsDialog = true,
     )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9659](https://bitwarden.atlassian.net/browse/PM-9659)

## 📔 Objective

This PR disables the push notifications permission request on FDroid since we do not use push notifications on FDroid.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9659]: https://bitwarden.atlassian.net/browse/PM-9659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ