### PR TITLE
PM-11642: Security stamp soft logout

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManager.kt
@@ -14,15 +14,15 @@ interface UserLogoutManager {
     val logoutEventFlow: SharedFlow<LogoutEvent>
 
     /**
-     * Completely logs out the given [userId], removing all data.
-     * If [isExpired] is true, a toast will be displayed
-     * letting the user know the session has expired.
+     * Completely logs out the given [userId], removing all data. If [isExpired] is true, a toast
+     * will be displayed letting the user know the session has expired.
      */
     fun logout(userId: String, isExpired: Boolean = false)
 
     /**
      * Partially logs out the given [userId]. All data for the given [userId] will be removed with
-     * the exception of basic account data.
+     * the exception of basic account data. If [isExpired] is true, a toast will be displayed
+     * letting the user know the session has expired.
      */
-    fun softLogout(userId: String)
+    fun softLogout(userId: String, isExpired: Boolean = false)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -64,7 +64,10 @@ class UserLogoutManagerImpl(
         mutableLogoutEventFlow.tryEmit(LogoutEvent(loggedOutUserId = userId))
     }
 
-    override fun softLogout(userId: String) {
+    override fun softLogout(userId: String, isExpired: Boolean) {
+        if (isExpired) {
+            showToast(message = R.string.login_expired)
+        }
         authDiskSource.storeAccountTokens(
             userId = userId,
             accountTokens = null,
@@ -74,7 +77,11 @@ class UserLogoutManagerImpl(
         val vaultTimeoutInMinutes = settingsDiskSource.getVaultTimeoutInMinutes(userId = userId)
         val vaultTimeoutAction = settingsDiskSource.getVaultTimeoutAction(userId = userId)
 
-        switchUserIfAvailable(currentUserId = userId, removeCurrentUserFromAccounts = false)
+        switchUserIfAvailable(
+            currentUserId = userId,
+            removeCurrentUserFromAccounts = false,
+            isExpired = isExpired,
+        )
 
         clearData(userId = userId)
         mutableLogoutEventFlow.tryEmit(LogoutEvent(loggedOutUserId = userId))

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -358,7 +358,7 @@ class VaultRepositoryImpl(
                         // Log the user out if the stamps do not match
                         localSecurityStamp?.let {
                             if (serverSecurityStamp != localSecurityStamp) {
-                                userLogoutManager.logout(userId = userId, isExpired = true)
+                                userLogoutManager.softLogout(userId = userId, isExpired = true)
                                 return@launch
                             }
                         }

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -140,7 +140,7 @@ class VaultRepositoryTest {
     )
     private val dispatcherManager: DispatcherManager = FakeDispatcherManager()
     private val userLogoutManager: UserLogoutManager = mockk {
-        every { logout(any(), any()) } just runs
+        every { softLogout(any(), any()) } just runs
     }
     private val fileManager: FileManager = mockk {
         coEvery { delete(*anyVararg()) } just runs
@@ -851,9 +851,8 @@ class VaultRepositoryTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val userId = "mockId-1"
             val mockSyncResponse = createMockSyncResponse(number = 1)
-            coEvery { syncService.sync() } returns mockSyncResponse.copy(
-                profile = createMockProfile(number = 1).copy(securityStamp = "newStamp"),
-            )
+            coEvery { syncService.sync() } returns mockSyncResponse
+                .copy(profile = createMockProfile(number = 1).copy(securityStamp = "newStamp"))
                 .asSuccess()
 
             coEvery {
@@ -868,7 +867,7 @@ class VaultRepositoryTest {
             vaultRepository.sync()
 
             coVerify {
-                userLogoutManager.logout(userId = userId, isExpired = true)
+                userLogoutManager.softLogout(userId = userId, isExpired = true)
             }
 
             coVerify(exactly = 0) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11642](https://bitwarden.atlassian.net/browse/PM-11642)

## 📔 Objective

This PR updates the logout process on invalid security stamp by performing a soft-logout instead of a full-logout.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11642]: https://bitwarden.atlassian.net/browse/PM-11642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ