### PR TITLE
Allow the ShowShareSheet event to be launched after the screen is paused

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
@@ -24,6 +24,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateSendResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
+import com.x8bit.bitwarden.ui.platform.base.util.BackgroundEvent
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.concat
@@ -868,7 +869,9 @@ sealed class AddSendEvent {
     /**
      * Show share sheet.
      */
-    data class ShowShareSheet(val message: String) : AddSendEvent()
+    data class ShowShareSheet(
+        val message: String,
+    ) : BackgroundEvent, AddSendEvent()
 
     /**
      * Show Toast.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10725](https://bitwarden.atlassian.net/browse/PM-10725)

## 📔 Objective

This PR updates the `AddSendEvent.ShowShareSheet` to allow it to be consumed in the background (when the screen is paused). This allows us to display the share sheet as the UI is being dismissed.

## Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/f94e0fe3-a63e-4d9f-8ace-9d994da74a58" width="300" /> | <video src="https://github.com/user-attachments/assets/4ee9589f-8657-41f3-8dcb-a4262a7a2d10" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10725]: https://bitwarden.atlassian.net/browse/PM-10725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ