### PR TITLE
PM-11155: Add logic for handling remove password flow

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
@@ -16,6 +16,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.PrevalidateSsoResult
 import com.x8bit.bitwarden.data.auth.repository.model.RegisterResult
+import com.x8bit.bitwarden.data.auth.repository.model.RemovePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.RequestOtpResult
 import com.x8bit.bitwarden.data.auth.repository.model.ResendEmailResult
 import com.x8bit.bitwarden.data.auth.repository.model.ResetPasswordResult
@@ -266,6 +267,12 @@ interface AuthRepository : AuthenticatorProvider, AuthRequestManager {
     suspend fun passwordHintRequest(
         email: String,
     ): PasswordHintResult
+
+    /**
+     * Removes the users password from the account. This used used when migrating from master
+     * password login to key connector login.
+     */
+    suspend fun removePassword(masterPassword: String): RemovePasswordResult
 
     /**
      * Resets the users password from the [currentPassword] (or null for account recovery resets),

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
@@ -8,6 +8,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.service.IdentityService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.OrganizationService
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.AuthRequestManager
+import com.x8bit.bitwarden.data.auth.manager.KeyConnectorManager
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -48,6 +49,7 @@ object AuthRepositoryModule {
         environmentRepository: EnvironmentRepository,
         settingsRepository: SettingsRepository,
         vaultRepository: VaultRepository,
+        keyConnectorManager: KeyConnectorManager,
         authRequestManager: AuthRequestManager,
         trustedDeviceManager: TrustedDeviceManager,
         userLogoutManager: UserLogoutManager,
@@ -67,6 +69,7 @@ object AuthRepositoryModule {
         environmentRepository = environmentRepository,
         settingsRepository = settingsRepository,
         vaultRepository = vaultRepository,
+        keyConnectorManager = keyConnectorManager,
         authRequestManager = authRequestManager,
         trustedDeviceManager = trustedDeviceManager,
         userLogoutManager = userLogoutManager,

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/RemovePasswordResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/RemovePasswordResult.kt
@@ -1,0 +1,16 @@
+package com.x8bit.bitwarden.data.auth.repository.model
+
+/**
+ * Models result of removing a user's password.
+ */
+sealed class RemovePasswordResult {
+    /**
+     * The password was removed successfully.
+     */
+    data object Success : RemovePasswordResult()
+
+    /**
+     * There was an error removing the password.
+     */
+    data object Error : RemovePasswordResult()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreen.kt
@@ -32,6 +32,8 @@ import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
+import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
+import com.x8bit.bitwarden.ui.platform.components.dialog.LoadingDialogState
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
@@ -144,6 +146,12 @@ private fun RemovePasswordDialogs(
                     message = dialogState.message,
                 ),
                 onDismissRequest = onDismissRequest,
+            )
+        }
+
+        is RemovePasswordState.DialogState.Loading -> {
+            BitwardenLoadingDialog(
+                visibilityState = LoadingDialogState.Shown(text = dialogState.title),
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordViewModel.kt
@@ -2,13 +2,16 @@ package com.x8bit.bitwarden.ui.auth.feature.removepassword
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.RemovePasswordResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
@@ -43,11 +46,36 @@ class RemovePasswordViewModel @Inject constructor(
             RemovePasswordAction.ContinueClick -> handleContinueClick()
             is RemovePasswordAction.InputChanged -> handleInputChanged(action)
             RemovePasswordAction.DialogDismiss -> handleDialogDismiss()
+            is RemovePasswordAction.Internal.ReceiveRemovePasswordResult -> {
+                handleReceiveRemovePasswordResult(action)
+            }
         }
     }
 
     private fun handleContinueClick() {
-        // TODO: Process removing the password (PM-11155)
+        if (state.input.isBlank()) {
+            mutableStateFlow.update {
+                it.copy(
+                    dialogState = RemovePasswordState.DialogState.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.validation_field_required
+                            .asText(R.string.master_password.asText()),
+                    ),
+                )
+            }
+            return
+        }
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = RemovePasswordState.DialogState.Loading(
+                    title = R.string.deleting.asText(),
+                ),
+            )
+        }
+        viewModelScope.launch {
+            val result = authRepository.removePassword(masterPassword = state.input)
+            sendAction(RemovePasswordAction.Internal.ReceiveRemovePasswordResult(result))
+        }
     }
 
     private fun handleInputChanged(action: RemovePasswordAction.InputChanged) {
@@ -56,6 +84,28 @@ class RemovePasswordViewModel @Inject constructor(
 
     private fun handleDialogDismiss() {
         mutableStateFlow.update { it.copy(dialogState = null) }
+    }
+
+    private fun handleReceiveRemovePasswordResult(
+        action: RemovePasswordAction.Internal.ReceiveRemovePasswordResult,
+    ) {
+        when (action.result) {
+            RemovePasswordResult.Error -> {
+                mutableStateFlow.update {
+                    it.copy(
+                        dialogState = RemovePasswordState.DialogState.Error(
+                            title = R.string.an_error_has_occurred.asText(),
+                            message = R.string.generic_error_message.asText(),
+                        ),
+                    )
+                }
+            }
+
+            RemovePasswordResult.Success -> {
+                mutableStateFlow.update { it.copy(dialogState = null) }
+                // We do nothing here because state-based navigation will handle it.
+            }
+        }
     }
 }
 
@@ -81,6 +131,12 @@ data class RemovePasswordState(
             val title: Text? = null,
             val message: Text,
         ) : DialogState()
+
+        /**
+         * Represents a loading dialog with the given [title].
+         */
+        @Parcelize
+        data class Loading(val title: Text) : DialogState()
     }
 }
 
@@ -104,4 +160,16 @@ sealed class RemovePasswordAction {
      * Indicates that the dialog has been dismissed.
      */
     data object DialogDismiss : RemovePasswordAction()
+
+    /**
+     * Models actions that the [RemovePasswordViewModel] might send itself.
+     */
+    sealed class Internal : RemovePasswordAction() {
+        /**
+         * Indicates that a remove password result has been received.
+         */
+        data class ReceiveRemovePasswordResult(
+            val result: RemovePasswordResult,
+        ) : Internal()
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -52,6 +52,7 @@ import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL
 import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_3
 import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_4
 import com.x8bit.bitwarden.data.auth.manager.AuthRequestManager
+import com.x8bit.bitwarden.data.auth.manager.KeyConnectorManager
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequest
@@ -66,6 +67,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.PasswordHintResult
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
 import com.x8bit.bitwarden.data.auth.repository.model.PrevalidateSsoResult
 import com.x8bit.bitwarden.data.auth.repository.model.RegisterResult
+import com.x8bit.bitwarden.data.auth.repository.model.RemovePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.RequestOtpResult
 import com.x8bit.bitwarden.data.auth.repository.model.ResendEmailResult
 import com.x8bit.bitwarden.data.auth.repository.model.ResetPasswordResult
@@ -99,6 +101,7 @@ import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentReposito
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
+import com.x8bit.bitwarden.data.vault.datasource.network.model.OrganizationType
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockOrganization
@@ -205,6 +208,7 @@ class AuthRepositoryTest {
         } returns "AsymmetricEncString".asSuccess()
     }
     private val authRequestManager: AuthRequestManager = mockk()
+    private val keyConnectorManager: KeyConnectorManager = mockk()
     private val trustedDeviceManager: TrustedDeviceManager = mockk()
     private val userLogoutManager: UserLogoutManager = mockk {
         every { logout(any(), any()) } just runs
@@ -237,6 +241,7 @@ class AuthRepositoryTest {
         settingsRepository = settingsRepository,
         vaultRepository = vaultRepository,
         authRequestManager = authRequestManager,
+        keyConnectorManager = keyConnectorManager,
         trustedDeviceManager = trustedDeviceManager,
         userLogoutManager = userLogoutManager,
         dispatcherManager = dispatcherManager,
@@ -3802,6 +3807,114 @@ class AuthRepositoryTest {
         )
         assertEquals(RegisterResult.Success(CAPTCHA_KEY), result)
     }
+
+    @Test
+    fun `removePassword with no active account should return error`() = runTest {
+        fakeAuthDiskSource.userState = null
+
+        val result = repository.removePassword(masterPassword = PASSWORD)
+
+        assertEquals(RemovePasswordResult.Error, result)
+    }
+
+    @Test
+    fun `removePassword with no userKey should return error`() = runTest {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = null)
+
+        val result = repository.removePassword(masterPassword = PASSWORD)
+
+        assertEquals(RemovePasswordResult.Error, result)
+    }
+
+    @Test
+    fun `removePassword with no keyConnectorUrl should return error`() = runTest {
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
+        val organizations = listOf(
+            mockk<SyncResponseJson.Profile.Organization> {
+                every { id } returns "orgId"
+                every { name } returns "orgName"
+                every { shouldUseKeyConnector } returns true
+                every { type } returns OrganizationType.USER
+                every { keyConnectorUrl } returns null
+            },
+        )
+        fakeAuthDiskSource.storeOrganizations(userId = USER_ID_1, organizations = organizations)
+
+        val result = repository.removePassword(masterPassword = PASSWORD)
+
+        assertEquals(RemovePasswordResult.Error, result)
+    }
+
+    @Test
+    fun `removePassword with migrateExistingUserToKeyConnector error should return error`() =
+        runTest {
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+            fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
+            val url = "www.example.com"
+            val organizations = listOf(
+                mockk<SyncResponseJson.Profile.Organization> {
+                    every { id } returns "orgId"
+                    every { name } returns "orgName"
+                    every { shouldUseKeyConnector } returns true
+                    every { type } returns OrganizationType.USER
+                    every { keyConnectorUrl } returns url
+                },
+            )
+            fakeAuthDiskSource.storeOrganizations(userId = USER_ID_1, organizations = organizations)
+            coEvery {
+                keyConnectorManager.migrateExistingUserToKeyConnector(
+                    userId = USER_ID_1,
+                    url = url,
+                    userKeyEncrypted = ENCRYPTED_USER_KEY,
+                    email = PROFILE_1.email,
+                    masterPassword = PASSWORD,
+                    kdf = PROFILE_1.toSdkParams(),
+                )
+            } returns Throwable("Fail").asFailure()
+
+            val result = repository.removePassword(masterPassword = PASSWORD)
+
+            assertEquals(RemovePasswordResult.Error, result)
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `removePassword with migrateExistingUserToKeyConnector success should sync and return success`() =
+        runTest {
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+            fakeAuthDiskSource.storeUserKey(userId = USER_ID_1, userKey = ENCRYPTED_USER_KEY)
+            val url = "www.example.com"
+            val organizations = listOf(
+                mockk<SyncResponseJson.Profile.Organization> {
+                    every { id } returns "orgId"
+                    every { name } returns "orgName"
+                    every { shouldUseKeyConnector } returns true
+                    every { type } returns OrganizationType.USER
+                    every { keyConnectorUrl } returns url
+                },
+            )
+            fakeAuthDiskSource.storeOrganizations(userId = USER_ID_1, organizations = organizations)
+            coEvery {
+                keyConnectorManager.migrateExistingUserToKeyConnector(
+                    userId = USER_ID_1,
+                    url = url,
+                    userKeyEncrypted = ENCRYPTED_USER_KEY,
+                    email = PROFILE_1.email,
+                    masterPassword = PASSWORD,
+                    kdf = PROFILE_1.toSdkParams(),
+                )
+            } returns Unit.asSuccess()
+            every { vaultRepository.sync() } just runs
+
+            val result = repository.removePassword(masterPassword = PASSWORD)
+
+            assertEquals(RemovePasswordResult.Success, result)
+            verify(exactly = 1) {
+                vaultRepository.sync()
+            }
+        }
 
     @Test
     fun `resetPassword Success should return Success`() = runTest {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreenTest.kt
@@ -63,6 +63,20 @@ class RemovePasswordScreenTest : BaseComposeTest() {
             .assert(hasAnyAncestor(isDialog()))
             .isDisplayed()
 
+        val loadingMessage = "Loading message"
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = RemovePasswordState.DialogState.Loading(
+                    title = loadingMessage.asText(),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(text = loadingMessage)
+            .assert(hasAnyAncestor(isDialog()))
+            .isDisplayed()
+
         mutableStateFlow.update { it.copy(dialogState = null) }
 
         composeTestRule.onNode(isDialog()).assertDoesNotExist()


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11155](https://bitwarden.atlassian.net/browse/PM-11155)

## 📔 Objective

This PR adds the Logic for processing a request to remove a users password.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11155]: https://bitwarden.atlassian.net/browse/PM-11155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ