### PR TITLE
PM-11643: Add LauncherPackageNameManager for tracking launcher apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -245,6 +245,10 @@
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.HOME" />
+        </intent>
     </queries>
 
 </manifest>

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/di/AccessibilityModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/di/AccessibilityModule.kt
@@ -1,11 +1,15 @@
 package com.x8bit.bitwarden.data.autofill.accessibility.di
 
+import android.content.pm.PackageManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityAutofillManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityAutofillManagerImpl
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.LauncherPackageNameManager
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.LauncherPackageNameManagerImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -18,4 +22,15 @@ object AccessibilityModule {
     @Provides
     fun providesAccessibilityInvokeManager(): AccessibilityAutofillManager =
         AccessibilityAutofillManagerImpl()
+
+    @Singleton
+    @Provides
+    fun providesLauncherPackageNameManager(
+        clock: Clock,
+        packageManager: PackageManager,
+    ): LauncherPackageNameManager =
+        LauncherPackageNameManagerImpl(
+            clockProvider = { clock },
+            packageManager = packageManager,
+        )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/LauncherPackageNameManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/LauncherPackageNameManager.kt
@@ -1,0 +1,11 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+/**
+ * A manager for getting the launcher packages from the operating system.
+ */
+interface LauncherPackageNameManager {
+    /**
+     * A list of launcher packages from the operating system.
+     */
+    val launcherPackages: List<String>
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/LauncherPackageNameManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/LauncherPackageNameManagerImpl.kt
@@ -1,0 +1,41 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import java.time.Clock
+
+/**
+ * How frequently the cached launcher list should be refreshed.
+ */
+private const val REFRESH_CACHE_MS: Long = 1L * 60L * 60L * 1000L
+
+/**
+ * The default implementation of the [LauncherPackageNameManager].
+ */
+class LauncherPackageNameManagerImpl(
+    private val clockProvider: () -> Clock,
+    private val packageManager: PackageManager,
+) : LauncherPackageNameManager {
+    private var lastLauncherFetchMs: Long = 0L
+    private var cachedLauncherPackages: List<String>? = null
+
+    override val launcherPackages: List<String>
+        get() {
+            if (cachedLauncherPackages == null ||
+                clockProvider().millis() - lastLauncherFetchMs > REFRESH_CACHE_MS
+            ) {
+                updateCachedLauncherPackages()
+            }
+            return cachedLauncherPackages.orEmpty()
+        }
+
+    private fun updateCachedLauncherPackages() {
+        cachedLauncherPackages = packageManager
+            .queryIntentActivities(
+                Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME),
+                0,
+            )
+            .map { it.activityInfo.packageName }
+        lastLauncherFetchMs = clockProvider().millis()
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/LauncherPackageNameManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/LauncherPackageNameManagerTest.kt
@@ -1,0 +1,70 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+class LauncherPackageNameManagerTest {
+    private val packageManager: PackageManager = mockk()
+    private var mutableClock: Clock = FIXED_CLOCK
+
+    private val launcherPackageNameManager: LauncherPackageNameManager =
+        LauncherPackageNameManagerImpl(
+            clockProvider = { mutableClock },
+            packageManager = packageManager,
+        )
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `launcherPackages should populate cache on first attempt and use cached value for second attempt and repopulate the cache after an hour`() {
+        val testPackageName = "testPackageName"
+        val testActivityInfo = ActivityInfo().apply {
+            packageName = testPackageName
+        }
+        val resolveInfo = ResolveInfo().apply {
+            activityInfo = testActivityInfo
+        }
+        val packages = listOf(resolveInfo)
+        every { packageManager.queryIntentActivities(any(), any<Int>()) } returns packages
+
+        val firstResult = launcherPackageNameManager.launcherPackages
+
+        assertEquals(listOf(testPackageName), firstResult)
+        verify(exactly = 1) {
+            packageManager.queryIntentActivities(any(), any<Int>())
+        }
+        clearMocks(packageManager)
+
+        val secondResult = launcherPackageNameManager.launcherPackages
+
+        assertEquals(listOf(testPackageName), secondResult)
+        verify(exactly = 0) {
+            packageManager.queryIntentActivities(any(), any<Int>())
+        }
+        clearMocks(packageManager)
+
+        every { packageManager.queryIntentActivities(any(), any<Int>()) } returns emptyList()
+        mutableClock = Clock.offset(FIXED_CLOCK, Duration.ofMinutes(61))
+        val thirdResult = launcherPackageNameManager.launcherPackages
+
+        assertEquals(emptyList<String>(), thirdResult)
+        verify(exactly = 1) {
+            packageManager.queryIntentActivities(any(), any<Int>())
+        }
+    }
+}
+
+private val FIXED_CLOCK: Clock = Clock.fixed(
+    Instant.parse("2023-10-27T12:00:00Z"),
+    ZoneOffset.UTC,
+)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11643](https://bitwarden.atlassian.net/browse/PM-11643)

## 📔 Objective

This PR adds the `LauncherPackageNameManager` which queries the OS for the any launcher apps the user may be using.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11643]: https://bitwarden.atlassian.net/browse/PM-11643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ