### PR TITLE
Add option to retrieve feature flag synchronously

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManager.kt
@@ -20,11 +20,19 @@ interface FeatureFlagManager {
 
     /**
      * Get value for feature flag with [key] and returns it as generic type [T].
-     * If no value is found the the given [key] its default value will be returned.
+     * If no value is found the given [key] its default value will be returned.
      * Cached flags can be invalidated with [forceRefresh]
      */
     suspend fun <T : Any> getFeatureFlag(
         key: FlagKey<T>,
         forceRefresh: Boolean,
+    ): T
+
+    /**
+     * Gets the value for feature flag with [key] and returns it as generic type [T].
+     * If no value is found the given [key] its [FlagKey.defaultValue] will be returned.
+     */
+    fun <T : Any> getFeatureFlag(
+        key: FlagKey<T>,
     ): T
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerImpl.kt
@@ -32,6 +32,12 @@ class FeatureFlagManagerImpl(
         serverConfigRepository
             .getServerConfig(forceRefresh = forceRefresh)
             .getFlagValueOrDefault(key = key)
+
+    override fun <T : Any> getFeatureFlag(key: FlagKey<T>): T =
+        serverConfigRepository
+            .serverConfigStateFlow
+            .value
+            .getFlagValueOrDefault(key = key)
 }
 
 private fun <T : Any> ServerConfig?.getFlagValueOrDefault(key: FlagKey<T>): T {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
@@ -216,6 +216,42 @@ class FeatureFlagManagerTest {
             flagValue,
         )
     }
+
+    @Test
+    fun `synchronous getFeatureFlag should return stored value when present`() {
+        fakeServerConfigRepository.serverConfigValue = SERVER_CONFIG.copy(
+            serverData = SERVER_CONFIG.serverData.copy(
+                featureStates = mapOf("dummy-int" to JsonPrimitive(true)),
+            ),
+        )
+
+        val flagValue = manager.getFeatureFlag(key = FlagKey.DummyInt)
+
+        assertEquals(Int.MIN_VALUE, flagValue)
+    }
+
+    @Test
+    fun `synchronous getFeatureFlag should return default value if flag is incorrect type`() {
+        val value = "nonDefaultValue"
+        fakeServerConfigRepository.serverConfigValue = SERVER_CONFIG.copy(
+            serverData = SERVER_CONFIG.serverData.copy(
+                featureStates = mapOf("dummy-string" to JsonPrimitive(value)),
+            ),
+        )
+
+        val flagValue = manager.getFeatureFlag(key = FlagKey.DummyString)
+
+        assertEquals(value, flagValue)
+    }
+
+    @Test
+    fun `synchronous getFeatureFlag should return default value if no flags available`() {
+        fakeServerConfigRepository.serverConfigValue = null
+
+        val flagValue = manager.getFeatureFlag(key = FlagKey.DummyString)
+
+        assertEquals("defaultValue", flagValue)
+    }
 }
 
 private val SERVER_CONFIG = ServerConfig(


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds a function for getting a feature flag synchronously using the cache.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
