### PR TITLE
[PM-10065] Use appropriate back behavior depending on how you are take to auth approval screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
@@ -138,7 +138,7 @@ class LoginApprovalViewModel @Inject constructor(
         when (action.result) {
             is AuthRequestResult.Success -> {
                 sendEvent(LoginApprovalEvent.ShowToast(R.string.login_approved.asText()))
-                sendEvent(LoginApprovalEvent.NavigateBack)
+                sendEventBasedOnSpecialCircumstance()
             }
 
             is AuthRequestResult.Error -> {
@@ -195,7 +195,7 @@ class LoginApprovalViewModel @Inject constructor(
         when (action.result) {
             is AuthRequestResult.Success -> {
                 sendEvent(LoginApprovalEvent.ShowToast(R.string.log_in_denied.asText()))
-                sendEvent(LoginApprovalEvent.NavigateBack)
+                sendEventBasedOnSpecialCircumstance()
             }
 
             is AuthRequestResult.Error -> {
@@ -207,11 +207,17 @@ class LoginApprovalViewModel @Inject constructor(
     }
 
     private fun closeScreen() {
-        if (state.specialCircumstance?.shouldFinishWhenComplete == true) {
-            sendEvent(LoginApprovalEvent.ExitApp)
+        sendEventBasedOnSpecialCircumstance()
+    }
+
+    private fun sendEventBasedOnSpecialCircumstance() {
+        val event = if (state.specialCircumstance?.shouldFinishWhenComplete == true) {
+            LoginApprovalEvent.ExitApp
         } else {
-            sendEvent(LoginApprovalEvent.NavigateBack)
+            LoginApprovalEvent.NavigateBack
         }
+
+        sendEvent(event)
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModelTest.kt
@@ -190,6 +190,45 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    @Suppress("MaxLineLength")
+    fun `When approval request is successful, should emit ExitApp when shouldFinishWhenComplete is true`() =
+        runTest {
+            every {
+                mockSpecialCircumstanceManager.specialCircumstance
+            } returns SpecialCircumstance.PasswordlessRequest(
+                passwordlessRequestData = PasswordlessRequestData(
+                    loginRequestId = REQUEST_ID,
+                    userId = USER_ID,
+                ),
+                shouldFinishWhenComplete = true,
+            )
+            val viewModel = createViewModel(
+                state = DEFAULT_STATE.copy(
+                    specialCircumstance = mockSpecialCircumstanceManager.specialCircumstance
+                        as? SpecialCircumstance.PasswordlessRequest
+                )
+            )
+            coEvery {
+                mockAuthRepository.updateAuthRequest(
+                    requestId = REQUEST_ID,
+                    masterPasswordHash = PASSWORD_HASH,
+                    publicKey = PUBLIC_KEY,
+                    isApproved = true,
+                )
+            } returns AuthRequestResult.Success(AUTH_REQUEST)
+
+
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(LoginApprovalAction.ApproveRequestClick)
+                assertEquals(
+                    LoginApprovalEvent.ShowToast(R.string.login_approved.asText()),
+                    awaitItem(),
+                )
+                assertEquals(LoginApprovalEvent.ExitApp, awaitItem())
+            }
+        }
+
+    @Test
     fun `on DeclineRequestClick should deny auth request`() = runTest {
         val viewModel = createViewModel()
         coEvery {
@@ -219,6 +258,45 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
             )
         }
     }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `When deny request is successful, should emit ExitApp when shouldFinishWhenComplete is true`() =
+        runTest {
+            every {
+                mockSpecialCircumstanceManager.specialCircumstance
+            } returns SpecialCircumstance.PasswordlessRequest(
+                passwordlessRequestData = PasswordlessRequestData(
+                    loginRequestId = REQUEST_ID,
+                    userId = USER_ID,
+                ),
+                shouldFinishWhenComplete = true,
+            )
+            val viewModel = createViewModel(
+                state = DEFAULT_STATE.copy(
+                    specialCircumstance = mockSpecialCircumstanceManager.specialCircumstance
+                        as? SpecialCircumstance.PasswordlessRequest
+                )
+            )
+            coEvery {
+                mockAuthRepository.updateAuthRequest(
+                    requestId = REQUEST_ID,
+                    masterPasswordHash = PASSWORD_HASH,
+                    publicKey = PUBLIC_KEY,
+                    isApproved = false,
+                )
+            } returns AuthRequestResult.Success(AUTH_REQUEST)
+
+
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(LoginApprovalAction.DeclineRequestClick)
+                assertEquals(
+                    LoginApprovalEvent.ShowToast(R.string.log_in_denied.asText()),
+                    awaitItem(),
+                )
+                assertEquals(LoginApprovalEvent.ExitApp, awaitItem())
+            }
+        }
 
     @Test
     fun `on ErrorDialogDismiss should update state`() = runTest {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10065
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Resolve bug where the LoginApproval screen would not dismiss if entered via the notification.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## Testing locally
To test locally you can apply this patch to force the notification: 
[throwaway_code_to_trigger_auth_notification.patch](https://github.com/user-attachments/files/16532282/throwaway_code_to_trigger_auth_notification.patch)


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
