### PR TITLE
PM-11264: Ensure user has valid timeout action after migrating to Key Connector

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
@@ -14,6 +14,32 @@ import com.x8bit.bitwarden.data.vault.repository.util.statusFor
 import com.x8bit.bitwarden.ui.platform.base.util.toHexColorRepresentation
 
 /**
+ * Updates the given [UserStateJson] with the data to indicate that the password has been removed.
+ * The original will be returned if the [userId] does not match any accounts in the [UserStateJson].
+ */
+fun UserStateJson.toRemovedPasswordUserStateJson(
+    userId: String,
+): UserStateJson {
+    val account = this.accounts[userId] ?: return this
+    val profile = account.profile
+    val updatedUserDecryptionOptions = profile
+        .userDecryptionOptions
+        ?.copy(hasMasterPassword = false)
+        ?: UserDecryptionOptionsJson(
+            hasMasterPassword = false,
+            trustedDeviceUserDecryptionOptions = null,
+            keyConnectorUserDecryptionOptions = null,
+        )
+    val updatedProfile = profile.copy(userDecryptionOptions = updatedUserDecryptionOptions)
+    val updatedAccount = account.copy(profile = updatedProfile)
+    return this.copy(
+        accounts = accounts
+            .toMutableMap()
+            .apply { replace(userId, updatedAccount) },
+    )
+}
+
+/**
  * Updates the given [UserStateJson] with the data from the [syncResponse] to return a new
  * [UserStateJson]. The original will be returned if the sync response does not match any accounts
  * in the [UserStateJson].

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -87,6 +87,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.DuoCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.SsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.repository.util.toOrganizations
+import com.x8bit.bitwarden.data.auth.repository.util.toRemovedPasswordUserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.toUserState
 import com.x8bit.bitwarden.data.auth.util.YubiKeyResult
@@ -255,12 +256,18 @@ class AuthRepositoryTest {
 
     @BeforeEach
     fun beforeEach() {
-        mockkStatic(GetTokenResponseJson.Success::toUserState)
+        mockkStatic(
+            GetTokenResponseJson.Success::toUserState,
+            UserStateJson::toRemovedPasswordUserStateJson,
+        )
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(GetTokenResponseJson.Success::toUserState)
+        unmockkStatic(
+            GetTokenResponseJson.Success::toUserState,
+            UserStateJson::toRemovedPasswordUserStateJson,
+        )
     }
 
     @Test
@@ -4341,13 +4348,19 @@ class AuthRepositoryTest {
                     kdf = PROFILE_1.toSdkParams(),
                 )
             } returns Unit.asSuccess()
+            every {
+                SINGLE_USER_STATE_1.toRemovedPasswordUserStateJson(userId = USER_ID_1)
+            } returns SINGLE_USER_STATE_1
             every { vaultRepository.sync() } just runs
+            every { settingsRepository.setDefaultsIfNecessary(userId = USER_ID_1) } just runs
 
             val result = repository.removePassword(masterPassword = PASSWORD)
 
             assertEquals(RemovePasswordResult.Success, result)
             verify(exactly = 1) {
+                SINGLE_USER_STATE_1.toRemovedPasswordUserStateJson(userId = USER_ID_1)
                 vaultRepository.sync()
+                settingsRepository.setDefaultsIfNecessary(userId = USER_ID_1)
             }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
@@ -25,6 +25,117 @@ import org.junit.jupiter.api.Test
 
 class UserStateJsonExtensionsTest {
     @Test
+    fun `toUpdatedUserStateJn should do nothing for a non-matching account`() {
+        val originalUserState = UserStateJson(
+            activeUserId = "activeUserId",
+            accounts = mapOf("activeUserId" to mockk()),
+        )
+        assertEquals(
+            originalUserState,
+            originalUserState.toRemovedPasswordUserStateJson(userId = "nonActiveUserId"),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toUpdatedUserStateJn should create user decryption options without a password if not present`() {
+        val originalProfile = AccountJson.Profile(
+            userId = "activeUserId",
+            email = "email",
+            isEmailVerified = true,
+            name = "name",
+            stamp = null,
+            organizationId = null,
+            avatarColorHex = null,
+            hasPremium = true,
+            forcePasswordResetReason = null,
+            kdfType = KdfTypeJson.ARGON2_ID,
+            kdfIterations = 600000,
+            kdfMemory = 16,
+            kdfParallelism = 4,
+            userDecryptionOptions = null,
+        )
+        val originalAccount = AccountJson(
+            profile = originalProfile,
+            tokens = null,
+            settings = AccountJson.Settings(environmentUrlData = null),
+        )
+        val originalUserState = UserStateJson(
+            activeUserId = "activeUserId",
+            accounts = mapOf("activeUserId" to originalAccount),
+        )
+
+        assertEquals(
+            UserStateJson(
+                activeUserId = "activeUserId",
+                accounts = mapOf(
+                    "activeUserId" to originalAccount.copy(
+                        profile = originalProfile.copy(
+                            userDecryptionOptions = UserDecryptionOptionsJson(
+                                hasMasterPassword = false,
+                                trustedDeviceUserDecryptionOptions = null,
+                                keyConnectorUserDecryptionOptions = null,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            originalUserState.toRemovedPasswordUserStateJson(userId = "activeUserId"),
+        )
+    }
+
+    @Test
+    fun `toUpdatedUserStateJn should update user decryption options to not have a password`() {
+        val originalProfile = AccountJson.Profile(
+            userId = "activeUserId",
+            email = "email",
+            isEmailVerified = true,
+            name = "name",
+            stamp = null,
+            organizationId = null,
+            avatarColorHex = null,
+            hasPremium = true,
+            forcePasswordResetReason = null,
+            kdfType = KdfTypeJson.ARGON2_ID,
+            kdfIterations = 600000,
+            kdfMemory = 16,
+            kdfParallelism = 4,
+            userDecryptionOptions = UserDecryptionOptionsJson(
+                hasMasterPassword = true,
+                trustedDeviceUserDecryptionOptions = null,
+                keyConnectorUserDecryptionOptions = null,
+            ),
+        )
+        val originalAccount = AccountJson(
+            profile = originalProfile,
+            tokens = null,
+            settings = AccountJson.Settings(environmentUrlData = null),
+        )
+        val originalUserState = UserStateJson(
+            activeUserId = "activeUserId",
+            accounts = mapOf("activeUserId" to originalAccount),
+        )
+
+        assertEquals(
+            UserStateJson(
+                activeUserId = "activeUserId",
+                accounts = mapOf(
+                    "activeUserId" to originalAccount.copy(
+                        profile = originalProfile.copy(
+                            userDecryptionOptions = UserDecryptionOptionsJson(
+                                hasMasterPassword = false,
+                                trustedDeviceUserDecryptionOptions = null,
+                                keyConnectorUserDecryptionOptions = null,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            originalUserState.toRemovedPasswordUserStateJson(userId = "activeUserId"),
+        )
+    }
+
+    @Test
     fun `toUpdatedUserStateJson should do nothing for a non-matching account`() {
         val originalUserState = UserStateJson(
             activeUserId = "activeUserId",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11264](https://bitwarden.atlassian.net/browse/PM-11264)

## 📔 Objective

This PR ensures that a user has a valid timeout action after removing the password.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11264]: https://bitwarden.atlassian.net/browse/PM-11264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ