### PR TITLE
[PM-9838] Custom field spacing on Add/Edit item screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
@@ -274,6 +274,7 @@ fun LazyListScope.vaultAddEditCardItems(
     }
 
     items(commonState.customFieldData) { customItem ->
+        Spacer(modifier = Modifier.height(8.dp))
         VaultAddEditCustomField(
             customField = customItem,
             onCustomFieldValueChange = commonHandlers.onCustomFieldValueChange,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
@@ -375,6 +375,7 @@ fun LazyListScope.vaultAddEditIdentityItems(
     }
 
     items(commonState.customFieldData) { customItem ->
+        Spacer(modifier = Modifier.height(8.dp))
         VaultAddEditCustomField(
             customField = customItem,
             onCustomFieldValueChange = commonTypeHandlers.onCustomFieldValueChange,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
@@ -301,6 +301,7 @@ fun LazyListScope.vaultAddEditLoginItems(
     }
 
     items(commonState.customFieldData) { customItem ->
+        Spacer(modifier = Modifier.height(8.dp))
         VaultAddEditCustomField(
             customField = customItem,
             onCustomFieldValueChange = commonActionHandler.onCustomFieldValueChange,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSecureNotesItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSecureNotesItems.kt
@@ -153,6 +153,7 @@ fun LazyListScope.vaultAddEditSecureNotesItems(
         )
     }
     items(commonState.customFieldData) { customItem ->
+        Spacer(modifier = Modifier.height(8.dp))
         VaultAddEditCustomField(
             customField = customItem,
             onCustomFieldValueChange = commonTypeHandlers.onCustomFieldValueChange,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-9838

## 📔 Objective
Add height spacer to all list items for the `VaultAddEdit*Items` lists so the spacing matches the "view" versions of the VaultItem screens
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
| before | after |
|--------|--------|
| ![beforepm9838](https://github.com/user-attachments/assets/7634f2a4-9ae6-474f-bfed-0903d21ce580) | ![afterpm9838](https://github.com/user-attachments/assets/8b64a512-86e3-4299-bc01-84d7b972a499) |
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
