### PR TITLE
Catch TransactionTooLargeExceptions in autofill

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
@@ -19,6 +19,7 @@ import com.x8bit.bitwarden.data.autofill.processor.AutofillProcessor
 import com.x8bit.bitwarden.data.autofill.processor.AutofillProcessorImpl
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProvider
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProviderImpl
+import com.x8bit.bitwarden.data.platform.manager.CrashLogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
@@ -101,6 +102,7 @@ object AutofillModule {
         policyManager: PolicyManager,
         saveInfoBuilder: SaveInfoBuilder,
         settingsRepository: SettingsRepository,
+        crashLogsManager: CrashLogsManager,
     ): AutofillProcessor =
         AutofillProcessorImpl(
             dispatcherManager = dispatcherManager,
@@ -110,6 +112,7 @@ object AutofillModule {
             policyManager = policyManager,
             saveInfoBuilder = saveInfoBuilder,
             settingsRepository = settingsRepository,
+            crashLogsManager = crashLogsManager,
         )
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
@@ -13,6 +13,7 @@ import com.x8bit.bitwarden.data.autofill.model.AutofillRequest
 import com.x8bit.bitwarden.data.autofill.parser.AutofillParser
 import com.x8bit.bitwarden.data.autofill.util.createAutofillSavedItemIntentSender
 import com.x8bit.bitwarden.data.autofill.util.toAutofillSaveItem
+import com.x8bit.bitwarden.data.platform.manager.CrashLogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -34,6 +35,7 @@ class AutofillProcessorImpl(
     private val parser: AutofillParser,
     private val saveInfoBuilder: SaveInfoBuilder,
     private val settingsRepository: SettingsRepository,
+    private val crashLogsManager: CrashLogsManager,
 ) : AutofillProcessor {
 
     /**
@@ -139,7 +141,14 @@ class AutofillProcessorImpl(
                     saveInfo = saveInfo,
                 )
 
-                fillCallback.onSuccess(response)
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    fillCallback.onSuccess(response)
+                } catch (e: RuntimeException) {
+                    // This is to catch any TransactionTooLargeExceptions that could occur here.
+                    // These exceptions get wrapped as a RuntimeException.
+                    crashLogsManager.trackNonFatalException(e)
+                }
             }
 
             AutofillRequest.Unfillable -> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
@@ -22,6 +22,7 @@ import com.x8bit.bitwarden.data.autofill.parser.AutofillParser
 import com.x8bit.bitwarden.data.autofill.util.createAutofillSavedItemIntentSender
 import com.x8bit.bitwarden.data.autofill.util.toAutofillSaveItem
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
+import com.x8bit.bitwarden.data.platform.manager.CrashLogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
@@ -56,6 +57,7 @@ class AutofillProcessorTest {
     private val policyManager: PolicyManager = mockk()
     private val saveInfoBuilder: SaveInfoBuilder = mockk()
     private val settingsRepository: SettingsRepository = mockk()
+    private val crashLogsManager: CrashLogsManager = mockk()
 
     private val appInfo: AutofillAppInfo = AutofillAppInfo(
         context = mockk(),
@@ -77,6 +79,7 @@ class AutofillProcessorTest {
             policyManager = policyManager,
             saveInfoBuilder = saveInfoBuilder,
             settingsRepository = settingsRepository,
+            crashLogsManager = crashLogsManager,
         )
     }
 
@@ -197,6 +200,80 @@ class AutofillProcessorTest {
                     saveInfo = saveInfo,
                 )
                 fillCallback.onSuccess(fillResponse)
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `processFillRequest should invoke callback with filled response when has filledItems and track exceptions thrown by callback`() =
+        runTest {
+            // Setup
+            val fillRequest: FillRequest = mockk()
+            val filledData = FilledData(
+                filledPartitions = listOf(mockk()),
+                ignoreAutofillIds = emptyList(),
+                originalPartition = mockk(),
+                uri = null,
+                vaultItemInlinePresentationSpec = null,
+                isVaultLocked = false,
+            )
+            val fillResponse: FillResponse = mockk()
+            val autofillPartition: AutofillPartition = mockk()
+            val autofillRequest: AutofillRequest.Fillable = mockk {
+                every { packageName } returns PACKAGE_NAME
+                every { partition } returns autofillPartition
+            }
+            val saveInfo: SaveInfo = mockk()
+            coEvery {
+                filledDataBuilder.build(autofillRequest = autofillRequest)
+            } returns filledData
+            every { cancellationSignal.setOnCancelListener(any()) } just runs
+            every {
+                parser.parse(autofillAppInfo = appInfo, fillRequest = fillRequest)
+            } returns autofillRequest
+            every {
+                saveInfoBuilder.build(
+                    autofillAppInfo = appInfo,
+                    autofillPartition = autofillPartition,
+                    fillRequest = fillRequest,
+                    packageName = PACKAGE_NAME,
+                )
+            } returns saveInfo
+            every {
+                fillResponseBuilder.build(
+                    autofillAppInfo = appInfo,
+                    filledData = filledData,
+                    saveInfo = saveInfo,
+                )
+            } returns fillResponse
+            val runtimeException = RuntimeException("TransactionToLarge")
+            every { fillCallback.onSuccess(fillResponse) } throws runtimeException
+            every { crashLogsManager.trackNonFatalException(runtimeException) } just runs
+
+            // Test
+            autofillProcessor.processFillRequest(
+                autofillAppInfo = appInfo,
+                cancellationSignal = cancellationSignal,
+                fillCallback = fillCallback,
+                request = fillRequest,
+            )
+
+            testDispatcher.scheduler.runCurrent()
+
+            // Verify
+            coVerify(exactly = 1) {
+                filledDataBuilder.build(autofillRequest = autofillRequest)
+            }
+            verify(exactly = 1) {
+                cancellationSignal.setOnCancelListener(any())
+                parser.parse(autofillAppInfo = appInfo, fillRequest = fillRequest)
+                fillResponseBuilder.build(
+                    autofillAppInfo = appInfo,
+                    filledData = filledData,
+                    saveInfo = saveInfo,
+                )
+                fillCallback.onSuccess(fillResponse)
+                crashLogsManager.trackNonFatalException(runtimeException)
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds a fallback to ensure that any `TransationToLargeException` in the AutofillService will be handled gracefully.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
