### PR TITLE
[PM-10902] Base64 encode sensitive 2FA nav args

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
@@ -110,7 +110,7 @@ fun NavGraphBuilder.authGraph(
             onNavigateToTwoFactorLogin = { emailAddress ->
                 navController.navigateToTwoFactorLogin(
                     emailAddress = emailAddress,
-                    password = null,
+                    base64EncodedPassword = null,
                 )
             },
         )
@@ -153,7 +153,7 @@ fun NavGraphBuilder.authGraph(
             onNavigateToTwoFactorLogin = { emailAddress, password ->
                 navController.navigateToTwoFactorLogin(
                     emailAddress = emailAddress,
-                    password = password,
+                    base64EncodedPassword = password,
                 )
             },
         )
@@ -162,7 +162,7 @@ fun NavGraphBuilder.authGraph(
             onNavigateToTwoFactorLogin = {
                 navController.navigateToTwoFactorLogin(
                     emailAddress = it,
-                    password = null,
+                    base64EncodedPassword = null,
                 )
             },
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
@@ -94,7 +94,7 @@ fun LoginScreen(
             }
 
             is LoginEvent.NavigateToTwoFactorLogin -> {
-                onNavigateToTwoFactorLogin(event.emailAddress, event.password)
+                onNavigateToTwoFactorLogin(event.emailAddress, event.base64EncodedPassword)
             }
 
             is LoginEvent.ShowToast -> {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
@@ -12,6 +12,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
 import com.x8bit.bitwarden.data.auth.repository.util.CaptchaCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForCaptcha
+import com.x8bit.bitwarden.data.platform.datasource.network.util.base64UrlEncode
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
@@ -159,7 +160,9 @@ class LoginViewModel @Inject constructor(
                 sendEvent(
                     LoginEvent.NavigateToTwoFactorLogin(
                         emailAddress = state.emailAddress,
-                        password = state.passwordInput,
+                        // Base64 URL encode the password to prevent corruption of escapable chars
+                        // when sending via navArgs.
+                        base64EncodedPassword = state.passwordInput.base64UrlEncode(),
                     ),
                 )
             }
@@ -342,7 +345,7 @@ sealed class LoginEvent {
      */
     data class NavigateToTwoFactorLogin(
         val emailAddress: String,
-        val password: String?,
+        val base64EncodedPassword: String?,
     ) : LoginEvent()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceEncryptionNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceEncryptionNavigation.kt
@@ -28,7 +28,7 @@ fun NavGraphBuilder.trustedDeviceGraph(navController: NavHostController) {
             onNavigateToTwoFactorLogin = {
                 navController.navigateToTwoFactorLogin(
                     emailAddress = it,
-                    password = null,
+                    base64EncodedPassword = null,
                 )
             },
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
+import com.x8bit.bitwarden.data.platform.datasource.network.util.base64UrlEncode
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 
 private const val EMAIL_ADDRESS = "email_address"
@@ -15,6 +16,8 @@ private const val TWO_FACTOR_LOGIN_ROUTE =
 
 /**
  * Class to retrieve Two-Factor Login arguments from the [SavedStateHandle].
+ *
+ * @property password Base64 URL encoded password input.
  */
 @OmitFromCoverage
 data class TwoFactorLoginArgs(val emailAddress: String, val password: String?) {
@@ -32,7 +35,13 @@ fun NavController.navigateToTwoFactorLogin(
     password: String?,
     navOptions: NavOptions? = null,
 ) {
-    this.navigate("$TWO_FACTOR_LOGIN_PREFIX/$emailAddress?$PASSWORD=$password", navOptions)
+    // Base64 encode the password in a URL safe way to prevent corruption when it includes
+    // characters that must be escaped
+    val encodedUrl = password?.base64UrlEncode()
+    this.navigate(
+        route = "$TWO_FACTOR_LOGIN_PREFIX/$emailAddress?$PASSWORD=$encodedUrl",
+        navOptions = navOptions,
+    )
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginNavigation.kt
@@ -5,7 +5,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
-import com.x8bit.bitwarden.data.platform.datasource.network.util.base64UrlEncode
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 
 private const val EMAIL_ADDRESS = "email_address"
@@ -17,13 +16,13 @@ private const val TWO_FACTOR_LOGIN_ROUTE =
 /**
  * Class to retrieve Two-Factor Login arguments from the [SavedStateHandle].
  *
- * @property password Base64 URL encoded password input.
+ * @property base64EncodedPassword Base64 URL encoded password input.
  */
 @OmitFromCoverage
-data class TwoFactorLoginArgs(val emailAddress: String, val password: String?) {
+data class TwoFactorLoginArgs(val emailAddress: String, val base64EncodedPassword: String?) {
     constructor(savedStateHandle: SavedStateHandle) : this(
         emailAddress = checkNotNull(savedStateHandle[EMAIL_ADDRESS]) as String,
-        password = savedStateHandle[PASSWORD],
+        base64EncodedPassword = savedStateHandle[PASSWORD],
     )
 }
 
@@ -32,14 +31,11 @@ data class TwoFactorLoginArgs(val emailAddress: String, val password: String?) {
  */
 fun NavController.navigateToTwoFactorLogin(
     emailAddress: String,
-    password: String?,
+    base64EncodedPassword: String?,
     navOptions: NavOptions? = null,
 ) {
-    // Base64 encode the password in a URL safe way to prevent corruption when it includes
-    // characters that must be escaped
-    val encodedUrl = password?.base64UrlEncode()
     this.navigate(
-        route = "$TWO_FACTOR_LOGIN_PREFIX/$emailAddress?$PASSWORD=$encodedUrl",
+        route = "$TWO_FACTOR_LOGIN_PREFIX/$emailAddress?$PASSWORD=$base64EncodedPassword",
         navOptions = navOptions,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -22,6 +22,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForCaptcha
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForWebAuth
 import com.x8bit.bitwarden.data.auth.util.YubiKeyResult
+import com.x8bit.bitwarden.data.platform.datasource.network.util.base64UrlDecodeOrNull
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.util.baseWebVaultUrlOrDefault
 import com.x8bit.bitwarden.ui.auth.feature.twofactorlogin.util.button
@@ -69,7 +70,7 @@ class TwoFactorLoginViewModel @Inject constructor(
             isRememberMeEnabled = false,
             captchaToken = null,
             email = TwoFactorLoginArgs(savedStateHandle).emailAddress,
-            password = TwoFactorLoginArgs(savedStateHandle).password,
+            password = TwoFactorLoginArgs(savedStateHandle).password?.base64UrlDecodeOrNull(),
         ),
 ) {
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -57,21 +57,24 @@ class TwoFactorLoginViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<TwoFactorLoginState, TwoFactorLoginEvent, TwoFactorLoginAction>(
     initialState = savedStateHandle[KEY_STATE]
-        ?: TwoFactorLoginState(
-            authMethod = authRepository.twoFactorResponse.preferredAuthMethod,
-            availableAuthMethods = authRepository.twoFactorResponse.availableAuthMethods,
-            codeInput = "",
-            displayEmail = authRepository.twoFactorResponse.twoFactorDisplayEmail,
-            dialogState = null,
-            isContinueButtonEnabled = authRepository
-                .twoFactorResponse
-                .preferredAuthMethod
-                .isContinueButtonEnabled,
-            isRememberMeEnabled = false,
-            captchaToken = null,
-            email = TwoFactorLoginArgs(savedStateHandle).emailAddress,
-            password = TwoFactorLoginArgs(savedStateHandle).password?.base64UrlDecodeOrNull(),
-        ),
+        ?: run {
+            val args = TwoFactorLoginArgs(savedStateHandle)
+            TwoFactorLoginState(
+                authMethod = authRepository.twoFactorResponse.preferredAuthMethod,
+                availableAuthMethods = authRepository.twoFactorResponse.availableAuthMethods,
+                codeInput = "",
+                displayEmail = authRepository.twoFactorResponse.twoFactorDisplayEmail,
+                dialogState = null,
+                isContinueButtonEnabled = authRepository
+                    .twoFactorResponse
+                    .preferredAuthMethod
+                    .isContinueButtonEnabled,
+                isRememberMeEnabled = false,
+                captchaToken = null,
+                email = args.emailAddress,
+                password = args.base64EncodedPassword?.base64UrlDecodeOrNull(),
+            )
+        },
 ) {
 
     private val recover2faUri: Uri

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForCaptcha
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForWebAuth
 import com.x8bit.bitwarden.data.auth.util.YubiKeyResult
+import com.x8bit.bitwarden.data.platform.datasource.network.util.base64UrlDecodeOrNull
 import com.x8bit.bitwarden.data.platform.datasource.network.util.base64UrlEncode
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
@@ -65,8 +66,12 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         mockkStatic(
             ::generateUriForCaptcha,
             ::generateUriForWebAuth,
+            String::base64UrlEncode,
         )
         mockkStatic(Uri::class)
+        every {
+            DEFAULT_ENCODED_PASSWORD.base64UrlDecodeOrNull()
+        } returns DEFAULT_PASSWORD
     }
 
     @AfterEach
@@ -74,6 +79,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         unmockkStatic(
             ::generateUriForCaptcha,
             ::generateUriForWebAuth,
+            String::base64UrlDecodeOrNull,
         )
         unmockkStatic(Uri::class)
     }
@@ -82,6 +88,9 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
     fun `initial state should be correct`() = runTest {
         val viewModel = createViewModel()
         viewModel.stateFlow.test {
+            verify {
+                DEFAULT_ENCODED_PASSWORD.base64UrlDecodeOrNull()
+            }
             assertEquals(DEFAULT_STATE, awaitItem())
         }
     }
@@ -108,7 +117,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coEvery {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = token,
                     method = TwoFactorAuthMethod.WEB_AUTH.value.toString(),
@@ -128,7 +137,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coVerify(exactly = 1) {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = token,
                     method = TwoFactorAuthMethod.WEB_AUTH.value.toString(),
@@ -159,7 +168,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coEvery {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = "",
                     method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -173,7 +182,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coVerify {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = "",
                     method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -189,7 +198,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coEvery {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = "token",
                     method = TwoFactorAuthMethod.DUO.value.toString(),
@@ -207,7 +216,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coVerify {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = "token",
                     method = TwoFactorAuthMethod.DUO.value.toString(),
@@ -275,7 +284,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coEvery {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = "",
                     method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -306,7 +315,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coVerify {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = "",
                     method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -461,7 +470,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
             coEvery {
                 authRepository.login(
                     email = "example@email.com",
-                    password = "password123",
+                    password = DEFAULT_PASSWORD,
                     twoFactorData = TwoFactorDataModel(
                         code = "",
                         method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -487,7 +496,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
             coVerify {
                 authRepository.login(
                     email = "example@email.com",
-                    password = "password123",
+                    password = DEFAULT_PASSWORD,
                     twoFactorData = TwoFactorDataModel(
                         code = "",
                         method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -503,7 +512,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coEvery {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = "",
                     method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -543,7 +552,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         coVerify {
             authRepository.login(
                 email = "example@email.com",
-                password = "password123",
+                password = DEFAULT_PASSWORD,
                 twoFactorData = TwoFactorDataModel(
                     code = "",
                     method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -560,7 +569,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
             coEvery {
                 authRepository.login(
                     email = "example@email.com",
-                    password = "password123",
+                    password = DEFAULT_PASSWORD,
                     twoFactorData = TwoFactorDataModel(
                         code = "",
                         method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -600,7 +609,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
             coVerify {
                 authRepository.login(
                     email = "example@email.com",
-                    password = "password123",
+                    password = DEFAULT_PASSWORD,
                     twoFactorData = TwoFactorDataModel(
                         code = "",
                         method = TwoFactorAuthMethod.AUTHENTICATOR_APP.value.toString(),
@@ -841,7 +850,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
             savedStateHandle = SavedStateHandle().also {
                 it["state"] = state
                 it["email_address"] = "example@email.com"
-                it["password"] = "password123".base64UrlEncode()
+                it["password"] = DEFAULT_ENCODED_PASSWORD
             },
         )
 }
@@ -859,7 +868,8 @@ private val TWO_FACTOR_RESPONSE = GetTokenResponseJson.TwoFactorRequired(
     ssoToken = null,
     twoFactorProviders = null,
 )
-
+private const val DEFAULT_PASSWORD = "password123"
+private const val DEFAULT_ENCODED_PASSWORD = "base64EncodedPassword"
 private val DEFAULT_STATE = TwoFactorLoginState(
     authMethod = TwoFactorAuthMethod.AUTHENTICATOR_APP,
     availableAuthMethods = listOf(
@@ -874,5 +884,5 @@ private val DEFAULT_STATE = TwoFactorLoginState(
     isRememberMeEnabled = false,
     captchaToken = null,
     email = "example@email.com",
-    password = "password123",
+    password = DEFAULT_PASSWORD,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForCaptcha
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForWebAuth
 import com.x8bit.bitwarden.data.auth.util.YubiKeyResult
+import com.x8bit.bitwarden.data.platform.datasource.network.util.base64UrlEncode
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.baseWebVaultUrlOrDefault
@@ -840,7 +841,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
             savedStateHandle = SavedStateHandle().also {
                 it["state"] = state
                 it["email_address"] = "example@email.com"
-                it["password"] = "password123"
+                it["password"] = "password123".base64UrlEncode()
             },
         )
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10902

## 📔 Objective

Base 64 encode password when passing it to the 2FA screen to prevent corruption when it includes characters that should be escaped for URL safety.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
