### PR TITLE
PM-10936: Add account apis for key connectors

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/AuthenticatedAccountsApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/AuthenticatedAccountsApi.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.auth.datasource.network.api
 
 import com.x8bit.bitwarden.data.auth.datasource.network.model.CreateAccountKeysRequest
 import com.x8bit.bitwarden.data.auth.datasource.network.model.DeleteAccountRequestJson
+import com.x8bit.bitwarden.data.auth.datasource.network.model.KeyConnectorKeyRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResetPasswordRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.SetPasswordRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.VerifyOtpRequestJson
@@ -13,6 +14,13 @@ import retrofit2.http.POST
  * Defines raw calls under the /accounts API with authentication applied.
  */
 interface AuthenticatedAccountsApi {
+
+    /**
+     * Converts the currently active account to a key-connector account.
+     */
+    @POST("/accounts/convert-to-key-connector")
+    suspend fun convertToKeyConnector(): Result<Unit>
+
     /**
      * Creates the keys for the current account.
      */
@@ -44,6 +52,12 @@ interface AuthenticatedAccountsApi {
      */
     @HTTP(method = "POST", path = "/accounts/password", hasBody = true)
     suspend fun resetPassword(@Body body: ResetPasswordRequestJson): Result<Unit>
+
+    /**
+     * Sets the key connector key.
+     */
+    @POST("/accounts/set-key-connector-key")
+    suspend fun setKeyConnectorKey(@Body body: KeyConnectorKeyRequestJson): Result<Unit>
 
     /**
      * Sets the password.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KeyConnectorKeyRequestJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KeyConnectorKeyRequestJson.kt
@@ -1,0 +1,33 @@
+package com.x8bit.bitwarden.data.auth.datasource.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the request body used to create the key connector keys for an account.
+ */
+@Serializable
+data class KeyConnectorKeyRequestJson(
+    @SerialName("key") val userKey: String,
+    @SerialName("keys") val keys: Keys,
+    @SerialName("kdf") val kdfType: KdfTypeJson,
+    @SerialName("kdfIterations") val kdfIterations: Int?,
+    @SerialName("kdfMemory") val kdfMemory: Int?,
+    @SerialName("kdfParallelism") val kdfParallelism: Int?,
+    @SerialName("orgIdentifier") val organizationIdentifier: String,
+) {
+    /**
+     * A keys object containing public and private keys.
+     *
+     * @param publicKey the public key (encrypted).
+     * @param encryptedPrivateKey the private key (encrypted).
+     */
+    @Serializable
+    data class Keys(
+        @SerialName("publicKey")
+        val publicKey: String,
+
+        @SerialName("encryptedPrivateKey")
+        val encryptedPrivateKey: String,
+    )
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsService.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.x8bit.bitwarden.data.auth.datasource.network.model.DeleteAccountResponseJson
+import com.x8bit.bitwarden.data.auth.datasource.network.model.KeyConnectorKeyRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.PasswordHintResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResendEmailRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResetPasswordRequestJson
@@ -10,6 +11,11 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.SetPasswordRequest
  * Provides an API for querying accounts endpoints.
  */
 interface AccountsService {
+
+    /**
+     * Converts the currently active account to a key-connector account.
+     */
+    suspend fun convertToKeyConnector(): Result<Unit>
 
     /**
      * Creates a new account's keys.
@@ -48,6 +54,11 @@ interface AccountsService {
      * Reset the password.
      */
     suspend fun resetPassword(body: ResetPasswordRequestJson): Result<Unit>
+
+    /**
+     * Set the key connector key.
+     */
+    suspend fun setKeyConnectorKey(body: KeyConnectorKeyRequestJson): Result<Unit>
 
     /**
      * Set the password.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
@@ -5,6 +5,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAccount
 import com.x8bit.bitwarden.data.auth.datasource.network.model.CreateAccountKeysRequest
 import com.x8bit.bitwarden.data.auth.datasource.network.model.DeleteAccountRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.DeleteAccountResponseJson
+import com.x8bit.bitwarden.data.auth.datasource.network.model.KeyConnectorKeyRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.PasswordHintRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.PasswordHintResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResendEmailRequestJson
@@ -20,6 +21,12 @@ class AccountsServiceImpl(
     private val authenticatedAccountsApi: AuthenticatedAccountsApi,
     private val json: Json,
 ) : AccountsService {
+
+    /**
+     * Converts the currently active account to a key-connector account.
+     */
+    override suspend fun convertToKeyConnector(): Result<Unit> =
+        authenticatedAccountsApi.convertToKeyConnector()
 
     override suspend fun createAccountKeys(
         publicKey: String,
@@ -92,6 +99,10 @@ class AccountsServiceImpl(
             authenticatedAccountsApi.resetPassword(body = body)
         }
     }
+
+    override suspend fun setKeyConnectorKey(
+        body: KeyConnectorKeyRequestJson,
+    ): Result<Unit> = authenticatedAccountsApi.setKeyConnectorKey(body)
 
     override suspend fun setPassword(
         body: SetPasswordRequestJson,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceTest.kt
@@ -2,6 +2,8 @@ package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AccountsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAccountsApi
+import com.x8bit.bitwarden.data.auth.datasource.network.model.KdfTypeJson
+import com.x8bit.bitwarden.data.auth.datasource.network.model.KeyConnectorKeyRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.PasswordHintResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResendEmailRequestJson
@@ -27,6 +29,16 @@ class AccountsServiceTest : BaseServiceTest() {
             ignoreUnknownKeys = true
         },
     )
+
+    @Test
+    fun `convertToKeyConnector with empty response is success`() = runTest {
+        val response = MockResponse().setBody("")
+        server.enqueue(response)
+
+        val result = service.convertToKeyConnector()
+
+        assertTrue(result.isSuccess)
+    }
 
     @Test
     fun `createAccountKeys with empty response is success`() = runTest {
@@ -166,6 +178,27 @@ class AccountsServiceTest : BaseServiceTest() {
                 kdfType = null,
                 key = "encryptedUserKey",
                 keys = RegisterRequestJson.Keys(
+                    publicKey = "public",
+                    encryptedPrivateKey = "private",
+                ),
+            ),
+        )
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `setKeyConnectorKey with empty response is success`() = runTest {
+        val response = MockResponse().setBody("")
+        server.enqueue(response)
+        val result = service.setKeyConnectorKey(
+            body = KeyConnectorKeyRequestJson(
+                organizationIdentifier = "organizationId",
+                kdfIterations = 7,
+                kdfMemory = 1,
+                kdfParallelism = 2,
+                kdfType = KdfTypeJson.ARGON2_ID,
+                userKey = "encryptedUserKey",
+                keys = KeyConnectorKeyRequestJson.Keys(
                     publicKey = "public",
                     encryptedPrivateKey = "private",
                 ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10936](https://bitwarden.atlassian.net/browse/PM-10936)

## 📔 Objective

This PR adds two new APIs using the account domain that will be used to support key connectors.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10936]: https://bitwarden.atlassian.net/browse/PM-10936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ