### PR TITLE
BITAU-107 Add Feature Flag and UI for Authenticator Syncing

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -25,11 +25,21 @@ sealed class FlagKey<out T : Any> {
          */
         val activeFlags: List<FlagKey<*>> by lazy {
             listOf(
+                AuthenticatorSync,
                 EmailVerification,
                 OnboardingFlow,
                 OnboardingCarousel,
             )
         }
+    }
+
+    /**
+     *  Data object holding the key for syncing with the Bitwarden Authenticator app.
+     */
+    data object AuthenticatorSync : FlagKey<Boolean>() {
+        override val keyName: String = "authenticator-sync"
+        override val defaultValue: Boolean = false
+        override val isRemotelyConfigured: Boolean = false
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -38,6 +38,11 @@ interface SettingsRepository {
     var initialAutofillDialogShown: Boolean
 
     /**
+     * Whether the user has enabled syncing with the Bitwarden Authenticator app.
+     */
+    var isAuthenticatorSyncEnabled: Boolean
+
+    /**
      * The currently stored last time the vault was synced.
      */
     var vaultLastSync: Instant?

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -99,6 +99,9 @@ class SettingsRepositoryImpl(
             }
             ?: MutableStateFlow(value = null)
 
+    // TODO: this should be backed by disk and should set and clear the sync key (BITAU-103)
+    override var isAuthenticatorSyncEnabled: Boolean = false
+
     override var isIconLoadingDisabled: Boolean
         get() = settingsDiskSource.isIconLoadingDisabled ?: false
         set(value) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
@@ -28,13 +28,15 @@ class DebugMenuViewModel @Inject constructor(
 
     init {
         combine(
+            featureFlagManager.getFeatureFlagFlow(FlagKey.AuthenticatorSync),
             featureFlagManager.getFeatureFlagFlow(FlagKey.EmailVerification),
             featureFlagManager.getFeatureFlagFlow(FlagKey.OnboardingCarousel),
             featureFlagManager.getFeatureFlagFlow(FlagKey.OnboardingFlow),
-        ) { (emailVerification, onboardingCarousel, onboardingFlow) ->
+        ) { (authenticatorSync, emailVerification, onboardingCarousel, onboardingFlow) ->
             sendAction(
                 DebugMenuAction.Internal.UpdateFeatureFlagMap(
                     mapOf(
+                        FlagKey.AuthenticatorSync to authenticatorSync,
                         FlagKey.EmailVerification to emailVerification,
                         FlagKey.OnboardingCarousel to onboardingCarousel,
                         FlagKey.OnboardingFlow to onboardingFlow,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -22,6 +22,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.DummyString,
     -> Unit
 
+    FlagKey.AuthenticatorSync,
     FlagKey.EmailVerification,
     FlagKey.OnboardingCarousel,
     FlagKey.OnboardingFlow,
@@ -62,6 +63,7 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.DummyString,
     -> this.keyName
 
+    FlagKey.AuthenticatorSync -> stringResource(R.string.authenticator_sync)
     FlagKey.EmailVerification -> stringResource(R.string.email_verification)
     FlagKey.OnboardingCarousel -> stringResource(R.string.onboarding_carousel)
     FlagKey.OnboardingFlow -> stringResource(R.string.onboarding_flow)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -54,6 +54,7 @@ import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.text.BitwardenPolicyWarningText
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenUnlockWithBiometricsSwitch
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenUnlockWithPinSwitch
+import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenWideSwitch
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.composition.LocalBiometricsManager
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
@@ -71,7 +72,7 @@ private const val MINUTES_PER_HOUR = 60
 /**
  * Displays the account security screen.
  */
-@Suppress("LongMethod", "LongParameterList")
+@Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountSecurityScreen(
@@ -229,6 +230,19 @@ fun AccountSecurityScreen(
                     .padding(horizontal = 16.dp),
             )
             Spacer(Modifier.height(16.dp))
+            if (state.shouldShowEnableAuthenticatorSync) {
+                SyncWithAuthenticatorRow(
+                    isChecked = state.isAuthenticatorSyncChecked,
+                    onCheckedChange = remember(viewModel) {
+                        {
+                            viewModel.trySendAction(
+                                AccountSecurityAction.AuthenticatorSyncToggle(enabled = it),
+                            )
+                        }
+                    },
+                )
+                Spacer(Modifier.height(16.dp))
+            }
             BitwardenListHeaderText(
                 label = stringResource(id = R.string.session_timeout),
                 modifier = Modifier
@@ -643,6 +657,27 @@ private fun SessionTimeoutActionRow(
             )
         }
     }
+}
+
+@Composable
+private fun SyncWithAuthenticatorRow(
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    BitwardenListHeaderText(
+        label = stringResource(R.string.authenticator_sync),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+    )
+    BitwardenWideSwitch(
+        label = stringResource(R.string.allow_bitwarden_authenticator_syncing),
+        onCheckedChange = onCheckedChange,
+        isChecked = isChecked,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+    )
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -992,4 +992,6 @@ Do you want to switch to this account?</string>
   <string name="expired_link">Expired link</string>
   <string name="please_restart_registration_or_try_logging_in">Please restart registration or try logging in. You may already have an account.</string>
   <string name="restart_registration">Restart registration</string>
+  <string name="authenticator_sync">Authenticator Sync</string>
+  <string name="allow_bitwarden_authenticator_syncing">Allow Bitwarden Authenticator Syncing</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -1,0 +1,13 @@
+package com.x8bit.bitwarden.data.platform.manager
+
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class FlagKeyTest {
+
+    @Test
+    fun `AuthenticatorSync default value should be false`() {
+        assertFalse(FlagKey.AuthenticatorSync.defaultValue)
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1014,6 +1014,18 @@ class SettingsRepositoryTest {
         settingsRepository.initialAutofillDialogShown = false
         assertEquals(false, fakeSettingsDiskSource.initialAutofillDialogShown)
     }
+
+    @Test
+    fun `isAuthenticatorSyncEnabled should default to false`() {
+        assertFalse(settingsRepository.isAuthenticatorSyncEnabled)
+    }
+
+    @Test
+    fun `isAuthenticatorSyncEnabled should be kept in memory and update accordingly`() = runTest {
+        assertFalse(settingsRepository.isAuthenticatorSyncEnabled)
+        settingsRepository.isAuthenticatorSyncEnabled = true
+        assertTrue(settingsRepository.isAuthenticatorSyncEnabled)
+    }
 }
 
 private const val USER_ID: String = "userId"

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -76,12 +76,14 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
 }
 
 private val DEFAULT_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
+    FlagKey.AuthenticatorSync to true,
     FlagKey.EmailVerification to true,
     FlagKey.OnboardingCarousel to true,
     FlagKey.OnboardingFlow to true,
 )
 
 private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
+    FlagKey.AuthenticatorSync to false,
     FlagKey.EmailVerification to false,
     FlagKey.OnboardingCarousel to true,
     FlagKey.OnboardingFlow to false,


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-107

## 📔 Objective

Add UI and feature flag for authenticator syncing.

## 📸 Screenshots


https://github.com/user-attachments/assets/059c0952-75e2-4c58-9b51-8dfa7ecd9d6e


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
