### PR TITLE
Update internal BitwardenTextButton padding to be consistent with all Bitwarden Buttons

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenTextButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenTextButton.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.components.button
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,16 +39,15 @@ fun BitwardenTextButton(
         onClick = onClick,
         modifier = modifier,
         enabled = isEnabled,
+        contentPadding = PaddingValues(
+            vertical = 10.dp,
+            horizontal = 24.dp,
+        ),
         colors = defaultColors,
     ) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelLarge,
-            modifier = Modifier
-                .padding(
-                    vertical = 10.dp,
-                    horizontal = 12.dp,
-                ),
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the internal padding on the `BitwardenTextButton` to be consistent with all other Bitwarden buttons in the app. This should make the buttons slightly shorter.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/f3197d37-bf49-4964-b3e8-a862f346eff5" width="300" /> | <img src="https://github.com/user-attachments/assets/ade59b23-cdec-444e-9440-b0fb1a382f6f" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
