### PR TITLE
Refactor PublicKeyCredentialCreationOptions

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
@@ -27,7 +27,7 @@ interface Fido2CredentialManager {
     /**
      * Attempt to extract FIDO 2 passkey creation options from the system [requestJson], or null.
      */
-    fun getPasskeyCreateOptionsOrNull(
+    fun getPasskeyAttestationOptionsOrNull(
         requestJson: String,
     ): PasskeyAttestationOptions?
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
@@ -1,10 +1,10 @@
 package com.x8bit.bitwarden.data.autofill.fido2.manager
 
 import com.bitwarden.vault.CipherView
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 
 /**
  * Responsible for managing FIDO 2 credential registration and authentication.
@@ -29,7 +29,7 @@ interface Fido2CredentialManager {
      */
     fun getPasskeyCreateOptionsOrNull(
         requestJson: String,
-    ): PublicKeyCredentialCreationOptions?
+    ): PasskeyAttestationOptions?
 
     /**
      * Register a new FIDO 2 credential to a users vault.

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
@@ -25,7 +25,7 @@ interface Fido2CredentialManager {
     ): Fido2ValidateOriginResult
 
     /**
-     * Attempt to extract FIDO 2 passkey creation options from the system [requestJson], or null.
+     * Attempt to extract FIDO 2 passkey attestation options from the system [requestJson], or null.
      */
     fun getPasskeyAttestationOptionsOrNull(
         requestJson: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
@@ -5,11 +5,11 @@ import com.bitwarden.fido.ClientData
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions
 import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.platform.manager.AssetManager
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
@@ -95,9 +95,9 @@ class Fido2CredentialManagerImpl(
 
     override fun getPasskeyCreateOptionsOrNull(
         requestJson: String,
-    ): PublicKeyCredentialCreationOptions? =
+    ): PasskeyAttestationOptions? =
         try {
-            json.decodeFromString<PublicKeyCredentialCreationOptions>(requestJson)
+            json.decodeFromString<PasskeyAttestationOptions>(requestJson)
         } catch (e: SerializationException) {
             null
         } catch (e: IllegalArgumentException) {
@@ -194,7 +194,7 @@ class Fido2CredentialManagerImpl(
     private fun String.getRpId(json: Json): Result<String> {
         return try {
             json
-                .decodeFromString<PublicKeyCredentialCreationOptions>(this)
+                .decodeFromString<PasskeyAttestationOptions>(this)
                 .relyingParty
                 .id
                 .asSuccess()

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
@@ -93,7 +93,7 @@ class Fido2CredentialManagerImpl(
         }
     }
 
-    override fun getPasskeyCreateOptionsOrNull(
+    override fun getPasskeyAttestationOptionsOrNull(
         requestJson: String,
     ): PasskeyAttestationOptions? =
         try {

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/PasskeyAttestationOptions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/PasskeyAttestationOptions.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model
+package com.x8bit.bitwarden.data.autofill.fido2.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  * Models a FIDO 2 credential creation request options received from a Relying Party (RP).
  */
 @Serializable
-data class PublicKeyCredentialCreationOptions(
+data class PasskeyAttestationOptions(
     @SerialName("authenticatorSelection")
     val authenticatorSelection: AuthenticatorSelectionCriteria,
     @SerialName("challenge")

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -8,10 +8,10 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -119,7 +119,7 @@ class VaultAddEditViewModel @Inject constructor(
             val fido2CreationOptions = fido2CreationRequest
                 ?.let { request ->
                     fido2CredentialManager
-                        .getPasskeyCreateOptionsOrNull(request.requestJson)
+                        .getPasskeyAttestationOptionsOrNull(request.requestJson)
                 }
 
             val dialogState =
@@ -142,7 +142,7 @@ class VaultAddEditViewModel @Inject constructor(
                                 ?.toDefaultAddTypeContent(isIndividualVaultDisabled)
                             ?: fido2CreationRequest
                                 ?.toDefaultAddTypeContent(
-                                    creationOptions = fido2CreationOptions,
+                                    attestationOptions = fido2CreationOptions,
                                     isIndividualVaultDisabled = isIndividualVaultDisabled,
                                 )
                             ?: VaultAddEditState.ViewState.Content(
@@ -423,7 +423,7 @@ class VaultAddEditViewModel @Inject constructor(
         }
 
         val createOptions = fido2CredentialManager
-            .getPasskeyCreateOptionsOrNull(request.requestJson)
+            .getPasskeyAttestationOptionsOrNull(request.requestJson)
             ?: run {
                 showFido2ErrorDialog()
                 return

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -116,7 +116,7 @@ class VaultAddEditViewModel @Inject constructor(
                 .specialCircumstance
                 ?.toFido2RequestOrNull()
 
-            val fido2CreationOptions = fido2CreationRequest
+            val fido2AttestationOptions = fido2CreationRequest
                 ?.let { request ->
                     fido2CredentialManager
                         .getPasskeyAttestationOptionsOrNull(request.requestJson)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -142,7 +142,7 @@ class VaultAddEditViewModel @Inject constructor(
                                 ?.toDefaultAddTypeContent(isIndividualVaultDisabled)
                             ?: fido2CreationRequest
                                 ?.toDefaultAddTypeContent(
-                                    attestationOptions = fido2CreationOptions,
+                                    attestationOptions = fido2AttestationOptions,
                                     isIndividualVaultDisabled = isIndividualVaultDisabled,
                                 )
                             ?: VaultAddEditState.ViewState.Content(
@@ -157,8 +157,8 @@ class VaultAddEditViewModel @Inject constructor(
                 },
                 dialog = dialogState,
                 // Set special conditions for autofill and fido2 save
-                shouldShowCloseButton = autofillSaveItem == null && fido2CreationOptions == null,
-                shouldExitOnSave = autofillSaveItem != null || fido2CreationOptions != null,
+                shouldShowCloseButton = autofillSaveItem == null && fido2AttestationOptions == null,
+                shouldExitOnSave = autofillSaveItem != null || fido2AttestationOptions != null,
             )
         },
 ) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensions.kt
@@ -13,7 +13,7 @@ import java.util.UUID
  * [VaultAddEditState.ViewState.Content] during FIDO 2 credential creation.
  */
 fun Fido2CredentialRequest.toDefaultAddTypeContent(
-    creationOptions: PasskeyAttestationOptions?,
+    attestationOptions: PasskeyAttestationOptions?,
     isIndividualVaultDisabled: Boolean,
 ): VaultAddEditState.ViewState.Content {
 
@@ -23,12 +23,12 @@ fun Fido2CredentialRequest.toDefaultAddTypeContent(
         ?: packageName
             .toAndroidAppUriString()
 
-    val rpName = creationOptions
+    val rpName = attestationOptions
         ?.relyingParty
         ?.name
         .orEmpty()
 
-    val username = creationOptions
+    val username = attestationOptions
         ?.user
         ?.name
         .orEmpty()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensions.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.platform.util.toUriOrNull
 import com.x8bit.bitwarden.ui.platform.base.util.toAndroidAppUriString
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
@@ -13,7 +13,7 @@ import java.util.UUID
  * [VaultAddEditState.ViewState.Content] during FIDO 2 credential creation.
  */
 fun Fido2CredentialRequest.toDefaultAddTypeContent(
-    creationOptions: PublicKeyCredentialCreationOptions?,
+    creationOptions: PasskeyAttestationOptions?,
     isIndividualVaultDisabled: Boolean,
 ): VaultAddEditState.ViewState.Content {
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -448,7 +448,7 @@ class VaultItemListingViewModel @Inject constructor(
         cipherView: CipherView,
     ) {
         val createOptions = fido2CredentialManager
-            .getPasskeyCreateOptionsOrNull(credentialRequest.requestJson)
+            .getPasskeyAttestationOptionsOrNull(credentialRequest.requestJson)
             ?: run {
                 showFido2ErrorDialog()
                 return

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -8,11 +8,11 @@ import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -447,7 +447,7 @@ class VaultItemListingViewModel @Inject constructor(
         credentialRequest: Fido2CredentialRequest,
         cipherView: CipherView,
     ) {
-        val createOptions = fido2CredentialManager
+        val attestationOptions = fido2CredentialManager
             .getPasskeyAttestationOptionsOrNull(credentialRequest.requestJson)
             ?: run {
                 showFido2ErrorDialog()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -453,7 +453,7 @@ class VaultItemListingViewModel @Inject constructor(
                 showFido2ErrorDialog()
                 return
             }
-        when (createOptions.authenticatorSelection.userVerification) {
+        when (attestationOptions.authenticatorSelection.userVerification) {
             UserVerificationRequirement.DISCOURAGED -> {
                 registerFido2CredentialToCipher(
                     request = credentialRequest,

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
@@ -21,7 +21,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.RegisterFido2CredentialRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPublicKeyAttestationResponse
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPublicKeyCredentialCreationOptions
+import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAttestationOptions
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -56,7 +56,7 @@ class Fido2CredentialManagerTest {
     private val json = mockk<Json> {
         every {
             decodeFromString<PasskeyAttestationOptions>(any())
-        } returns createMockPublicKeyCredentialCreationOptions(number = 1)
+        } returns createMockPasskeyAttestationOptions(number = 1)
     }
     private val mockPrivilegedCallingAppInfo = mockk<CallingAppInfo> {
         every { packageName } returns "com.x8bit.bitwarden"
@@ -269,8 +269,8 @@ class Fido2CredentialManagerTest {
     fun `getPasskeyCreateOptionsOrNull should return passkey options when deserialized`() =
         runTest {
             assertEquals(
-                createMockPublicKeyCredentialCreationOptions(number = 1),
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                createMockPasskeyAttestationOptions(number = 1),
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = "",
                 ),
             )
@@ -283,7 +283,7 @@ class Fido2CredentialManagerTest {
                 json.decodeFromString<PasskeyAttestationOptions>(any())
             } throws SerializationException()
             assertNull(
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = "",
                 ),
             )
@@ -296,7 +296,7 @@ class Fido2CredentialManagerTest {
             json.decodeFromString<PasskeyAttestationOptions>(any())
         } throws IllegalArgumentException()
 
-        assertNull(fido2CredentialManager.getPasskeyCreateOptionsOrNull(requestJson = ""))
+        assertNull(fido2CredentialManager.getPasskeyAttestationOptionsOrNull(requestJson = ""))
     }
 
     @Suppress("MaxLineLength")

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
@@ -266,7 +266,7 @@ class Fido2CredentialManagerTest {
         }
 
     @Test
-    fun `getPasskeyCreateOptionsOrNull should return passkey options when deserialized`() =
+    fun `getPasskeyAttestationOptionsOrNull should return passkey options when deserialized`() =
         runTest {
             assertEquals(
                 createMockPasskeyAttestationOptions(number = 1),

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
@@ -7,12 +7,12 @@ import androidx.credentials.provider.CallingAppInfo
 import com.bitwarden.fido.ClientData
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions
 import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2AttestationResponse
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
 import com.x8bit.bitwarden.data.platform.manager.AssetManager
 import com.x8bit.bitwarden.data.platform.util.asFailure
@@ -55,7 +55,7 @@ class Fido2CredentialManagerTest {
     }
     private val json = mockk<Json> {
         every {
-            decodeFromString<PublicKeyCredentialCreationOptions>(any())
+            decodeFromString<PasskeyAttestationOptions>(any())
         } returns createMockPublicKeyCredentialCreationOptions(number = 1)
     }
     private val mockPrivilegedCallingAppInfo = mockk<CallingAppInfo> {
@@ -184,7 +184,7 @@ class Fido2CredentialManagerTest {
     @Test
     fun `validateOrigin should return error when request cannot be decoded`() = runTest {
         every {
-            json.decodeFromString<PublicKeyCredentialCreationOptions>(any())
+            json.decodeFromString<PasskeyAttestationOptions>(any())
         } throws SerializationException()
 
         assertEquals(
@@ -197,7 +197,7 @@ class Fido2CredentialManagerTest {
     fun `validateOrigin should return error when request cannot be cast to object type`() =
         runTest {
             every {
-                json.decodeFromString<PublicKeyCredentialCreationOptions>(any())
+                json.decodeFromString<PasskeyAttestationOptions>(any())
             } throws IllegalArgumentException()
 
             assertEquals(
@@ -280,7 +280,7 @@ class Fido2CredentialManagerTest {
     fun `getPasskeyCreateOptionsOrNull should return null when deserialization fails`() =
         runTest {
             every {
-                json.decodeFromString<PublicKeyCredentialCreationOptions>(any())
+                json.decodeFromString<PasskeyAttestationOptions>(any())
             } throws SerializationException()
             assertNull(
                 fido2CredentialManager.getPasskeyCreateOptionsOrNull(
@@ -293,7 +293,7 @@ class Fido2CredentialManagerTest {
     @Test
     fun `getPasskeyCreateOptionsOrNull should return null when IllegalArgumentException is thrown`() {
         every {
-            json.decodeFromString<PublicKeyCredentialCreationOptions>(any())
+            json.decodeFromString<PasskeyAttestationOptions>(any())
         } throws IllegalArgumentException()
 
         assertNull(fido2CredentialManager.getPasskeyCreateOptionsOrNull(requestJson = ""))

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -748,7 +748,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = fido2CredentialRequest.requestJson,
                 )
-            } returns mockCreateOptions
+            } returns mockAttestationOptions
             every { authRepository.activeUserId } returns "mockUserId"
 
             turbineScope {
@@ -826,7 +826,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = fido2CredentialRequest.requestJson,
                 )
-            } returns mockCreateOptions
+            } returns mockAttestationOptions
             every { authRepository.activeUserId } returns mockUserId
 
             turbineScope {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -15,10 +15,10 @@ import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -732,7 +732,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val mockCreateResult = Fido2RegisterCredentialResult.Success(
                 registrationResponse = "mockRegistrationResponse",
             )
-            val mockCreateOptions = createMockPasskeyAttestationOptions(
+            val mockAttestationOptions = createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.REQUIRED,
             )
@@ -811,7 +811,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 ),
             )
             val mockCreateResult = Fido2RegisterCredentialResult.Success("mockResponse")
-            val mockCreateOptions = createMockPasskeyAttestationOptions(
+            val mockAttestationOptions = createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
             )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -54,7 +54,7 @@ import com.x8bit.bitwarden.ui.vault.feature.addedit.model.CustomFieldAction
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.CustomFieldType
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.toCustomField
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPublicKeyCredentialCreationOptions
+import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAttestationOptions
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.toDefaultAddTypeContent
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.toViewState
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
@@ -326,7 +326,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             fido2CredentialRequest = fido2CredentialRequest,
         )
         val fido2ContentState = fido2CredentialRequest.toDefaultAddTypeContent(
-            creationOptions = createMockPublicKeyCredentialCreationOptions(number = 1),
+            attestationOptions = createMockPasskeyAttestationOptions(number = 1),
             isIndividualVaultDisabled = false,
         )
         val vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN)
@@ -732,7 +732,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val mockCreateResult = Fido2RegisterCredentialResult.Success(
                 registrationResponse = "mockRegistrationResponse",
             )
-            val mockCreateOptions = createMockPublicKeyCredentialCreationOptions(
+            val mockCreateOptions = createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.REQUIRED,
             )
@@ -745,7 +745,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 )
             } returns mockCreateResult
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = fido2CredentialRequest.requestJson,
                 )
             } returns mockCreateOptions
@@ -811,7 +811,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 ),
             )
             val mockCreateResult = Fido2RegisterCredentialResult.Success("mockResponse")
-            val mockCreateOptions = createMockPublicKeyCredentialCreationOptions(
+            val mockCreateOptions = createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
             )
@@ -823,7 +823,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 )
             } returns mockCreateResult
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = fido2CredentialRequest.requestJson,
                 )
             } returns mockCreateOptions
@@ -904,7 +904,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             }
 
             verify(exactly = 0) {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(any())
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any())
             }
         }
 
@@ -927,7 +927,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 .copy(shouldExitOnSave = true)
 
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = fido2CredentialRequest.requestJson,
                 )
             } returns null
@@ -971,10 +971,10 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 .copy(shouldExitOnSave = true)
 
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = fido2CredentialRequest.requestJson,
                 )
-            } returns createMockPublicKeyCredentialCreationOptions(
+            } returns createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.PREFERRED,
             )
@@ -1017,10 +1017,10 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 .copy(shouldExitOnSave = true)
 
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = fido2CredentialRequest.requestJson,
                 )
-            } returns createMockPublicKeyCredentialCreationOptions(
+            } returns createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.REQUIRED,
             )
@@ -1062,10 +1062,10 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CredentialRequest = fido2CredentialRequest,
                 )
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
                     requestJson = fido2CredentialRequest.requestJson,
                 )
-            } returns createMockPublicKeyCredentialCreationOptions(
+            } returns createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = null,
             )
@@ -1545,8 +1545,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             } returns stateWithName.viewState
             every { fido2CredentialManager.isUserVerified } returns false
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(any())
-            } returns createMockPublicKeyCredentialCreationOptions(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any())
+            } returns createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.REQUIRED,
             )
@@ -1565,7 +1565,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
             coVerify {
                 fido2CredentialManager.isUserVerified
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(mockFidoRequest.requestJson)
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(mockFidoRequest.requestJson)
             }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensionsTest.kt
@@ -55,7 +55,7 @@ class Fido2CredentialRequestExtensionsTest {
                 origin = null,
             )
                 .toDefaultAddTypeContent(
-                    creationOptions = createMockPublicKeyCredentialCreationOptions(1),
+                    attestationOptions = createMockPasskeyAttestationOptions(1),
                     isIndividualVaultDisabled = false,
                 ),
         )
@@ -91,7 +91,7 @@ class Fido2CredentialRequestExtensionsTest {
                 origin = "www.test.com",
             )
                 .toDefaultAddTypeContent(
-                    creationOptions = createMockPublicKeyCredentialCreationOptions(number = 1),
+                    attestationOptions = createMockPasskeyAttestationOptions(number = 1),
                     isIndividualVaultDisabled = false,
                 ),
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PublicKeyCredentialCreationOptionsTestHelpers.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PublicKeyCredentialCreationOptionsTestHelpers.kt
@@ -1,37 +1,37 @@
 package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 
 /**
- * Returns a mock FIDO 2 [PublicKeyCredentialCreationOptions] object to simulate a credential
+ * Returns a mock FIDO 2 [PasskeyAttestationOptions] object to simulate a credential
  * creation request.
  */
 @Suppress("MaxLineLength")
 fun createMockPublicKeyCredentialCreationOptions(
     number: Int,
-    userVerificationRequirement: PublicKeyCredentialCreationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement? = null,
-) = PublicKeyCredentialCreationOptions(
-    authenticatorSelection = PublicKeyCredentialCreationOptions
+    userVerificationRequirement: PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement? = null,
+) = PasskeyAttestationOptions(
+    authenticatorSelection = PasskeyAttestationOptions
         .AuthenticatorSelectionCriteria(userVerification = userVerificationRequirement),
     challenge = "mockPublicKeyCredentialCreationOptionsChallenge-$number",
     excludeCredentials = listOf(
-        PublicKeyCredentialCreationOptions.PublicKeyCredentialDescriptor(
+        PasskeyAttestationOptions.PublicKeyCredentialDescriptor(
             type = "mockPublicKeyCredentialDescriptorType-$number",
             id = "mockPublicKeyCredentialDescriptorId-$number",
             transports = listOf("mockPublicKeyCredentialDescriptorTransports-$number"),
         ),
     ),
     pubKeyCredParams = listOf(
-        PublicKeyCredentialCreationOptions.PublicKeyCredentialParameters(
+        PasskeyAttestationOptions.PublicKeyCredentialParameters(
             type = "PublicKeyCredentialParametersType-$number",
             alg = number.toLong(),
         ),
     ),
-    relyingParty = PublicKeyCredentialCreationOptions.PublicKeyCredentialRpEntity(
+    relyingParty = PasskeyAttestationOptions.PublicKeyCredentialRpEntity(
         name = "mockPublicKeyCredentialRpEntityName-$number",
         id = "mockPublicKeyCredentialRpEntity-$number",
     ),
-    user = PublicKeyCredentialCreationOptions.PublicKeyCredentialUserEntity(
+    user = PasskeyAttestationOptions.PublicKeyCredentialUserEntity(
         name = "mockPublicKeyCredentialUserEntityName-$number",
         id = "mockPublicKeyCredentialUserEntityId-$number",
         displayName = "mockPublicKeyCredentialUserEntityDisplayName-$number",

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PublicKeyCredentialCreationOptionsTestHelpers.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PublicKeyCredentialCreationOptionsTestHelpers.kt
@@ -7,7 +7,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
  * creation request.
  */
 @Suppress("MaxLineLength")
-fun createMockPublicKeyCredentialCreationOptions(
+fun createMockPasskeyAttestationOptions(
     number: Int,
     userVerificationRequirement: PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement? = null,
 ) = PasskeyAttestationOptions(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -51,7 +51,7 @@ import com.x8bit.bitwarden.ui.platform.base.util.concat
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPublicKeyCredentialCreationOptions
+import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAttestationOptions
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.util.createMockDisplayItemForCipher
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
@@ -380,7 +380,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 sendViewList = emptyList(),
             ),
         )
-        every { fido2CredentialManager.getPasskeyCreateOptionsOrNull(any()) } returns null
+        every { fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any()) } returns null
 
         val viewModel = createVaultItemListingViewModel()
         viewModel.trySendAction(VaultItemListingsAction.ItemClick(cipherView.id.orEmpty()))
@@ -416,8 +416,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(any())
-            } returns createMockPublicKeyCredentialCreationOptions(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any())
+            } returns createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.REQUIRED,
             )
@@ -459,8 +459,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(any())
-            } returns createMockPublicKeyCredentialCreationOptions(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any())
+            } returns createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.REQUIRED,
             )
@@ -513,8 +513,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(any())
-            } returns createMockPublicKeyCredentialCreationOptions(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any())
+            } returns createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
             )
@@ -556,8 +556,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             ),
         )
         every {
-            fido2CredentialManager.getPasskeyCreateOptionsOrNull(any())
-        } returns createMockPublicKeyCredentialCreationOptions(
+            fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any())
+        } returns createMockPasskeyAttestationOptions(
             number = 1,
             userVerificationRequirement = UserVerificationRequirement.REQUIRED,
         )
@@ -2371,8 +2371,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             every {
-                fido2CredentialManager.getPasskeyCreateOptionsOrNull(any())
-            } returns createMockPublicKeyCredentialCreationOptions(
+                fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any())
+            } returns createMockPasskeyAttestationOptions(
                 number = 1,
                 userVerificationRequirement = UserVerificationRequirement.REQUIRED,
             )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -10,11 +10,11 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.PublicKeyCredentialCreationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Rename PublicKeyCredentialCreationOptions to PasskeyAttestationOptions. Relocated it to the data model package since it is not a network model.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
