### PR TITLE
[PM-10373] Fix FIDO 2 credential creation from unprivileged apps

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
@@ -54,8 +54,7 @@ class Fido2CredentialManagerImpl(
         fido2CredentialRequest: Fido2CredentialRequest,
         selectedCipherView: CipherView,
     ): Fido2RegisterCredentialResult {
-        val clientData =
-            if (fido2CredentialRequest.callingAppInfo.isOriginPopulated()) {
+        val clientData = if (fido2CredentialRequest.callingAppInfo.isOriginPopulated()) {
                 fido2CredentialRequest
                     .callingAppInfo
                     .getAppSigningSignatureFingerprint()

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/PublicKeyAuthenticatorAssertionResponseUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/PublicKeyAuthenticatorAssertionResponseUtil.kt
@@ -1,0 +1,34 @@
+package com.x8bit.bitwarden.data.vault.datasource.sdk.model
+
+import com.bitwarden.fido.AuthenticatorAssertionResponse
+import com.bitwarden.fido.ClientExtensionResults
+import com.bitwarden.fido.CredPropsResult
+import com.bitwarden.fido.PublicKeyCredentialAuthenticatorAssertionResponse
+import com.bitwarden.fido.SelectedCredential
+
+/**
+ * Creates a mock [PublicKeyCredentialAuthenticatorAssertionResponse] for testing.
+ */
+fun createMockPublicKeyAssertionResponse(number: Int) =
+    PublicKeyCredentialAuthenticatorAssertionResponse(
+        id = "mockId-$number",
+        rawId = "mockId-$number".toByteArray(),
+        ty = "mockTy-$number",
+        authenticatorAttachment = "mockAuthenticatorAttachment-$number",
+        clientExtensionResults = ClientExtensionResults(
+            credProps = CredPropsResult(
+                rk = true,
+                authenticatorDisplayName = "mockAuthenticatorDisplayName-$number",
+            ),
+        ),
+        response = AuthenticatorAssertionResponse(
+            clientDataJson = byteArrayOf(0),
+            authenticatorData = byteArrayOf(0),
+            signature = byteArrayOf(0),
+            userHandle = byteArrayOf(0),
+        ),
+        selectedCredential = SelectedCredential(
+            cipher = createMockCipherView(number = number),
+            credential = createMockFido2CredentialView(number = 1),
+        ),
+    )


### PR DESCRIPTION
## 🎟️ Tracking

PM-10373

## 📔 Objective

This pull request fixes incorrect arguments passed to Bitwarden SDK when handling passkey registration and authentication requests from unprivileged applications.

When registering a passkey from an unprivileged application, Bitwarden SDK expects `ClientData.DefaultWithExtraData.androidPackageName` to be the calling application package name. However, during authentication `ClientData.DefaultWithExtraData.androidPackageName` is the apk-key-hash.

Bitwarden SDK requires `origin` to be a valid HTTP URL, including the protocol preamble, when performing registration and authentication.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
