### PR TITLE
[PM-10686] Change the background colour of the app launcher to Bitwarden's blue

### DIFF
--- a/app/src/main/res/values-night/ic_launcher_background.xml
+++ b/app/src/main/res/values-night/ic_launcher_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">@color/dark_gray</color>
+    <color name="ic_launcher_background">@color/blue_175DDC</color>
     <color name="ic_shortcut_background">@color/white</color>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10686

## 📔 Objective

Change the app launcher background colour to Bitwarden blue when devices are using the Dark theme. Can be tested with builds from [run/10282330788](https://github.com/bitwarden/android/actions/runs/10282330788).

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/c1f53a19-0665-4897-9469-732f5121e081)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
