### PR TITLE
PM-10528: Fix user switching issue due to rapid Activity recreation when locking

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -112,6 +112,10 @@ class MainViewModel @Inject constructor(
             .onEach {
                 when (it) {
                     is VaultStateEvent.Locked -> {
+                        // Similar to account switching, triggering this action too soon can
+                        // interfere with animations or navigation logic, so we will delay slightly.
+                        @Suppress("MagicNumber")
+                        delay(500)
                         trySendAction(MainAction.Internal.VaultUnlockStateChange)
                     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10528](https://bitwarden.atlassian.net/browse/PM-10528)

## 📔 Objective

This PR fixes a bug in which switching from a user with a lock type of "immediate" to an unlocked account from the Vault screen doesn't actually update the Vault screen. The issue is that the fallback logic we have in place for restarting `MainActivity` whenever a vault locking event occurs (in order to clear out all vault data from memory) is happening too soon and this is interfering with the logic that destroys the current `VaultScreen`/`VaultViewModel` and creates a new set. This is a very similar reason why we added a delay of 500 milliseconds before restarting `MainActivity` whenever a user switch event occurs. This PR just adds the same delay for the locking events. This does not seem to have any visual downsides as far as I can tell and brings great parity to the user switching / vault locking behavior as far as restarting `MainActivity` is concerned.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/0eba6b26-3342-4620-9604-10ddf04f115b" /> | <video src="https://github.com/user-attachments/assets/7a31a72b-3a86-43f9-b5a9-1ae572830b71" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10528]: https://bitwarden.atlassian.net/browse/PM-10528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ