### PR TITLE
PM-10729: Add a helper method for determining if the app is in portrait orientation

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.auth.feature.welcome
 
-import android.content.res.Configuration
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -46,6 +45,7 @@ import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.util.isPortrait
 
 /**
  * Top level composable for the welcome screen.
@@ -107,7 +107,7 @@ private fun WelcomeScreenContent(
     onLoginClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val isLandscape = !LocalConfiguration.current.isPortrait
     val horizontalPadding = if (isLandscape) 128.dp else 16.dp
 
     LaunchedEffect(pagerState.currentPage) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/ConfigurationExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/ConfigurationExtensions.kt
@@ -1,0 +1,15 @@
+@file:OmitFromCoverage
+
+package com.x8bit.bitwarden.ui.platform.util
+
+import android.content.res.Configuration
+import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
+
+/**
+ * A helper method to indicate if the current UI configuration is portrait or not.
+ */
+val Configuration.isPortrait: Boolean
+    get() = when (this.orientation) {
+        Configuration.ORIENTATION_LANDSCAPE -> false
+        else -> true
+    }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.vault.feature.qrcodescan
 
-import android.content.res.Configuration
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.Toast
@@ -59,6 +58,7 @@ import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.text.BitwardenClickableText
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.util.isPortrait
 import com.x8bit.bitwarden.ui.vault.feature.qrcodescan.util.QrCodeAnalyzer
 import com.x8bit.bitwarden.ui.vault.feature.qrcodescan.util.QrCodeAnalyzerImpl
 import java.util.concurrent.Executors
@@ -80,8 +80,6 @@ fun QrCodeScanScreen(
     qrCodeAnalyzer.onQrCodeScanned = remember(viewModel) {
         { viewModel.trySendAction(QrCodeScanAction.QrCodeScanReceive(it)) }
     }
-
-    val orientation = LocalConfiguration.current.orientation
 
     val context = LocalContext.current
 
@@ -129,20 +127,16 @@ fun QrCodeScanScreen(
             modifier = Modifier.padding(innerPadding),
         )
 
-        when (orientation) {
-            Configuration.ORIENTATION_LANDSCAPE -> {
-                LandscapeQRCodeContent(
-                    onEnterCodeManuallyClick = onEnterCodeManuallyClick,
-                    modifier = Modifier.padding(innerPadding),
-                )
-            }
-
-            else -> {
-                PortraitQRCodeContent(
-                    onEnterCodeManuallyClick = onEnterCodeManuallyClick,
-                    modifier = Modifier.padding(innerPadding),
-                )
-            }
+        if (LocalConfiguration.current.isPortrait) {
+            PortraitQRCodeContent(
+                onEnterCodeManuallyClick = onEnterCodeManuallyClick,
+                modifier = Modifier.padding(innerPadding),
+            )
+        } else {
+            LandscapeQRCodeContent(
+                onEnterCodeManuallyClick = onEnterCodeManuallyClick,
+                modifier = Modifier.padding(innerPadding),
+            )
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10729](https://bitwarden.atlassian.net/browse/PM-10729)

## 📔 Objective

This PR adds a helper method for determining if the app is in portrait orientation. This function defaults to portrait mode when the orientation is unknown.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10729]: https://bitwarden.atlassian.net/browse/PM-10729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ