### PR TITLE
[PM-10556] Move FIDO 2 intent filter to main manifest

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -3,17 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application tools:ignore="MissingApplicationIcon">
-
-        <activity
-            android:name=".MainActivity"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.x8bit.bitwarden.fido2.ACTION_CREATE_PASSKEY" />
-                <action android:name="com.x8bit.bitwarden.fido2.ACTION_GET_PASSKEY" />
-                <action android:name="com.x8bit.bitwarden.fido2.ACTION_UNLOCK_ACCOUNT" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-        </activity>
         <!-- Disable Crashlytics for debug builds -->
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,6 +55,12 @@
                 <data android:mimeType="video/*" />
                 <data android:mimeType="text/*" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="com.x8bit.bitwarden.fido2.ACTION_CREATE_PASSKEY" />
+                <action android:name="com.x8bit.bitwarden.fido2.ACTION_GET_PASSKEY" />
+                <action android:name="com.x8bit.bitwarden.fido2.ACTION_UNLOCK_ACCOUNT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
## 🎟️ Tracking

PM-10556

## 📔 Objective

Move FIDO 2 intent filter to the primary manifest.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
