### PR TITLE
PM-10954: Update the key connector APIs to use the correct url and responses

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/GetTokenResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/GetTokenResponseJson.kt
@@ -28,6 +28,7 @@ sealed class GetTokenResponseJson {
      * this token will be cached and used for future auth requests.
      * @property masterPasswordPolicyOptions The options available for a user's master password.
      * @property userDecryptionOptions The options available to a user for decryption.
+     * @property keyConnectorUrl URL to the user's key connector.
      */
     @Serializable
     data class Success(
@@ -75,6 +76,9 @@ sealed class GetTokenResponseJson {
 
         @SerialName("UserDecryptionOptions")
         val userDecryptionOptions: UserDecryptionOptionsJson?,
+
+        @SerialName("KeyConnectorUrl")
+        val keyConnectorUrl: String?,
     ) : GetTokenResponseJson()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KeyConnectorMasterKeyResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KeyConnectorMasterKeyResponseJson.kt
@@ -8,5 +8,5 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class KeyConnectorMasterKeyResponseJson(
-    @SerialName("Key") val masterKey: String,
+    @SerialName("key") val masterKey: String,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
@@ -119,14 +119,14 @@ class AccountsServiceImpl(
     override suspend fun getMasterKeyFromKeyConnector(
         url: String,
     ): Result<KeyConnectorMasterKeyResponseJson> =
-        authenticatedKeyConnectorApi.getMasterKeyFromKeyConnector(url = url)
+        authenticatedKeyConnectorApi.getMasterKeyFromKeyConnector(url = "$url/user-keys")
 
     override suspend fun storeMasterKeyToKeyConnector(
         url: String,
         masterKey: String,
     ): Result<Unit> =
         authenticatedKeyConnectorApi.storeMasterKeyToKeyConnector(
-            url = url,
+            url = "$url/user-keys",
             body = KeyConnectorMasterKeyRequestJson(masterKey = masterKey),
         )
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceTest.kt
@@ -212,7 +212,7 @@ class AccountsServiceTest : BaseServiceTest() {
     @Test
     fun `getMasterKeyFromKeyConnector with empty response is success`() = runTest {
         val masterKey = "masterKey"
-        val response = MockResponse().setBody("""{ "Key": "$masterKey" }""")
+        val response = MockResponse().setBody("""{ "key": "$masterKey" }""")
         server.enqueue(response)
         val result = service.getMasterKeyFromKeyConnector(url = "$url/test")
         assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
@@ -491,7 +491,8 @@ private const val LOGIN_SUCCESS_JSON = """
     "KeyConnectorOption": {
       "KeyConnectorUrl": "keyConnectorUrl"
     }
-  }
+  },
+  "KeyConnectorUrl": "keyConnectorUrl"
 }    
 """
 
@@ -531,6 +532,7 @@ private val LOGIN_SUCCESS = GetTokenResponseJson.Success(
             keyConnectorUrl = "keyConnectorUrl",
         ),
     ),
+    keyConnectorUrl = "keyConnectorUrl",
 )
 
 private const val INVALID_LOGIN_JSON = """

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -5504,6 +5504,7 @@ class AuthRepositoryTest {
             twoFactorToken = null,
             masterPasswordPolicyOptions = null,
             userDecryptionOptions = null,
+            keyConnectorUrl = null,
         )
         private val PROFILE_1 = AccountJson.Profile(
             userId = USER_ID_1,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensionsTest.kt
@@ -113,6 +113,7 @@ private val GET_TOKEN_RESPONSE_SUCCESS = GetTokenResponseJson.Success(
     twoFactorToken = null,
     masterPasswordPolicyOptions = null,
     userDecryptionOptions = null,
+    keyConnectorUrl = null,
 )
 private val USER_DECRYPTION_OPTIONS = UserDecryptionOptionsJson(
     hasMasterPassword = false,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10954](https://bitwarden.atlassian.net/browse/PM-10954)

## 📔 Objective

This PR updates the key-connector APIs with a few minor changes:
* custom url APIs have the `/user-keys` appended to them.
* The sync API includes the `KeyConnectorUrl` property.
* The `KeyConnectorMasterKeyResponseJson` uses a lowercase `k` in the variable name.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10954]: https://bitwarden.atlassian.net/browse/PM-10954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ