### PR TITLE
PM-8522: Fix vault tab nav bar title when logging in

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
@@ -1,12 +1,17 @@
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 
 import androidx.annotation.StringRes
+import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 /**
@@ -14,25 +19,22 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class VaultUnlockedNavBarViewModel @Inject constructor(
-    private val authRepository: AuthRepository,
+    authRepository: AuthRepository,
     specialCircumstancesManager: SpecialCircumstanceManager,
 ) : BaseViewModel<VaultUnlockedNavBarState, VaultUnlockedNavBarEvent, VaultUnlockedNavBarAction>(
-    initialState = run {
-        val hasOrganization = authRepository
-            .userStateFlow
-            .value
-            ?.activeAccount
-            ?.organizations
-            ?.isNotEmpty()
-            ?: false
-        val vaultRes = if (hasOrganization) R.string.vaults else R.string.my_vault
-        VaultUnlockedNavBarState(
-            vaultNavBarLabelRes = vaultRes,
-            vaultNavBarContentDescriptionRes = vaultRes,
-        )
-    },
+    initialState = VaultUnlockedNavBarState(
+        vaultNavBarLabelRes = R.string.my_vault,
+        vaultNavBarContentDescriptionRes = R.string.my_vault,
+    ),
 ) {
     init {
+        authRepository
+            .userStateFlow
+            .onEach {
+                sendAction(VaultUnlockedNavBarAction.Internal.UserStateUpdateReceive(it))
+            }
+            .launchIn(viewModelScope)
+
         when (specialCircumstancesManager.specialCircumstance) {
             SpecialCircumstance.GeneratorShortcut -> {
                 sendEvent(VaultUnlockedNavBarEvent.NavigateToGeneratorScreen)
@@ -54,6 +56,15 @@ class VaultUnlockedNavBarViewModel @Inject constructor(
             VaultUnlockedNavBarAction.SendTabClick -> handleSendTabClicked()
             VaultUnlockedNavBarAction.SettingsTabClick -> handleSettingsTabClicked()
             VaultUnlockedNavBarAction.VaultTabClick -> handleVaultTabClicked()
+            is VaultUnlockedNavBarAction.Internal -> handleInternalAction(action)
+        }
+    }
+
+    private fun handleInternalAction(action: VaultUnlockedNavBarAction.Internal) {
+        when (action) {
+            is VaultUnlockedNavBarAction.Internal.UserStateUpdateReceive -> {
+                handleUserStateUpdateReceive(action)
+            }
         }
     }
     // #region BottomTabViewModel Action Handlers
@@ -84,6 +95,27 @@ class VaultUnlockedNavBarViewModel @Inject constructor(
     private fun handleSettingsTabClicked() {
         sendEvent(VaultUnlockedNavBarEvent.NavigateToSettingsScreen)
     }
+
+    /**
+     * Updates the nav bar title according to whether the user is part of any organizations or not.
+     */
+    private fun handleUserStateUpdateReceive(
+        action: VaultUnlockedNavBarAction.Internal.UserStateUpdateReceive,
+    ) {
+        val hasOrganizations = action
+            .userState
+            ?.activeAccount
+            ?.organizations
+            ?.isNotEmpty()
+            ?: false
+        val vaultRes = if (hasOrganizations) R.string.vaults else R.string.my_vault
+        mutableStateFlow.update {
+            it.copy(
+                vaultNavBarLabelRes = vaultRes,
+                vaultNavBarContentDescriptionRes = vaultRes,
+            )
+        }
+    }
     // #endregion BottomTabViewModel Action Handlers
 }
 
@@ -100,24 +132,36 @@ data class VaultUnlockedNavBarState(
  */
 sealed class VaultUnlockedNavBarAction {
     /**
-     * click Generator tab.
+     * Click Generator tab.
      */
     data object GeneratorTabClick : VaultUnlockedNavBarAction()
 
     /**
-     * click Send tab.
+     * Click Send tab.
      */
     data object SendTabClick : VaultUnlockedNavBarAction()
 
     /**
-     * click Vault tab.
+     * Click Vault tab.
      */
     data object VaultTabClick : VaultUnlockedNavBarAction()
 
     /**
-     * click Settings tab.
+     * Click Settings tab.
      */
     data object SettingsTabClick : VaultUnlockedNavBarAction()
+
+    /**
+     * Models actions that the [VaultUnlockedNavBarViewModel] itself might send.
+     */
+    sealed class Internal : VaultUnlockedNavBarAction() {
+        /**
+         * Indicates a change in user state has been received.
+         */
+        data class UserStateUpdateReceive(
+            val userState: UserState?,
+        ) : Internal()
+    }
 }
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8522](https://bitwarden.atlassian.net/browse/PM-8522)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix the nav bar vault title of an account just logging in with organizations.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/9a0992b7-a4ad-4e7c-add9-3bd0ea69bbcb" /> | <video src="https://github.com/user-attachments/assets/02fdccee-6157-4d5b-9ca4-c1eb78c02bc8" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8522]: https://bitwarden.atlassian.net/browse/PM-8522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ