### PR TITLE
PM-10851 make the default top app bar reactive 

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
@@ -118,7 +118,6 @@ fun BitwardenTopAppBar(
             scrollBehavior = scrollBehavior,
             navigationIcon = navigationIconContent,
             title = {
-
                 // The height of the component is controlled and will only allow for 1 extra row,
                 // making adding any arguments for softWrap and minLines superfluous.
                 Text(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
@@ -118,10 +118,9 @@ fun BitwardenTopAppBar(
             scrollBehavior = scrollBehavior,
             navigationIcon = navigationIconContent,
             title = {
-                /*
-                 * The height of the component is controlled and will only allow for 1 extra row,
-                 * making adding any arguments for softWrap and minLines superfluous.
-                 */
+
+                // The height of the component is controlled and will only allow for 1 extra row,
+                // making adding any arguments for softWrap and minLines superfluous.
                 Text(
                     text = title,
                     style = MaterialTheme.typography.titleLarge,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
@@ -87,7 +87,7 @@ fun BitwardenTopAppBar(
         mutableStateOf(false)
     }
 
-    val navigationIconContent: @Composable () -> Unit = remember {
+    val navigationIconContent: @Composable () -> Unit = remember(navigationIcon) {
         {
             navigationIcon?.let {
                 IconButton(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10851
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The goal is to make it so the title drops to the second row (MediumTopAppBar layout) in the event it overflows the title space.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
 **juiced the navigation to go the screen where we have a longer title**

https://github.com/user-attachments/assets/05a9f85c-7d10-469d-8bb1-bc257af6840e


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
