### PR TITLE
PM-11273: Update the 'useKeyConnector' with 'keyConnectorEnabled'

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
@@ -246,7 +246,7 @@ data class SyncResponseJson(
             @SerialName("usePolicies")
             val shouldUsePolicies: Boolean,
 
-            @SerialName("useKeyConnector")
+            @SerialName("keyConnectorEnabled")
             val shouldUseKeyConnector: Boolean,
 
             @SerialName("keyConnectorUrl")

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceTest.kt
@@ -58,7 +58,7 @@ private const val SYNC_SUCCESS_JSON = """
     "organizations": [
       {
         "usePolicies": false,
-        "useKeyConnector": false,
+        "keyConnectorEnabled": false,
         "keyConnectorUrl": "mockKeyConnectorUrl-1",
         "type": 1,
         "seats": 1,
@@ -133,7 +133,7 @@ private const val SYNC_SUCCESS_JSON = """
     "providerOrganizations": [
       {
         "usePolicies": false,
-        "useKeyConnector": false,
+        "keyConnectorEnabled": false,
         "keyConnectorUrl": "mockKeyConnectorUrl-1",
         "type": 1,
         "seats": 1,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11273](https://bitwarden.atlassian.net/browse/PM-11273)

## 📔 Objective

This PR replaces the `useKeyConnector` key with the `keyConnectorEnabled` key. While the sync response does still get the `useKeyConnector` value, it is not accurate and resulted in bugs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11273]: https://bitwarden.atlassian.net/browse/PM-11273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ