### PR TITLE
PM-10628: Add pin unlock to SetupUnlockViewModel

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
@@ -103,7 +103,22 @@ class SetupUnlockViewModel @Inject constructor(
     }
 
     private fun handleUnlockWithPinToggle(action: SetupUnlockAction.UnlockWithPinToggle) {
-        // TODO: Handle pin unlocking logic PM-10628
+        mutableStateFlow.update {
+            it.copy(isUnlockWithPinEnabled = action.state.isUnlockWithPinEnabled)
+        }
+
+        when (val state = action.state) {
+            UnlockWithPinState.PendingEnabled -> Unit
+            UnlockWithPinState.Disabled -> settingsRepository.clearUnlockPin()
+
+            is UnlockWithPinState.Enabled -> {
+                settingsRepository.storeUnlockPin(
+                    pin = state.pin,
+                    shouldRequireMasterPasswordOnRestart =
+                    state.shouldRequireMasterPasswordOnRestart,
+                )
+            }
+        }
     }
 
     private fun handleInternalActions(action: SetupUnlockAction.Internal) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10628](https://bitwarden.atlassian.net/browse/PM-10628)

## 📔 Objective

This PR adds pin unlock logic to the `SetupUnlockViewModel`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10628]: https://bitwarden.atlassian.net/browse/PM-10628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ