### PR TITLE
PM-10909: Add persistance layer for usersKeyConnector

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
@@ -46,6 +46,16 @@ interface AuthDiskSource {
     fun clearData(userId: String)
 
     /**
+     * Retrieves the state indicating that the user should use a key connector.
+     */
+    fun getShouldUseKeyConnector(userId: String): Boolean?
+
+    /**
+     * Stores the boolean indicating that the user should use a key connector.
+     */
+    fun storeShouldUseKeyConnector(userId: String, shouldUseKeyConnector: Boolean?)
+
+    /**
      * Retrieves the state indicating that the user has chosen to trust this device.
      *
      * Note: This indicates intent to trust the device, the device may not be trusted yet.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
@@ -39,6 +39,7 @@ private const val TWO_FACTOR_TOKEN_KEY = "twoFactorToken"
 private const val MASTER_PASSWORD_HASH_KEY = "keyHash"
 private const val POLICIES_KEY = "policies"
 private const val SHOULD_TRUST_DEVICE_KEY = "shouldTrustDevice"
+private const val USES_KEY_CONNECTOR = "usesKeyConnector"
 
 /**
  * Primary implementation of [AuthDiskSource].
@@ -122,9 +123,21 @@ class AuthDiskSourceImpl(
         storeMasterPasswordHash(userId = userId, passwordHash = null)
         storePolicies(userId = userId, policies = null)
         storeAccountTokens(userId = userId, accountTokens = null)
+        storeShouldUseKeyConnector(userId = userId, shouldUseKeyConnector = null)
 
         // Do not remove the DeviceKey or PendingAuthRequest on logout, these are persisted
         // indefinitely unless the TDE flow explicitly removes them.
+    }
+
+    override fun getShouldUseKeyConnector(
+        userId: String,
+    ): Boolean? = getBoolean(key = USES_KEY_CONNECTOR.appendIdentifier(userId))
+
+    override fun storeShouldUseKeyConnector(userId: String, shouldUseKeyConnector: Boolean?) {
+        putBoolean(
+            key = USES_KEY_CONNECTOR.appendIdentifier(userId),
+            value = shouldUseKeyConnector,
+        )
     }
 
     override fun getShouldTrustDevice(userId: String): Boolean =

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -898,27 +898,29 @@ class VaultRepositoryImpl(
     ) {
         val profile = syncResponse.profile
         val userId = profile.id
-        val userKey = profile.key
-        val privateKey = profile.privateKey
         authDiskSource.apply {
             storeUserKey(
                 userId = userId,
-                userKey = userKey,
+                userKey = profile.key,
             )
             storePrivateKey(
                 userId = userId,
-                privateKey = privateKey,
+                privateKey = profile.privateKey,
             )
             storeOrganizationKeys(
-                userId = profile.id,
+                userId = userId,
                 organizationKeys = profile.organizations
                     .orEmpty()
                     .filter { it.key != null }
                     .associate { it.id to requireNotNull(it.key) },
             )
+            storeShouldUseKeyConnector(
+                userId = userId,
+                shouldUseKeyConnector = profile.shouldUseKeyConnector,
+            )
             storeOrganizations(
-                userId = profile.id,
-                organizations = syncResponse.profile.organizations,
+                userId = userId,
+                organizations = profile.organizations,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -122,6 +122,24 @@ class AuthDiskSourceTest {
     }
 
     @Test
+    fun `shouldUseKeyConnector should pull from and update SharedPreferences`() {
+        val userId = "userId"
+        val shouldUseKeyConnectorKey = "bwPreferencesStorage:usesKeyConnector_$userId"
+
+        // Shared preferences and the disk source start with the same value.
+        assertNull(authDiskSource.getShouldUseKeyConnector(userId = userId))
+        assertFalse(fakeSharedPreferences.getBoolean(shouldUseKeyConnectorKey, false))
+
+        // Updating the disk source updates shared preferences
+        authDiskSource.storeShouldUseKeyConnector(userId = userId, shouldUseKeyConnector = true)
+        assertTrue(fakeSharedPreferences.getBoolean(shouldUseKeyConnectorKey, false))
+
+        // Update SharedPreferences updates the disk source
+        fakeSharedPreferences.edit { putBoolean(shouldUseKeyConnectorKey, false) }
+        assertFalse(authDiskSource.getShouldUseKeyConnector(userId = userId) ?: true)
+    }
+
+    @Test
     fun `shouldTrustDevice should pull from and update SharedPreferences`() {
         val userId = "userId"
         val shouldTrustDeviceKey = "bwPreferencesStorage:shouldTrustDevice_$userId"
@@ -191,6 +209,7 @@ class AuthDiskSourceTest {
             userId = userId,
             pendingAuthRequest = pendingAuthRequestJson,
         )
+        authDiskSource.storeShouldUseKeyConnector(userId = userId, shouldUseKeyConnector = true)
         val shouldTrustDevice = true
         authDiskSource.storeShouldTrustDevice(
             userId = userId,
@@ -258,6 +277,7 @@ class AuthDiskSourceTest {
         assertNull(authDiskSource.getAccountTokens(userId = userId))
         assertNull(authDiskSource.getEncryptedPin(userId = userId))
         assertNull(authDiskSource.getMasterPasswordHash(userId = userId))
+        assertNull(authDiskSource.getShouldUseKeyConnector(userId = userId))
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
@@ -26,6 +26,7 @@ class FakeAuthDiskSource : AuthDiskSource {
         mutableMapOf<String, MutableSharedFlow<AccountTokensJson?>>()
     private val mutableUserStateFlow = bufferedMutableSharedFlow<UserStateJson?>(replay = 1)
 
+    private val storedShouldUseKeyConnector = mutableMapOf<String, Boolean?>()
     private val storedShouldTrustDevice = mutableMapOf<String, Boolean?>()
     private val storedInvalidUnlockAttempts = mutableMapOf<String, Int?>()
     private val storedUserKeys = mutableMapOf<String, String?>()
@@ -70,6 +71,14 @@ class FakeAuthDiskSource : AuthDiskSource {
         mutableOrganizationsFlowMap.remove(userId)
         mutablePoliciesFlowMap.remove(userId)
         mutableAccountTokensFlowMap.remove(userId)
+    }
+
+    override fun getShouldUseKeyConnector(
+        userId: String,
+    ): Boolean = storedShouldUseKeyConnector[userId] ?: false
+
+    override fun storeShouldUseKeyConnector(userId: String, shouldUseKeyConnector: Boolean?) {
+        storedShouldUseKeyConnector[userId] = shouldUseKeyConnector
     }
 
     override fun getShouldTrustDevice(userId: String): Boolean =
@@ -212,6 +221,13 @@ class FakeAuthDiskSource : AuthDiskSource {
     override fun storeAccountTokens(userId: String, accountTokens: AccountTokensJson?) {
         storedAccountTokens[userId] = accountTokens
         getMutableAccountTokensFlow(userId = userId).tryEmit(accountTokens)
+    }
+
+    /**
+     * Assert the the [shouldUseKeyConnector] was stored successfully using the [userId].
+     */
+    fun assertShouldUseKeyConnector(userId: String, shouldUseKeyConnector: Boolean?) {
+        assertEquals(shouldUseKeyConnector, storedShouldUseKeyConnector[userId])
     }
 
     /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -826,6 +826,10 @@ class VaultRepositoryTest {
                 userId = "mockId-1",
                 policies = listOf(createMockPolicy(number = 1)),
             )
+            fakeAuthDiskSource.assertShouldUseKeyConnector(
+                userId = "mockId-1",
+                shouldUseKeyConnector = false,
+            )
             coVerify {
                 vaultDiskSource.replaceVaultData(
                     userId = MOCK_USER_STATE.activeUserId,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10909](https://bitwarden.atlassian.net/browse/PM-10909)

## 📔 Objective

This PR adds the persistance layer for the `usersKeyConnector` boolean that is received from the sync API.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10909]: https://bitwarden.atlassian.net/browse/PM-10909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ