### PR TITLE
PM-10140: Update the VaultSdkSource and VaultDiskSource to use parallelization when processing heavier loads

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -66,10 +66,16 @@ class VaultDiskSourceImpl(
             ciphersDao
                 .getAllCiphers(userId = userId)
                 .map { entities ->
-                    entities.map { entity ->
-                        withContext(dispatcherManager.default) {
-                            json.decodeFromString<SyncResponseJson.Cipher>(entity.cipherJson)
-                        }
+                    withContext(context = dispatcherManager.default) {
+                        entities
+                            .map { entity ->
+                                async {
+                                    json.decodeFromString<SyncResponseJson.Cipher>(
+                                        string = entity.cipherJson,
+                                    )
+                                }
+                            }
+                            .awaitAll()
                     }
                 },
         )
@@ -180,10 +186,14 @@ class VaultDiskSourceImpl(
             sendsDao
                 .getAllSends(userId = userId)
                 .map { entities ->
-                    entities.map { entity ->
-                        withContext(dispatcherManager.default) {
-                            json.decodeFromString<SyncResponseJson.Send>(entity.sendJson)
-                        }
+                    withContext(context = dispatcherManager.default) {
+                        entities
+                            .map { entity ->
+                                async {
+                                    json.decodeFromString<SyncResponseJson.Send>(entity.sendJson)
+                                }
+                            }
+                            .awaitAll()
                     }
                 },
         )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/di/VaultSdkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/di/VaultSdkModule.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.vault.datasource.sdk.di
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.SdkClientManager
+import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.vault.datasource.sdk.BitwardenFeatureFlagManager
 import com.x8bit.bitwarden.data.vault.datasource.sdk.BitwardenFeatureFlagManagerImpl
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
@@ -26,9 +27,11 @@ object VaultSdkModule {
     @Singleton
     fun providesVaultSdkSource(
         sdkClientManager: SdkClientManager,
+        dispatcherManager: DispatcherManager,
     ): VaultSdkSource =
         VaultSdkSourceImpl(
             sdkClientManager = sdkClientManager,
+            dispatcherManager = dispatcherManager,
         )
 
     @Provides

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
@@ -39,6 +39,7 @@ import com.bitwarden.vault.FolderView
 import com.bitwarden.vault.PasswordHistory
 import com.bitwarden.vault.PasswordHistoryView
 import com.bitwarden.vault.TotpResponse
+import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.manager.SdkClientManager
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
@@ -100,8 +101,10 @@ class VaultSdkSourceTest {
         every { destroyClient(any()) } just runs
     }
     private val mockFido2CredentialStore: Fido2CredentialStore = mockk()
+    private val fakeDispatcherManager = FakeDispatcherManager()
     private val vaultSdkSource: VaultSdkSource = VaultSdkSourceImpl(
         sdkClientManager = sdkClientManager,
+        dispatcherManager = fakeDispatcherManager,
     )
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

PM-10140

## 📔 Objective

This PR updates the `VaultSdkSource` and `VaultDiskSource` to parallelize the heavy loads when possible.
Currently we are doing this when decrypting ciphers or sends and when deserializing ciphers and sends.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
