### PR TITLE
Fix IllegalArgumentException in test

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -4210,29 +4210,24 @@ class VaultRepositoryTest {
         val userId = "userId"
         val fido2CredentialStore: Fido2CredentialStore = mockk()
         val relyingPartyId = "relyingPartyId"
-        val expected: Result<List<Fido2CredentialAutofillView>> = mockk()
+        val expected: List<Fido2CredentialAutofillView> = mockk()
         coEvery {
             vaultSdkSource.silentlyDiscoverCredentials(
                 userId = userId,
                 fido2CredentialStore = fido2CredentialStore,
                 relyingPartyId = relyingPartyId,
             )
-        } returns expected
+        } returns expected.asSuccess()
 
-        turbineScope {
-            val result = vaultRepository.silentlyDiscoverCredentials(
-                userId = userId,
-                fido2CredentialStore = fido2CredentialStore,
-                relyingPartyId = relyingPartyId,
-            )
+        val result = vaultRepository.silentlyDiscoverCredentials(
+            userId = userId,
+            fido2CredentialStore = fido2CredentialStore,
+            relyingPartyId = relyingPartyId,
+        )
 
-            assertEquals(
-                expected,
-                result,
-            )
-        }
+        assertEquals(expected.asSuccess(), result)
 
-        coVerify {
+        coVerify(exactly = 1) {
             vaultSdkSource.silentlyDiscoverCredentials(
                 userId = userId,
                 fido2CredentialStore = fido2CredentialStore,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes an `IllegalArgumentException` that occurs when running a `VaultRepository` test caused by trying to mock a `Result`. Looks like the `turbineScope` was eating the exception allowing the test to pass.

The Warning:
```
WARNING: Failed to transform class kotlin/Result
java.lang.IllegalArgumentException: Cannot resolve T from private static final ? kotlin.Result.getOrNull-impl(?)
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
