### PR TITLE
PM-10140: Update looping SDK calls to use single instance of client

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -246,12 +246,8 @@ class VaultSdkSourceImpl(
         cipherList: List<Cipher>,
     ): Result<List<CipherView>> =
         runCatching {
-            cipherList.map {
-                getClient(userId = userId)
-                    .vault()
-                    .ciphers()
-                    .decrypt(it)
-            }
+            val ciphers = getClient(userId = userId).vault().ciphers()
+            cipherList.map { ciphers.decrypt(cipher = it) }
         }
 
     override suspend fun decryptCollection(
@@ -291,11 +287,8 @@ class VaultSdkSourceImpl(
         sendList: List<Send>,
     ): Result<List<SendView>> =
         runCatching {
-            sendList.map {
-                getClient(userId = userId)
-                    .sends()
-                    .decrypt(it)
-            }
+            val sends = getClient(userId = userId).sends()
+            sendList.map { sends.decrypt(send = it) }
         }
 
     override suspend fun encryptFolder(
@@ -517,12 +510,8 @@ class VaultSdkSourceImpl(
         userId: String,
         vararg cipherViews: CipherView,
     ): Result<List<Fido2CredentialAutofillView>> = runCatching {
-        cipherViews.flatMap {
-            getClient(userId)
-                .platform()
-                .fido2()
-                .decryptFido2AutofillCredentials(it)
-        }
+        val fido2 = getClient(userId).platform().fido2()
+        cipherViews.flatMap { fido2.decryptFido2AutofillCredentials(cipherView = it) }
     }
 
     override suspend fun silentlyDiscoverCredentials(

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
@@ -79,7 +79,9 @@ class VaultSdkSourceTest {
     }
     private val clientPasswordHistory = mockk<ClientPasswordHistory>()
     private val clientSends = mockk<ClientSends>()
+    private val clientCiphers = mockk<ClientCiphers>()
     private val clientVault = mockk<ClientVault> {
+        every { ciphers() } returns clientCiphers
         every { passwordHistory() } returns clientPasswordHistory
     }
     private val clientExporters = mockk<ClientExporters> {
@@ -435,11 +437,7 @@ class VaultSdkSourceTest {
         val userId = "userId"
         val mockCipher = mockk<CipherView>()
         val expectedResult = mockk<Cipher>()
-        coEvery {
-            clientVault.ciphers().encrypt(
-                cipherView = mockCipher,
-            )
-        } returns expectedResult
+        coEvery { clientCiphers.encrypt(cipherView = mockCipher) } returns expectedResult
         val result = vaultSdkSource.encryptCipher(
             userId = userId,
             cipherView = mockCipher,
@@ -449,11 +447,9 @@ class VaultSdkSourceTest {
             result,
         )
         coVerify {
-            clientVault.ciphers().encrypt(
-                cipherView = mockCipher,
-            )
+            clientCiphers.encrypt(cipherView = mockCipher)
+            sdkClientManager.getOrCreateClient(userId = userId)
         }
-        coVerify { sdkClientManager.getOrCreateClient(userId = userId) }
     }
 
     @Test
@@ -461,11 +457,7 @@ class VaultSdkSourceTest {
         val userId = "userId"
         val mockCipher = mockk<Cipher>()
         val expectedResult = mockk<CipherView>()
-        coEvery {
-            clientVault.ciphers().decrypt(
-                cipher = mockCipher,
-            )
-        } returns expectedResult
+        coEvery { clientCiphers.decrypt(cipher = mockCipher) } returns expectedResult
         val result = vaultSdkSource.decryptCipher(
             userId = userId,
             cipher = mockCipher,
@@ -475,11 +467,9 @@ class VaultSdkSourceTest {
             result,
         )
         coVerify {
-            clientVault.ciphers().decrypt(
-                cipher = mockCipher,
-            )
+            clientCiphers.decrypt(cipher = mockCipher)
+            sdkClientManager.getOrCreateClient(userId = userId)
         }
-        coVerify { sdkClientManager.getOrCreateClient(userId = userId) }
     }
 
     @Test
@@ -488,11 +478,7 @@ class VaultSdkSourceTest {
             val userId = "userId"
             val mockCiphers = mockk<List<Cipher>>()
             val expectedResult = mockk<List<CipherListView>>()
-            coEvery {
-                clientVault.ciphers().decryptList(
-                    ciphers = mockCiphers,
-                )
-            } returns expectedResult
+            coEvery { clientCiphers.decryptList(ciphers = mockCiphers) } returns expectedResult
             val result = vaultSdkSource.decryptCipherListCollection(
                 userId = userId,
                 cipherList = mockCiphers,
@@ -502,37 +488,36 @@ class VaultSdkSourceTest {
                 result,
             )
             coVerify {
-                clientVault.ciphers().decryptList(
-                    ciphers = mockCiphers,
-                )
+                clientCiphers.decryptList(ciphers = mockCiphers)
+                sdkClientManager.getOrCreateClient(userId = userId)
             }
-            coVerify { sdkClientManager.getOrCreateClient(userId = userId) }
         }
 
     @Test
     fun `Cipher decryptList should call SDK and return a Result with correct data`() = runBlocking {
         val userId = "userId"
-        val mockCiphers = mockk<Cipher>()
-        val expectedResult = mockk<CipherView>()
-        coEvery {
-            clientVault.ciphers().decrypt(
-                cipher = mockCiphers,
-            )
-        } returns expectedResult
+        val mockCipher1 = mockk<Cipher>()
+        val mockCipher2 = mockk<Cipher>()
+        val cipherView1 = mockk<CipherView>()
+        val cipherView2 = mockk<CipherView>()
+        coEvery { clientCiphers.decrypt(cipher = mockCipher1) } returns cipherView1
+        coEvery { clientCiphers.decrypt(cipher = mockCipher2) } returns cipherView2
         val result = vaultSdkSource.decryptCipherList(
             userId = userId,
-            cipherList = listOf(mockCiphers),
+            cipherList = listOf(mockCipher1, mockCipher2),
         )
         assertEquals(
-            listOf(expectedResult).asSuccess(),
+            listOf(cipherView1, cipherView2).asSuccess(),
             result,
         )
-        coVerify {
-            clientVault.ciphers().decrypt(
-                cipher = mockCiphers,
-            )
+        coVerify(exactly = 1) {
+            clientCiphers.decrypt(cipher = mockCipher1)
+            clientCiphers.decrypt(cipher = mockCipher2)
+            // It's important that we only fetch the client once
+            sdkClientManager.getOrCreateClient(userId = userId)
+            client.vault()
+            clientVault.ciphers()
         }
-        coVerify { sdkClientManager.getOrCreateClient(userId = userId) }
     }
 
     @Test
@@ -592,20 +577,26 @@ class VaultSdkSourceTest {
     fun `decryptSendList should call SDK and return correct data wrapped in a Result`() =
         runBlocking {
             val userId = "userId"
-            val mockSend = mockk<Send>()
-            val expectedResult = mockk<SendView>()
-            coEvery { clientSends.decrypt(send = mockSend) } returns expectedResult
+            val mockSend1 = mockk<Send>()
+            val mockSend2 = mockk<Send>()
+            val mockSendView1 = mockk<SendView>()
+            val mockSendView2 = mockk<SendView>()
+            coEvery { clientSends.decrypt(send = mockSend1) } returns mockSendView1
+            coEvery { clientSends.decrypt(send = mockSend2) } returns mockSendView2
             val result = vaultSdkSource.decryptSendList(
                 userId = userId,
-                sendList = listOf(mockSend),
+                sendList = listOf(mockSend1, mockSend2),
             )
             assertEquals(
-                listOf(expectedResult).asSuccess(),
+                listOf(mockSendView1, mockSendView2).asSuccess(),
                 result,
             )
-            coVerify {
-                clientSends.decrypt(send = mockSend)
+            coVerify(exactly = 1) {
+                clientSends.decrypt(send = mockSend1)
+                clientSends.decrypt(send = mockSend2)
+                // It's important that we only fetch the client once
                 sdkClientManager.getOrCreateClient(userId = userId)
+                client.sends()
             }
         }
 
@@ -880,12 +871,9 @@ class VaultSdkSourceTest {
         val organizationId = "organizationId"
         val mockCipher = mockk<CipherView>()
         val expectedResult = mockk<CipherView>()
-        val clientCipher = mockk<ClientCiphers> {
-            coEvery {
-                moveToOrganization(cipher = mockCipher, organizationId = organizationId)
-            } returns expectedResult
-        }
-        every { clientVault.ciphers() } returns clientCipher
+        coEvery {
+            clientCiphers.moveToOrganization(cipher = mockCipher, organizationId = organizationId)
+        } returns expectedResult
 
         val result = vaultSdkSource.moveToOrganization(
             userId = userId,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10140](https://bitwarden.atlassian.net/browse/PM-10140)

## 📔 Objective

This PR makes a minor performance improvement to the `VaultSdkSource` when it loops through multiple items by ensuring that it only uses a single instance of the client.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10140]: https://bitwarden.atlassian.net/browse/PM-10140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ