### PR TITLE
[PM-9409] Complete FIDO 2 assertion with appropriate response

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionResult.kt
@@ -1,0 +1,22 @@
+package com.x8bit.bitwarden.data.autofill.fido2.model
+
+/**
+ * Represents possible outcomes of a FIDO 2 credential assertion request.
+ */
+sealed class Fido2CredentialAssertionResult {
+
+    /**
+     * Indicates the assertion request completed and [responseJson] was successfully generated.
+     */
+    data class Success(val responseJson: String) : Fido2CredentialAssertionResult()
+
+    /**
+     * Indicates there was an error and the assertion was not successful.
+     */
+    data object Error : Fido2CredentialAssertionResult()
+
+    /**
+     * Indicates assertion was cancelled by the user.
+     */
+    data object Cancelled : Fido2CredentialAssertionResult()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManager.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.autofill.fido2.manager
 
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 
 /**
@@ -11,4 +12,9 @@ interface Fido2CompletionManager {
      * Completes the FIDO 2 registration process with the provided [result].
      */
     fun completeFido2Registration(result: Fido2RegisterCredentialResult)
+
+    /**
+     * Complete the FIDO 2 credential assertion process with the provided [result].
+     */
+    fun completeFido2Assertion(result: Fido2CredentialAssertionResult)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerUnsupportedApiImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerUnsupportedApiImpl.kt
@@ -2,13 +2,11 @@ package com.x8bit.bitwarden.ui.autofill.fido2.manager
 
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
-import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 
 /**
  * A no-op implementation of [Fido2CompletionManagerImpl] provided when the build version is below
  * UPSIDE_DOWN_CAKE (34). These versions do not support [androidx.credentials.CredentialProvider].
  */
-@OmitFromCoverage
 object Fido2CompletionManagerUnsupportedApiImpl : Fido2CompletionManager {
     override fun completeFido2Registration(result: Fido2RegisterCredentialResult) {
         // no-op

--- a/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerUnsupportedApiImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerUnsupportedApiImpl.kt
@@ -8,11 +8,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResu
  * UPSIDE_DOWN_CAKE (34). These versions do not support [androidx.credentials.CredentialProvider].
  */
 object Fido2CompletionManagerUnsupportedApiImpl : Fido2CompletionManager {
-    override fun completeFido2Registration(result: Fido2RegisterCredentialResult) {
-        // no-op
-    }
+    override fun completeFido2Registration(result: Fido2RegisterCredentialResult) = Unit
 
-    override fun completeFido2Assertion(result: Fido2CredentialAssertionResult) {
-        // no-op
-    }
+    override fun completeFido2Assertion(result: Fido2CredentialAssertionResult) = Unit
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerUnsupportedApiImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerUnsupportedApiImpl.kt
@@ -1,0 +1,20 @@
+package com.x8bit.bitwarden.ui.autofill.fido2.manager
+
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
+import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
+
+/**
+ * A no-op implementation of [Fido2CompletionManagerImpl] provided when the build version is below
+ * UPSIDE_DOWN_CAKE (34). These versions do not support [androidx.credentials.CredentialProvider].
+ */
+@OmitFromCoverage
+object Fido2CompletionManagerUnsupportedApiImpl : Fido2CompletionManager {
+    override fun completeFido2Registration(result: Fido2RegisterCredentialResult) {
+        // no-op
+    }
+
+    override fun completeFido2Assertion(result: Fido2CredentialAssertionResult) {
+        // no-op
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerTest.kt
@@ -38,14 +38,17 @@ class Fido2CompletionManagerTest {
         }
 
         @Test
-        fun `all functions are no-op`() {
+        fun `completeFido2Registration should perform no operations`() {
             val mockRegistrationResult = mockk<Fido2RegisterCredentialResult>()
             fido2CompletionManager.completeFido2Registration(mockRegistrationResult)
             verify {
                 mockRegistrationResult wasNot Called
                 mockActivity wasNot Called
             }
+        }
 
+        @Test
+        fun `completeFido2Assertion should perform no operations`() {
             val mockAssertionResult = mockk<Fido2CredentialAssertionResult>()
             fido2CompletionManager.completeFido2Assertion(mockAssertionResult)
             verify {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerTest.kt
@@ -146,8 +146,8 @@ class Fido2CompletionManagerTest {
 
         /**
          * Convenience function to ensure the given [calls] are performed before setting the
-         * [mockActivity] result and calling finish. This sequence is expected to be performed for all
-         * FIDO 2 operations triggered by [androidx.credentials.CredentialProvider] APIs.
+         * [mockActivity] result and calling finish. This sequence is expected to be performed for
+         * all FIDO 2 operations triggered by [androidx.credentials.CredentialProvider] APIs.
          */
         private fun verifyActivityResultIsSetAndFinishedAfter(
             calls: MockKVerificationScope.() -> Unit,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/Fido2CompletionManagerTest.kt
@@ -1,0 +1,130 @@
+package com.x8bit.bitwarden.ui.autofill.fido2.manager
+
+import android.app.Activity
+import android.content.Intent
+import androidx.credentials.provider.PendingIntentHandler
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
+import io.mockk.MockKVerificationScope
+import io.mockk.Ordering
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class Fido2CompletionManagerTest {
+
+    private val mockActivity = mockk<Activity> {
+        every { setResult(Activity.RESULT_OK, any()) } just runs
+        every { finish() } just runs
+    }
+    private val fido2CompletionManager = Fido2CompletionManagerImpl(mockActivity)
+
+    @BeforeEach
+    fun setUp() {
+        mockkConstructor(Intent::class)
+        mockkObject(PendingIntentHandler.Companion)
+        every {
+            PendingIntentHandler.setCreateCredentialException(any(), any())
+        } just runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkConstructor(Intent::class)
+        unmockkObject(PendingIntentHandler.Companion)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `completeFido2Registration should set CreateCredentialResponse, set activity result, then finish activity when result is Success`() {
+        fido2CompletionManager
+            .completeFido2Registration(
+                Fido2RegisterCredentialResult.Success(
+                    registrationResponse = "registrationResponse",
+                ),
+            )
+
+        verifyActivityResultIsSetAndFinishedAfter {
+            PendingIntentHandler.setCreateCredentialResponse(any(), any())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `completeFido2Registration should set CreateCredentialException, set activity result, then finish activity when result is Error`() {
+        fido2CompletionManager
+            .completeFido2Registration(Fido2RegisterCredentialResult.Error)
+
+        verifyActivityResultIsSetAndFinishedAfter {
+            PendingIntentHandler.setCreateCredentialException(any(), any())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `completeFido2Registration should set CreateCredentialException, set activity result, then finish activity when result is Canclled`() {
+        fido2CompletionManager
+            .completeFido2Registration(Fido2RegisterCredentialResult.Cancelled)
+
+        verifyActivityResultIsSetAndFinishedAfter {
+            PendingIntentHandler.setCreateCredentialException(any(), any())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `completeFido2Assertion should set GetCredentialResponse, set activity result, then finish activity when result is Success`() {
+        fido2CompletionManager
+            .completeFido2Assertion(Fido2CredentialAssertionResult.Success("responseJson"))
+
+        verifyActivityResultIsSetAndFinishedAfter {
+            PendingIntentHandler.setGetCredentialResponse(any(), any())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `completeFido2Assertion should set GetCredentialException, set activity result, then finish activity when result is Error`() {
+        fido2CompletionManager
+            .completeFido2Assertion(Fido2CredentialAssertionResult.Error)
+
+        verifyActivityResultIsSetAndFinishedAfter {
+            PendingIntentHandler.setGetCredentialException(any(), any())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `completeFido2Assertion should set cancellation exception, set activity result, then finish activity when result is Cancelled`() {
+        fido2CompletionManager
+            .completeFido2Assertion(Fido2CredentialAssertionResult.Cancelled)
+
+        verifyActivityResultIsSetAndFinishedAfter {
+            PendingIntentHandler.setGetCredentialException(any(), any())
+        }
+    }
+
+    /**
+     * Convenience function to ensure the given [calls] are performed before setting the
+     * [mockActivity] result and calling finish. This sequence is expected to be performed for all
+     * FIDO 2 operations triggered by [androidx.credentials.CredentialProvider] APIs.
+     */
+    private fun verifyActivityResultIsSetAndFinishedAfter(
+        calls: MockKVerificationScope.() -> Unit,
+    ) {
+        verify(Ordering.SEQUENCE) {
+            calls()
+            mockActivity.setResult(Activity.RESULT_OK, any())
+            mockActivity.finish()
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-9409

## 📔 Objective

Update Fido2CompletionManager to handle FIDO 2 assertion results and respond to the system based on the assertion result.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
