### PR TITLE
PM-11387 on new create account with email verification, attempt login…

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationNavigation.kt
@@ -54,7 +54,7 @@ fun NavGraphBuilder.completeRegistrationDestination(
     onNavigateBack: () -> Unit,
     onNavigateToPasswordGuidance: () -> Unit,
     onNavigateToPreventAccountLockout: () -> Unit,
-    onNavigateToLogin: (email: String, token: String) -> Unit,
+    onNavigateToLogin: (email: String, token: String?) -> Unit,
 ) {
     composableWithSlideTransitions(
         route = COMPLETE_REGISTRATION_ROUTE,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
@@ -73,7 +73,7 @@ fun CompleteRegistrationScreen(
     onNavigateBack: () -> Unit,
     onNavigateToPasswordGuidance: () -> Unit,
     onNavigateToPreventAccountLockout: () -> Unit,
-    onNavigateToLogin: (email: String, token: String) -> Unit,
+    onNavigateToLogin: (email: String, token: String?) -> Unit,
     viewModel: CompleteRegistrationViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
@@ -269,7 +269,7 @@ class CompleteRegistrationViewModel @Inject constructor(
     }
 
     private fun handleLoginResult(action: Internal.ReceiveLoginResult) {
-        handleDialogDismiss()
+        clearDialogState()
         sendEvent(
             CompleteRegistrationEvent.ShowToast(
                 message = R.string.account_created_success.asText(),
@@ -294,9 +294,7 @@ class CompleteRegistrationViewModel @Inject constructor(
     }
 
     private fun handleDialogDismiss() {
-        mutableStateFlow.update {
-            it.copy(dialog = null)
-        }
+        clearDialogState()
     }
 
     private fun handleBackClicked() {
@@ -419,6 +417,12 @@ class CompleteRegistrationViewModel @Inject constructor(
                 )
                 trySendAction(ReceivePasswordStrengthResult(result))
             }
+        }
+    }
+
+    private fun clearDialogState() {
+        mutableStateFlow.update {
+            it.copy(dialog = null)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
   <string name="yes">Yes</string>
   <string name="account">Account</string>
   <string name="account_created">Your new account has been created! You may now log in.</string>
+  <string name="account_created_success">Your new account has been created!</string>
   <string name="add_an_item">Add an Item</string>
   <string name="app_extension">App extension</string>
   <string name="autofill_accessibility_description">Use the Bitwarden accessibility service to auto-fill your logins across apps and the web.</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
@@ -59,10 +59,24 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
     private val mutableUserStateFlow = MutableStateFlow<UserState?>(null)
     private val mockAuthRepository = mockk<AuthRepository>() {
         every { userStateFlow } returns mutableUserStateFlow
-        coEvery { login(any(), any(), any()) } returns LoginResult.Success
+        coEvery {
+            login(
+                email = any(),
+                password = any(),
+                captchaToken = any(),
+            )
+        } returns LoginResult.Success
 
         coEvery {
-            register(any(), any(), any(), any(), any(), any(), any())
+            register(
+                email = any(),
+                masterPassword = any(),
+                masterPasswordHint = any(),
+                emailVerificationToken = any(),
+                captchaToken = any(),
+                shouldCheckDataBreaches = any(),
+                isMasterPasswordStrong = any(),
+            )
         } returns RegisterResult.Success(captchaToken = CAPTCHA_BYPASS_TOKEN)
     }
 
@@ -215,6 +229,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
     fun `when login attempt returns anything other than success should send navigate to login event`() =
         runTest {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-11387
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- with the new create account through email verification we want to attempt logging in after the account is successfully created.
- If the login attempt is successful state based navigation takes over, currently takes user to the vault, in the future new onboarding flow.
- If the account is created, but the login attempt fails the user will land on the login with the MP page.
- Shows a toast once the account is created to provide feedback to the user.
- Went with approach of going through the ViewModel, advantage is that its already behind the feature flag and keeps the existing logic unchanged in the repository as well as allows for separate handling of the Register and Login results.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
| Login Succeeds | Login Fails |
|--------|--------|
| https://github.com/user-attachments/assets/cb60a8bf-5e10-4152-b33a-419b81064ed8 | https://github.com/user-attachments/assets/f177e5fa-a793-4859-8047-51288f482298 | 
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
