### PR TITLE
[PM-10697] Auto-focus on PIN Dialog field

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -7,11 +7,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
@@ -61,10 +64,11 @@ fun BitwardenTextField(
     shouldAddCustomLineBreaks: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
     isError: Boolean = false,
+    autoFocus: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
 ) {
     var widthPx by remember { mutableIntStateOf(0) }
-
+    val focusRequester = remember { FocusRequester() }
     val currentTextStyle = textStyle ?: LocalTextStyle.current
     val formattedText = if (shouldAddCustomLineBreaks) {
         value.withLineBreaksAtWidth(
@@ -78,7 +82,8 @@ fun BitwardenTextField(
 
     OutlinedTextField(
         modifier = modifier
-            .onGloballyPositioned { widthPx = it.size.width },
+            .onGloballyPositioned { widthPx = it.size.width }
+            .focusRequester(focusRequester),
         enabled = enabled,
         label = { Text(text = label) },
         value = formattedText,
@@ -113,6 +118,9 @@ fun BitwardenTextField(
         isError = isError,
         visualTransformation = visualTransformation,
     )
+    if (autoFocus) {
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
@@ -108,6 +108,7 @@ fun PinInputDialog(
                 BitwardenTextField(
                     label = stringResource(id = R.string.pin),
                     value = pin,
+                    autoFocus = true,
                     onValueChange = { pin = it },
                     keyboardType = KeyboardType.Number,
                     modifier = Modifier

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity
 
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertTextEquals
@@ -281,6 +282,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .onAllNodesWithText("PIN")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
+            .assertIsFocused()
         composeTestRule
             .onAllNodesWithText("Cancel")
             .filterToOne(hasAnyAncestor(isDialog()))


### PR DESCRIPTION
## 🎟️ Tracking

PM-10697

## 📔 Objective

Auto-focus on the PIN field within the PIN dialog.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/196e1b7b-0968-4ee6-975f-cdf36933160b" />  | <video src="https://github.com/user-attachments/assets/1cf2a33a-a19e-44b1-919f-6746cb401e99" />| 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
