### PR TITLE
All booleans stored are nullable for consistency

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
@@ -60,7 +60,7 @@ interface AuthDiskSource {
      *
      * Note: This indicates intent to trust the device, the device may not be trusted yet.
      */
-    fun getShouldTrustDevice(userId: String): Boolean
+    fun getShouldTrustDevice(userId: String): Boolean?
 
     /**
      * Stores the boolean indicating that the user has chosen to trust this device for the given

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
@@ -140,10 +140,9 @@ class AuthDiskSourceImpl(
         )
     }
 
-    override fun getShouldTrustDevice(userId: String): Boolean =
-        requireNotNull(
-            getBoolean(key = SHOULD_TRUST_DEVICE_KEY.appendIdentifier(userId), default = false),
-        )
+    override fun getShouldTrustDevice(
+        userId: String,
+    ): Boolean? = getBoolean(key = SHOULD_TRUST_DEVICE_KEY.appendIdentifier(userId))
 
     override fun storeShouldTrustDevice(userId: String, shouldTrustDevice: Boolean?) {
         putBoolean(SHOULD_TRUST_DEVICE_KEY.appendIdentifier(userId), shouldTrustDevice)

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/TrustedDeviceManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/TrustedDeviceManagerImpl.kt
@@ -17,7 +17,7 @@ class TrustedDeviceManagerImpl(
     private val devicesService: DevicesService,
 ) : TrustedDeviceManager {
     override suspend fun trustThisDeviceIfNecessary(userId: String): Result<Boolean> =
-        if (!authDiskSource.getShouldTrustDevice(userId = userId)) {
+        if (authDiskSource.getShouldTrustDevice(userId = userId) != true) {
             false.asSuccess()
         } else {
             vaultSdkSource

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -470,7 +470,8 @@ class AuthRepositoryImpl(
                             userId = userId,
                             email = account.profile.email,
                             orgPublicKey = organizationKeys.publicKey,
-                            rememberDevice = authDiskSource.getShouldTrustDevice(userId = userId),
+                            rememberDevice = authDiskSource
+                                .getShouldTrustDevice(userId = userId) == true,
                         )
                     }
                     .flatMap { keys ->

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/BaseDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/BaseDiskSource.kt
@@ -11,18 +11,15 @@ abstract class BaseDiskSource(
     private val sharedPreferences: SharedPreferences,
 ) {
     /**
-     * Gets the [Boolean] for the given [key] from [SharedPreferences], or return the [default]
-     * value if that key is not present.
+     * Gets the [Boolean] for the given [key] from [SharedPreferences], or returns `null` if that
+     * key is not present.
      */
-    protected fun getBoolean(
-        key: String,
-        default: Boolean? = null,
-    ): Boolean? =
+    protected fun getBoolean(key: String): Boolean? =
         if (sharedPreferences.contains(key.withBase())) {
             sharedPreferences.getBoolean(key.withBase(), false)
         } else {
             // Make sure we can return a null value as a default if necessary
-            default
+            null
         }
 
     /**
@@ -42,18 +39,15 @@ abstract class BaseDiskSource(
         }
 
     /**
-     * Gets the [Int] for the given [key] from [SharedPreferences], or return the [default] value
-     * if that key is not present.
+     * Gets the [Int] for the given [key] from [SharedPreferences], or returns `null` if that key
+     * is not present.
      */
-    protected fun getInt(
-        key: String,
-        default: Int? = null,
-    ): Int? =
+    protected fun getInt(key: String): Int? =
         if (sharedPreferences.contains(key.withBase())) {
             sharedPreferences.getInt(key.withBase(), 0)
         } else {
             // Make sure we can return a null value as a default if necessary
-            default
+            null
         }
 
     /**
@@ -73,18 +67,15 @@ abstract class BaseDiskSource(
         }
 
     /**
-     * Gets the [Long] for the given [key] from [SharedPreferences], or return the [default] value
-     * if that key is not present.
+     * Gets the [Long] for the given [key] from [SharedPreferences], or returns `null` if that key
+     * is not present.
      */
-    protected fun getLong(
-        key: String,
-        default: Long? = null,
-    ): Long? =
+    protected fun getLong(key: String): Long? =
         if (sharedPreferences.contains(key.withBase())) {
             sharedPreferences.getLong(key.withBase(), 0)
         } else {
             // Make sure we can return a null value as a default if necessary
-            default
+            null
         }
 
     /**
@@ -105,8 +96,7 @@ abstract class BaseDiskSource(
 
     protected fun getString(
         key: String,
-        default: String? = null,
-    ): String? = sharedPreferences.getString(key.withBase(), default)
+    ): String? = sharedPreferences.getString(key.withBase(), null)
 
     protected fun putString(
         key: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/PushDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/PushDiskSourceImpl.kt
@@ -35,7 +35,7 @@ class PushDiskSourceImpl(
     }
 
     override fun getLastPushTokenRegistrationDate(userId: String): ZonedDateTime? {
-        return getLong(LAST_REGISTRATION_DATE_KEY.appendIdentifier(userId), null)
+        return getLong(LAST_REGISTRATION_DATE_KEY.appendIdentifier(userId))
             ?.let { getZoneDateTimeFromBinaryLong(it) }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -145,7 +145,7 @@ class AuthDiskSourceTest {
         val shouldTrustDeviceKey = "bwPreferencesStorage:shouldTrustDevice_$userId"
 
         // Shared preferences and the disk source start with the same value.
-        assertFalse(authDiskSource.getShouldTrustDevice(userId = userId))
+        assertNull(authDiskSource.getShouldTrustDevice(userId = userId))
         assertFalse(fakeSharedPreferences.getBoolean(shouldTrustDeviceKey, false))
 
         // Updating the disk source updates shared preferences
@@ -154,7 +154,7 @@ class AuthDiskSourceTest {
 
         // Update SharedPreferences updates the disk source
         fakeSharedPreferences.edit { putBoolean(shouldTrustDeviceKey, false) }
-        assertFalse(authDiskSource.getShouldTrustDevice(userId = userId))
+        assertFalse(authDiskSource.getShouldTrustDevice(userId = userId) ?: true)
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the way data is stored in the various DiskSources by forcing them to be nullable (null meaning not present).

This change only affects one boolean and makes the disk source more consistent.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
