### PR TITLE
PM-9135: Update host matching to include optional port value

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ciphermatching/CipherMatchingManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ciphermatching/CipherMatchingManagerImpl.kt
@@ -7,7 +7,7 @@ import com.bitwarden.vault.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.util.firstWithTimeoutOrNull
 import com.x8bit.bitwarden.data.platform.util.getDomainOrNull
-import com.x8bit.bitwarden.data.platform.util.getHostOrNull
+import com.x8bit.bitwarden.data.platform.util.getHostWithPortOrNull
 import com.x8bit.bitwarden.data.platform.util.getWebHostFromAndroidUriOrNull
 import com.x8bit.bitwarden.data.platform.util.isAndroidApp
 import com.x8bit.bitwarden.data.platform.util.regexOrNull
@@ -210,8 +210,8 @@ private fun LoginUriView.checkForMatch(
             UriMatchType.EXACT -> exactIfTrue(loginViewUri == matchUri)
 
             UriMatchType.HOST -> {
-                val loginUriHost = loginViewUri.getHostOrNull()
-                val matchUriHost = matchUri.getHostOrNull()
+                val loginUriHost = loginViewUri.getHostWithPortOrNull()
+                val matchUriHost = matchUri.getHostWithPortOrNull()
                 exactIfTrue(matchUriHost != null && loginUriHost == matchUriHost)
             }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
@@ -53,10 +53,20 @@ fun String.getDomainOrNull(context: Context): String? =
         ?.parseDomainOrNull(context = context)
 
 /**
- * Extract the host from this [String] if possible, otherwise return null.
+ * Extract the host with optional port from this [String] if possible, otherwise return null.
  */
 @OmitFromCoverage
-fun String.getHostOrNull(): String? = this.toUriOrNull()?.host
+fun String.getHostWithPortOrNull(): String? {
+    val uri = this.toUriOrNull() ?: return null
+    return uri.host?.let { host ->
+        val port = uri.port
+        if (port != -1) {
+            "$host:$port"
+        } else {
+            host
+        }
+    }
+}
 
 /**
  * Find the indices of the last occurrences of [substring] within this [String]. Return null if no

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/ciphermatching/CipherMatchingManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/ciphermatching/CipherMatchingManagerTest.kt
@@ -8,7 +8,7 @@ import com.bitwarden.vault.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.DataState
 import com.x8bit.bitwarden.data.platform.util.getDomainOrNull
-import com.x8bit.bitwarden.data.platform.util.getHostOrNull
+import com.x8bit.bitwarden.data.platform.util.getHostWithPortOrNull
 import com.x8bit.bitwarden.data.platform.util.getWebHostFromAndroidUriOrNull
 import com.x8bit.bitwarden.data.platform.util.isAndroidApp
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
@@ -357,7 +357,7 @@ class CipherMatchingManagerTest {
         with(uri) {
             every { isAndroidApp() } returns isAndroidApp
             every { getDomainOrNull(context = context) } returns this.takeIf { isAndroidApp }
-            every { getHostOrNull() } returns HOST
+            every { getHostWithPortOrNull() } returns HOST_WITH_PORT
             every {
                 getWebHostFromAndroidUriOrNull()
             } returns ANDROID_APP_WEB_URL.takeIf { isAndroidApp }
@@ -378,8 +378,8 @@ class CipherMatchingManagerTest {
             DEFAULT_LOGIN_VIEW_URI_FIVE.getDomainOrNull(context = context)
         } returns null
 
-        every { HOST_LOGIN_VIEW_URI_MATCHING.getHostOrNull() } returns HOST
-        every { HOST_LOGIN_VIEW_URI_NOT_MATCHING.getHostOrNull() } returns null
+        every { HOST_LOGIN_VIEW_URI_MATCHING.getHostWithPortOrNull() } returns HOST_WITH_PORT
+        every { HOST_LOGIN_VIEW_URI_NOT_MATCHING.getHostWithPortOrNull() } returns null
     }
 }
 
@@ -415,4 +415,4 @@ private const val DEFAULT_LOGIN_VIEW_URI_FIVE: String = "DEFAULT_LOGIN_VIEW_URI_
 // Setup state for host ciphers
 private const val HOST_LOGIN_VIEW_URI_MATCHING: String = "DEFAULT_LOGIN_VIEW_URI_MATCHING"
 private const val HOST_LOGIN_VIEW_URI_NOT_MATCHING: String = "DEFAULT_LOGIN_VIEW_URI_NOT_MATCHING"
-private const val HOST: String = "HOST"
+private const val HOST_WITH_PORT: String = "HOST_WITH_PORT"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9135](https://bitwarden.atlassian.net/browse/PM-9135)
https://github.com/bitwarden/android/issues/3341

## 📔 Objective

This PR adds back port matching to the Host matching logic, the main difference between this implementation and the original is that the port is now an optional property instead of a required property.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9135]: https://bitwarden.atlassian.net/browse/PM-9135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ