### PR TITLE
PM-10874: Prompt for biometrics after switching accounts

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -101,14 +101,7 @@ class VaultUnlockViewModel @Inject constructor(
             }
             .launchIn(viewModelScope)
 
-        val cipher = biometricsEncryptionManager.getOrCreateCipher(state.userId)
-        if (state.showBiometricLogin && cipher != null) {
-            sendEvent(
-                VaultUnlockEvent.PromptForBiometrics(
-                    cipher = cipher,
-                ),
-            )
-        }
+        promptForBiometricsIfAvailable()
     }
 
     override fun onCleared() {
@@ -318,6 +311,20 @@ class VaultUnlockViewModel @Inject constructor(
                 isBiometricEnabled = userState.activeAccount.isBiometricsEnabled,
                 vaultUnlockType = userState.activeAccount.vaultUnlockType,
                 input = "",
+            )
+        }
+
+        // If the new account has biometrics available, automatically prompt for biometrics.
+        promptForBiometricsIfAvailable()
+    }
+
+    private fun promptForBiometricsIfAvailable() {
+        val cipher = biometricsEncryptionManager.getOrCreateCipher(state.userId)
+        if (state.showBiometricLogin && cipher != null) {
+            sendEvent(
+                VaultUnlockEvent.PromptForBiometrics(
+                    cipher = cipher,
+                ),
             )
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-10874](https://bitwarden.atlassian.net/browse/PM-10874)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix an additional bug to automatically prompt the user for biometrics if they switch to an account that has it enabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/f3f0feab-315b-48b5-abda-c02a0873517e" /> | <video src="https://github.com/user-attachments/assets/4bd36f81-a9f4-432c-8b7c-db77aefef7a6" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10874]: https://bitwarden.atlassian.net/browse/PM-10874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ