### PR TITLE
Allow null network responses for 204s

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/core/ResultCall.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/core/ResultCall.kt
@@ -12,6 +12,11 @@ import retrofit2.Response
 import java.lang.reflect.Type
 
 /**
+ * The integer code value for a "No Content" response.
+ */
+private const val NO_CONTENT_RESPONSE_CODE: Int = 204
+
+/**
  * A [Call] for wrapping a network request into a [Result].
  */
 class ResultCall<T>(
@@ -64,8 +69,13 @@ class ResultCall<T>(
             val body = this.body()
             @Suppress("UNCHECKED_CAST")
             when {
+                // We got a nonnull T as the body, just return it.
                 body != null -> body.asSuccess()
+                // We expected the body to be null since the successType is Unit, just return Unit.
                 successType == Unit::class.java -> (Unit as T).asSuccess()
+                // We allow null for 204's, just return null.
+                this.code() == NO_CONTENT_RESPONSE_CODE -> (null as T).asSuccess()
+                // All other null bodies result in an error.
                 else -> IllegalStateException("Unexpected null body!").asFailure()
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the `ResultCall` class to allow for 204 responses that are nullable classes instead of `Unit`.

Ideally we could determine if the `successType` is a nullable value and allow null based on that but unfortunately the information is not available to us.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
