### PR TITLE
Simplify error responses

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/RegisterResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/RegisterResponseJson.kt
@@ -46,7 +46,6 @@ sealed class RegisterResponseJson {
     /**
      * Represents the json body of an invalid register request.
      *
-     * @param message
      * @param validationErrors a map where each value is a list of error messages for each key.
      * The values in the array should be used for display to the user, since the keys tend to come
      * back as nonsense. (eg: empty string key)
@@ -54,18 +53,17 @@ sealed class RegisterResponseJson {
     @Serializable
     data class Invalid(
         @SerialName("message")
-        val message: String?,
+        private val invalidMessage: String? = null,
+
+        @SerialName("Message")
+        private val errorMessage: String? = null,
 
         @SerialName("validationErrors")
         val validationErrors: Map<String, List<String>>?,
-    ) : RegisterResponseJson()
-
-    /**
-     * A different register error with a message.
-     */
-    @Serializable
-    data class Error(
-        @SerialName("Message")
-        val message: String?,
-    ) : RegisterResponseJson()
+    ) : RegisterResponseJson() {
+        /**
+         * A generic error message.
+         */
+        val message: String? get() = invalidMessage ?: errorMessage
+    }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/SendVerificationEmailResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/SendVerificationEmailResponseJson.kt
@@ -22,7 +22,6 @@ sealed class SendVerificationEmailResponseJson {
     /**
      * Represents the json body of an invalid request.
      *
-     * @param message
      * @param validationErrors a map where each value is a list of error messages for each key.
      * The values in the array should be used for display to the user, since the keys tend to come
      * back as nonsense. (eg: empty string key)
@@ -30,18 +29,17 @@ sealed class SendVerificationEmailResponseJson {
     @Serializable
     data class Invalid(
         @SerialName("message")
-        val message: String?,
+        private val invalidMessage: String? = null,
+
+        @SerialName("Message")
+        private val errorMessage: String? = null,
 
         @SerialName("validationErrors")
         val validationErrors: Map<String, List<String>>?,
-    ) : SendVerificationEmailResponseJson()
-
-    /**
-     * A different error with a message.
-     */
-    @Serializable
-    data class Error(
-        @SerialName("Message")
-        val message: String?,
-    ) : SendVerificationEmailResponseJson()
+    ) : SendVerificationEmailResponseJson() {
+        /**
+         * A generic error message.
+         */
+        val message: String? get() = invalidMessage ?: errorMessage
+    }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceImpl.kt
@@ -43,10 +43,6 @@ class IdentityServiceImpl(
                         codes = listOf(400, 429),
                         json = json,
                     )
-                    ?: bitwardenError.parseErrorBodyOrNull<RegisterResponseJson.Error>(
-                        code = 429,
-                        json = json,
-                    )
                     ?: throw throwable
             }
 
@@ -119,10 +115,6 @@ class IdentityServiceImpl(
                 bitwardenError
                     .parseErrorBodyOrNull<RegisterResponseJson.Invalid>(
                         codes = listOf(400, 429),
-                        json = json,
-                    )
-                    ?: bitwardenError.parseErrorBodyOrNull<RegisterResponseJson.Error>(
-                        code = 429,
                         json = json,
                     )
                     ?: throw throwable

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -815,10 +815,6 @@ class AuthRepositoryImpl(
                                     ?: it.message,
                             )
                         }
-
-                        is RegisterResponseJson.Error -> {
-                            RegisterResult.Error(it.message)
-                        }
                     }
                 },
                 onFailure = { RegisterResult.Error(errorMessage = null) },

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
@@ -22,7 +22,6 @@ import com.x8bit.bitwarden.data.platform.util.asSuccess
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -41,9 +40,7 @@ class IdentityServiceTest : BaseServiceTest() {
 
     private val identityService = IdentityServiceImpl(
         unauthenticatedIdentityApi = unauthenticatedIdentityApi,
-        json = Json {
-            ignoreUnknownKeys = true
-        },
+        json = json,
         deviceModelProvider = deviceModelProvider,
     )
 
@@ -154,7 +151,7 @@ class IdentityServiceTest : BaseServiceTest() {
         val result = identityService.register(registerRequestBody)
         assertEquals(
             RegisterResponseJson.Invalid(
-                message = "The model state is invalid.",
+                invalidMessage = "The model state is invalid.",
                 validationErrors = mapOf("" to listOf("Email '' is already taken.")),
             ),
             result.getOrThrow(),
@@ -167,8 +164,9 @@ class IdentityServiceTest : BaseServiceTest() {
         server.enqueue(response)
         val result = identityService.register(registerRequestBody)
         assertEquals(
-            RegisterResponseJson.Error(
-                message = "Slow down! Too many requests. Try again soon.",
+            RegisterResponseJson.Invalid(
+                errorMessage = "Slow down! Too many requests. Try again soon.",
+                validationErrors = null,
             ),
             result.getOrThrow(),
         )
@@ -328,7 +326,7 @@ class IdentityServiceTest : BaseServiceTest() {
         val result = identityService.registerFinish(registerFinishRequestBody)
         assertEquals(
             RegisterResponseJson.Invalid(
-                message = "The model state is invalid.",
+                invalidMessage = "The model state is invalid.",
                 validationErrors = mapOf("" to listOf("Email '' is already taken.")),
             ),
             result.getOrThrow(),
@@ -341,8 +339,9 @@ class IdentityServiceTest : BaseServiceTest() {
         server.enqueue(response)
         val result = identityService.registerFinish(registerFinishRequestBody)
         assertEquals(
-            RegisterResponseJson.Error(
-                message = "Slow down! Too many requests. Try again soon.",
+            RegisterResponseJson.Invalid(
+                errorMessage = "Slow down! Too many requests. Try again soon.",
+                validationErrors = null,
             ),
             result.getOrThrow(),
         )

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -3712,7 +3712,9 @@ class AuthRepositoryTest {
                     kdfIterations = DEFAULT_KDF_ITERATIONS.toUInt(),
                 ),
             )
-        } returns RegisterResponseJson.Invalid("message", mapOf()).asSuccess()
+        } returns RegisterResponseJson
+            .Invalid(invalidMessage = "message", validationErrors = mapOf())
+            .asSuccess()
 
         val result = repository.register(
             email = EMAIL,
@@ -3746,7 +3748,7 @@ class AuthRepositoryTest {
             )
         } returns RegisterResponseJson
             .Invalid(
-                message = "message",
+                invalidMessage = "message",
                 validationErrors = mapOf("" to listOf("expected")),
             )
             .asSuccess()
@@ -3760,38 +3762,6 @@ class AuthRepositoryTest {
             isMasterPasswordStrong = true,
         )
         assertEquals(RegisterResult.Error(errorMessage = "expected"), result)
-    }
-
-    @Test
-    fun `register returns Error body should return Error with message`() = runTest {
-        coEvery { identityService.preLogin(EMAIL) } returns PRE_LOGIN_SUCCESS.asSuccess()
-        coEvery {
-            identityService.register(
-                body = RegisterRequestJson(
-                    email = EMAIL,
-                    masterPasswordHash = PASSWORD_HASH,
-                    masterPasswordHint = null,
-                    captchaResponse = null,
-                    key = ENCRYPTED_USER_KEY,
-                    keys = RegisterRequestJson.Keys(
-                        publicKey = PUBLIC_KEY,
-                        encryptedPrivateKey = PRIVATE_KEY,
-                    ),
-                    kdfType = KdfTypeJson.PBKDF2_SHA256,
-                    kdfIterations = DEFAULT_KDF_ITERATIONS.toUInt(),
-                ),
-            )
-        } returns RegisterResponseJson.Error(message = "message").asSuccess()
-
-        val result = repository.register(
-            email = EMAIL,
-            masterPassword = PASSWORD,
-            masterPasswordHint = null,
-            captchaToken = null,
-            shouldCheckDataBreaches = false,
-            isMasterPasswordStrong = true,
-        )
-        assertEquals(RegisterResult.Error(errorMessage = "message"), result)
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR addresses a testing inconsistency with our network APIs.

The `Json` instance used in some tests did not match the instance used in production code. Once I addressed this, certain tests began to fail because production code does not require `explicitNulls`. This means that the `Error` case of many network responses will never be used, so I have removed those.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
