### PR TITLE
[PM-11216] Lock and clear clipboard on app exit

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManager.kt
@@ -39,4 +39,10 @@ interface BitwardenClipboardManager {
         isSensitive: Boolean = true,
         toastDescriptorOverride: String? = null,
     )
+
+    /**
+     * Clears the clipboard content. If a delay is specified, the clipboard will be cleared
+     * after the designated number of seconds [delay]; otherwise, it will be cleared immediately.
+     */
+    fun clearClipboard(delay: Long = 0)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
@@ -57,17 +57,7 @@ class BitwardenClipboardManagerImpl(
         }
 
         val frequency = clearClipboardFrequencySeconds ?: return
-        val clearClipboardRequest: OneTimeWorkRequest =
-            OneTimeWorkRequest
-                .Builder(ClearClipboardWorker::class.java)
-                .setInitialDelay(frequency.toLong(), TimeUnit.SECONDS)
-                .build()
-
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            "ClearClipboard",
-            ExistingWorkPolicy.REPLACE,
-            clearClipboardRequest,
-        )
+        clearClipboard(frequency.toLong())
     }
 
     override fun setText(text: String, isSensitive: Boolean, toastDescriptorOverride: String?) {
@@ -76,5 +66,19 @@ class BitwardenClipboardManagerImpl(
 
     override fun setText(text: Text, isSensitive: Boolean, toastDescriptorOverride: String?) {
         setText(text.toString(context.resources), isSensitive, toastDescriptorOverride)
+    }
+
+    override fun clearClipboard(delay: Long) {
+        val clearClipboardRequest: OneTimeWorkRequest =
+            OneTimeWorkRequest
+                .Builder(ClearClipboardWorker::class.java)
+                .setInitialDelay(delay, TimeUnit.SECONDS)
+                .build()
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            "ClearClipboard",
+            ExistingWorkPolicy.REPLACE,
+            clearClipboardRequest,
+        )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -256,6 +256,8 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleExitConfirmationClick() {
+        clipboardManager.clearClipboard()
+        vaultRepository.lockVaultForCurrentUser()
         sendEvent(VaultEvent.NavigateOutOfApp)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR aims to make the exit button in the drop-down menu on the vault page more functional. Currently, when the exit option is selected, the app is merely sent to the background. With this PR, the exit button will lock the vault and clear the clipboard. This enhancement is particularly useful for users like myself who copy content from notes that are not automatically cleared by the 'Clear Clipboard' setting, because the text is copied using Android's text selection rather than the Bitwarden copy button.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
