### PR TITLE
PM-10692 pass a generated password back to the complete registration …

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
@@ -10,6 +10,7 @@ import com.x8bit.bitwarden.ui.auth.feature.checkemail.checkEmailDestination
 import com.x8bit.bitwarden.ui.auth.feature.checkemail.navigateToCheckEmail
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.completeRegistrationDestination
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.navigateToCompleteRegistration
+import com.x8bit.bitwarden.ui.auth.feature.completeregistration.popUpToCompleteRegistration
 import com.x8bit.bitwarden.ui.auth.feature.createaccount.createAccountDestination
 import com.x8bit.bitwarden.ui.auth.feature.createaccount.navigateToCreateAccount
 import com.x8bit.bitwarden.ui.auth.feature.enterprisesignon.enterpriseSignOnDestination
@@ -184,6 +185,9 @@ fun NavGraphBuilder.authGraph(
         masterPasswordGeneratorDestination(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToPreventLockout = { navController.navigateToPreventAccountLockout() },
+            onNavigateBackWithPassword = {
+                navController.popUpToCompleteRegistration()
+            },
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationNavigation.kt
@@ -72,3 +72,10 @@ fun NavGraphBuilder.completeRegistrationDestination(
         )
     }
 }
+
+/**
+ * Pop up to the complete registration screen.
+ */
+fun NavController.popUpToCompleteRegistration() {
+    popBackStack(route = COMPLETE_REGISTRATION_ROUTE, inclusive = false)
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
@@ -216,7 +216,8 @@ private fun CompleteRegistrationContent(
                 callToActionText = stringResource(id = R.string.learn_more),
                 onCardClicked = handler.onMakeStrongPassword,
                 modifier = Modifier
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
             )
         } else {
             LegacyHeaderContent(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
@@ -145,15 +145,14 @@ class CompleteRegistrationViewModel @Inject constructor(
     private fun handleGeneratedPasswordResult(
         action: Internal.GeneratedPasswordResult,
     ) {
-        action.generatedPassword?.let { password ->
-            mutableStateFlow.update {
-                it.copy(
-                    passwordInput = password,
-                    confirmPasswordInput = password,
-                )
-            }
-            checkPasswordStrength(input = password)
+        val password = action.generatedPassword
+        mutableStateFlow.update {
+            it.copy(
+                passwordInput = password,
+                confirmPasswordInput = password,
+            )
         }
+        checkPasswordStrength(input = password)
     }
 
     private fun verifyEmailAddress() {
@@ -601,6 +600,6 @@ sealed class CompleteRegistrationAction {
         /**
          * Indicates a generated password has been received.
          */
-        data class GeneratedPasswordResult(val generatedPassword: String?) : Internal()
+        data class GeneratedPasswordResult(val generatedPassword: String) : Internal()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
@@ -30,6 +30,7 @@ import com.x8bit.bitwarden.ui.platform.base.util.isValidEmail
 import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -96,9 +97,9 @@ class CompleteRegistrationViewModel @Inject constructor(
 
         generatorRepository
             .generatorResultFlow
+            .filterIsInstance<GeneratorResult.Password>()
             .map {
-                val passwordResult = it as? GeneratorResult.Password
-                Internal.GeneratedPasswordResult(generatedPassword = passwordResult?.password)
+                Internal.GeneratedPasswordResult(generatedPassword = it.password)
             }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
@@ -299,10 +300,10 @@ class CompleteRegistrationViewModel @Inject constructor(
 
     private fun handleCallToActionClick() = when {
         state.userEmail.isBlank() -> {
-            @Suppress("MaxLineLength")
             val dialog = BasicDialogState.Shown(
                 title = R.string.an_error_has_occurred.asText(),
-                message = R.string.validation_field_required.asText(R.string.email_address.asText()),
+                message = R.string.validation_field_required
+                    .asText(R.string.email_address.asText()),
             )
             mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorNavigation.kt
@@ -20,6 +20,7 @@ fun NavController.navigateToMasterPasswordGenerator(navOptions: NavOptions? = nu
 fun NavGraphBuilder.masterPasswordGeneratorDestination(
     onNavigateBack: () -> Unit,
     onNavigateToPreventLockout: () -> Unit,
+    onNavigateBackWithPassword: () -> Unit,
 ) {
     composableWithSlideTransitions(
         route = MASTER_PASSWORD_GENERATOR,
@@ -27,6 +28,7 @@ fun NavGraphBuilder.masterPasswordGeneratorDestination(
         MasterPasswordGeneratorScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToPreventLockout = onNavigateToPreventLockout,
+            onNavigateBackWithPassword = onNavigateBackWithPassword,
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreen.kt
@@ -53,6 +53,7 @@ import com.x8bit.bitwarden.ui.platform.theme.LocalNonMaterialTypography
 fun MasterPasswordGeneratorScreen(
     onNavigateBack: () -> Unit,
     onNavigateToPreventLockout: () -> Unit,
+    onNavigateBackWithPassword: () -> Unit,
     viewModel: MasterPasswordGeneratorViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
@@ -70,6 +71,10 @@ fun MasterPasswordGeneratorScreen(
                     message = event.text.toString(resources),
                     duration = SnackbarDuration.Short,
                 )
+            }
+
+            is MasterPasswordGeneratorEvent.NavigateBackToRegistration -> {
+                onNavigateBackWithPassword()
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorViewModel.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.util.getActivePolicies
 import com.x8bit.bitwarden.data.tools.generator.repository.GeneratorRepository
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratedPassphraseResult
+import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratorResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
@@ -73,7 +74,8 @@ class MasterPasswordGeneratorViewModel @Inject constructor(
     private fun handleBackAction() = sendEvent(MasterPasswordGeneratorEvent.NavigateBack)
 
     private fun handleSavePasswordAction() {
-        // TODO [PM-10692](https://bitwarden.atlassian.net/browse/PM-10692)
+        generatorRepository.emitGeneratorResult(GeneratorResult.Password(state.generatedPassword))
+        sendEvent(MasterPasswordGeneratorEvent.NavigateBackToRegistration)
     }
 
     private fun handlePreventLockoutAction() =
@@ -163,6 +165,11 @@ sealed class MasterPasswordGeneratorEvent {
      * Show a Snackbar message.
      */
     data class ShowSnackbar(val text: Text) : MasterPasswordGeneratorEvent()
+
+    /**
+     * Navigate back to the complete registration screen.
+     */
+    data object NavigateBackToRegistration : MasterPasswordGeneratorEvent()
 }
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
@@ -20,6 +20,9 @@ import com.x8bit.bitwarden.data.platform.manager.model.CompleteRegistrationData
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
+import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
+import com.x8bit.bitwarden.data.tools.generator.repository.GeneratorRepository
+import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratorResult
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.CompleteRegistrationAction.BackClick
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.CompleteRegistrationAction.ConfirmPasswordInputChange
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.CompleteRegistrationAction.Internal.ReceivePasswordStrengthResult
@@ -61,6 +64,10 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
         every { getFeatureFlag(FlagKey.OnboardingFlow) } returns false
         every { getFeatureFlagFlow(FlagKey.OnboardingFlow) } returns mutableFeatureFlagFlow
     }
+    private val mutableGeneratorResultFlow = bufferedMutableSharedFlow<GeneratorResult>()
+    private val generatorRepository = mockk<GeneratorRepository>(relaxed = true) {
+        every { generatorResultFlow } returns mutableGeneratorResultFlow
+    }
 
     @BeforeEach
     fun setUp() {
@@ -95,35 +102,34 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
             environmentRepository = fakeEnvironmentRepository,
             specialCircumstanceManager = specialCircumstanceManager,
             featureFlagManager = featureFlagManager,
+            generatorRepository = generatorRepository,
         )
         viewModel.onCleared()
         assertTrue(specialCircumstanceManager.specialCircumstance == null)
     }
 
     @Test
-    fun `Password below 12 chars should have non-valid state`() =
-        runTest {
-            val input = "abcdefghikl"
-            coEvery {
-                mockAuthRepository.getPasswordStrength(EMAIL, input)
-            } returns PasswordStrengthResult.Error
-            val viewModel = createCompleteRegistrationViewModel()
-            viewModel.trySendAction(PasswordInputChange(input))
+    fun `Password below 12 chars should have non-valid state`() = runTest {
+        val input = "abcdefghikl"
+        coEvery {
+            mockAuthRepository.getPasswordStrength(EMAIL, input)
+        } returns PasswordStrengthResult.Error
+        val viewModel = createCompleteRegistrationViewModel()
+        viewModel.trySendAction(PasswordInputChange(input))
 
-            assertFalse(viewModel.stateFlow.value.validSubmissionReady)
-        }
+        assertFalse(viewModel.stateFlow.value.validSubmissionReady)
+    }
 
     @Test
-    fun `Passwords not matching should have non-valid state`() =
-        runTest {
-            coEvery {
-                mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD)
-            } returns PasswordStrengthResult.Error
-            val viewModel = createCompleteRegistrationViewModel()
-            viewModel.trySendAction(PasswordInputChange(PASSWORD))
+    fun `Passwords not matching should have non-valid state`() = runTest {
+        coEvery {
+            mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD)
+        } returns PasswordStrengthResult.Error
+        val viewModel = createCompleteRegistrationViewModel()
+        viewModel.trySendAction(PasswordInputChange(PASSWORD))
 
-            assertFalse(viewModel.stateFlow.value.validSubmissionReady)
-        }
+        assertFalse(viewModel.stateFlow.value.validSubmissionReady)
+    }
 
     @Test
     fun `CallToActionClick with all inputs valid should show and hide loading dialog`() = runTest {
@@ -344,11 +350,10 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
                     )
                 } returns RegisterResult.WeakPassword
             }
-            val initialState = VALID_INPUT_STATE
-                .copy(
-                    passwordStrengthState = PasswordStrengthState.WEAK_1,
-                    isCheckDataBreachesToggled = true,
-                )
+            val initialState = VALID_INPUT_STATE.copy(
+                passwordStrengthState = PasswordStrengthState.WEAK_1,
+                isCheckDataBreachesToggled = true,
+            )
             val viewModel =
                 createCompleteRegistrationViewModel(completeRegistrationState = initialState)
             viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
@@ -417,6 +422,47 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
         }
         coVerify { mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD) }
     }
+
+    @Test
+    fun `Empty PasswordInputChange update should result in password strength being NONE`() =
+        runTest {
+            val viewModel = createCompleteRegistrationViewModel(
+                completeRegistrationState = DEFAULT_STATE.copy(
+                    passwordInput = PASSWORD,
+                    passwordStrengthState = PasswordStrengthState.STRONG,
+                ),
+            )
+            viewModel.trySendAction(PasswordInputChange(""))
+            val expectedStrengthUpdateState = DEFAULT_STATE.copy(
+                passwordInput = "",
+                passwordStrengthState = PasswordStrengthState.NONE,
+            )
+            viewModel.stateFlow.test {
+                assertEquals(expectedStrengthUpdateState, awaitItem())
+            }
+            coVerify(exactly = 0) { mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD) }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Internal GeneratedPasswordResult update passwordInput and confirmPasswordInput and call getPasswordStrength`() =
+        runTest {
+            coEvery {
+                mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD)
+            } returns PasswordStrengthResult.Error
+            val viewModel = createCompleteRegistrationViewModel()
+            mutableGeneratorResultFlow.emit(GeneratorResult.Password(PASSWORD))
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        passwordInput = PASSWORD,
+                        confirmPasswordInput = PASSWORD,
+                    ),
+                    awaitItem(),
+                )
+            }
+            coVerify { mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD) }
+        }
 
     @Test
     fun `CheckDataBreachesToggle should change isCheckDataBreachesToggled`() = runTest {
@@ -565,47 +611,47 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `CreateAccountClick with no email not should show dialog`() =
-        runTest {
-            coEvery {
-                mockAuthRepository.getPasswordStrength("", PASSWORD)
-            } returns PasswordStrengthResult.Error
-            val viewModel = createCompleteRegistrationViewModel(
-                DEFAULT_STATE.copy(userEmail = ""),
-            )
-            viewModel.trySendAction(PasswordInputChange(PASSWORD))
-            val expectedState = DEFAULT_STATE.copy(
-                userEmail = "",
-                passwordInput = PASSWORD,
-                dialog = CompleteRegistrationDialog.Error(
-                    BasicDialogState.Shown(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.validation_field_required
-                            .asText(R.string.email_address.asText()),
+    fun `CreateAccountClick with no email not should show dialog`() = runTest {
+        coEvery {
+            mockAuthRepository.getPasswordStrength("", PASSWORD)
+        } returns PasswordStrengthResult.Error
+        val viewModel = createCompleteRegistrationViewModel(
+            DEFAULT_STATE.copy(userEmail = ""),
+        )
+        viewModel.trySendAction(PasswordInputChange(PASSWORD))
+        val expectedState = DEFAULT_STATE.copy(
+            userEmail = "",
+            passwordInput = PASSWORD,
+            dialog = CompleteRegistrationDialog.Error(
+                BasicDialogState.Shown(
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.validation_field_required.asText(
+                        R.string.email_address.asText(),
                     ),
                 ),
-            )
-            viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
-            viewModel.stateFlow.test {
-                assertEquals(expectedState, awaitItem())
-            }
+            ),
+        )
+        viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
+        viewModel.stateFlow.test {
+            assertEquals(expectedState, awaitItem())
         }
+    }
 
     private fun createCompleteRegistrationViewModel(
         completeRegistrationState: CompleteRegistrationState? = DEFAULT_STATE,
         authRepository: AuthRepository = mockAuthRepository,
-    ): CompleteRegistrationViewModel =
-        CompleteRegistrationViewModel(
-            savedStateHandle = SavedStateHandle(
-                mapOf(
-                    "state" to completeRegistrationState,
-                ),
+    ): CompleteRegistrationViewModel = CompleteRegistrationViewModel(
+        savedStateHandle = SavedStateHandle(
+            mapOf(
+                "state" to completeRegistrationState,
             ),
-            authRepository = authRepository,
-            environmentRepository = fakeEnvironmentRepository,
-            specialCircumstanceManager = specialCircumstanceManager,
-            featureFlagManager = featureFlagManager,
-        )
+        ),
+        authRepository = authRepository,
+        environmentRepository = fakeEnvironmentRepository,
+        specialCircumstanceManager = specialCircumstanceManager,
+        featureFlagManager = featureFlagManager,
+        generatorRepository = generatorRepository,
+    )
 
     companion object {
         private const val PASSWORD = "longenoughtpassword"

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreenTest.kt
@@ -20,6 +20,7 @@ import org.junit.Test
 class MasterPasswordGeneratorScreenTest : BaseComposeTest() {
     private var onNavigateBackCalled = false
     private var onNavigateToPreventLockoutCalled = false
+    private var navigateBackWithPasswordCalled = false
     private val mutableEventFlow = bufferedMutableSharedFlow<MasterPasswordGeneratorEvent>()
     private val mutableStateFlow = MutableStateFlow(
         value = MasterPasswordGeneratorState(generatedPassword = "-"),
@@ -35,6 +36,7 @@ class MasterPasswordGeneratorScreenTest : BaseComposeTest() {
             MasterPasswordGeneratorScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToPreventLockout = { onNavigateToPreventLockoutCalled = true },
+                onNavigateBackWithPassword = { navigateBackWithPasswordCalled = true },
                 viewModel = viewModel,
             )
         }
@@ -42,7 +44,7 @@ class MasterPasswordGeneratorScreenTest : BaseComposeTest() {
 
     @Test
     fun `Generated password field state should update with ViewModel state`() {
-        val updatedValue = "soup-r-stronk-pazzwerd"
+        val updatedValue = PASSWORD_INPUT
         mutableStateFlow.update { it.copy(generatedPassword = updatedValue) }
 
         composeTestRule
@@ -104,4 +106,15 @@ class MasterPasswordGeneratorScreenTest : BaseComposeTest() {
 
         verify { viewModel.trySendAction(MasterPasswordGeneratorAction.PreventLockoutClickAction) }
     }
+
+    @Test
+    fun `Verify navigating back with password invokes the lambda`() {
+        mutableEventFlow.tryEmit(
+            MasterPasswordGeneratorEvent.NavigateBackToRegistration,
+        )
+
+        assertTrue(navigateBackWithPasswordCalled)
+    }
 }
+
+private const val PASSWORD_INPUT = "password1234"

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorViewModelTest.kt
@@ -5,7 +5,6 @@ import app.cash.turbine.test
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratedPassphraseResult
-import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratorResult
 import com.x8bit.bitwarden.data.tools.generator.repository.util.FakeGeneratorRepository
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorViewModelTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.test
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratedPassphraseResult
+import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratorResult
 import com.x8bit.bitwarden.data.tools.generator.repository.util.FakeGeneratorRepository
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
@@ -121,6 +122,21 @@ class MasterPasswordGeneratorViewModelTest : BaseViewModelTest() {
             viewModel.eventFlow.test {
                 viewModel.trySendAction(MasterPasswordGeneratorAction.PreventLockoutClickAction)
                 assertEquals(MasterPasswordGeneratorEvent.NavigateToPreventLockout, awaitItem())
+            }
+        }
+
+    @Test
+    fun `NavigateBackWithPassword event is sent when SavePasswordClickAction is handled`() =
+        runTest {
+            val viewModel = createViewModel(
+                initialState = MasterPasswordGeneratorState(generatedPassword = "saved-pw"),
+            )
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(MasterPasswordGeneratorAction.SavePasswordClickAction)
+                assertEquals(
+                    MasterPasswordGeneratorEvent.NavigateBackToRegistration,
+                    awaitItem(),
+                )
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-10692
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- return a generate master password back to the complete registration screen
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/b0a91a62-63de-4884-ae69-085ef29dbcff


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
