### PR TITLE
Add helper function for static retrofit instances

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/di/AuthNetworkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/di/AuthNetworkModule.kt
@@ -73,10 +73,8 @@ object AuthNetworkModule {
     fun providesHaveIBeenPwnedService(
         retrofits: Retrofits,
     ): HaveIBeenPwnedService = HaveIBeenPwnedServiceImpl(
-        retrofits
-            .staticRetrofitBuilder
-            .baseUrl("https://api.pwnedpasswords.com")
-            .build()
+        api = retrofits
+            .createStaticRetrofit(baseUrl = "https://api.pwnedpasswords.com")
             .create(),
     )
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/datasource/network/di/Fido2NetworkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/datasource/network/di/Fido2NetworkModule.kt
@@ -24,10 +24,7 @@ object Fido2NetworkModule {
     ): DigitalAssetLinkService =
         DigitalAssetLinkServiceImpl(
             digitalAssetLinkApi = retrofits
-                .staticRetrofitBuilder
-                // This URL will be overridden dynamically.
-                .baseUrl("https://www.bitwarden.com")
-                .build()
+                .createStaticRetrofit()
                 .create(),
         )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/retrofit/Retrofits.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/retrofit/Retrofits.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.datasource.network.retrofit
 
 import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.BaseUrlInterceptors
 import retrofit2.Retrofit
+import retrofit2.http.Url
 
 /**
  * A collection of various [Retrofit] instances that serve different purposes.
@@ -36,11 +37,14 @@ interface Retrofits {
     val unauthenticatedIdentityRetrofit: Retrofit
 
     /**
-     * Allows access to static API calls (ex: external APIs) that do not therefore require
-     * authentication with Bitwarden's servers.
+     * Allows access to static API calls (ex: external APIs).
      *
-     * No base URL is supplied as part of the builder and no longer is added to make this URL
-     * dynamically updatable.
+     * @param isAuthenticated Indicates if the [Retrofit] instance should use authentication.
+     * @param baseUrl The static base url associated with this retrofit instance. This can be
+     * overridden with the [Url] annotation.
      */
-    val staticRetrofitBuilder: Retrofit.Builder
+    fun createStaticRetrofit(
+        isAuthenticated: Boolean = false,
+        baseUrl: String = "https://api.bitwarden.com",
+    ): Retrofit
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/retrofit/RetrofitsImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/retrofit/RetrofitsImpl.kt
@@ -60,19 +60,22 @@ class RetrofitsImpl(
 
     //endregion Unauthenticated Retrofits
 
-    //region Other Retrofits
+    //region Static Retrofit
 
-    override val staticRetrofitBuilder: Retrofit.Builder
-        get() =
-            baseRetrofitBuilder
-                .client(
-                    baseOkHttpClient
-                        .newBuilder()
-                        .addInterceptor(loggingInterceptor)
-                        .build(),
-                )
+    override fun createStaticRetrofit(isAuthenticated: Boolean, baseUrl: String): Retrofit {
+        val baseClient = if (isAuthenticated) authenticatedOkHttpClient else baseOkHttpClient
+        return baseRetrofitBuilder
+            .baseUrl(baseUrl)
+            .client(
+                baseClient
+                    .newBuilder()
+                    .addInterceptor(loggingInterceptor)
+                    .build(),
+            )
+            .build()
+    }
 
-    //endregion Other Retrofits
+    //endregion Static Retrofit
 
     //region Helper properties and functions
     private val loggingInterceptor: HttpLoggingInterceptor by lazy {

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/di/VaultNetworkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/di/VaultNetworkModule.kt
@@ -35,10 +35,7 @@ object VaultNetworkModule {
         clock: Clock,
     ): CiphersService = CiphersServiceImpl(
         azureApi = retrofits
-            .staticRetrofitBuilder
-            // This URL will be overridden dynamically
-            .baseUrl("https://www.bitwarden.com")
-            .build()
+            .createStaticRetrofit()
             .create(),
         ciphersApi = retrofits.authenticatedApiRetrofit.create(),
         json = json,
@@ -63,10 +60,7 @@ object VaultNetworkModule {
         clock: Clock,
     ): SendsService = SendsServiceImpl(
         azureApi = retrofits
-            .staticRetrofitBuilder
-            // This URL will be overridden dynamically
-            .baseUrl("https://www.bitwarden.com")
-            .build()
+            .createStaticRetrofit()
             .create(),
         sendsApi = retrofits.authenticatedApiRetrofit.create(),
         json = json,
@@ -87,10 +81,7 @@ object VaultNetworkModule {
         retrofits: Retrofits,
     ): DownloadService = DownloadServiceImpl(
         downloadApi = retrofits
-            .staticRetrofitBuilder
-            // This URL will be overridden dynamically
-            .baseUrl("https://www.bitwarden.com")
-            .build()
+            .createStaticRetrofit()
             .create(),
     )
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/retrofit/RetrofitsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/retrofit/RetrofitsTest.kt
@@ -218,24 +218,42 @@ class RetrofitsTest {
     }
 
     @Test
-    fun `staticRetrofitBuilder should invoke the correct interceptors`() = runBlocking {
-        val testApi = retrofits
-            .staticRetrofitBuilder
-            .baseUrl(server.url("/").toString())
-            .build()
-            .createMockRetrofit()
-            .create<TestApi>()
+    fun `createStaticRetrofit when authenticated should invoke the correct interceptors`() =
+        runBlocking {
+            val testApi = retrofits
+                .createStaticRetrofit(isAuthenticated = true)
+                .createMockRetrofit()
+                .create<TestApi>()
 
-        server.enqueue(MockResponse().setBody("""{}"""))
+            server.enqueue(MockResponse().setBody("""{}"""))
 
-        testApi.test()
+            testApi.test()
 
-        assertFalse(isAuthInterceptorCalled)
-        assertFalse(isApiInterceptorCalled)
-        assertTrue(isheadersInterceptorCalled)
-        assertFalse(isIdentityInterceptorCalled)
-        assertFalse(isEventsInterceptorCalled)
-    }
+            assertTrue(isAuthInterceptorCalled)
+            assertFalse(isApiInterceptorCalled)
+            assertTrue(isheadersInterceptorCalled)
+            assertFalse(isIdentityInterceptorCalled)
+            assertFalse(isEventsInterceptorCalled)
+        }
+
+    @Test
+    fun `createStaticRetrofit when unauthenticated should invoke the correct interceptors`() =
+        runBlocking {
+            val testApi = retrofits
+                .createStaticRetrofit(isAuthenticated = false)
+                .createMockRetrofit()
+                .create<TestApi>()
+
+            server.enqueue(MockResponse().setBody("""{}"""))
+
+            testApi.test()
+
+            assertFalse(isAuthInterceptorCalled)
+            assertFalse(isApiInterceptorCalled)
+            assertTrue(isheadersInterceptorCalled)
+            assertFalse(isIdentityInterceptorCalled)
+            assertFalse(isEventsInterceptorCalled)
+        }
 
     private fun Retrofit.createMockRetrofit(): Retrofit =
         this


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the way we manage instances of Retrofit with static base urls. This is just a small bit of clean up that will be nice as I add another static retrofit instance for Key Connectors.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
