### PR TITLE
PM-10878: Access parcelable data in a safe manor across SDK versions

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/IntentExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/IntentExtensions.kt
@@ -3,37 +3,24 @@
 package com.x8bit.bitwarden.data.platform.util
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.core.content.IntentCompat
+import androidx.core.os.BundleCompat
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 
 /**
  * A means of retrieving a [Parcelable] from an [Intent] using the given [name] in a manner that
  * is safe across SDK versions.
  */
-inline fun <reified T> Intent.getSafeParcelableExtra(name: String): T? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelableExtra(
-            name,
-            T::class.java,
-        )
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelableExtra(name)
-    }
+inline fun <reified T> Intent.getSafeParcelableExtra(
+    name: String,
+): T? = IntentCompat.getParcelableExtra(this, name, T::class.java)
 
 /**
  * A means of retrieving a [Parcelable] from a [Bundle] using the given [name] in a manner that
  * is safe across SDK versions.
  */
-inline fun <reified T> Bundle.getSafeParcelableExtra(name: String): T? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelable(
-            name,
-            T::class.java,
-        )
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelable(name)
-    }
+inline fun <reified T> Bundle.getSafeParcelableExtra(
+    name: String,
+): T? = BundleCompat.getParcelable(this, name, T::class.java)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10878](https://bitwarden.atlassian.net/browse/PM-10878)

## 📔 Objective

This PR addresses a crash caused by a bug in Android 13, using the `IntentCompat` and `BundleCompat` methods resolve this crash for us.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10878]: https://bitwarden.atlassian.net/browse/PM-10878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ