### PR TITLE
PM-9937 an existing email should be able to add account from a different hosted instance.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -42,21 +42,26 @@ class LandingViewModel @Inject constructor(
             isContinueButtonEnabled = authRepository.rememberedEmailAddress != null,
             isRememberMeEnabled = authRepository.rememberedEmailAddress != null,
             selectedEnvironmentType = environmentRepository.environment.type,
+            selectedEnvironmentLabel = environmentRepository.environment.label,
             dialog = null,
             accountSummaries = authRepository.userStateFlow.value?.toAccountSummaries().orEmpty(),
         ),
 ) {
 
     /**
-     * Returns the [AccountSummary] from the current state that matches the current email input,
-     * of `null` if there is no match.
+     * Returns the [AccountSummary] from the current state that matches the current email input and
+     * the the current environment, or `null` if there is no match.
      */
     private val matchingAccountSummary: AccountSummary?
         get() {
             val currentEmail = state.emailInput
+            val currentEnvironmentLabel = state.selectedEnvironmentLabel
             val accountSummaries = state.accountSummaries
             return accountSummaries
-                .find { it.email == currentEmail }
+                .find {
+                    it.email == currentEmail &&
+                        it.environmentLabel == currentEnvironmentLabel
+                }
                 ?.takeUnless { !it.isLoggedIn }
         }
 
@@ -221,6 +226,7 @@ class LandingViewModel @Inject constructor(
         mutableStateFlow.update {
             it.copy(
                 selectedEnvironmentType = action.environment.type,
+                selectedEnvironmentLabel = action.environment.label,
             )
         }
     }
@@ -248,6 +254,7 @@ data class LandingState(
     val isContinueButtonEnabled: Boolean,
     val isRememberMeEnabled: Boolean,
     val selectedEnvironmentType: Environment.Type,
+    val selectedEnvironmentLabel: String,
     val dialog: DialogState?,
     val accountSummaries: List<AccountSummary>,
 ) : Parcelable {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
@@ -473,6 +473,7 @@ private val DEFAULT_STATE = LandingState(
     isContinueButtonEnabled = true,
     isRememberMeEnabled = false,
     selectedEnvironmentType = Environment.Type.US,
+    selectedEnvironmentLabel = Environment.Us.label,
     dialog = null,
     accountSummaries = emptyList(),
 )


### PR DESCRIPTION

## 🎟️ Tracking

[PM-9937](https://bitwarden.atlassian.net/browse/PM-9937)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

If a user is trying to use the same email to sign in or create account using an existing email tied to another account but on a different host instance they should be able to.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/10132144-319a-4897-8080-b3c387e0e30d



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9937]: https://bitwarden.atlassian.net/browse/PM-9937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ