### PR TITLE
[Build Issue] use full source set to match fastfile test task

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -253,7 +253,7 @@ kover {
 tasks {
     getByName("check") {
         // Add detekt with type resolution to check
-        dependsOn("detektMain")
+        dependsOn("detekt")
     }
 
     withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {


### PR DESCRIPTION
I believe this is why there are cases of the builds passing on open PR jobs for `Detekt` but then failing on the merge job. I think cause this is triggered by the sonar `check` only in the dev builds it passes the check if all the files in the `main` source set pass, but ignores the tests.