### PR TITLE
Rename APIs for extra specificity

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedAccountsApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedAccountsApi.kt
@@ -8,7 +8,7 @@ import retrofit2.http.POST
 /**
  * Defines raw calls under the /accounts API.
  */
-interface AccountsApi {
+interface UnauthenticatedAccountsApi {
     @POST("/accounts/password-hint")
     suspend fun passwordHintRequest(
         @Body body: PasswordHintRequestJson,

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedIdentityApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedIdentityApi.kt
@@ -22,7 +22,7 @@ import retrofit2.http.Query
 /**
  * Defines raw calls under the /identity API.
  */
-interface IdentityApi {
+interface UnauthenticatedIdentityApi {
 
     @POST("/connect/token")
     @Suppress("LongParameterList")

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedOrganizationApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedOrganizationApi.kt
@@ -8,7 +8,7 @@ import retrofit2.http.POST
 /**
  * Defines raw calls under the /organizations API.
  */
-interface OrganizationApi {
+interface UnauthenticatedOrganizationApi {
     /**
      * Checks for the claimed domain organization of an email for SSO purposes.
      */

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/di/AuthNetworkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/di/AuthNetworkModule.kt
@@ -36,7 +36,7 @@ object AuthNetworkModule {
         retrofits: Retrofits,
         json: Json,
     ): AccountsService = AccountsServiceImpl(
-        accountsApi = retrofits.unauthenticatedApiRetrofit.create(),
+        unauthenticatedAccountsApi = retrofits.unauthenticatedApiRetrofit.create(),
         authenticatedAccountsApi = retrofits.authenticatedApiRetrofit.create(),
         authenticatedKeyConnectorApi = retrofits
             .createStaticRetrofit(isAuthenticated = true)
@@ -67,7 +67,7 @@ object AuthNetworkModule {
         retrofits: Retrofits,
         json: Json,
     ): IdentityService = IdentityServiceImpl(
-        api = retrofits.unauthenticatedIdentityRetrofit.create(),
+        unauthenticatedIdentityApi = retrofits.unauthenticatedIdentityRetrofit.create(),
         json = json,
     )
 
@@ -96,6 +96,6 @@ object AuthNetworkModule {
         retrofits: Retrofits,
     ): OrganizationService = OrganizationServiceImpl(
         authenticatedOrganizationApi = retrofits.authenticatedApiRetrofit.create(),
-        organizationApi = retrofits.unauthenticatedApiRetrofit.create(),
+        unauthenticatedOrganizationApi = retrofits.unauthenticatedApiRetrofit.create(),
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
-import com.x8bit.bitwarden.data.auth.datasource.network.api.AccountsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAccountsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedKeyConnectorApi
+import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedAccountsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.model.CreateAccountKeysRequest
 import com.x8bit.bitwarden.data.auth.datasource.network.model.DeleteAccountRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.DeleteAccountResponseJson
@@ -24,7 +24,7 @@ import kotlinx.serialization.json.Json
  */
 @Suppress("TooManyFunctions")
 class AccountsServiceImpl(
-    private val accountsApi: AccountsApi,
+    private val unauthenticatedAccountsApi: UnauthenticatedAccountsApi,
     private val authenticatedAccountsApi: AuthenticatedAccountsApi,
     private val authenticatedKeyConnectorApi: AuthenticatedKeyConnectorApi,
     private val json: Json,
@@ -84,7 +84,7 @@ class AccountsServiceImpl(
     override suspend fun requestPasswordHint(
         email: String,
     ): Result<PasswordHintResponseJson> =
-        accountsApi
+        unauthenticatedAccountsApi
             .passwordHintRequest(PasswordHintRequestJson(email))
             .map { PasswordHintResponseJson.Success }
             .recoverCatching { throwable ->
@@ -98,7 +98,7 @@ class AccountsServiceImpl(
             }
 
     override suspend fun resendVerificationCodeEmail(body: ResendEmailRequestJson): Result<Unit> =
-        accountsApi.resendVerificationCodeEmail(body = body)
+        unauthenticatedAccountsApi.resendVerificationCodeEmail(body = body)
 
     override suspend fun resetPassword(body: ResetPasswordRequestJson): Result<Unit> {
         return if (body.currentPasswordHash == null) {

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceImpl.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
-import com.x8bit.bitwarden.data.auth.datasource.network.api.IdentityApi
+import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedIdentityApi
 import com.x8bit.bitwarden.data.auth.datasource.network.model.GetTokenResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.IdentityTokenAuthModel
 import com.x8bit.bitwarden.data.auth.datasource.network.model.PreLoginRequestJson
@@ -20,17 +20,17 @@ import com.x8bit.bitwarden.data.platform.util.DeviceModelProvider
 import kotlinx.serialization.json.Json
 
 class IdentityServiceImpl(
-    private val api: IdentityApi,
+    private val unauthenticatedIdentityApi: UnauthenticatedIdentityApi,
     private val json: Json,
     private val deviceModelProvider: DeviceModelProvider = DeviceModelProvider(),
 ) : IdentityService {
 
     override suspend fun preLogin(email: String): Result<PreLoginResponseJson> =
-        api.preLogin(PreLoginRequestJson(email = email))
+        unauthenticatedIdentityApi.preLogin(PreLoginRequestJson(email = email))
 
     @Suppress("MagicNumber")
     override suspend fun register(body: RegisterRequestJson): Result<RegisterResponseJson> =
-        api
+        unauthenticatedIdentityApi
             .register(body)
             .recoverCatching { throwable ->
                 val bitwardenError = throwable.toBitwardenError()
@@ -39,11 +39,10 @@ class IdentityServiceImpl(
                         code = 400,
                         json = json,
                     )
-                    ?: bitwardenError
-                        .parseErrorBodyOrNull<RegisterResponseJson.Invalid>(
-                            codes = listOf(400, 429),
-                            json = json,
-                        )
+                    ?: bitwardenError.parseErrorBodyOrNull<RegisterResponseJson.Invalid>(
+                        codes = listOf(400, 429),
+                        json = json,
+                    )
                     ?: bitwardenError.parseErrorBodyOrNull<RegisterResponseJson.Error>(
                         code = 429,
                         json = json,
@@ -58,7 +57,7 @@ class IdentityServiceImpl(
         authModel: IdentityTokenAuthModel,
         captchaToken: String?,
         twoFactorData: TwoFactorDataModel?,
-    ): Result<GetTokenResponseJson> = api
+    ): Result<GetTokenResponseJson> = unauthenticatedIdentityApi
         .getToken(
             scope = "api offline_access",
             clientId = "mobile",
@@ -94,14 +93,14 @@ class IdentityServiceImpl(
 
     override suspend fun prevalidateSso(
         organizationIdentifier: String,
-    ): Result<PrevalidateSsoResponseJson> = api
+    ): Result<PrevalidateSsoResponseJson> = unauthenticatedIdentityApi
         .prevalidateSso(
             organizationIdentifier = organizationIdentifier,
         )
 
     override fun refreshTokenSynchronously(
         refreshToken: String,
-    ): Result<RefreshTokenResponseJson> = api
+    ): Result<RefreshTokenResponseJson> = unauthenticatedIdentityApi
         .refreshTokenCall(
             clientId = "mobile",
             grantType = "refresh_token",
@@ -113,7 +112,7 @@ class IdentityServiceImpl(
     override suspend fun registerFinish(
         body: RegisterFinishRequestJson,
     ): Result<RegisterResponseJson> =
-        api
+        unauthenticatedIdentityApi
             .registerFinish(body)
             .recoverCatching { throwable ->
                 val bitwardenError = throwable.toBitwardenError()
@@ -132,7 +131,7 @@ class IdentityServiceImpl(
     override suspend fun sendVerificationEmail(
         body: SendVerificationEmailRequestJson,
     ): Result<String?> {
-        return api
+        return unauthenticatedIdentityApi
             .sendVerificationEmail(body = body)
             .map { it?.content }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedOrganizationApi
-import com.x8bit.bitwarden.data.auth.datasource.network.api.OrganizationApi
+import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedOrganizationApi
 import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationAutoEnrollStatusResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationDomainSsoDetailsRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationDomainSsoDetailsResponseJson
@@ -13,7 +13,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationResetP
  */
 class OrganizationServiceImpl(
     private val authenticatedOrganizationApi: AuthenticatedOrganizationApi,
-    private val organizationApi: OrganizationApi,
+    private val unauthenticatedOrganizationApi: UnauthenticatedOrganizationApi,
 ) : OrganizationService {
     override suspend fun organizationResetPasswordEnroll(
         organizationId: String,
@@ -32,7 +32,7 @@ class OrganizationServiceImpl(
 
     override suspend fun getOrganizationDomainSsoDetails(
         email: String,
-    ): Result<OrganizationDomainSsoDetailsResponseJson> = organizationApi
+    ): Result<OrganizationDomainSsoDetailsResponseJson> = unauthenticatedOrganizationApi
         .getClaimedDomainOrganizationDetails(
             body = OrganizationDomainSsoDetailsRequestJson(
                 email = email,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceTest.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
-import com.x8bit.bitwarden.data.auth.datasource.network.api.AccountsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAccountsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedKeyConnectorApi
+import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedAccountsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.model.KdfTypeJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.KeyConnectorKeyRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.KeyConnectorMasterKeyResponseJson
@@ -22,11 +22,11 @@ import retrofit2.create
 
 class AccountsServiceTest : BaseServiceTest() {
 
-    private val accountsApi: AccountsApi = retrofit.create()
+    private val unauthenticatedAccountsApi: UnauthenticatedAccountsApi = retrofit.create()
     private val authenticatedAccountsApi: AuthenticatedAccountsApi = retrofit.create()
     private val authenticatedKeyConnectorApi: AuthenticatedKeyConnectorApi = retrofit.create()
     private val service = AccountsServiceImpl(
-        accountsApi = accountsApi,
+        unauthenticatedAccountsApi = unauthenticatedAccountsApi,
         authenticatedAccountsApi = authenticatedAccountsApi,
         authenticatedKeyConnectorApi = authenticatedKeyConnectorApi,
         json = json,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
-import com.x8bit.bitwarden.data.auth.datasource.network.api.IdentityApi
+import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedIdentityApi
 import com.x8bit.bitwarden.data.auth.datasource.network.model.GetTokenResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.IdentityTokenAuthModel
 import com.x8bit.bitwarden.data.auth.datasource.network.model.KdfTypeJson
@@ -34,13 +34,13 @@ import retrofit2.create
 
 class IdentityServiceTest : BaseServiceTest() {
 
-    private val identityApi: IdentityApi = retrofit.create()
+    private val unauthenticatedIdentityApi: UnauthenticatedIdentityApi = retrofit.create()
     private val deviceModelProvider = mockk<DeviceModelProvider> {
         every { deviceModel } returns "Test Device"
     }
 
     private val identityService = IdentityServiceImpl(
-        api = identityApi,
+        unauthenticatedIdentityApi = unauthenticatedIdentityApi,
         json = Json {
             ignoreUnknownKeys = true
         },

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/OrganizationServiceTest.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedOrganizationApi
-import com.x8bit.bitwarden.data.auth.datasource.network.api.OrganizationApi
+import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedOrganizationApi
 import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationAutoEnrollStatusResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationDomainSsoDetailsResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.OrganizationKeysResponseJson
@@ -17,11 +17,11 @@ import java.time.ZonedDateTime
 
 class OrganizationServiceTest : BaseServiceTest() {
     private val authenticatedOrganizationApi: AuthenticatedOrganizationApi = retrofit.create()
-    private val organizationApi: OrganizationApi = retrofit.create()
+    private val unauthenticatedOrganizationApi: UnauthenticatedOrganizationApi = retrofit.create()
 
     private val organizationService = OrganizationServiceImpl(
         authenticatedOrganizationApi = authenticatedOrganizationApi,
-        organizationApi = organizationApi,
+        unauthenticatedOrganizationApi = unauthenticatedOrganizationApi,
     )
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes some ambiguity from some of our API interfaces by adding the `Unauthenticated` prefix to the classes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
