### PR TITLE
PM-10956: Add support for leave organization API

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/AuthenticatedOrganizationApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/AuthenticatedOrganizationApi.kt
@@ -5,6 +5,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationKeysRe
 import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationResetPasswordEnrollRequestJson
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
 
@@ -37,4 +38,12 @@ interface AuthenticatedOrganizationApi {
     suspend fun getOrganizationKeys(
         @Path("id") organizationId: String,
     ): Result<OrganizationKeysResponseJson>
+
+    /**
+     * Leaves the this organization.
+     */
+    @POST("/organizations/{id}/leave")
+    suspend fun leaveOrganization(
+        @Path("id") organizationId: String,
+    ): Result<Unit>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationService.kt
@@ -38,4 +38,11 @@ interface OrganizationService {
     suspend fun getOrganizationKeys(
         organizationId: String,
     ): Result<OrganizationKeysResponseJson>
+
+    /**
+     * Leaves this organization.
+     */
+    suspend fun leaveOrganization(
+        organizationId: String,
+    ): Result<Unit>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationServiceImpl.kt
@@ -52,4 +52,9 @@ class OrganizationServiceImpl(
         .getOrganizationKeys(
             organizationId = organizationId,
         )
+
+    override suspend fun leaveOrganization(
+        organizationId: String,
+    ): Result<Unit> =
+        authenticatedOrganizationApi.leaveOrganization(organizationId = organizationId)
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationServiceTest.kt
@@ -104,6 +104,13 @@ class OrganizationServiceTest : BaseServiceTest() {
         val result = organizationService.getOrganizationKeys("orgId")
         assertTrue(result.isFailure)
     }
+
+    @Test
+    fun `leaveOrganization when response is success should return success`() = runTest {
+        server.enqueue(MockResponse())
+        val result = organizationService.leaveOrganization(organizationId = "orgId")
+        assertTrue(result.isSuccess)
+    }
 }
 
 private const val ORGANIZATION_AUTO_ENROLL_STATUS_JSON = """


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10956](https://bitwarden.atlassian.net/browse/PM-10956)

## 📔 Objective

This PR adds support for the leave organization network API that will be used for key connectors.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10956]: https://bitwarden.atlassian.net/browse/PM-10956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ