### PR TITLE
[PM-11270] hide new UI in complete registration screen behind flag pt. 2

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
@@ -136,7 +136,7 @@ fun CompleteRegistrationScreen(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BitwardenTopAppBar(
-                title = if (state.onBoardingEnabled) {
+                title = if (state.onboardingEnabled) {
                     stringResource(id = R.string.create_account)
                 } else {
                     stringResource(id = R.string.set_password)
@@ -146,7 +146,7 @@ fun CompleteRegistrationScreen(
                 navigationIconContentDescription = stringResource(id = R.string.back),
                 onNavigationIconClick = handler.onBackClick,
                 actions = {
-                    if (!state.onBoardingEnabled) {
+                    if (!state.onboardingEnabled) {
                         BitwardenTextButton(
                             label = state.callToActionText(),
                             onClick = handler.onCallToAction,
@@ -175,7 +175,7 @@ fun CompleteRegistrationScreen(
                 nextButtonEnabled = state.validSubmissionReady,
                 callToActionText = state.callToActionText(),
                 minimumPasswordLength = state.minimumPasswordLength,
-                showNewOnboardingUi = state.onBoardingEnabled,
+                showNewOnboardingUi = state.onboardingEnabled,
                 userEmail = state.userEmail,
             )
             Spacer(modifier = Modifier.navigationBarsPadding())

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
@@ -171,7 +171,6 @@ fun CompleteRegistrationScreen(
                 passwordHintInput = state.passwordHintInput,
                 isCheckDataBreachesToggled = state.isCheckDataBreachesToggled,
                 handler = handler,
-                modifier = Modifier.standardHorizontalMargin(),
                 nextButtonEnabled = state.validSubmissionReady,
                 callToActionText = state.callToActionText(),
                 minimumPasswordLength = state.minimumPasswordLength,
@@ -206,7 +205,9 @@ private fun CompleteRegistrationContent(
         Spacer(modifier = Modifier.height(8.dp))
         if (showNewOnboardingUi) {
             CompleteRegistrationContentHeader(
-                modifier = Modifier.align(Alignment.CenterHorizontally),
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .standardHorizontalMargin(),
             )
             Spacer(modifier = Modifier.height(24.dp))
             BitwardenActionCard(
@@ -214,12 +215,15 @@ private fun CompleteRegistrationContent(
                 actionText = stringResource(id = R.string.what_makes_a_password_strong),
                 callToActionText = stringResource(id = R.string.learn_more),
                 onCardClicked = handler.onMakeStrongPassword,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth(),
             )
         } else {
             LegacyHeaderContent(
                 userEmail = userEmail,
-                modifier = Modifier.align(Alignment.CenterHorizontally),
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .standardHorizontalMargin(),
             )
         }
         Spacer(modifier = Modifier.height(24.dp))
@@ -233,7 +237,8 @@ private fun CompleteRegistrationContent(
             onValueChange = handler.onPasswordInputChange,
             modifier = Modifier
                 .testTag("MasterPasswordEntry")
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
             showPasswordTestTag = "PasswordVisibilityToggle",
             imeAction = ImeAction.Next,
         )
@@ -242,6 +247,7 @@ private fun CompleteRegistrationContent(
             state = passwordStrengthState,
             currentCharacterCount = passwordInput.length,
             minimumCharacterCount = minimumPasswordLength.takeIf { showNewOnboardingUi },
+            modifier = Modifier.standardHorizontalMargin(),
         )
         Spacer(modifier = Modifier.height(16.dp))
         BitwardenPasswordField(
@@ -252,7 +258,8 @@ private fun CompleteRegistrationContent(
             onValueChange = handler.onConfirmPasswordInputChange,
             modifier = Modifier
                 .testTag("ConfirmMasterPasswordEntry")
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
             showPasswordTestTag = "ConfirmPasswordVisibilityToggle",
         )
         Spacer(modifier = Modifier.height(16.dp))
@@ -269,7 +276,8 @@ private fun CompleteRegistrationContent(
             },
             modifier = Modifier
                 .testTag("MasterPasswordHintLabel")
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
         )
         if (showNewOnboardingUi) {
             BitwardenClickableText(
@@ -278,6 +286,7 @@ private fun CompleteRegistrationContent(
                 ),
                 onClick = handler.onLearnToPreventLockout,
                 style = nonMaterialTypography.labelMediumProminent,
+                modifier = Modifier.standardHorizontalMargin(),
             )
         }
         Spacer(modifier = Modifier.height(24.dp))
@@ -285,7 +294,9 @@ private fun CompleteRegistrationContent(
             label = stringResource(id = R.string.check_known_data_breaches_for_this_password),
             isChecked = isCheckDataBreachesToggled,
             onCheckedChange = handler.onCheckDataBreachesToggle,
-            modifier = Modifier.testTag("CheckExposedMasterPasswordToggle"),
+            modifier = Modifier
+                .testTag("CheckExposedMasterPasswordToggle")
+                .standardHorizontalMargin(),
         )
         if (showNewOnboardingUi) {
             Spacer(modifier = Modifier.height(24.dp))
@@ -293,7 +304,9 @@ private fun CompleteRegistrationContent(
                 label = callToActionText,
                 isEnabled = nextButtonEnabled,
                 onClick = handler.onCallToAction,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
             )
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
@@ -65,7 +65,7 @@ class CompleteRegistrationViewModel @Inject constructor(
                 isCheckDataBreachesToggled = true,
                 dialog = null,
                 passwordStrengthState = PasswordStrengthState.NONE,
-                onBoardingEnabled = featureFlagManager.getFeatureFlag(FlagKey.OnboardingFlow),
+                onboardingEnabled = featureFlagManager.getFeatureFlag(FlagKey.OnboardingFlow),
                 minimumPasswordLength = MIN_PASSWORD_LENGTH,
             )
         },
@@ -143,7 +143,7 @@ class CompleteRegistrationViewModel @Inject constructor(
 
     private fun handleUpdateOnboardingFeatureState(action: Internal.UpdateOnboardingFeatureState) {
         mutableStateFlow.update {
-            it.copy(onBoardingEnabled = action.newValue)
+            it.copy(onboardingEnabled = action.newValue)
         }
     }
 
@@ -383,7 +383,7 @@ data class CompleteRegistrationState(
     val isCheckDataBreachesToggled: Boolean,
     val dialog: CompleteRegistrationDialog?,
     val passwordStrengthState: PasswordStrengthState,
-    val onBoardingEnabled: Boolean,
+    val onboardingEnabled: Boolean,
     val minimumPasswordLength: Int,
 ) : Parcelable {
 
@@ -391,7 +391,7 @@ data class CompleteRegistrationState(
      * The text to display on the call to action button.
      */
     val callToActionText: Text
-        get() = if (onBoardingEnabled) {
+        get() = if (onboardingEnabled) {
             R.string.next.asText()
         } else {
             R.string.create_account.asText()
@@ -417,7 +417,9 @@ data class CompleteRegistrationState(
      * Whether the form is valid.
      */
     val validSubmissionReady: Boolean
-        get() = passwordInput.isNotBlank() && confirmPasswordInput.isNotBlank()
+        get() = passwordInput.isNotBlank() &&
+            confirmPasswordInput.isNotBlank() &&
+            passwordInput.length >= minimumPasswordLength
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
@@ -29,6 +29,7 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -82,6 +83,14 @@ class CompleteRegistrationViewModel @Inject constructor(
         stateFlow
             .onEach { savedStateHandle[KEY_STATE] = it }
             .launchIn(viewModelScope)
+
+        featureFlagManager
+            .getFeatureFlagFlow(FlagKey.OnboardingFlow)
+            .map {
+                Internal.UpdateOnboardingFeatureState(newValue = it)
+            }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
     }
 
     @VisibleForTesting
@@ -114,6 +123,7 @@ class CompleteRegistrationViewModel @Inject constructor(
             }
 
             CompleteRegistrationAction.CallToActionClick -> handleCallToActionClick()
+            is Internal.UpdateOnboardingFeatureState -> handleUpdateOnboardingFeatureState(action)
         }
     }
 
@@ -128,6 +138,12 @@ class CompleteRegistrationViewModel @Inject constructor(
                     message = R.string.email_verified.asText(),
                 ),
             )
+        }
+    }
+
+    private fun handleUpdateOnboardingFeatureState(action: Internal.UpdateOnboardingFeatureState) {
+        mutableStateFlow.update {
+            it.copy(onBoardingEnabled = action.newValue)
         }
     }
 
@@ -267,14 +283,41 @@ class CompleteRegistrationViewModel @Inject constructor(
         mutableStateFlow.update { it.copy(confirmPasswordInput = action.input) }
     }
 
-    private fun handleCallToActionClick() {
-        if (!state.userEmail.isValidEmail()) {
+    private fun handleCallToActionClick() = when {
+        state.userEmail.isBlank() -> {
+            val dialog = BasicDialogState.Shown(
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.validation_field_required
+                    .asText(R.string.email_address.asText()),
+            )
+            mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
+        }
+
+        !state.userEmail.isValidEmail() -> {
             val dialog = BasicDialogState.Shown(
                 title = R.string.an_error_has_occurred.asText(),
                 message = R.string.invalid_email.asText(),
             )
             mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
-        } else {
+        }
+
+        state.passwordInput.length < MIN_PASSWORD_LENGTH -> {
+            val dialog = BasicDialogState.Shown(
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.master_password_length_val_message_x.asText(MIN_PASSWORD_LENGTH),
+            )
+            mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
+        }
+
+        state.passwordInput != state.confirmPasswordInput -> {
+            val dialog = BasicDialogState.Shown(
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.master_password_confirmation_val_message.asText(),
+            )
+            mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
+        }
+
+        else -> {
             submitRegisterAccountRequest(
                 shouldCheckForDataBreaches = state.isCheckDataBreachesToggled,
                 shouldIgnorePasswordStrength = false,
@@ -373,10 +416,8 @@ data class CompleteRegistrationState(
     /**
      * Whether the form is valid.
      */
-    val hasValidMasterPassword: Boolean
-        get() = passwordInput == confirmPasswordInput &&
-            passwordInput.isNotBlank() &&
-            passwordInput.length >= MIN_PASSWORD_LENGTH
+    val validSubmissionReady: Boolean
+        get() = passwordInput.isNotBlank() && confirmPasswordInput.isNotBlank()
 }
 
 /**
@@ -516,5 +557,10 @@ sealed class CompleteRegistrationAction {
         data class ReceivePasswordStrengthResult(
             val result: PasswordStrengthResult,
         ) : Internal()
+
+        /**
+         * Indicate on boarding feature state has been updated.
+         */
+        data class UpdateOnboardingFeatureState(val newValue: Boolean) : Internal()
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreenTest.kt
@@ -384,13 +384,13 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
 
     private fun turnFeatureFlagOn() {
         mutableStateFlow.update {
-            it.copy(onBoardingEnabled = true)
+            it.copy(onboardingEnabled = true)
         }
     }
 
     private fun turnFeatureFlagOff() {
         mutableStateFlow.update {
-            it.copy(onBoardingEnabled = false)
+            it.copy(onboardingEnabled = false)
         }
     }
 
@@ -408,7 +408,7 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
             isCheckDataBreachesToggled = true,
             dialog = null,
             passwordStrengthState = PasswordStrengthState.NONE,
-            onBoardingEnabled = false,
+            onboardingEnabled = false,
             minimumPasswordLength = 12,
         )
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreenTest.kt
@@ -74,6 +74,17 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
     }
 
     @Test
+    fun `determine if using the old ui by title text`() {
+        composeTestRule
+            .onNodeWithText("Set password")
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNode(hasText("Create account") and !hasClickAction())
+            .assertDoesNotExist()
+    }
+
+    @Test
     fun `call to action with valid input click should send CreateAccountClick action`() {
         mutableStateFlow.update {
             it.copy(
@@ -83,28 +94,9 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
         }
         composeTestRule
             .onNode(hasText("Create account") and hasClickAction())
-            .performScrollTo()
             .assertIsEnabled()
             .performClick()
         verify { viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick) }
-    }
-
-    @Test
-    fun `call to action not enabled if passwords don't match`() {
-        mutableStateFlow.update {
-            it.copy(
-                passwordInput = "4321drowssap",
-                confirmPasswordInput = "password1234",
-            )
-        }
-        composeTestRule
-            .onNode(hasText("Create account") and hasClickAction())
-            .performScrollTo()
-            .assertIsNotEnabled()
-            .performClick()
-        verify(exactly = 0) {
-            viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
-        }
     }
 
     @Test
@@ -261,28 +253,6 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
             .assertCountEquals(2)
     }
 
-    @Test
-    fun `Click on action card should send MakePasswordStrongClick action`() {
-        composeTestRule
-            .onNodeWithText("Learn more")
-            .performScrollTo()
-            .performClick()
-
-        verify { viewModel.trySendAction(CompleteRegistrationAction.MakePasswordStrongClick) }
-    }
-
-    @Test
-    fun `Click on prevent account lockout should send LearnToPreventLockoutClick action`() {
-        composeTestRule
-            .onNodeWithText("Learn about other ways to prevent account lockout")
-            .performScrollTo()
-            .performClick()
-
-        verify {
-            viewModel.trySendAction(CompleteRegistrationAction.LearnToPreventLockoutClick)
-        }
-    }
-
     @Suppress("MaxLineLength")
     @Test
     fun `NavigateToPreventAccountLockout event should invoke navigate to prevent account lockout lambda`() {
@@ -297,7 +267,90 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `Header should be displayed in portrait mode`() {
+    fun `NavigateToLogin event should invoke navigate to login lambda`() {
+        mutableEventFlow.tryEmit(
+            CompleteRegistrationEvent.NavigateToLogin(
+                email = EMAIL,
+                captchaToken = TOKEN,
+            ),
+        )
+
+        assertTrue(onNavigateToLoginCalled)
+    }
+
+    // New Onboarding UI tests
+    @Test
+    fun `determine if using the new ui by title text`() = testWithFeatureFlagOn {
+        composeTestRule
+            .onNode(hasText("Create account") and !hasClickAction())
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("Set password")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `call to action state should update with input based on if both fields are populated`() =
+        testWithFeatureFlagOn {
+            mutableStateFlow.update {
+                it.copy(
+                    passwordInput = "",
+                    confirmPasswordInput = "password1234",
+                )
+            }
+            composeTestRule
+                .onNodeWithText("Next")
+                .assertIsNotEnabled()
+                .performScrollTo()
+                .performClick()
+            verify(exactly = 0) {
+                viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
+            }
+
+            mutableStateFlow.update {
+                it.copy(
+                    passwordInput = "password1234",
+                    confirmPasswordInput = "password1234",
+                )
+            }
+
+            composeTestRule
+                .onNodeWithText("Next")
+                .assertIsEnabled()
+                .performScrollTo()
+                .performClick()
+            verify(exactly = 1) {
+                viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
+            }
+        }
+
+    @Test
+    fun `Click on action card should send MakePasswordStrongClick action`() =
+        testWithFeatureFlagOn {
+            composeTestRule
+                .onNodeWithText("Learn more")
+                .performScrollTo()
+                .performClick()
+
+            verify { viewModel.trySendAction(CompleteRegistrationAction.MakePasswordStrongClick) }
+        }
+
+    @Test
+    fun `Click on prevent account lockout should send LearnToPreventLockoutClick action`() =
+        testWithFeatureFlagOn {
+            composeTestRule
+                .onNodeWithText("Learn about other ways to prevent account lockout")
+                .performScrollTo()
+                .performClick()
+
+        verify {
+            viewModel.trySendAction(CompleteRegistrationAction.LearnToPreventLockoutClick)
+        }
+    }
+
+    @Test
+    fun `Header should be displayed in portrait mode`() = testWithFeatureFlagOn {
         composeTestRule
             .onNodeWithText("Choose your master password")
             .performScrollTo()
@@ -311,7 +364,7 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
 
     @Config(qualifiers = "land")
     @Test
-    fun `Header should be displayed in landscape mode`() {
+    fun `Header should be displayed in landscape mode`() = testWithFeatureFlagOn {
         composeTestRule
             .onNodeWithText("Choose your master password")
             .performScrollTo()
@@ -323,16 +376,22 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
             .assertIsDisplayed()
     }
 
-    @Test
-    fun `NavigateToLogin event should invoke navigate to login lambda`() {
-        mutableEventFlow.tryEmit(
-            CompleteRegistrationEvent.NavigateToLogin(
-                email = EMAIL,
-                captchaToken = TOKEN,
-            ),
-        )
+    private fun testWithFeatureFlagOn(test: () -> Unit) {
+        turnFeatureFlagOn()
+        test()
+        turnFeatureFlagOff()
+    }
 
-        assertTrue(onNavigateToLoginCalled)
+    private fun turnFeatureFlagOn() {
+        mutableStateFlow.update {
+            it.copy(onBoardingEnabled = true)
+        }
+    }
+
+    private fun turnFeatureFlagOff() {
+        mutableStateFlow.update {
+            it.copy(onBoardingEnabled = false)
+        }
     }
 
     companion object {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
@@ -34,6 +34,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -55,9 +56,10 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
 
     private val specialCircumstanceManager: SpecialCircumstanceManager =
         SpecialCircumstanceManagerImpl()
-
+    private val mutableFeatureFlagFlow = MutableStateFlow(false)
     private val featureFlagManager = mockk<FeatureFlagManager>(relaxed = true) {
         every { getFeatureFlag(FlagKey.OnboardingFlow) } returns false
+        every { getFeatureFlagFlow(FlagKey.OnboardingFlow) } returns mutableFeatureFlagFlow
     }
 
     @BeforeEach
@@ -108,7 +110,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
             val viewModel = createCompleteRegistrationViewModel()
             viewModel.trySendAction(PasswordInputChange(input))
 
-            assertFalse(viewModel.stateFlow.value.hasValidMasterPassword)
+            assertFalse(viewModel.stateFlow.value.validSubmissionReady)
         }
 
     @Test
@@ -120,7 +122,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
             val viewModel = createCompleteRegistrationViewModel()
             viewModel.trySendAction(PasswordInputChange(PASSWORD))
 
-            assertFalse(viewModel.stateFlow.value.hasValidMasterPassword)
+            assertFalse(viewModel.stateFlow.value.validSubmissionReady)
         }
 
     @Test
@@ -506,6 +508,61 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
             assertEquals(CompleteRegistrationEvent.NavigateToMakePasswordStrong, awaitItem())
         }
     }
+
+    @Test
+    fun `feature flag state update is captured in ViewModel state`() {
+        mutableFeatureFlagFlow.value = true
+        val viewModel = createCompleteRegistrationViewModel()
+        assertTrue(viewModel.stateFlow.value.onBoardingEnabled)
+    }
+
+    @Test
+    fun `CreateAccountClick with password below 12 chars should show password length dialog`() =
+        runTest {
+            val input = "abcdefghikl"
+            coEvery {
+                mockAuthRepository.getPasswordStrength(EMAIL, input)
+            } returns PasswordStrengthResult.Error
+            val viewModel = createCompleteRegistrationViewModel()
+            viewModel.trySendAction(PasswordInputChange(input))
+            val expectedState = DEFAULT_STATE.copy(
+                passwordInput = input,
+                dialog = CompleteRegistrationDialog.Error(
+                    BasicDialogState.Shown(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.master_password_length_val_message_x.asText(12),
+                    ),
+                ),
+            )
+            viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
+            viewModel.stateFlow.test {
+                assertEquals(expectedState, awaitItem())
+            }
+        }
+
+    @Test
+    fun `CreateAccountClick with passwords not matching should show password match dialog`() =
+        runTest {
+            coEvery {
+                mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD)
+            } returns PasswordStrengthResult.Error
+            val viewModel = createCompleteRegistrationViewModel()
+            viewModel.trySendAction(PasswordInputChange(PASSWORD))
+            val expectedState = DEFAULT_STATE.copy(
+                userEmail = EMAIL,
+                passwordInput = PASSWORD,
+                dialog = CompleteRegistrationDialog.Error(
+                    BasicDialogState.Shown(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.master_password_confirmation_val_message.asText(),
+                    ),
+                ),
+            )
+            viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
+            viewModel.stateFlow.test {
+                assertEquals(expectedState, awaitItem())
+            }
+        }
 
     private fun createCompleteRegistrationViewModel(
         completeRegistrationState: CompleteRegistrationState? = DEFAULT_STATE,


### PR DESCRIPTION
## 🎟️ Tracking
Part 2 of https://bitwarden.atlassian.net/browse/PM-11270
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Hide new UI on complete registration screen behind feature flag.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/1f2195a8-b9f3-4ab0-ae41-55eb0c67d543


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
