### PR TITLE
[PM-10058] Non-remembered device TDE issue in same session

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManager.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.auth.manager
 
-import com.x8bit.bitwarden.data.auth.manager.model.LogoutResult
+import com.x8bit.bitwarden.data.auth.manager.model.LogoutEvent
 import kotlinx.coroutines.flow.SharedFlow
 
 /**
@@ -9,9 +9,9 @@ import kotlinx.coroutines.flow.SharedFlow
 interface UserLogoutManager {
 
     /**
-     * Observable flow of [LogoutResult]s
+     * Observable flow of [LogoutEvent]s
      */
-    val logoutResultFlow: SharedFlow<LogoutResult>
+    val logoutEventFlow: SharedFlow<LogoutEvent>
 
     /**
      * Completely logs out the given [userId], removing all data.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManager.kt
@@ -1,9 +1,18 @@
 package com.x8bit.bitwarden.data.auth.manager
 
+import com.x8bit.bitwarden.data.auth.manager.model.LogoutResult
+import kotlinx.coroutines.flow.SharedFlow
+
 /**
  * Manages the logging out of users and clearing of their data.
  */
 interface UserLogoutManager {
+
+    /**
+     * Observable flow of [LogoutResult]s
+     */
+    val logoutResultFlow: SharedFlow<LogoutResult>
+
     /**
      * Completely logs out the given [userId], removing all data.
      * If [isExpired] is true, a toast will be displayed

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -5,14 +5,19 @@ import android.widget.Toast
 import androidx.annotation.StringRes
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.manager.model.LogoutResult
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
+import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.GeneratorDiskSource
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.PasswordHistoryDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -33,6 +38,10 @@ class UserLogoutManagerImpl(
     private val scope = CoroutineScope(dispatcherManager.unconfined)
     private val mainScope = CoroutineScope(dispatcherManager.main)
 
+    private val mutableLogoutResultFlow: MutableSharedFlow<LogoutResult> =
+        bufferedMutableSharedFlow()
+    override val logoutResultFlow: SharedFlow<LogoutResult> = mutableLogoutResultFlow.asSharedFlow()
+
     override fun logout(userId: String, isExpired: Boolean) {
         authDiskSource.userState ?: return
 
@@ -52,6 +61,7 @@ class UserLogoutManagerImpl(
         }
 
         clearData(userId = userId)
+        mutableLogoutResultFlow.tryEmit(LogoutResult(loggedOutUserId = userId))
     }
 
     override fun softLogout(userId: String) {
@@ -67,6 +77,7 @@ class UserLogoutManagerImpl(
         switchUserIfAvailable(currentUserId = userId, removeCurrentUserFromAccounts = false)
 
         clearData(userId = userId)
+        mutableLogoutResultFlow.tryEmit(LogoutResult(loggedOutUserId = userId))
 
         // Restore data that is still required
         settingsDiskSource.apply {

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -5,7 +5,7 @@ import android.widget.Toast
 import androidx.annotation.StringRes
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
-import com.x8bit.bitwarden.data.auth.manager.model.LogoutResult
+import com.x8bit.bitwarden.data.auth.manager.model.LogoutEvent
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
@@ -38,9 +38,9 @@ class UserLogoutManagerImpl(
     private val scope = CoroutineScope(dispatcherManager.unconfined)
     private val mainScope = CoroutineScope(dispatcherManager.main)
 
-    private val mutableLogoutResultFlow: MutableSharedFlow<LogoutResult> =
+    private val mutableLogoutEventFlow: MutableSharedFlow<LogoutEvent> =
         bufferedMutableSharedFlow()
-    override val logoutResultFlow: SharedFlow<LogoutResult> = mutableLogoutResultFlow.asSharedFlow()
+    override val logoutEventFlow: SharedFlow<LogoutEvent> = mutableLogoutEventFlow.asSharedFlow()
 
     override fun logout(userId: String, isExpired: Boolean) {
         authDiskSource.userState ?: return
@@ -61,7 +61,7 @@ class UserLogoutManagerImpl(
         }
 
         clearData(userId = userId)
-        mutableLogoutResultFlow.tryEmit(LogoutResult(loggedOutUserId = userId))
+        mutableLogoutEventFlow.tryEmit(LogoutEvent(loggedOutUserId = userId))
     }
 
     override fun softLogout(userId: String) {
@@ -77,7 +77,7 @@ class UserLogoutManagerImpl(
         switchUserIfAvailable(currentUserId = userId, removeCurrentUserFromAccounts = false)
 
         clearData(userId = userId)
-        mutableLogoutResultFlow.tryEmit(LogoutResult(loggedOutUserId = userId))
+        mutableLogoutEventFlow.tryEmit(LogoutEvent(loggedOutUserId = userId))
 
         // Restore data that is still required
         settingsDiskSource.apply {

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/LogoutEvent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/LogoutEvent.kt
@@ -4,6 +4,6 @@ package com.x8bit.bitwarden.data.auth.manager.model
  * Result class to share the [loggedOutUserId] of a user
  * that was successfully logged out.
  */
-data class LogoutResult(
+data class LogoutEvent(
     val loggedOutUserId: String,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/LogoutResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/LogoutResult.kt
@@ -1,0 +1,9 @@
+package com.x8bit.bitwarden.data.auth.manager.model
+
+/**
+ * Result class to share the [loggedOutUserId] of a user
+ * that was successfully logged out.
+ */
+data class LogoutResult(
+    val loggedOutUserId: String,
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -373,7 +373,7 @@ class VaultLockManagerImpl(
 
     private fun observeUserLogoutResults() {
         userLogoutManager
-            .logoutResultFlow
+            .logoutEventFlow
             .onEach {
                 setVaultToLocked(it.loggedOutUserId)
             }

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -12,7 +12,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
-import com.x8bit.bitwarden.data.auth.manager.model.LogoutResult
+import com.x8bit.bitwarden.data.auth.manager.model.LogoutEvent
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.manager.model.AppForegroundState
@@ -68,11 +68,11 @@ class VaultLockManagerTest {
         every { clearCrypto(userId = any()) } just runs
     }
 
-    private val mutableLogoutResultFlow = MutableSharedFlow<LogoutResult>()
+    private val mutableLogoutResultFlow = MutableSharedFlow<LogoutEvent>()
     private val userLogoutManager: UserLogoutManager = mockk {
         every { logout(any()) } just runs
         every { softLogout(any()) } just runs
-        every { logoutResultFlow } returns mutableLogoutResultFlow.asSharedFlow()
+        every { logoutEventFlow } returns mutableLogoutResultFlow.asSharedFlow()
     }
     private val trustedDeviceManager: TrustedDeviceManager = mockk()
     private val mutableVaultTimeoutStateFlow =
@@ -1372,7 +1372,7 @@ class VaultLockManagerTest {
         verifyUnlockedVault(USER_ID)
 
         vaultLockManager.vaultStateEventFlow.test {
-            mutableLogoutResultFlow.emit(LogoutResult(loggedOutUserId = USER_ID))
+            mutableLogoutResultFlow.emit(LogoutEvent(loggedOutUserId = USER_ID))
             assertEquals(VaultStateEvent.Locked(userId = USER_ID), awaitItem())
             assertFalse(vaultLockManager.isVaultUnlocked(USER_ID))
         }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-10058
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

If a user, using SSO TDE  logouts out and attempts to log back in during an active app session (app has not been destroyed) they will get stuck in a state where they are unable to fully authenticate with Admin approval or other device. 

The root cause found was in debugging
```
val updatedRootNavState = when {
            userState?.activeAccount?.trustedDevice?.isDeviceTrusted == false &&
                !userState.activeAccount.isVaultUnlocked &&
                !userState.activeAccount.hasManualUnlockMechanism -> RootNavState.TrustedDevice
```
once the vault was unlocked for the user if it was never set to locked and they logged it, it would always return true.
                
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
