### PR TITLE
PM-11214 change navoptions to support single top without retaining VM

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph
@@ -267,12 +268,11 @@ private fun VaultBottomAppBar(
             VaultUnlockedNavBarTab.Generator,
             VaultUnlockedNavBarTab.Settings,
         )
+        // Collecting the back stack entry here as state is crucial to ensuring that the items
+        // below recompose when the navigation state changes to update the selected tab.
         val navBackStackEntry by navController.currentBackStackEntryAsState()
-        val currentDestination = navBackStackEntry?.destination
         destinations.forEach { destination ->
-            val isSelected = currentDestination?.hierarchy?.any {
-                it.route == destination.route
-            } == true
+            val isSelected = navBackStackEntry.isCurrentTab(destination)
 
             NavigationBarItem(
                 icon = {
@@ -327,7 +327,7 @@ private fun VaultBottomAppBar(
 private fun NavController.vaultUnlockedNavBarScreenNavOptions(
     tabToNavigateTo: VaultUnlockedNavBarTab,
 ): NavOptions {
-    val returnToCurrentSubRoot = isCurrentTab(tabToNavigateTo)
+    val returnToCurrentSubRoot = currentBackStackEntry.isCurrentTab(tabToNavigateTo)
     val startDestination = graph.findStartDestination().id
     val currentSubRootGraph = currentDestination?.parent?.id
     val popUpToDestination = graph
@@ -346,8 +346,8 @@ private fun NavController.vaultUnlockedNavBarScreenNavOptions(
 /**
  * Determine if the current destination is the same as the given tab.
  */
-private fun NavController.isCurrentTab(tab: VaultUnlockedNavBarTab): Boolean =
-    currentDestination?.hierarchy?.any {
+private fun NavBackStackEntry?.isCurrentTab(tab: VaultUnlockedNavBarTab): Boolean =
+    this?.destination?.hierarchy?.any {
         it.route == tab.route
     } == true
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 
-import android.os.Parcelable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -42,7 +41,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
-import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.base.util.max
 import com.x8bit.bitwarden.ui.platform.base.util.toDp
@@ -50,21 +48,18 @@ import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.scrim.BitwardenAnimatedScrim
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
-import com.x8bit.bitwarden.ui.platform.feature.settings.SETTINGS_GRAPH_ROUTE
 import com.x8bit.bitwarden.ui.platform.feature.settings.navigateToSettingsGraph
 import com.x8bit.bitwarden.ui.platform.feature.settings.settingsGraph
+import com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.model.VaultUnlockedNavBarTab
 import com.x8bit.bitwarden.ui.platform.theme.RootTransitionProviders
-import com.x8bit.bitwarden.ui.tools.feature.generator.GENERATOR_GRAPH_ROUTE
 import com.x8bit.bitwarden.ui.tools.feature.generator.generatorGraph
 import com.x8bit.bitwarden.ui.tools.feature.generator.navigateToGeneratorGraph
-import com.x8bit.bitwarden.ui.tools.feature.send.SEND_GRAPH_ROUTE
 import com.x8bit.bitwarden.ui.tools.feature.send.navigateToSendGraph
 import com.x8bit.bitwarden.ui.tools.feature.send.sendGraph
 import com.x8bit.bitwarden.ui.vault.feature.vault.VAULT_GRAPH_ROUTE
 import com.x8bit.bitwarden.ui.vault.feature.vault.navigateToVaultGraph
 import com.x8bit.bitwarden.ui.vault.feature.vault.vaultGraph
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
-import kotlinx.parcelize.Parcelize
 
 /**
  * Top level composable for the Vault Unlocked Screen.
@@ -91,7 +86,8 @@ fun VaultUnlockedNavBarScreen(
 
     EventsEffect(viewModel = viewModel) { event ->
         navController.apply {
-            val navOptions = vaultUnlockedNavBarScreenNavOptions(event.returnToSubgraphRoot)
+            val navOptions =
+                vaultUnlockedNavBarScreenNavOptions(tabToNavigateTo = event.tab)
             when (event) {
                 is VaultUnlockedNavBarEvent.NavigateToVaultScreen -> {
                     navigateToVaultGraph(navOptions)
@@ -323,112 +319,15 @@ private fun VaultBottomAppBar(
 }
 
 /**
- * Represents the different tabs available in the navigation bar
- * for the unlocked portion of the vault.
- *
- * Each tab is modeled with properties that provide information on:
- * - Regular icon resource
- * - Icon resource when selected
- * and other essential UI and navigational data.
- *
- * @property iconRes The resource ID for the regular (unselected) icon representing the tab.
- * @property iconResSelected The resource ID for the icon representing the tab when it's selected.
- */
-@Parcelize
-private sealed class VaultUnlockedNavBarTab : Parcelable {
-    /**
-     * The resource ID for the icon representing the tab when it is selected.
-     */
-    abstract val iconResSelected: Int
-
-    /**
-     * Resource id for the icon representing the tab.
-     */
-    abstract val iconRes: Int
-
-    /**
-     * Resource id for the label describing the tab.
-     */
-    abstract val labelRes: Int
-
-    /**
-     * Resource id for the content description describing the tab.
-     */
-    abstract val contentDescriptionRes: Int
-
-    /**
-     * Route of the tab.
-     */
-    abstract val route: String
-
-    /**
-     * The test tag of the tab.
-     */
-    abstract val testTag: String
-
-    /**
-     * Show the Generator screen.
-     */
-    @Parcelize
-    data object Generator : VaultUnlockedNavBarTab() {
-        override val iconResSelected get() = R.drawable.ic_generator_filled
-        override val iconRes get() = R.drawable.ic_generator
-        override val labelRes get() = R.string.generator
-        override val contentDescriptionRes get() = R.string.generator
-        override val route get() = GENERATOR_GRAPH_ROUTE
-        override val testTag get() = "GeneratorTab"
-    }
-
-    /**
-     * Show the Send screen.
-     */
-    @Parcelize
-    data object Send : VaultUnlockedNavBarTab() {
-        override val iconResSelected get() = R.drawable.ic_send_filled
-        override val iconRes get() = R.drawable.ic_send
-        override val labelRes get() = R.string.send
-        override val contentDescriptionRes get() = R.string.send
-        override val route get() = SEND_GRAPH_ROUTE
-        override val testTag get() = "SendTab"
-    }
-
-    /**
-     * Show the Vault screen.
-     */
-    @Parcelize
-    data class Vault(
-        override val labelRes: Int,
-        override val contentDescriptionRes: Int,
-    ) : VaultUnlockedNavBarTab() {
-        override val iconResSelected get() = R.drawable.ic_vault_filled
-        override val iconRes get() = R.drawable.ic_vault
-        override val route get() = VAULT_GRAPH_ROUTE
-        override val testTag get() = "VaultTab"
-    }
-
-    /**
-     * Show the Settings screen.
-     */
-    @Parcelize
-    data object Settings : VaultUnlockedNavBarTab() {
-        override val iconResSelected get() = R.drawable.ic_settings_filled
-        override val iconRes get() = R.drawable.ic_settings
-        override val labelRes get() = R.string.settings
-        override val contentDescriptionRes get() = R.string.settings
-        override val route get() = SETTINGS_GRAPH_ROUTE
-        override val testTag get() = "SettingsTab"
-    }
-}
-
-/**
  * Helper function to generate [NavOptions] for [VaultUnlockedNavBarScreen].
  *
- * @param returnToCurrentSubRoot Whether to return to the current sub-root destination. This would
- * be marked true in the case the current selected tab has been clicked again.
+ * @param tabToNavigateTo The [VaultUnlockedNavBarTab] to prepare the NavOptions for.
+ * NavOptions are determined on whether or not the tab is already selected.
  */
 private fun NavController.vaultUnlockedNavBarScreenNavOptions(
-    returnToCurrentSubRoot: Boolean,
+    tabToNavigateTo: VaultUnlockedNavBarTab,
 ): NavOptions {
+    val returnToCurrentSubRoot = isCurrentTab(tabToNavigateTo)
     val startDestination = graph.findStartDestination().id
     val currentSubRootGraph = currentDestination?.parent?.id
     val popUpToDestination = graph
@@ -443,6 +342,14 @@ private fun NavController.vaultUnlockedNavBarScreenNavOptions(
         restoreState = !returnToCurrentSubRoot
     }
 }
+
+/**
+ * Determine if the current destination is the same as the given tab.
+ */
+private fun NavController.isCurrentTab(tab: VaultUnlockedNavBarTab): Boolean =
+    currentDestination?.hierarchy?.any {
+        it.route == tab.route
+    } == true
 
 /**
  * Helper function to determine the start destination of a subgraph.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -87,22 +87,21 @@ fun VaultUnlockedNavBarScreen(
 
     EventsEffect(viewModel = viewModel) { event ->
         navController.apply {
-            val navOptions =
-                vaultUnlockedNavBarScreenNavOptions(tabToNavigateTo = event.tab)
+            val navOptions = vaultUnlockedNavBarScreenNavOptions(tabToNavigateTo = event.tab)
             when (event) {
                 is VaultUnlockedNavBarEvent.NavigateToVaultScreen -> {
                     navigateToVaultGraph(navOptions)
                 }
 
-                is VaultUnlockedNavBarEvent.NavigateToSendScreen -> {
+                VaultUnlockedNavBarEvent.NavigateToSendScreen -> {
                     navigateToSendGraph(navOptions)
                 }
 
-                is VaultUnlockedNavBarEvent.NavigateToGeneratorScreen -> {
+                VaultUnlockedNavBarEvent.NavigateToGeneratorScreen -> {
                     navigateToGeneratorGraph(navOptions)
                 }
 
-                is VaultUnlockedNavBarEvent.NavigateToSettingsScreen -> {
+                VaultUnlockedNavBarEvent.NavigateToSettingsScreen -> {
                     navigateToSettingsGraph(navOptions)
                 }
             }
@@ -356,7 +355,7 @@ private fun NavBackStackEntry?.isCurrentTab(tab: VaultUnlockedNavBarTab): Boolea
  *
  * @param subgraphId the id of the subgraph to find the start destination of.
  *
- * @return the id of the start destination of the subgraph, or null if the subgraph does not exist.
+ * @return the ID of the start destination of the subgraph, or null if the subgraph does not exist.
  */
 private fun NavGraph.getSubgraphStartDestinationOrNull(subgraphId: Int?): Int? {
     subgraphId ?: return null

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
@@ -43,7 +43,12 @@ class VaultUnlockedNavBarViewModel @Inject constructor(
             }
 
             SpecialCircumstance.VaultShortcut -> {
-                sendEvent(VaultUnlockedNavBarEvent.NavigateToVaultScreen)
+                sendEvent(
+                    VaultUnlockedNavBarEvent.NavigateToVaultScreen(
+                        labelRes = state.vaultNavBarLabelRes,
+                        contentDescRes = state.vaultNavBarContentDescriptionRes,
+                    ),
+                )
                 specialCircumstancesManager.specialCircumstance = null
             }
 
@@ -87,7 +92,12 @@ class VaultUnlockedNavBarViewModel @Inject constructor(
      * Attempts to send [VaultUnlockedNavBarEvent.NavigateToVaultScreen] event
      */
     private fun handleVaultTabClicked() {
-        sendEvent(VaultUnlockedNavBarEvent.NavigateToVaultScreen)
+        sendEvent(
+            VaultUnlockedNavBarEvent.NavigateToVaultScreen(
+                labelRes = state.vaultNavBarLabelRes,
+                contentDescRes = state.vaultNavBarContentDescriptionRes,
+            ),
+        )
     }
 
     /**
@@ -189,10 +199,13 @@ sealed class VaultUnlockedNavBarEvent {
     /**
      * Navigate to the Vault screen.
      */
-    data object NavigateToVaultScreen : VaultUnlockedNavBarEvent() {
+    data class NavigateToVaultScreen(
+        val labelRes: Int,
+        val contentDescRes: Int,
+    ) : VaultUnlockedNavBarEvent() {
         override val tab: VaultUnlockedNavBarTab = VaultUnlockedNavBarTab.Vault(
-            labelRes = R.string.my_vault,
-            contentDescriptionRes = R.string.my_vault,
+            labelRes = labelRes,
+            contentDescriptionRes = contentDescRes,
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
@@ -180,6 +180,9 @@ sealed class VaultUnlockedNavBarAction {
  */
 sealed class VaultUnlockedNavBarEvent {
 
+    /**
+     * The [VaultUnlockedNavBarTab] to be associated with the event.
+     */
     abstract val tab: VaultUnlockedNavBarTab
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
@@ -1,0 +1,107 @@
+package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.model
+
+import android.os.Parcelable
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.feature.settings.SETTINGS_GRAPH_ROUTE
+import com.x8bit.bitwarden.ui.tools.feature.generator.GENERATOR_GRAPH_ROUTE
+import com.x8bit.bitwarden.ui.tools.feature.send.SEND_GRAPH_ROUTE
+import com.x8bit.bitwarden.ui.vault.feature.vault.VAULT_GRAPH_ROUTE
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Represents the different tabs available in the navigation bar
+ * for the unlocked portion of the vault.
+ *
+ * Each tab is modeled with properties that provide information on:
+ * - Regular icon resource
+ * - Icon resource when selected
+ * and other essential UI and navigational data.
+ *
+ * @property iconRes The resource ID for the regular (unselected) icon representing the tab.
+ * @property iconResSelected The resource ID for the icon representing the tab when it's selected.
+ */
+@Parcelize
+sealed class VaultUnlockedNavBarTab : Parcelable {
+    /**
+     * The resource ID for the icon representing the tab when it is selected.
+     */
+    abstract val iconResSelected: Int
+
+    /**
+     * Resource id for the icon representing the tab.
+     */
+    abstract val iconRes: Int
+
+    /**
+     * Resource id for the label describing the tab.
+     */
+    abstract val labelRes: Int
+
+    /**
+     * Resource id for the content description describing the tab.
+     */
+    abstract val contentDescriptionRes: Int
+
+    /**
+     * Route of the tab.
+     */
+    abstract val route: String
+
+    /**
+     * The test tag of the tab.
+     */
+    abstract val testTag: String
+
+    /**
+     * Show the Generator screen.
+     */
+    @Parcelize
+    data object Generator : VaultUnlockedNavBarTab() {
+        override val iconResSelected get() = R.drawable.ic_generator_filled
+        override val iconRes get() = R.drawable.ic_generator
+        override val labelRes get() = R.string.generator
+        override val contentDescriptionRes get() = R.string.generator
+        override val route get() = GENERATOR_GRAPH_ROUTE
+        override val testTag get() = "GeneratorTab"
+    }
+
+    /**
+     * Show the Send screen.
+     */
+    @Parcelize
+    data object Send : VaultUnlockedNavBarTab() {
+        override val iconResSelected get() = R.drawable.ic_send_filled
+        override val iconRes get() = R.drawable.ic_send
+        override val labelRes get() = R.string.send
+        override val contentDescriptionRes get() = R.string.send
+        override val route get() = SEND_GRAPH_ROUTE
+        override val testTag get() = "SendTab"
+    }
+
+    /**
+     * Show the Vault screen.
+     */
+    @Parcelize
+    data class Vault(
+        override val labelRes: Int,
+        override val contentDescriptionRes: Int,
+    ) : VaultUnlockedNavBarTab() {
+        override val iconResSelected get() = R.drawable.ic_vault_filled
+        override val iconRes get() = R.drawable.ic_vault
+        override val route get() = VAULT_GRAPH_ROUTE
+        override val testTag get() = "VaultTab"
+    }
+
+    /**
+     * Show the Settings screen.
+     */
+    @Parcelize
+    data object Settings : VaultUnlockedNavBarTab() {
+        override val iconResSelected get() = R.drawable.ic_settings_filled
+        override val iconRes get() = R.drawable.ic_settings
+        override val labelRes get() = R.string.settings
+        override val contentDescriptionRes get() = R.string.settings
+        override val route get() = SETTINGS_GRAPH_ROUTE
+        override val testTag get() = "SettingsTab"
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
@@ -16,9 +16,6 @@ import kotlinx.parcelize.Parcelize
  * - Regular icon resource
  * - Icon resource when selected
  * and other essential UI and navigational data.
- *
- * @property iconRes The resource ID for the regular (unselected) icon representing the tab.
- * @property iconResSelected The resource ID for the icon representing the tab when it's selected.
  */
 @Parcelize
 sealed class VaultUnlockedNavBarTab : Parcelable {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -66,11 +66,35 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     @Test
     fun `NavigateToVaultScreen should navigate to VaultScreen`() {
         composeTestRule.runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
-        mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToVaultScreen)
+        mutableEventFlow.tryEmit(
+            VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = false),
+        )
         composeTestRule.runOnIdle {
             fakeNavHostController.assertLastNavigation(
                 route = "vault_graph",
                 navOptions = expectedNavOptions,
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `NavigateToVaultScreen should navigate to VaultScreen with correct options when returnToSubgraphRoot is true`() {
+        composeTestRule.runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
+        mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = true))
+        val expectedSubRootNavOptions = navOptions {
+            // When changing root navigation state, pop everything else off the back stack:
+            popUpTo(fakeNavHostController.graphId) {
+                inclusive = false
+                saveState = false
+            }
+            launchSingleTop = true
+            restoreState = false
+        }
+        composeTestRule.runOnIdle {
+            fakeNavHostController.assertLastNavigation(
+                route = "vault_graph",
+                navOptions = expectedSubRootNavOptions,
             )
         }
     }
@@ -85,7 +109,11 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     fun `NavigateToSendScreen should navigate to SendScreen`() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
-            mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToSendScreen)
+            mutableEventFlow.tryEmit(
+                VaultUnlockedNavBarEvent.NavigateToSendScreen(
+                    returnToSubgraphRoot = false,
+                ),
+            )
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
                     route = "send_graph",
@@ -105,7 +133,11 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     fun `NavigateToGeneratorScreen should navigate to GeneratorScreen`() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
-            mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToGeneratorScreen)
+            mutableEventFlow.tryEmit(
+                VaultUnlockedNavBarEvent.NavigateToGeneratorScreen(
+                    returnToSubgraphRoot = false,
+                ),
+            )
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
                     route = "generator_graph",
@@ -125,7 +157,11 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     fun `NavigateToSettingsScreen should navigate to SettingsScreen`() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
-            mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToSettingsScreen)
+            mutableEventFlow.tryEmit(
+                VaultUnlockedNavBarEvent.NavigateToSettingsScreen(
+                    returnToSubgraphRoot = false,
+                ),
+            )
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
                     route = "settings_graph",
@@ -144,7 +180,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
             VaultUnlockedNavBarState(
                 vaultNavBarLabelRes = R.string.vaults,
                 vaultNavBarContentDescriptionRes = R.string.vaults,
-                currentTab = SelectedBottomTab.Vault,
+                currentTab = BottomNavDestination.VAULT,
             ),
         )
 
@@ -156,5 +192,5 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
 private val DEFAULT_STATE = VaultUnlockedNavBarState(
     vaultNavBarLabelRes = R.string.my_vault,
     vaultNavBarContentDescriptionRes = R.string.my_vault,
-    currentTab = SelectedBottomTab.Vault,
+    currentTab = BottomNavDestination.VAULT,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -65,36 +65,15 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
 
     @Test
     fun `NavigateToVaultScreen should navigate to VaultScreen`() {
-        composeTestRule.runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
+        mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToSendScreen)
+        composeTestRule.runOnIdle { fakeNavHostController.assertCurrentRoute("send_graph") }
         mutableEventFlow.tryEmit(
-            VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = false),
+            VaultUnlockedNavBarEvent.NavigateToVaultScreen,
         )
         composeTestRule.runOnIdle {
             fakeNavHostController.assertLastNavigation(
                 route = "vault_graph",
                 navOptions = expectedNavOptions,
-            )
-        }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `NavigateToVaultScreen should navigate to VaultScreen with correct options when returnToSubgraphRoot is true`() {
-        composeTestRule.runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
-        mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = true))
-        val expectedSubRootNavOptions = navOptions {
-            // When changing root navigation state, pop everything else off the back stack:
-            popUpTo(fakeNavHostController.graphId) {
-                inclusive = false
-                saveState = false
-            }
-            launchSingleTop = true
-            restoreState = false
-        }
-        composeTestRule.runOnIdle {
-            fakeNavHostController.assertLastNavigation(
-                route = "vault_graph",
-                navOptions = expectedSubRootNavOptions,
             )
         }
     }
@@ -110,9 +89,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
             mutableEventFlow.tryEmit(
-                VaultUnlockedNavBarEvent.NavigateToSendScreen(
-                    returnToSubgraphRoot = false,
-                ),
+                VaultUnlockedNavBarEvent.NavigateToSendScreen,
             )
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
@@ -134,9 +111,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
             mutableEventFlow.tryEmit(
-                VaultUnlockedNavBarEvent.NavigateToGeneratorScreen(
-                    returnToSubgraphRoot = false,
-                ),
+                VaultUnlockedNavBarEvent.NavigateToGeneratorScreen,
             )
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
@@ -158,9 +133,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
             mutableEventFlow.tryEmit(
-                VaultUnlockedNavBarEvent.NavigateToSettingsScreen(
-                    returnToSubgraphRoot = false,
-                ),
+                VaultUnlockedNavBarEvent.NavigateToSettingsScreen,
             )
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
@@ -180,7 +153,6 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
             VaultUnlockedNavBarState(
                 vaultNavBarLabelRes = R.string.vaults,
                 vaultNavBarContentDescriptionRes = R.string.vaults,
-                currentTab = BottomNavDestination.VAULT,
             ),
         )
 
@@ -192,5 +164,4 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
 private val DEFAULT_STATE = VaultUnlockedNavBarState(
     vaultNavBarLabelRes = R.string.my_vault,
     vaultNavBarContentDescriptionRes = R.string.my_vault,
-    currentTab = BottomNavDestination.VAULT,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -144,6 +144,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
             VaultUnlockedNavBarState(
                 vaultNavBarLabelRes = R.string.vaults,
                 vaultNavBarContentDescriptionRes = R.string.vaults,
+                currentTab = SelectedBottomTab.Vault,
             ),
         )
 
@@ -155,4 +156,5 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
 private val DEFAULT_STATE = VaultUnlockedNavBarState(
     vaultNavBarLabelRes = R.string.my_vault,
     vaultNavBarContentDescriptionRes = R.string.my_vault,
+    currentTab = SelectedBottomTab.Vault,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -68,7 +68,10 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
         mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToSendScreen)
         composeTestRule.runOnIdle { fakeNavHostController.assertCurrentRoute("send_graph") }
         mutableEventFlow.tryEmit(
-            VaultUnlockedNavBarEvent.NavigateToVaultScreen,
+            VaultUnlockedNavBarEvent.NavigateToVaultScreen(
+                labelRes = R.string.my_vault,
+                contentDescRes = R.string.my_vault,
+            ),
         )
         composeTestRule.runOnIdle {
             fakeNavHostController.assertLastNavigation(
@@ -88,9 +91,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     fun `NavigateToSendScreen should navigate to SendScreen`() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
-            mutableEventFlow.tryEmit(
-                VaultUnlockedNavBarEvent.NavigateToSendScreen,
-            )
+            mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToSendScreen)
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
                     route = "send_graph",
@@ -110,9 +111,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     fun `NavigateToGeneratorScreen should navigate to GeneratorScreen`() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
-            mutableEventFlow.tryEmit(
-                VaultUnlockedNavBarEvent.NavigateToGeneratorScreen,
-            )
+            mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToGeneratorScreen)
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
                     route = "generator_graph",
@@ -132,9 +131,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     fun `NavigateToSettingsScreen should navigate to SettingsScreen`() {
         composeTestRule.apply {
             runOnIdle { fakeNavHostController.assertCurrentRoute("vault_graph") }
-            mutableEventFlow.tryEmit(
-                VaultUnlockedNavBarEvent.NavigateToSettingsScreen,
-            )
+            mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToSettingsScreen)
             runOnIdle {
                 fakeNavHostController.assertLastNavigation(
                     route = "settings_graph",

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 
-import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -39,10 +38,7 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.eventFlow.test {
-                assertEquals(
-                    VaultUnlockedNavBarEvent.NavigateToGeneratorScreen(returnToSubgraphRoot = false),
-                    awaitItem(),
-                )
+                assertEquals(VaultUnlockedNavBarEvent.NavigateToGeneratorScreen, awaitItem())
             }
             verify(exactly = 1) {
                 specialCircumstancesManager.specialCircumstance
@@ -61,10 +57,7 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.eventFlow.test {
-                assertEquals(
-                    VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = true),
-                    awaitItem(),
-                )
+                assertEquals(VaultUnlockedNavBarEvent.NavigateToVaultScreen, awaitItem())
             }
             verify(exactly = 1) {
                 specialCircumstancesManager.specialCircumstance
@@ -99,7 +92,6 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val expectedWithOrganizations = VaultUnlockedNavBarState(
             vaultNavBarLabelRes = R.string.vaults,
             vaultNavBarContentDescriptionRes = R.string.vaults,
-            currentTab = BottomNavDestination.VAULT,
         )
         val accountWithoutOrganizations: UserState.Account = mockk {
             every { userId } returns activeUserId
@@ -108,7 +100,6 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val expectedWithoutOrganizations = VaultUnlockedNavBarState(
             vaultNavBarLabelRes = R.string.my_vault,
             vaultNavBarContentDescriptionRes = R.string.my_vault,
-            currentTab = BottomNavDestination.VAULT,
         )
 
         val viewModel = createViewModel()
@@ -143,78 +134,22 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         }
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `VaultTabClick should navigate to the vault screen with option to return to subgraph root true`() =
-        runTest {
-            val viewModel = createViewModel()
-            assertEquals(
-                DEFAULT_STATE,
-                viewModel.stateFlow.value,
-            )
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(VaultUnlockedNavBarAction.VaultTabClick)
-                assertEquals(
-                    VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = true),
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `VaultTabClick should navigate to the vault screen with option to return to subgraph root false`() =
-        runTest {
-            val viewModel = createViewModel()
-
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(VaultUnlockedNavBarAction.SendTabClick)
-                assertEquals(
-                    VaultUnlockedNavBarState(
-                        vaultNavBarLabelRes = R.string.my_vault,
-                        vaultNavBarContentDescriptionRes = R.string.my_vault,
-                        currentTab = BottomNavDestination.SEND,
-                    ),
-                    viewModel.stateFlow.value,
-                )
-                assertEquals(
-                    VaultUnlockedNavBarEvent.NavigateToSendScreen(returnToSubgraphRoot = false),
-                    awaitItem(),
-                )
-                viewModel.trySendAction(VaultUnlockedNavBarAction.VaultTabClick)
-                assertEquals(
-                    VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = false),
-                    awaitItem(),
-                )
-            }
-            assertEquals(
-                DEFAULT_STATE,
-                viewModel.stateFlow.value,
-            )
-        }
-
-    @Test
-    fun `SendTabClick should navigate to the send screen and update the state`() = runTest {
+    fun `VaultTabClick should navigate to the vault screen`() = runTest {
         val viewModel = createViewModel()
-        assertEquals(
-            DEFAULT_STATE,
-            viewModel.stateFlow.value,
-        )
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(VaultUnlockedNavBarAction.VaultTabClick)
+            assertEquals(VaultUnlockedNavBarEvent.NavigateToVaultScreen, awaitItem())
+        }
+    }
+
+    @Test
+    fun `SendTabClick should navigate to the send screen`() = runTest {
+        val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultUnlockedNavBarAction.SendTabClick)
-            assertEquals(
-                VaultUnlockedNavBarEvent.NavigateToSendScreen(returnToSubgraphRoot = false),
-                awaitItem(),
-            )
+            assertEquals(VaultUnlockedNavBarEvent.NavigateToSendScreen, awaitItem())
         }
-        assertEquals(
-            VaultUnlockedNavBarState(
-                vaultNavBarLabelRes = R.string.my_vault,
-                vaultNavBarContentDescriptionRes = R.string.my_vault,
-                currentTab = BottomNavDestination.SEND,
-            ),
-            viewModel.stateFlow.value,
-        )
     }
 
     @Test
@@ -222,10 +157,7 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultUnlockedNavBarAction.GeneratorTabClick)
-            assertEquals(
-                VaultUnlockedNavBarEvent.NavigateToGeneratorScreen(returnToSubgraphRoot = false),
-                awaitItem(),
-            )
+            assertEquals(VaultUnlockedNavBarEvent.NavigateToGeneratorScreen, awaitItem())
         }
     }
 
@@ -234,30 +166,13 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultUnlockedNavBarAction.SettingsTabClick)
-            assertEquals(
-                VaultUnlockedNavBarEvent.NavigateToSettingsScreen(returnToSubgraphRoot = false),
-                awaitItem(),
-            )
+            assertEquals(VaultUnlockedNavBarEvent.NavigateToSettingsScreen, awaitItem())
         }
     }
 
-    @Test
-    fun `if state exists in SavedStateHandle apply as the initial state`() {
-        val savedState = DEFAULT_STATE.copy(currentTab = BottomNavDestination.SEND)
-        val viewModel = createViewModel(savedState)
-        assertEquals(savedState, viewModel.stateFlow.value)
-    }
-
-    private fun createViewModel(initialState: VaultUnlockedNavBarState = DEFAULT_STATE) =
+    private fun createViewModel() =
         VaultUnlockedNavBarViewModel(
             authRepository = authRepository,
             specialCircumstancesManager = specialCircumstancesManager,
-            savedStateHandle = SavedStateHandle(initialState = mapOf("state" to initialState)),
         )
 }
-
-private val DEFAULT_STATE = VaultUnlockedNavBarState(
-    vaultNavBarLabelRes = R.string.my_vault,
-    vaultNavBarContentDescriptionRes = R.string.my_vault,
-    currentTab = BottomNavDestination.VAULT,
-)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
@@ -57,7 +57,13 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.eventFlow.test {
-                assertEquals(VaultUnlockedNavBarEvent.NavigateToVaultScreen, awaitItem())
+                assertEquals(
+                    VaultUnlockedNavBarEvent.NavigateToVaultScreen(
+                        labelRes = R.string.my_vault,
+                        contentDescRes = R.string.my_vault,
+                    ),
+                    awaitItem(),
+                )
             }
             verify(exactly = 1) {
                 specialCircumstancesManager.specialCircumstance
@@ -139,7 +145,13 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultUnlockedNavBarAction.VaultTabClick)
-            assertEquals(VaultUnlockedNavBarEvent.NavigateToVaultScreen, awaitItem())
+            assertEquals(
+                VaultUnlockedNavBarEvent.NavigateToVaultScreen(
+                    labelRes = R.string.my_vault,
+                    contentDescRes = R.string.my_vault,
+                ),
+                awaitItem(),
+            )
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
@@ -39,7 +39,10 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.eventFlow.test {
-                assertEquals(VaultUnlockedNavBarEvent.NavigateToGeneratorScreen, awaitItem())
+                assertEquals(
+                    VaultUnlockedNavBarEvent.NavigateToGeneratorScreen(returnToSubgraphRoot = false),
+                    awaitItem(),
+                )
             }
             verify(exactly = 1) {
                 specialCircumstancesManager.specialCircumstance
@@ -58,7 +61,10 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.eventFlow.test {
-                assertEquals(VaultUnlockedNavBarEvent.NavigateToVaultScreen, awaitItem())
+                assertEquals(
+                    VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = true),
+                    awaitItem(),
+                )
             }
             verify(exactly = 1) {
                 specialCircumstancesManager.specialCircumstance
@@ -93,7 +99,7 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val expectedWithOrganizations = VaultUnlockedNavBarState(
             vaultNavBarLabelRes = R.string.vaults,
             vaultNavBarContentDescriptionRes = R.string.vaults,
-            currentTab = SelectedBottomTab.Vault,
+            currentTab = BottomNavDestination.VAULT,
         )
         val accountWithoutOrganizations: UserState.Account = mockk {
             every { userId } returns activeUserId
@@ -102,7 +108,7 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val expectedWithoutOrganizations = VaultUnlockedNavBarState(
             vaultNavBarLabelRes = R.string.my_vault,
             vaultNavBarContentDescriptionRes = R.string.my_vault,
-            currentTab = SelectedBottomTab.Vault,
+            currentTab = BottomNavDestination.VAULT,
         )
 
         val viewModel = createViewModel()
@@ -137,8 +143,9 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `VaultTabClick should not navigate to the vault screen if already on the vault screen`() =
+    fun `VaultTabClick should navigate to the vault screen with option to return to subgraph root true`() =
         runTest {
             val viewModel = createViewModel()
             assertEquals(
@@ -147,12 +154,16 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
             )
             viewModel.eventFlow.test {
                 viewModel.trySendAction(VaultUnlockedNavBarAction.VaultTabClick)
-                expectNoEvents()
+                assertEquals(
+                    VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = true),
+                    awaitItem(),
+                )
             }
         }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `VaultTabClick should navigate to the vault screen if not already on the vault screen`() =
+    fun `VaultTabClick should navigate to the vault screen with option to return to subgraph root false`() =
         runTest {
             val viewModel = createViewModel()
 
@@ -162,13 +173,19 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
                     VaultUnlockedNavBarState(
                         vaultNavBarLabelRes = R.string.my_vault,
                         vaultNavBarContentDescriptionRes = R.string.my_vault,
-                        currentTab = SelectedBottomTab.Send,
+                        currentTab = BottomNavDestination.SEND,
                     ),
                     viewModel.stateFlow.value,
                 )
-                assertEquals(VaultUnlockedNavBarEvent.NavigateToSendScreen, awaitItem())
+                assertEquals(
+                    VaultUnlockedNavBarEvent.NavigateToSendScreen(returnToSubgraphRoot = false),
+                    awaitItem(),
+                )
                 viewModel.trySendAction(VaultUnlockedNavBarAction.VaultTabClick)
-                assertEquals(VaultUnlockedNavBarEvent.NavigateToVaultScreen, awaitItem())
+                assertEquals(
+                    VaultUnlockedNavBarEvent.NavigateToVaultScreen(returnToSubgraphRoot = false),
+                    awaitItem(),
+                )
             }
             assertEquals(
                 DEFAULT_STATE,
@@ -185,13 +202,16 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         )
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultUnlockedNavBarAction.SendTabClick)
-            assertEquals(VaultUnlockedNavBarEvent.NavigateToSendScreen, awaitItem())
+            assertEquals(
+                VaultUnlockedNavBarEvent.NavigateToSendScreen(returnToSubgraphRoot = false),
+                awaitItem(),
+            )
         }
         assertEquals(
             VaultUnlockedNavBarState(
                 vaultNavBarLabelRes = R.string.my_vault,
                 vaultNavBarContentDescriptionRes = R.string.my_vault,
-                currentTab = SelectedBottomTab.Send,
+                currentTab = BottomNavDestination.SEND,
             ),
             viewModel.stateFlow.value,
         )
@@ -202,7 +222,10 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultUnlockedNavBarAction.GeneratorTabClick)
-            assertEquals(VaultUnlockedNavBarEvent.NavigateToGeneratorScreen, awaitItem())
+            assertEquals(
+                VaultUnlockedNavBarEvent.NavigateToGeneratorScreen(returnToSubgraphRoot = false),
+                awaitItem(),
+            )
         }
     }
 
@@ -211,13 +234,16 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultUnlockedNavBarAction.SettingsTabClick)
-            assertEquals(VaultUnlockedNavBarEvent.NavigateToSettingsScreen, awaitItem())
+            assertEquals(
+                VaultUnlockedNavBarEvent.NavigateToSettingsScreen(returnToSubgraphRoot = false),
+                awaitItem(),
+            )
         }
     }
 
     @Test
     fun `if state exists in SavedStateHandle apply as the initial state`() {
-        val savedState = DEFAULT_STATE.copy(currentTab = SelectedBottomTab.Send)
+        val savedState = DEFAULT_STATE.copy(currentTab = BottomNavDestination.SEND)
         val viewModel = createViewModel(savedState)
         assertEquals(savedState, viewModel.stateFlow.value)
     }
@@ -233,5 +259,5 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
 private val DEFAULT_STATE = VaultUnlockedNavBarState(
     vaultNavBarLabelRes = R.string.my_vault,
     vaultNavBarContentDescriptionRes = R.string.my_vault,
-    currentTab = SelectedBottomTab.Vault,
+    currentTab = BottomNavDestination.VAULT,
 )


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-11214
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- If the tab the user is already on is clicked again, popBack to the top of the graph, this unblocks interaction with the sub screens as mentioned in the defect. 

**NOTE** Key difference is on the settings tab where tapping settings again will take you back to the start of the graph**
I do have another fix locked and loaded where the VM keeps hold of a `SelectedBottomTab` enum and no interaction with the navController takes place if its the currently selected one, this matches what is seen today in the settings screen where the user would just stay on the submenu view.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/cecfe155-b13c-4f32-bf88-bbe938c9d74c


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
