### PR TITLE
PM-10066 don't prompt for MP if the user does not have one

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.vault.feature.itemlisting
 import android.widget.Toast
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -441,7 +442,8 @@ private fun VaultItemListingScaffold(
                 FloatingActionButton(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     onClick = vaultItemListingHandlers.addVaultItemClick,
-                    modifier = Modifier.testTag("AddItemButton"),
+                    modifier = Modifier.testTag("AddItemButton")
+                        .systemBarsPadding(),
                 ) {
                     Icon(
                         painter = rememberVectorPainter(id = R.drawable.ic_plus),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.vault.feature.itemlisting
 import android.widget.Toast
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -442,8 +441,7 @@ private fun VaultItemListingScaffold(
                 FloatingActionButton(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     onClick = vaultItemListingHandlers.addVaultItemClick,
-                    modifier = Modifier.testTag("AddItemButton")
-                        .systemBarsPadding(),
+                    modifier = Modifier.testTag("AddItemButton"),
                 ) {
                     Icon(
                         painter = rememberVectorPainter(id = R.drawable.ic_plus),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -337,7 +337,8 @@ private fun CipherView.toDisplayItem(
         optionsTestTag = "CipherOptionsButton",
         isAutofill = isAutofill,
         isFido2Creation = isFido2Creation,
-        shouldShowMasterPasswordReprompt = reprompt == CipherRepromptType.PASSWORD,
+        shouldShowMasterPasswordReprompt = (reprompt == CipherRepromptType.PASSWORD) &&
+            hasMasterPassword,
     )
 
 private fun CipherView.toSecondSubtitle(fido2CredentialRpId: String?): String? =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -16,6 +16,7 @@ fun createMockDisplayItemForCipher(
     number: Int,
     cipherType: CipherType = CipherType.LOGIN,
     subtitle: String? = "mockUsername-$number",
+    requiresPasswordReprompt: Boolean = true,
 ): VaultItemListingState.DisplayItem =
     when (cipherType) {
         CipherType.LOGIN -> {
@@ -47,14 +48,14 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
-                        requiresPasswordReprompt = true,
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyUsernameClick(
                         username = "mockUsername-$number",
                     ),
                     ListingItemOverflowAction.VaultAction.CopyPasswordClick(
                         password = "mockPassword-$number",
-                        requiresPasswordReprompt = true,
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                         cipherId = "mockId-$number",
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
@@ -98,7 +99,7 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
-                        requiresPasswordReprompt = true,
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyNoteClick(
                         notes = "mockNotes-$number",
@@ -107,7 +108,7 @@ fun createMockDisplayItemForCipher(
                 optionsTestTag = "CipherOptionsButton",
                 isAutofill = false,
                 isFido2Creation = false,
-                shouldShowMasterPasswordReprompt = false,
+                shouldShowMasterPasswordReprompt = requiresPasswordReprompt,
                 iconTestTag = "SecureNoteCipherIcon",
             )
         }
@@ -138,16 +139,16 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
-                        requiresPasswordReprompt = true,
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyNumberClick(
                         number = "mockNumber-$number",
-                        requiresPasswordReprompt = true,
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
                         securityCode = "mockCode-$number",
                         cipherId = "mockId-$number",
-                        requiresPasswordReprompt = true,
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                 ),
                 optionsTestTag = "CipherOptionsButton",

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -108,7 +108,7 @@ fun createMockDisplayItemForCipher(
                 optionsTestTag = "CipherOptionsButton",
                 isAutofill = false,
                 isFido2Creation = false,
-                shouldShowMasterPasswordReprompt = requiresPasswordReprompt,
+                shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "SecureNoteCipherIcon",
             )
         }
@@ -185,7 +185,7 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
-                        requiresPasswordReprompt = true,
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                 ),
                 optionsTestTag = "CipherOptionsButton",


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-10066
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

If a user if authenticated w/o a MP as they would be in the instance of SSO via TDE flow, and there is a vault item that has a masterpassword, we should not prompt the user for adding one when they go through the autofill flow.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
