### PR TITLE
[PM-10024] Force focus on Master Password or Pin input field.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -196,6 +196,7 @@ fun VaultUnlockScreen(
                             .testTag(state.vaultUnlockType.unlockScreenInputTestTag)
                             .padding(horizontal = 16.dp)
                             .fillMaxWidth(),
+                        autoFocus = state.showKeyboard,
                     )
                     Spacer(modifier = Modifier.height(24.dp))
                     Text(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -355,6 +355,11 @@ data class VaultUnlockState(
     val showBiometricLogin: Boolean get() = isBiometricEnabled && isBiometricsValid
 
     /**
+     * Indicates if we want force focus on Master Password \ PIN input field and show keyboard.
+     */
+    val showKeyboard: Boolean get() = !showBiometricLogin && !hideInput
+
+    /**
      * Represents the various dialogs the vault unlock screen can display.
      */
     sealed class VaultUnlockDialog : Parcelable {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.auth.feature.vaultunlock
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
@@ -415,6 +416,15 @@ class VaultUnlockScreenTest : BaseComposeTest() {
             .performScrollTo()
             .performClick()
         verify { viewModel.trySendAction(VaultUnlockAction.UnlockClick) }
+    }
+
+    @Test
+    fun `state with input and without biometrics should request focus on input field`() {
+        mutableStateFlow.update { it.copy(hideInput = false, isBiometricEnabled = false) }
+        composeTestRule
+            .onNodeWithText("Master password")
+            .performScrollTo()
+            .assertIsFocused()
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

[issues/3383](https://github.com/bitwarden/android/issues/3383)

## 📔 Objective

Request autofocus on input field to show keyboard on Unlock Vault screen if biometric unlock is disabled or unavailable.
Also extent input field to support keyboard actions and and bind Unlick action to keyboard Done event too.
Add tests to cover cases with empty PIN\Password and ingnore Unlock action  and focus related tests too.

## Screenshots \ Video

![demo_password](https://github.com/user-attachments/assets/7d1b7a1a-263e-4915-82fe-87f615a35d60)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
