### PR TITLE
PM-8522: Vault tab bar title for organization users

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -88,6 +89,8 @@ fun VaultUnlockedNavBarScreen(
     onNavigateToPendingRequests: () -> Unit,
     onNavigateToPasswordHistory: () -> Unit,
 ) {
+    val state by viewModel.stateFlow.collectAsStateWithLifecycle()
+
     EventsEffect(viewModel = viewModel) { event ->
         navController.apply {
             val navOptions = vaultUnlockedNavBarScreenNavOptions()
@@ -120,6 +123,7 @@ fun VaultUnlockedNavBarScreen(
     }
 
     VaultUnlockedNavBarScaffold(
+        state = state,
         navController = navController,
         onNavigateToVaultItem = onNavigateToVaultItem,
         onNavigateToVaultEditItem = onNavigateToVaultEditItem,
@@ -155,6 +159,7 @@ fun VaultUnlockedNavBarScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Suppress("LongMethod")
 private fun VaultUnlockedNavBarScaffold(
+    state: VaultUnlockedNavBarState,
     navController: NavHostController,
     vaultTabClickedAction: () -> Unit,
     sendTabClickedAction: () -> Unit,
@@ -184,6 +189,7 @@ private fun VaultUnlockedNavBarScaffold(
             Box {
                 var appBarHeightPx by remember { mutableIntStateOf(0) }
                 VaultBottomAppBar(
+                    state = state,
                     navController = navController,
                     vaultTabClickedAction = vaultTabClickedAction,
                     sendTabClickedAction = sendTabClickedAction,
@@ -254,6 +260,7 @@ private fun VaultUnlockedNavBarScaffold(
 @Suppress("LongMethod")
 @Composable
 private fun VaultBottomAppBar(
+    state: VaultUnlockedNavBarState,
     navController: NavHostController,
     vaultTabClickedAction: () -> Unit,
     sendTabClickedAction: () -> Unit,
@@ -266,7 +273,10 @@ private fun VaultBottomAppBar(
         modifier = modifier,
     ) {
         val destinations = listOf(
-            VaultUnlockedNavBarTab.Vault,
+            VaultUnlockedNavBarTab.Vault(
+                labelRes = state.vaultNavBarLabelRes,
+                contentDescriptionRes = state.vaultNavBarContentDescriptionRes,
+            ),
             VaultUnlockedNavBarTab.Send,
             VaultUnlockedNavBarTab.Generator,
             VaultUnlockedNavBarTab.Settings,
@@ -303,7 +313,7 @@ private fun VaultBottomAppBar(
                 selected = isSelected,
                 onClick = {
                     when (destination) {
-                        VaultUnlockedNavBarTab.Vault -> vaultTabClickedAction()
+                        is VaultUnlockedNavBarTab.Vault -> vaultTabClickedAction()
                         VaultUnlockedNavBarTab.Send -> sendTabClickedAction()
                         VaultUnlockedNavBarTab.Generator -> generatorTabClickedAction()
                         VaultUnlockedNavBarTab.Settings -> settingsTabClickedAction()
@@ -396,11 +406,12 @@ private sealed class VaultUnlockedNavBarTab : Parcelable {
      * Show the Vault screen.
      */
     @Parcelize
-    data object Vault : VaultUnlockedNavBarTab() {
+    data class Vault(
+        override val labelRes: Int,
+        override val contentDescriptionRes: Int,
+    ) : VaultUnlockedNavBarTab() {
         override val iconResSelected get() = R.drawable.ic_vault_filled
         override val iconRes get() = R.drawable.ic_vault
-        override val labelRes get() = R.string.my_vault
-        override val contentDescriptionRes get() = R.string.my_vault
         override val route get() = VAULT_GRAPH_ROUTE
         override val testTag get() = "VaultTab"
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
@@ -1,5 +1,7 @@
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 
+import androidx.annotation.StringRes
+import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
@@ -14,8 +16,21 @@ import javax.inject.Inject
 class VaultUnlockedNavBarViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     specialCircumstancesManager: SpecialCircumstanceManager,
-) : BaseViewModel<Unit, VaultUnlockedNavBarEvent, VaultUnlockedNavBarAction>(
-    initialState = Unit,
+) : BaseViewModel<VaultUnlockedNavBarState, VaultUnlockedNavBarEvent, VaultUnlockedNavBarAction>(
+    initialState = run {
+        val hasOrganization = authRepository
+            .userStateFlow
+            .value
+            ?.activeAccount
+            ?.organizations
+            ?.isNotEmpty()
+            ?: false
+        val vaultRes = if (hasOrganization) R.string.vaults else R.string.my_vault
+        VaultUnlockedNavBarState(
+            vaultNavBarLabelRes = vaultRes,
+            vaultNavBarContentDescriptionRes = vaultRes,
+        )
+    },
 ) {
     init {
         when (specialCircumstancesManager.specialCircumstance) {
@@ -76,6 +91,14 @@ class VaultUnlockedNavBarViewModel @Inject constructor(
     }
     // #endregion BottomTabViewModel Action Handlers
 }
+
+/**
+ * Models state for the [VaultUnlockedNavBarViewModel].
+ */
+data class VaultUnlockedNavBarState(
+    @StringRes val vaultNavBarLabelRes: Int,
+    @StringRes val vaultNavBarContentDescriptionRes: Int,
+)
 
 /**
  * Models actions for the bottom tab of the vault unlocked portion of the app.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/model/VaultFilterType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/model/VaultFilterType.kt
@@ -31,7 +31,7 @@ sealed class VaultFilterType : Parcelable {
     }
 
     /**
-     * Only data from the user's personal vault shoudl be present.
+     * Only data from the user's personal vault should be present.
      */
     @Parcelize
     data object MyVault : VaultFilterType() {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.navigation.navOptions
+import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.FakeNavHostController
@@ -16,7 +17,7 @@ import org.junit.Test
 class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     private val fakeNavHostController = FakeNavHostController()
     private val mutableEventFlow = bufferedMutableSharedFlow<VaultUnlockedNavBarEvent>()
-    private val mutableStateFlow = MutableStateFlow(Unit)
+    private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
     val viewModel = mockk<VaultUnlockedNavBarViewModel>(relaxed = true) {
         every { eventFlow } returns mutableEventFlow
         every { stateFlow } returns mutableStateFlow
@@ -133,4 +134,25 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
             }
         }
     }
+
+    @Test
+    fun `vault nav bar should update according to state`() {
+        composeTestRule.onNodeWithText("My vault").assertExists()
+        composeTestRule.onNodeWithText("Vaults").assertDoesNotExist()
+
+        mutableStateFlow.tryEmit(
+            VaultUnlockedNavBarState(
+                vaultNavBarLabelRes = R.string.vaults,
+                vaultNavBarContentDescriptionRes = R.string.vaults,
+            ),
+        )
+
+        composeTestRule.onNodeWithText("My vault").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Vaults").assertExists()
+    }
 }
+
+private val DEFAULT_STATE = VaultUnlockedNavBarState(
+    vaultNavBarLabelRes = R.string.my_vault,
+    vaultNavBarContentDescriptionRes = R.string.my_vault,
+)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8522](https://bitwarden.atlassian.net/browse/PM-8522)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The label of the tab bar for the vault tab should be "My vault" when the user doesn't have organizations and "Vaults" when they do.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/188a6030-5062-4b0b-bc61-7b4ac8211d65" /> | <img src="https://github.com/user-attachments/assets/cc8804d7-be83-4b58-b0b7-0b29f9d3ffec" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8522]: https://bitwarden.atlassian.net/browse/PM-8522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ