### PR TITLE
[PM-10644] Re-prompt master password for protected passkeys

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.fido.Fido2CredentialAutofillView
+import com.bitwarden.vault.CipherRepromptType
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -1413,7 +1414,24 @@ class VaultItemListingViewModel @Inject constructor(
                     showFido2ErrorDialog()
                     return
                 }
-            verifyUserAndAuthenticateCredential(request, selectedCipher)
+
+            if (state.hasMasterPassword &&
+                selectedCipher.reprompt == CipherRepromptType.PASSWORD
+            ) {
+                repromptMasterPasswordForFido2Assertion(request.cipherId)
+            } else {
+                verifyUserAndAuthenticateCredential(request, selectedCipher)
+            }
+        }
+    }
+
+    private fun repromptMasterPasswordForFido2Assertion(cipherId: String) {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = VaultItemListingState.DialogState.Fido2MasterPasswordPrompt(
+                    selectedCipherId = cipherId,
+                ),
+            )
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-10644

## 📔 Objective

Re-prompt for master password entry when authenticating a protected passkey.

## 📸 Screenshots
[protected-passkey-mp-reprompt.webm](https://github.com/user-attachments/assets/2b177add-7adb-4a16-a73c-fa3b2552061a)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
