### PR TITLE
[PM-9407] Create reusable overwrite passkey confirmation dialog

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenOverwritePasskeyConfirmationDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenOverwritePasskeyConfirmationDialog.kt
@@ -1,0 +1,29 @@
+package com.x8bit.bitwarden.ui.platform.components.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.x8bit.bitwarden.R
+
+/**
+ * A reusable dialog for confirming whether or not the user wants to overwrite an existing FIDO 2
+ * credential.
+ *
+ * @param onConfirmClick A callback for when the overwrite confirmation button is clicked.
+ * @param onDismissRequest A callback for when the dialog is requesting dismissal.
+ */
+@Suppress("MaxLineLength")
+@Composable
+fun BitwardenOverwritePasskeyConfirmationDialog(
+    onConfirmClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    BitwardenTwoButtonDialog(
+        title = stringResource(id = R.string.overwrite_passkey),
+        message = stringResource(id = R.string.this_item_already_contains_a_passkey_are_you_sure_you_want_to_overwrite_the_current_passkey),
+        confirmButtonText = stringResource(id = R.string.ok),
+        dismissButtonText = stringResource(id = R.string.cancel),
+        onConfirmClick = onConfirmClick,
+        onDismissClick = onDismissRequest,
+        onDismissRequest = onDismissRequest,
+    )
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-9407

## 📔 Objective

Create a reusable dialog that prompts the user to confirm overwriting an existing passkey during FIDO 2 credential registration.

## 📸 Screenshots

<img width="264" alt="image" src="https://github.com/user-attachments/assets/1f756b58-747b-4922-ab12-d0bcc0a2eb33">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
