### PR TITLE
[PM-10670] Prompt for PIN creation during passkey user verification

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -10,7 +10,6 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
-import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
@@ -370,7 +369,7 @@ class VaultItemListingViewModel @Inject constructor(
                 return
             }
 
-        if (activeAccount.vaultUnlockType == VaultUnlockType.PIN) {
+        if (settingsRepository.isUnlockWithPinEnabled) {
             mutableStateFlow.update {
                 it.copy(
                     dialogState = VaultItemListingState.DialogState.Fido2PinPrompt(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -141,6 +141,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         every { isIconLoadingDisabled } returns false
         every { isIconLoadingDisabledFlow } returns mutableIsIconLoadingDisabledFlow
         every { getPullToRefreshEnabledFlow() } returns mutablePullToRefreshEnabledFlow
+        every { isUnlockWithPinEnabled } returns false
     }
     private val specialCircumstanceManager = SpecialCircumstanceManagerImpl()
     private val policyManager: PolicyManager = mockk {
@@ -3107,6 +3108,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             ),
         )
+        every { settingsRepository.isUnlockWithPinEnabled } returns true
 
         viewModel.trySendAction(
             VaultItemListingsAction.UserVerificationNotSupported(


### PR DESCRIPTION
## 🎟️ Tracking

PM-10670

## 📔 Objective

Prompt for PIN creation when performing FIDO 2 user verification if the user is using TDE, does not have a master password, and has not previously setup a PIN.  

How does this change fix the issue?
During FIDO 2 user verification flows, we only need to know if a PIN has been setup. We don't technically care what the vault unlock method is because we're performing user verification, not unlocking the vault.

## 📸 Screenshots

[passkey-uv-pin-setup.webm](https://github.com/user-attachments/assets/1f0f4f99-9a38-4777-b223-5a2211c9df67)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
