### PR TITLE
BIT-877: Mockk update fixed a disabled test

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceTest.kt
@@ -21,7 +21,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class AuthSdkSourceTest {
@@ -192,9 +191,6 @@ class AuthSdkSourceTest {
             }
         }
 
-    // TODO: This test is disabled due to issue here with mocking UByte (BIT-877).
-    //  See: https://github.com/mockk/mockk/issues/544
-    @Disabled
     @Test
     fun `passwordStrength should call SDK and return a Result with the correct data`() =
         runBlocking {


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-877](https://livefront.atlassian.net/browse/BIT-877)

## 📔 Objective

This PR re-enables a test that was blocked by a bug in Mockk. This bug has been resolved in the latest version and the test now works properly.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
