### PR TITLE
PM-10621: Create common biometrics and pin unlock UI elements

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
@@ -1,0 +1,39 @@
+package com.x8bit.bitwarden.ui.platform.components.toggle
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.x8bit.bitwarden.R
+
+/**
+ * Displays a switch for enabling or disabling unlock with biometrics functionality.
+ *
+ * @param isChecked Indicates that the switch should be checked or not.
+ * @param isBiometricsSupported Indicates if biometrics is supported and we should display the
+ * switch.
+ * @param onDisableBiometrics Callback invoked when the toggle has be turned off.
+ * @param onEnableBiometrics Callback invoked when the toggle has be turned on.
+ * @param modifier The [Modifier] to be applied to the switch.
+ */
+@Composable
+fun BitwardenUnlockWithBiometricsSwitch(
+    isBiometricsSupported: Boolean,
+    isChecked: Boolean,
+    onDisableBiometrics: () -> Unit,
+    onEnableBiometrics: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!isBiometricsSupported) return
+    BitwardenWideSwitch(
+        modifier = modifier,
+        label = stringResource(id = R.string.unlock_with, stringResource(id = R.string.biometrics)),
+        isChecked = isChecked,
+        onCheckedChange = { toggled ->
+            if (toggled) {
+                onEnableBiometrics()
+            } else {
+                onDisableBiometrics()
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithPinSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithPinSwitch.kt
@@ -1,0 +1,161 @@
+package com.x8bit.bitwarden.ui.platform.components.toggle
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
+import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.PinInputDialog
+
+/**
+ * Displays a switch for enabling or disabling unlock with pin functionality.
+ *
+ * @param isUnlockWithPasswordEnabled Indicates whether or not the password unlocking is enabled.
+ * @param isUnlockWithPinEnabled Indicates whether or not the pin unlocking is enabled.
+ * @param onUnlockWithPinToggleAction Callback that is invoked when the current state of the switch
+ * changes.
+ * @param modifier The [Modifier] to be applied to the switch.
+ */
+@Suppress("LongMethod")
+@Composable
+fun BitwardenUnlockWithPinSwitch(
+    isUnlockWithPasswordEnabled: Boolean,
+    isUnlockWithPinEnabled: Boolean,
+    onUnlockWithPinToggleAction: (UnlockWithPinState) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var shouldShowPinInputDialog by rememberSaveable { mutableStateOf(value = false) }
+    var shouldShowPinConfirmationDialog by rememberSaveable { mutableStateOf(value = false) }
+    var pin by remember { mutableStateOf(value = "") }
+    BitwardenWideSwitch(
+        label = stringResource(id = R.string.unlock_with_pin),
+        isChecked = isUnlockWithPinEnabled,
+        onCheckedChange = { isChecked ->
+            if (isChecked) {
+                onUnlockWithPinToggleAction(UnlockWithPinState.PendingEnabled)
+                shouldShowPinInputDialog = true
+            } else {
+                onUnlockWithPinToggleAction(UnlockWithPinState.Disabled)
+            }
+        },
+        modifier = modifier,
+    )
+
+    when {
+        shouldShowPinInputDialog -> {
+            PinInputDialog(
+                onCancelClick = {
+                    shouldShowPinInputDialog = false
+                    onUnlockWithPinToggleAction(UnlockWithPinState.Disabled)
+                    pin = ""
+                },
+                onSubmitClick = {
+                    pin = it
+                    if (pin.isNotEmpty()) {
+                        shouldShowPinInputDialog = false
+                        if (isUnlockWithPasswordEnabled) {
+                            shouldShowPinConfirmationDialog = true
+                            onUnlockWithPinToggleAction(UnlockWithPinState.PendingEnabled)
+                        } else {
+                            onUnlockWithPinToggleAction(
+                                UnlockWithPinState.Enabled(
+                                    pin = pin,
+                                    shouldRequireMasterPasswordOnRestart = false,
+                                ),
+                            )
+                        }
+                    } else {
+                        shouldShowPinInputDialog = false
+                        onUnlockWithPinToggleAction(UnlockWithPinState.Disabled)
+                    }
+                },
+                onDismissRequest = {
+                    shouldShowPinInputDialog = false
+                    onUnlockWithPinToggleAction(UnlockWithPinState.Disabled)
+                    pin = ""
+                },
+            )
+        }
+
+        shouldShowPinConfirmationDialog -> {
+            BitwardenTwoButtonDialog(
+                title = stringResource(id = R.string.unlock_with_pin),
+                message = stringResource(id = R.string.pin_require_master_password_restart),
+                confirmButtonText = stringResource(id = R.string.yes),
+                dismissButtonText = stringResource(id = R.string.no),
+                onConfirmClick = {
+                    shouldShowPinConfirmationDialog = false
+                    onUnlockWithPinToggleAction(
+                        UnlockWithPinState.Enabled(
+                            pin = pin,
+                            shouldRequireMasterPasswordOnRestart = true,
+                        ),
+                    )
+                    pin = ""
+                },
+                onDismissClick = {
+                    shouldShowPinConfirmationDialog = false
+                    onUnlockWithPinToggleAction(
+                        UnlockWithPinState.Enabled(
+                            pin = pin,
+                            shouldRequireMasterPasswordOnRestart = false,
+                        ),
+                    )
+                    pin = ""
+                },
+                onDismissRequest = {
+                    // Dismissing the dialog is the same as requiring a master password
+                    // confirmation.
+                    shouldShowPinConfirmationDialog = false
+                    onUnlockWithPinToggleAction(
+                        UnlockWithPinState.Enabled(
+                            pin = pin,
+                            shouldRequireMasterPasswordOnRestart = true,
+                        ),
+                    )
+                    pin = ""
+                },
+            )
+        }
+    }
+}
+
+/**
+ * User toggled the unlock with pin switch.
+ */
+sealed class UnlockWithPinState {
+    /**
+     * Whether or not the action represents PIN unlocking being enabled.
+     */
+    abstract val isUnlockWithPinEnabled: Boolean
+
+    /**
+     * The toggle was disabled.
+     */
+    data object Disabled : UnlockWithPinState() {
+        override val isUnlockWithPinEnabled: Boolean get() = false
+    }
+
+    /**
+     * The toggle was enabled but the behavior is pending confirmation.
+     */
+    data object PendingEnabled : UnlockWithPinState() {
+        override val isUnlockWithPinEnabled: Boolean get() = true
+    }
+
+    /**
+     * The toggle was enabled and the user's [pin] and [shouldRequireMasterPasswordOnRestart]
+     * preference were confirmed.
+     */
+    data class Enabled(
+        val pin: String,
+        val shouldRequireMasterPasswordOnRestart: Boolean,
+    ) : UnlockWithPinState() {
+        override val isUnlockWithPinEnabled: Boolean get() = true
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
+import com.x8bit.bitwarden.ui.platform.components.toggle.UnlockWithPinState
 import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricsManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.util.assertNoDialogExists
@@ -244,7 +245,11 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .performScrollTo()
             .performClick()
 
-        verify { viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle.Disabled) }
+        verify {
+            viewModel.trySendAction(
+                AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.Disabled),
+            )
+        }
     }
 
     @Suppress("MaxLineLength")
@@ -285,7 +290,11 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
 
-        verify { viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle.PendingEnabled) }
+        verify {
+            viewModel.trySendAction(
+                AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.PendingEnabled),
+            )
+        }
     }
 
     @Suppress("MaxLineLength")
@@ -304,7 +313,11 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .filterToOne(hasAnyAncestor(isDialog()))
             .performClick()
 
-        verify { viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle.Disabled) }
+        verify {
+            viewModel.trySendAction(
+                AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.Disabled),
+            )
+        }
         composeTestRule.assertNoDialogExists()
     }
 
@@ -324,7 +337,11 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .filterToOne(hasAnyAncestor(isDialog()))
             .performClick()
 
-        verify { viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle.Disabled) }
+        verify {
+            viewModel.trySendAction(
+                AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.Disabled),
+            )
+        }
         composeTestRule.assertNoDialogExists()
     }
 
@@ -368,7 +385,11 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
 
-        verify { viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle.PendingEnabled) }
+        verify {
+            viewModel.trySendAction(
+                AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.PendingEnabled),
+            )
+        }
     }
 
     @Suppress("MaxLineLength")
@@ -398,9 +419,11 @@ class AccountSecurityScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                AccountSecurityAction.UnlockWithPinToggle.Enabled(
-                    pin = "1234",
-                    shouldRequireMasterPasswordOnRestart = false,
+                AccountSecurityAction.UnlockWithPinToggle(
+                    UnlockWithPinState.Enabled(
+                        pin = "1234",
+                        shouldRequireMasterPasswordOnRestart = false,
+                    ),
                 ),
             )
         }
@@ -432,9 +455,11 @@ class AccountSecurityScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                AccountSecurityAction.UnlockWithPinToggle.Enabled(
-                    pin = "1234",
-                    shouldRequireMasterPasswordOnRestart = false,
+                AccountSecurityAction.UnlockWithPinToggle(
+                    UnlockWithPinState.Enabled(
+                        pin = "1234",
+                        shouldRequireMasterPasswordOnRestart = false,
+                    ),
                 ),
             )
         }
@@ -467,9 +492,11 @@ class AccountSecurityScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                AccountSecurityAction.UnlockWithPinToggle.Enabled(
-                    pin = "1234",
-                    shouldRequireMasterPasswordOnRestart = true,
+                AccountSecurityAction.UnlockWithPinToggle(
+                    UnlockWithPinState.Enabled(
+                        pin = "1234",
+                        shouldRequireMasterPasswordOnRestart = true,
+                    ),
                 ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockPolicy
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
+import com.x8bit.bitwarden.ui.platform.components.toggle.UnlockWithPinState
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -458,7 +459,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         every { settingsRepository.clearUnlockPin() } just runs
         val viewModel = createViewModel(initialState = initialState)
         viewModel.trySendAction(
-            AccountSecurityAction.UnlockWithPinToggle.Disabled,
+            AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.Disabled),
         )
         assertEquals(
             initialState.copy(isUnlockWithPinEnabled = false),
@@ -478,7 +479,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         every { settingsRepository.vaultTimeoutAction = VaultTimeoutAction.LOGOUT } just runs
         val viewModel = createViewModel(initialState = initialState)
         viewModel.trySendAction(
-            AccountSecurityAction.UnlockWithPinToggle.Disabled,
+            AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.Disabled),
         )
         assertEquals(
             initialState.copy(
@@ -500,7 +501,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         )
         val viewModel = createViewModel(initialState = initialState)
         viewModel.trySendAction(
-            AccountSecurityAction.UnlockWithPinToggle.PendingEnabled,
+            AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.PendingEnabled),
         )
         assertEquals(
             initialState.copy(isUnlockWithPinEnabled = true),
@@ -518,9 +519,11 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
         val viewModel = createViewModel(initialState = initialState)
         viewModel.trySendAction(
-            AccountSecurityAction.UnlockWithPinToggle.Enabled(
-                pin = "1234",
-                shouldRequireMasterPasswordOnRestart = true,
+            AccountSecurityAction.UnlockWithPinToggle(
+                UnlockWithPinState.Enabled(
+                    pin = "1234",
+                    shouldRequireMasterPasswordOnRestart = true,
+                ),
             ),
         )
         assertEquals(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10621](https://bitwarden.atlassian.net/browse/PM-10621) Part 1

## 📔 Objective

This PR extracts the biometrics and pin switches from the `AccountSecurityScreen` in order to make reusable components out of them. These new components will get additional use in a future PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10621]: https://bitwarden.atlassian.net/browse/PM-10621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ