### PR TITLE
All of the autofill processing happens in a job

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
@@ -107,6 +107,7 @@ class AutofillProcessorTest {
             fillCallback = fillCallback,
             request = fillRequest,
         )
+        testDispatcher.scheduler.runCurrent()
 
         // Verify
         verify(exactly = 1) {
@@ -445,9 +446,9 @@ class AutofillProcessorTest {
         verify(exactly = 1) {
             // These run as they are not part of the coroutine
             cancellationSignal.setOnCancelListener(any())
-            parser.parse(autofillAppInfo = appInfo, fillRequest = fillRequest)
         }
         coVerify(exactly = 0) {
+            parser.parse(autofillAppInfo = appInfo, fillRequest = fillRequest)
             filledDataBuilder.build(autofillRequest = autofillRequest)
         }
         verify(exactly = 0) {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the Autofill Processor to do _all_ the parsing and processing of autofill data inside a single `Job`. This means that a cancellation will stop everything.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
