### PR TITLE
PM-11483: Create AutofillTileService

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -3,6 +3,24 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application tools:ignore="MissingApplicationIcon">
+        <!--
+        The AutofillTileService name below refers to the legacy Xamarin app's service name.
+        This must always match in order for the app to properly query if it is providing autofill
+        tile services.
+        -->
+        <!--suppress AndroidDomInspection -->
+        <service
+            android:name="com.x8bit.bitwarden.AutofillTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_notification"
+            android:label="@string/autofill"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
         <!-- Disable Crashlytics for debug builds -->
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,13 @@
         </activity>
 
         <activity
+            android:name=".AccessibilityActivity"
+            android:exported="false"
+            android:launchMode="singleTop"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay" />
+
+        <activity
             android:name=".AutofillTotpCopyActivity"
             android:exported="true"
             android:launchMode="singleTop"

--- a/app/src/main/java/com/x8bit/bitwarden/AccessibilityActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/AccessibilityActivity.kt
@@ -1,0 +1,17 @@
+package com.x8bit.bitwarden
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
+
+/**
+ * An activity to be launched and then immediately closed so that the OS Shade can be collapsed
+ * after the user clicks on the Autofill Quick Tile.
+ */
+@OmitFromCoverage
+class AccessibilityActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        finish()
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/BitwardenAppComponentFactory.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/BitwardenAppComponentFactory.kt
@@ -3,16 +3,19 @@ package com.x8bit.bitwarden
 import android.app.Service
 import android.content.Intent
 import android.os.Build
+import androidx.annotation.Keep
 import androidx.core.app.AppComponentFactory
 import com.x8bit.bitwarden.data.autofill.BitwardenAutofillService
 import com.x8bit.bitwarden.data.autofill.fido2.BitwardenFido2ProviderService
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
+import com.x8bit.bitwarden.data.tiles.BitwardenAutofillTileService
 import com.x8bit.bitwarden.data.tiles.BitwardenGeneratorTileService
 import com.x8bit.bitwarden.data.tiles.BitwardenVaultTileService
 
 private const val LEGACY_AUTOFILL_SERVICE_NAME = "com.x8bit.bitwarden.Autofill.AutofillService"
 private const val LEGACY_CREDENTIAL_SERVICE_NAME =
     "com.x8bit.bitwarden.Autofill.CredentialProviderService"
+private const val LEGACY_AUTOFILL_TILE_SERVICE_NAME = "com.x8bit.bitwarden.AutofillTileService"
 private const val LEGACY_VAULT_TILE_SERVICE_NAME = "com.x8bit.bitwarden.MyVaultTileService"
 private const val LEGACY_GENERATOR_TILE_SERVICE_NAME = "com.x8bit.bitwarden.GeneratorTileService"
 
@@ -21,14 +24,20 @@ private const val LEGACY_GENERATOR_TILE_SERVICE_NAME = "com.x8bit.bitwarden.Gene
  * and modify various characteristics before initialization.
  */
 @Suppress("unused")
+@Keep
 @OmitFromCoverage
 class BitwardenAppComponentFactory : AppComponentFactory() {
     /**
-     * Used to intercept when the [BitwardenAutofillService], [BitwardenFido2ProviderService],
-     * [BitwardenVaultTileService], or [BitwardenGeneratorTileService] is being instantiated and
-     * modify which service is created. This is required because the [className] used in the
-     * manifest must match the legacy Xamarin app service name but the service name in this app is
-     * different.
+     * Used to intercept when certain legacy services are being instantiated and modify which
+     * service is created. This is required because the [className] used in the manifest must match
+     * the legacy Xamarin app service name but the service name in this app is different.
+     *
+     * Services currently being managed:
+     * * [BitwardenAutofillService]
+     * * [BitwardenAutofillTileService]
+     * * [BitwardenFido2ProviderService]
+     * * [BitwardenVaultTileService]
+     * * [BitwardenGeneratorTileService]
      */
     override fun instantiateServiceCompat(
         cl: ClassLoader,
@@ -37,6 +46,14 @@ class BitwardenAppComponentFactory : AppComponentFactory() {
     ): Service = when (className) {
         LEGACY_AUTOFILL_SERVICE_NAME -> {
             super.instantiateServiceCompat(cl, BitwardenAutofillService::class.java.name, intent)
+        }
+
+        LEGACY_AUTOFILL_TILE_SERVICE_NAME -> {
+            super.instantiateServiceCompat(
+                cl,
+                BitwardenAutofillTileService::class.java.name,
+                intent,
+            )
         }
 
         LEGACY_CREDENTIAL_SERVICE_NAME -> {

--- a/app/src/main/java/com/x8bit/bitwarden/data/accessibility/di/AccessibilityModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/accessibility/di/AccessibilityModule.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.data.accessibility.di
+
+import com.x8bit.bitwarden.data.accessibility.manager.AccessibilityAutofillManager
+import com.x8bit.bitwarden.data.accessibility.manager.AccessibilityAutofillManagerImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Provides dependencies within the accessibility package.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object AccessibilityModule {
+    @Singleton
+    @Provides
+    fun providesAccessibilityInvokeManager(): AccessibilityAutofillManager =
+        AccessibilityAutofillManagerImpl()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/accessibility/manager/AccessibilityAutofillManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/accessibility/manager/AccessibilityAutofillManager.kt
@@ -1,0 +1,12 @@
+package com.x8bit.bitwarden.data.accessibility.manager
+
+/**
+ * A relay manager used to notify the accessibility service to attempt an autofill.
+ */
+interface AccessibilityAutofillManager {
+    /**
+     * Indicates that the Autofill tile has been clicked and we attempt an accessibility-based
+     * autofill.
+     */
+    var isAccessibilityTileClicked: Boolean
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/accessibility/manager/AccessibilityAutofillManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/accessibility/manager/AccessibilityAutofillManagerImpl.kt
@@ -1,0 +1,8 @@
+package com.x8bit.bitwarden.data.accessibility.manager
+
+/**
+ * The default implementation for the [AccessibilityAutofillManager].
+ */
+class AccessibilityAutofillManagerImpl : AccessibilityAutofillManager {
+    override var isAccessibilityTileClicked: Boolean = false
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/tiles/BitwardenAutofillTileService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tiles/BitwardenAutofillTileService.kt
@@ -1,0 +1,52 @@
+package com.x8bit.bitwarden.data.tiles
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Build
+import android.service.quicksettings.TileService
+import androidx.annotation.Keep
+import com.x8bit.bitwarden.AccessibilityActivity
+import com.x8bit.bitwarden.data.accessibility.manager.AccessibilityAutofillManager
+import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/**
+ * A service for handling the Autofill quick settings tile.
+ */
+@AndroidEntryPoint
+@Keep
+@OmitFromCoverage
+class BitwardenAutofillTileService : TileService() {
+    @Inject
+    lateinit var accessibilityAutofillManager: AccessibilityAutofillManager
+
+    override fun onClick() {
+        if (isLocked) {
+            unlockAndRun { launchAutofill() }
+        } else {
+            launchAutofill()
+        }
+    }
+
+    @SuppressLint("StartActivityAndCollapseDeprecated")
+    private fun launchAutofill() {
+        accessibilityAutofillManager.isAccessibilityTileClicked = true
+        val intent = Intent(applicationContext, AccessibilityActivity::class.java)
+        if (isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
+            @Suppress("DEPRECATION")
+            startActivityAndCollapse(intent)
+        } else {
+            startActivityAndCollapse(
+                PendingIntent.getActivity(
+                    applicationContext,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE,
+                ),
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/accessibility/manager/AccessibilityAutofillManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/accessibility/manager/AccessibilityAutofillManagerTest.kt
@@ -1,0 +1,19 @@
+package com.x8bit.bitwarden.data.accessibility.manager
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AccessibilityAutofillManagerTest {
+    private val accessibilityAutofillManager: AccessibilityAutofillManager =
+        AccessibilityAutofillManagerImpl()
+
+    @Test
+    fun `isAccessibilityTileClicked should simply hold the state it is provided`() {
+        assertFalse(accessibilityAutofillManager.isAccessibilityTileClicked)
+        accessibilityAutofillManager.isAccessibilityTileClicked = true
+        assertTrue(accessibilityAutofillManager.isAccessibilityTileClicked)
+        accessibilityAutofillManager.isAccessibilityTileClicked = false
+        assertFalse(accessibilityAutofillManager.isAccessibilityTileClicked)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11483](https://bitwarden.atlassian.net/browse/PM-11483)

## 📔 Objective

This PR adds the `BitwardenAutofillTileService` as a baseline for the Autofill fallback feature.

## 📸 Screenshots

<img src="https://github.com/user-attachments/assets/f0fb478a-6099-4ac0-bc3d-6e37a4144664" width="350" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11483]: https://bitwarden.atlassian.net/browse/PM-11483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ