### PR TITLE
[PM-10282] Default to last active account for passkey creation

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
@@ -21,6 +21,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
+import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -41,6 +42,7 @@ object Fido2ProviderModule {
         fido2CredentialManager: Fido2CredentialManager,
         dispatcherManager: DispatcherManager,
         intentManager: IntentManager,
+        clock: Clock,
     ): Fido2ProviderProcessor =
         Fido2ProviderProcessorImpl(
             context,
@@ -49,6 +51,7 @@ object Fido2ProviderModule {
             fido2CredentialStore,
             fido2CredentialManager,
             intentManager,
+            clock,
             dispatcherManager,
         )
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/processor/Fido2ProviderProcessorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/processor/Fido2ProviderProcessorTest.kt
@@ -53,6 +53,9 @@ import kotlinx.serialization.encodeToString
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 class Fido2ProviderProcessorTest {
 
@@ -80,6 +83,7 @@ class Fido2ProviderProcessorTest {
     private val cancellationSignal: CancellationSignal = mockk()
 
     private val json = PlatformNetworkModule.providesJson()
+    private val clock = FIXED_CLOCK
 
     @BeforeEach
     fun setUp() {
@@ -90,6 +94,7 @@ class Fido2ProviderProcessorTest {
             fido2CredentialStore,
             fido2CredentialManager,
             intentManager,
+            clock,
             dispatcherManager,
         )
     }
@@ -244,6 +249,12 @@ class Fido2ProviderProcessorTest {
         verify(exactly = 0) { callback.onError(any()) }
 
         assertEquals(DEFAULT_USER_STATE.accounts.size, captureSlot.captured.createEntries.size)
+
+        // Verify only the active account entry has a lastUsedTime
+        assertEquals(
+            1,
+            captureSlot.captured.createEntries.filter { it.lastUsedTime != null }.size,
+        )
         DEFAULT_USER_STATE.accounts.forEachIndexed { index, mockAccount ->
             assertEquals(mockAccount.email, captureSlot.captured.createEntries[index].accountName)
         }
@@ -493,6 +504,11 @@ class Fido2ProviderProcessorTest {
 private val DEFAULT_USER_STATE = UserState(
     activeUserId = "mockUserId-1",
     accounts = createMockAccounts(2),
+)
+
+private val FIXED_CLOCK: Clock = Clock.fixed(
+    Instant.parse("2023-10-27T12:00:00Z"),
+    ZoneOffset.UTC,
 )
 
 private fun createMockAccounts(number: Int): List<UserState.Account> {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10753

## 📔 Objective

When creating a passkey, the last active account should be the initial default option.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/86c7801c-5e2b-4cc8-9007-a9d571a85aa6" /> | <video src="https://github.com/user-attachments/assets/588e92b0-1138-4db7-9596-6ca5c048d040" /> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
