### PR TITLE
PM-10899: Fix user not being logged out properly on app restart

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -476,10 +476,15 @@ class VaultLockManagerImpl(
             }
 
             else -> {
-                // Only perform action for users losing "fully active" status in some way.
                 when (checkTimeoutReason) {
-                    // Don't perform delayed actions when first starting the app
-                    CheckTimeoutReason.APP_RESTARTED -> Unit
+                    // Always preform the timeout action on app restart to ensure the user is
+                    // in the correct state.
+                    CheckTimeoutReason.APP_RESTARTED -> {
+                        handleTimeoutAction(
+                            userId = userId,
+                            vaultTimeoutAction = vaultTimeoutAction,
+                        )
+                    }
 
                     // User no longer active or engaging with the app.
                     CheckTimeoutReason.APP_BACKGROUNDED,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -63,8 +63,7 @@ class RootNavViewModel @Inject constructor(
         val specialCircumstance = action.specialCircumstance
         val updatedRootNavState = when {
             userState?.activeAccount?.trustedDevice?.isDeviceTrusted == false &&
-                !userState.activeAccount.isVaultUnlocked &&
-                !userState.activeAccount.hasManualUnlockMechanism -> RootNavState.TrustedDevice
+                !userState.activeAccount.isVaultUnlocked -> RootNavState.TrustedDevice
 
             userState?.activeAccount?.needsMasterPassword == true -> RootNavState.SetPassword
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -275,7 +275,7 @@ class VaultLockManagerTest {
 
         fakeAppForegroundManager.appForegroundState = AppForegroundState.FOREGROUNDED
 
-        assertTrue(vaultLockManager.isVaultUnlocked(USER_ID))
+        assertFalse(vaultLockManager.isVaultUnlocked(USER_ID))
     }
 
     @Suppress("MaxLineLength")
@@ -330,6 +330,8 @@ class VaultLockManagerTest {
 
         // Start in a foregrounded state
         fakeAppForegroundManager.appForegroundState = AppForegroundState.BACKGROUNDED
+        // We want to skip the first time since that is different from subsequent foregrounds
+        fakeAppForegroundManager.appForegroundState = AppForegroundState.FOREGROUNDED
 
         // Will be used within each loop to reset the test to a suitable initial state.
         fun resetTest(vaultTimeout: VaultTimeout) {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -170,8 +170,9 @@ class RootNavViewModelTest : BaseViewModelTest() {
         )
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `when the active user has an untrusted device the nav state should be TrustedDevice`() {
+    fun `when the active user has an untrusted device without password the nav state should be TrustedDevice`() {
         mutableUserStateFlow.tryEmit(
             UserState(
                 activeUserId = "activeUserId",
@@ -207,7 +208,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `when the active user has an untrusted device with password the nav state should be VaultLocked`() {
+    fun `when the active user has an untrusted device with password the nav state should be TrustedDevice`() {
         mutableUserStateFlow.tryEmit(
             UserState(
                 activeUserId = "activeUserId",
@@ -238,7 +239,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
             ),
         )
         val viewModel = createViewModel()
-        assertEquals(RootNavState.VaultLocked, viewModel.stateFlow.value)
+        assertEquals(RootNavState.TrustedDevice, viewModel.stateFlow.value)
     }
 
     @Suppress("MaxLineLength")


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10899](https://bitwarden.atlassian.net/browse/PM-10899)

## 📔 Objective

This PR addresses a bug where after closing the app with a TDE user, the app would return to the `TrustedDevice` screen because the user was not being properly logged-out from their timeout action.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10899]: https://bitwarden.atlassian.net/browse/PM-10899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ