### PR TITLE
PM-11256: Add RootNav logic to display Remove Password Screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/JwtTokenDataJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/JwtTokenDataJson.kt
@@ -37,4 +37,10 @@ data class JwtTokenDataJson(
 
     @SerialName("amr")
     val authenticationMethodsReference: List<String>,
-)
+) {
+    /**
+     * Indicates that this is an external user. Mainly used for SSO users with a key connector.
+     */
+    val isExternal: Boolean
+        get() = authenticationMethodsReference.any { it == "external" }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -19,6 +19,9 @@ import com.x8bit.bitwarden.ui.auth.feature.auth.AUTH_GRAPH_ROUTE
 import com.x8bit.bitwarden.ui.auth.feature.auth.authGraph
 import com.x8bit.bitwarden.ui.auth.feature.auth.navigateToAuthGraph
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.navigateToCompleteRegistration
+import com.x8bit.bitwarden.ui.auth.feature.removepassword.REMOVE_PASSWORD_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.removepassword.navigateToRemovePassword
+import com.x8bit.bitwarden.ui.auth.feature.removepassword.removePasswordDestination
 import com.x8bit.bitwarden.ui.auth.feature.resetpassword.RESET_PASSWORD_ROUTE
 import com.x8bit.bitwarden.ui.auth.feature.resetpassword.navigateToResetPasswordGraph
 import com.x8bit.bitwarden.ui.auth.feature.resetpassword.resetPasswordDestination
@@ -79,6 +82,7 @@ fun RootNavScreen(
     ) {
         splashDestination()
         authGraph(navController)
+        removePasswordDestination()
         resetPasswordDestination()
         trustedDeviceGraph(navController)
         vaultUnlockDestination()
@@ -93,6 +97,7 @@ fun RootNavScreen(
 
         RootNavState.ResetPassword -> RESET_PASSWORD_ROUTE
         RootNavState.SetPassword -> SET_PASSWORD_ROUTE
+        RootNavState.RemovePassword -> REMOVE_PASSWORD_ROUTE
         RootNavState.Splash -> SPLASH_ROUTE
         RootNavState.TrustedDevice -> TRUSTED_DEVICE_GRAPH_ROUTE
         RootNavState.VaultLocked -> VAULT_UNLOCK_ROUTE
@@ -149,13 +154,14 @@ fun RootNavScreen(
                 )
             }
 
+            RootNavState.RemovePassword -> navController.navigateToRemovePassword(rootNavOptions)
             RootNavState.ResetPassword -> navController.navigateToResetPasswordGraph(rootNavOptions)
             RootNavState.SetPassword -> navController.navigateToSetPassword(rootNavOptions)
             RootNavState.Splash -> navController.navigateToSplash(rootNavOptions)
             RootNavState.TrustedDevice -> navController.navigateToTrustedDeviceGraph(rootNavOptions)
             RootNavState.VaultLocked -> navController.navigateToVaultUnlock(rootNavOptions)
             is RootNavState.VaultUnlocked -> navController.navigateToVaultUnlockedGraph(
-                rootNavOptions,
+                navOptions = rootNavOptions,
             )
 
             RootNavState.VaultUnlockedForNewSend -> {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -2,7 +2,11 @@ package com.x8bit.bitwarden.ui.platform.feature.rootnav
 
 import android.content.pm.SigningInfo
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.AuthState
+import com.x8bit.bitwarden.data.auth.repository.model.JwtTokenDataJson
+import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.auth.repository.util.parseJwtTokenDataOrNull
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2GetCredentialsRequest
@@ -12,11 +16,16 @@ import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.model.CompleteRegistrationData
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
+import com.x8bit.bitwarden.data.vault.datasource.network.model.OrganizationType
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
@@ -24,12 +33,24 @@ import java.time.ZoneOffset
 
 @Suppress("LargeClass")
 class RootNavViewModelTest : BaseViewModelTest() {
+    private val mutableAuthStateFlow = MutableStateFlow<AuthState>(AuthState.Uninitialized)
     private val mutableUserStateFlow = MutableStateFlow<UserState?>(null)
     private val authRepository = mockk<AuthRepository> {
         every { userStateFlow } returns mutableUserStateFlow
+        every { authStateFlow } returns mutableAuthStateFlow
         every { showWelcomeCarousel } returns false
     }
     private val specialCircumstanceManager = SpecialCircumstanceManagerImpl()
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(::parseJwtTokenDataOrNull)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(::parseJwtTokenDataOrNull)
+    }
 
     @Test
     fun `when there are no accounts the nav state should be Auth`() {
@@ -292,6 +313,49 @@ class RootNavViewModelTest : BaseViewModelTest() {
             RootNavState.Auth,
             viewModel.stateFlow.value,
         )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when the active user has an unlocked vault with an external user, a key-connector user account and is not currently using key connector the nav state should be RemovePassword`() {
+        val jwtTokenDataJson = mockk<JwtTokenDataJson> {
+            every { isExternal } returns true
+        }
+        every { parseJwtTokenDataOrNull(ACCESS_TOKEN) } returns jwtTokenDataJson
+        mutableUserStateFlow.tryEmit(
+            UserState(
+                activeUserId = "activeUserId",
+                accounts = listOf(
+                    UserState.Account(
+                        userId = "activeUserId",
+                        name = "name",
+                        email = "email",
+                        avatarColorHex = "avatarColorHex",
+                        environment = Environment.Us,
+                        isPremium = true,
+                        isLoggedIn = true,
+                        isVaultUnlocked = true,
+                        needsPasswordReset = false,
+                        isBiometricsEnabled = false,
+                        organizations = listOf(
+                            Organization(
+                                id = "orgId",
+                                name = "orgName",
+                                shouldUseKeyConnector = true,
+                                role = OrganizationType.USER,
+                            ),
+                        ),
+                        needsMasterPassword = false,
+                        trustedDevice = null,
+                        hasMasterPassword = true,
+                        isUsingKeyConnector = false,
+                    ),
+                ),
+            ),
+        )
+        mutableAuthStateFlow.value = AuthState.Authenticated(accessToken = ACCESS_TOKEN)
+        val viewModel = createViewModel()
+        assertEquals(RootNavState.RemovePassword, viewModel.stateFlow.value)
     }
 
     @Test
@@ -742,9 +806,11 @@ class RootNavViewModelTest : BaseViewModelTest() {
             authRepository = authRepository,
             specialCircumstanceManager = specialCircumstanceManager,
         )
-
-    private val FIXED_CLOCK: Clock = Clock.fixed(
-        Instant.parse("2023-10-27T12:00:00Z"),
-        ZoneOffset.UTC,
-    )
 }
+
+private val FIXED_CLOCK: Clock = Clock.fixed(
+    Instant.parse("2023-10-27T12:00:00Z"),
+    ZoneOffset.UTC,
+)
+
+private const val ACCESS_TOKEN: String = "access_token"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11256](https://bitwarden.atlassian.net/browse/PM-11256)

## 📔 Objective

This PR updates the `RootNavViewModel` to display the `RemovePasswordScreen` when appropriate. This completes the Remove Password flow.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/a346e009-7afe-4600-81fe-16328704112a" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11256]: https://bitwarden.atlassian.net/browse/PM-11256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ