### PR TITLE
[PM-11307] Fix typo in method name: shouldShouldRequestPermissionRationale

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/permissions/PermissionsManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/permissions/PermissionsManager.kt
@@ -39,7 +39,7 @@ interface PermissionsManager {
     /**
      * Method for checking if an informative UI should be shown the user.
      */
-    fun shouldShouldRequestPermissionRationale(
+    fun shouldShowRequestPermissionRationale(
         permission: String,
     ): Boolean
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/permissions/PermissionsManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/permissions/PermissionsManagerImpl.kt
@@ -44,7 +44,7 @@ class PermissionsManagerImpl(
     override fun checkPermissions(permissions: Array<String>): Boolean =
         permissions.map { checkPermission(it) }.all { isGranted -> isGranted }
 
-    override fun shouldShouldRequestPermissionRationale(
+    override fun shouldShowRequestPermissionRationale(
         permission: String,
     ): Boolean =
         activity.shouldShowRequestPermissionRationale(permission)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/manager/permissions/FakePermissionManager.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/manager/permissions/FakePermissionManager.kt
@@ -62,7 +62,7 @@ class FakePermissionManager : PermissionsManager {
         return checkPermissionResult
     }
 
-    override fun shouldShouldRequestPermissionRationale(
+    override fun shouldShowRequestPermissionRationale(
         permission: String,
     ): Boolean {
         return shouldShowRequestRationale


### PR DESCRIPTION
### Summary
This PR addresses a typo in the codebase where the method `shouldShowRequestPermissionRationale` was incorrectly named as `shouldShouldRequestPermissionRationale`. 

### Details
- Renamed the method `shouldShouldRequestPermissionRationale` to the correct name `shouldShowRequestPermissionRationale`.
- Updated all instances where the incorrect method name was used.

### Impact
This change should improve code readability and prevent any potential confusion or errors related to this method.

Thank you for your consideration!
