### PR TITLE
PM-11354: TDE unlock since we already have the correct key from the identity service

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -554,7 +554,6 @@ class AuthRepositoryImpl(
             )
         }
 
-        authDiskSource.storeUserKey(userId = userId, userKey = asymmetricalKey)
         vaultRepository.syncIfNecessary()
         return LoginResult.Success
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -1346,7 +1346,6 @@ class AuthRepositoryTest {
             )
             vaultRepository.syncIfNecessary()
         }
-        fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = asymmetricalKey)
         assertEquals(LoginResult.Success, result)
     }
 
@@ -1392,12 +1391,9 @@ class AuthRepositoryTest {
                 organizationKeys = orgKeys,
             )
         }
-
         coVerify(exactly = 0) {
             vaultRepository.syncIfNecessary()
         }
-
-        fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
         assertEquals(LoginResult.Error(errorMessage = null), result)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11354](https://bitwarden.atlassian.net/browse/PM-11354)

## 📔 Objective

This PR removes the logic to store the user key after completing a login with TDE. The `asymmetricalKey` that we have at that point is not the correct key to store and it causes errors when unlocking the vault with a password. The real `userKey` is already stored from the identity response and does allow the user to login via password.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/2a2d35a0-605f-4821-81f5-755dc2b85066" width="300" /> | <video src="https://github.com/user-attachments/assets/6a5f3661-aaaa-4d9d-b2fc-21b051bf1b9d" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11354]: https://bitwarden.atlassian.net/browse/PM-11354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ