### PR TITLE
PM-10140: Allow for the vault data to have a pending state by default when data is already present

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -994,9 +994,7 @@ class VaultRepositoryImpl(
     ): Flow<DataState<List<CipherView>>> =
         vaultDiskSource
             .getCiphers(userId = userId)
-            .onStart {
-                mutableCiphersStateFlow.value = DataState.Loading
-            }
+            .onStart { mutableCiphersStateFlow.updateToPendingOrLoading() }
             .map {
                 waitUntilUnlocked(userId = userId)
                 vaultSdkSource
@@ -1017,7 +1015,7 @@ class VaultRepositoryImpl(
     ): Flow<DataState<DomainsData>> =
         vaultDiskSource
             .getDomains(userId = userId)
-            .onStart { mutableDomainsStateFlow.value = DataState.Loading }
+            .onStart { mutableDomainsStateFlow.updateToPendingOrLoading() }
             .map {
                 DataState.Loaded(
                     data = it.toDomainsData(),
@@ -1030,7 +1028,7 @@ class VaultRepositoryImpl(
     ): Flow<DataState<List<FolderView>>> =
         vaultDiskSource
             .getFolders(userId = userId)
-            .onStart { mutableFoldersStateFlow.value = DataState.Loading }
+            .onStart { mutableFoldersStateFlow.updateToPendingOrLoading() }
             .map {
                 waitUntilUnlocked(userId = userId)
                 vaultSdkSource
@@ -1051,7 +1049,7 @@ class VaultRepositoryImpl(
     ): Flow<DataState<List<CollectionView>>> =
         vaultDiskSource
             .getCollections(userId = userId)
-            .onStart { mutableCollectionsStateFlow.value = DataState.Loading }
+            .onStart { mutableCollectionsStateFlow.updateToPendingOrLoading() }
             .map {
                 waitUntilUnlocked(userId = userId)
                 vaultSdkSource
@@ -1076,7 +1074,7 @@ class VaultRepositoryImpl(
     ): Flow<DataState<SendData>> =
         vaultDiskSource
             .getSends(userId = userId)
-            .onStart { mutableSendDataStateFlow.value = DataState.Loading }
+            .onStart { mutableSendDataStateFlow.updateToPendingOrLoading() }
             .map {
                 waitUntilUnlocked(userId = userId)
                 vaultSdkSource


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10140](https://bitwarden.atlassian.net/browse/PM-10140)

## 📔 Objective

This PR updates the vault repository to no longer clear the data from the various `mutableStateFlows` when a user is first subscribing. This allows us to better utilize the cache data, which is especially useful in Autofill scenarios.

Note that the `mutableStateFlows` are still cleared when the the user changes or a lock event occurs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10140]: https://bitwarden.atlassian.net/browse/PM-10140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ