### PR TITLE
PM-9017 updated the continue button state when switching 2FA method

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -465,7 +465,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                         )
                     }
                 }
-                mutableStateFlow.update { it.copy(authMethod = action.authMethod) }
+                updateAuthMethodRelatedState(action.authMethod)
             }
 
             TwoFactorAuthMethod.AUTHENTICATOR_APP,
@@ -476,8 +476,17 @@ class TwoFactorLoginViewModel @Inject constructor(
             TwoFactorAuthMethod.DUO_ORGANIZATION,
             TwoFactorAuthMethod.WEB_AUTH,
             -> {
-                mutableStateFlow.update { it.copy(authMethod = action.authMethod) }
+                updateAuthMethodRelatedState(action.authMethod)
             }
+        }
+    }
+
+    private fun updateAuthMethodRelatedState(authMethod: TwoFactorAuthMethod) {
+        mutableStateFlow.update {
+            it.copy(
+                authMethod = authMethod,
+                isContinueButtonEnabled = authMethod.isContinueButtonEnabled,
+            )
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -691,7 +691,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         assertEquals(
             DEFAULT_STATE.copy(
                 authMethod = TwoFactorAuthMethod.DUO,
-                isContinueButtonEnabled = true
+                isContinueButtonEnabled = true,
             ),
             viewModel.stateFlow.value,
         )
@@ -699,8 +699,8 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         // To method with continue button disabled by default
         viewModel.trySendAction(
             TwoFactorLoginAction.SelectAuthMethod(
-                TwoFactorAuthMethod.YUBI_KEY
-            )
+                TwoFactorAuthMethod.YUBI_KEY,
+            ),
         )
 
         assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -680,14 +680,33 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
     @Test
     fun `SelectAuthMethod with other method should update the state`() {
         val viewModel = createViewModel()
+
+        // To method with continue button enabled by default
         viewModel.trySendAction(
             TwoFactorLoginAction.SelectAuthMethod(
-                TwoFactorAuthMethod.AUTHENTICATOR_APP,
+                TwoFactorAuthMethod.DUO,
             ),
         )
+
         assertEquals(
             DEFAULT_STATE.copy(
-                authMethod = TwoFactorAuthMethod.AUTHENTICATOR_APP,
+                authMethod = TwoFactorAuthMethod.DUO,
+                isContinueButtonEnabled = true
+            ),
+            viewModel.stateFlow.value,
+        )
+
+        // To method with continue button disabled by default
+        viewModel.trySendAction(
+            TwoFactorLoginAction.SelectAuthMethod(
+                TwoFactorAuthMethod.YUBI_KEY
+            )
+        )
+
+        assertEquals(
+            DEFAULT_STATE.copy(
+                authMethod = TwoFactorAuthMethod.YUBI_KEY,
+                isContinueButtonEnabled = false,
             ),
             viewModel.stateFlow.value,
         )


### PR DESCRIPTION
## 🎟️ Tracking
[PM-9017](https://bitwarden.atlassian.net/browse/PM-9017)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Update the continue button state when switching the AuthMethod state so it updates if there is a needed default state (i.e. with Duo)
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8017]: https://bitwarden.atlassian.net/browse/PM-8017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-9017]: https://bitwarden.atlassian.net/browse/PM-9017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ