### PR TITLE
PM-10917: Fix crash caused when adding an item from a collection

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensions.kt
@@ -37,8 +37,8 @@ fun VaultItemListingState.ItemListingType.Vault.toVaultItemCipherType(): VaultIt
         is VaultItemListingState.ItemListingType.Vault.Identity -> VaultItemCipherType.IDENTITY
         is VaultItemListingState.ItemListingType.Vault.SecureNote -> VaultItemCipherType.SECURE_NOTE
         is VaultItemListingState.ItemListingType.Vault.Login -> VaultItemCipherType.LOGIN
+        is VaultItemListingState.ItemListingType.Vault.Collection -> VaultItemCipherType.LOGIN
         is VaultItemListingState.ItemListingType.Vault.Trash,
-        is VaultItemListingState.ItemListingType.Vault.Collection,
         is VaultItemListingState.ItemListingType.Vault.Folder,
         -> throw IllegalStateException("Cannot create vault item from this VaultItemListingState!")
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensionsTest.kt
@@ -118,6 +118,7 @@ class VaultItemListingStateExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Identity,
             VaultItemListingState.ItemListingType.Vault.SecureNote,
             VaultItemListingState.ItemListingType.Vault.Login,
+            VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId"),
         )
 
         val result = itemListingTypes.map { it.toVaultItemCipherType() }
@@ -128,6 +129,7 @@ class VaultItemListingStateExtensionsTest {
                 VaultItemCipherType.IDENTITY,
                 VaultItemCipherType.SECURE_NOTE,
                 VaultItemCipherType.LOGIN,
+                VaultItemCipherType.LOGIN,
             ),
             result,
         )
@@ -137,9 +139,6 @@ class VaultItemListingStateExtensionsTest {
     fun `toVaultItemCipherType should throw an exception for unsupported ItemListingTypes`() {
         val itemListingTypes = listOf(
             VaultItemListingState.ItemListingType.Vault.Trash,
-            VaultItemListingState.ItemListingType.Vault.Collection(
-                collectionId = "mockId",
-            ),
             VaultItemListingState.ItemListingType.Vault.Folder(
                 folderId = "mockId",
             ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10917](https://bitwarden.atlassian.net/browse/PM-10917)

## 📔 Objective

This PR addresses a crash that occurs when creating a new cipher from the Empty Collections UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10917]: https://bitwarden.atlassian.net/browse/PM-10917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ