### PR TITLE
Extract FIDO 2 user verification enum

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/PasskeyAssertionOptions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/PasskeyAssertionOptions.kt
@@ -2,14 +2,19 @@ package com.x8bit.bitwarden.data.autofill.fido2.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
 /**
  * Models the request options for a passkey request, based off the spec found at:
  * https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options
  */
 @Serializable
 data class PasskeyAssertionOptions(
-    @SerialName("challenge") val challenge: String,
-    @SerialName("allowCredentials") val allowCredentials: List<PublicKeyCredentialDescriptor>?,
-    @SerialName("rpId") val relyingPartyId: String?,
-    @SerialName("userVerification") val userVerification: String?,
+    @SerialName("challenge")
+    val challenge: String,
+    @SerialName("allowCredentials")
+    val allowCredentials: List<PublicKeyCredentialDescriptor>?,
+    @SerialName("rpId")
+    val relyingPartyId: String?,
+    @SerialName("userVerification")
+    val userVerification: UserVerificationRequirement?,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/PasskeyAttestationOptions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/PasskeyAttestationOptions.kt
@@ -63,31 +63,6 @@ data class PasskeyAttestationOptions(
             @SerialName("required")
             REQUIRED,
         }
-
-        /**
-         * Enum class indicating the type of user verification requested by the relying party.
-         */
-        @Serializable
-        enum class UserVerificationRequirement {
-            /**
-             * User verification should not be performed.
-             */
-            @SerialName("discouraged")
-            DISCOURAGED,
-
-            /**
-             * User verification is preferred, if supported by the device or application.
-             */
-            @SerialName("preferred")
-            PREFERRED,
-
-            /**
-             * User verification is required. If is cannot be performed the registration process
-             * should be terminated.
-             */
-            @SerialName("required")
-            REQUIRED,
-        }
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/UserVerificationRequirement.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/UserVerificationRequirement.kt
@@ -1,0 +1,29 @@
+package com.x8bit.bitwarden.data.autofill.fido2.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Enum class indicating the type of user verification requested by the relying party.
+ */
+@Serializable
+enum class UserVerificationRequirement {
+    /**
+     * User verification should not be performed.
+     */
+    @SerialName("discouraged")
+    DISCOURAGED,
+
+    /**
+     * User verification is preferred, if supported by the device or application.
+     */
+    @SerialName("preferred")
+    PREFERRED,
+
+    /**
+     * User verification is required. If is cannot be performed the registration process
+     * should be terminated.
+     */
+    @SerialName("required")
+    REQUIRED,
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -11,7 +11,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
+import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -13,7 +13,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
+import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -18,7 +18,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
+import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PasskeyAssertionOptionsTestHelpers.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PasskeyAssertionOptionsTestHelpers.kt
@@ -1,7 +1,8 @@
 package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
-import com.x8bit.bitwarden.data.autofill.fido2.model.PublicKeyCredentialDescriptor
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAssertionOptions
+import com.x8bit.bitwarden.data.autofill.fido2.model.PublicKeyCredentialDescriptor
+import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 
 /**
  * Returns a mock FIDO 2 [PasskeyAssertionOptions] object to simulate a credential
@@ -19,5 +20,5 @@ fun createMockPasskeyAssertionOptions(
         ),
     ),
     relyingPartyId = "mockRelyingPartyId-$number",
-    userVerification = "mockUserVerification-$number",
+    userVerification = UserVerificationRequirement.PREFERRED,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PasskeyAttestationOptionsTestHelpers.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PasskeyAttestationOptionsTestHelpers.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.PublicKeyCredentialDescriptor
+import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 
 /**
  * Returns a mock FIDO 2 [PasskeyAttestationOptions] object to simulate a credential
@@ -10,7 +11,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.PublicKeyCredentialDescript
 @Suppress("MaxLineLength")
 fun createMockPasskeyAttestationOptions(
     number: Int,
-    userVerificationRequirement: PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement? = null,
+    userVerificationRequirement: UserVerificationRequirement? = null,
 ) = PasskeyAttestationOptions(
     authenticatorSelection = PasskeyAttestationOptions
         .AuthenticatorSelectionCriteria(userVerification = userVerificationRequirement),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -14,7 +14,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions.AuthenticatorSelectionCriteria.UserVerificationRequirement
+import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

Reduce code duplication by extracting the FIDO 2 user verification constants to their own enum class since it is common across multiple FIDO 2 objects.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
