### PR TITLE
Remove unsued shouldFinishOnComplete property

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -109,11 +109,6 @@ class VaultItemListingViewModel @Inject constructor(
         val fido2AssertionData = specialCircumstance as? SpecialCircumstance.Fido2Assertion
         val fido2GetCredentialsData =
             specialCircumstance as? SpecialCircumstance.Fido2GetCredentials
-        val shouldFinishOnComplete = autofillSelectionData
-            ?.shouldFinishWhenComplete
-            ?: (fido2CreationData != null ||
-                fido2AssertionData != null ||
-                fido2GetCredentialsData != null)
         val dialogState = fido2CreationData
             ?.let { VaultItemListingState.DialogState.Loading(R.string.loading.asText()) }
         VaultItemListingState(
@@ -133,7 +128,6 @@ class VaultItemListingViewModel @Inject constructor(
                 .getActivePolicies(type = PolicyTypeJson.DISABLE_SEND)
                 .any(),
             autofillSelectionData = autofillSelectionData?.autofillSelectionData,
-            shouldFinishOnComplete = shouldFinishOnComplete,
             hasMasterPassword = userState.activeAccount.hasMasterPassword,
             fido2CredentialRequest = fido2CreationData?.fido2CredentialRequest,
             fido2CredentialAssertionRequest = fido2AssertionData?.fido2AssertionRequest,
@@ -1644,7 +1638,6 @@ data class VaultItemListingState(
     val fido2CredentialRequest: Fido2CredentialRequest? = null,
     val fido2CredentialAssertionRequest: Fido2CredentialAssertionRequest? = null,
     val fido2GetCredentialsRequest: Fido2GetCredentialsRequest? = null,
-    val shouldFinishOnComplete: Boolean = false,
     val hasMasterPassword: Boolean,
     val isPremium: Boolean,
 ) {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -206,7 +206,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     dialogState = VaultItemListingState.DialogState.Loading(
                         message = R.string.loading.asText(),
                     ),
-                    shouldFinishOnComplete = true,
                 ),
                 awaitItem(),
             )
@@ -1295,10 +1294,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         displayFolderList = emptyList(),
                     ),
                 )
-                    .copy(
-                        autofillSelectionData = autofillSelectionData,
-                        shouldFinishOnComplete = true,
-                    ),
+                    .copy(autofillSelectionData = autofillSelectionData),
                 viewModel.stateFlow.value,
             )
             coVerify {
@@ -1378,10 +1374,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         displayFolderList = emptyList(),
                     ),
                 )
-                    .copy(
-                        fido2CredentialRequest = fido2CredentialRequest,
-                        shouldFinishOnComplete = true,
-                    ),
+                    .copy(fido2CredentialRequest = fido2CredentialRequest),
                 viewModel.stateFlow.value,
             )
             coVerify {
@@ -1460,10 +1453,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         displayFolderList = emptyList(),
                     ),
                 )
-                    .copy(
-                        fido2GetCredentialsRequest = fido2GetCredentialRequest,
-                        shouldFinishOnComplete = true,
-                    ),
+                    .copy(fido2GetCredentialsRequest = fido2GetCredentialRequest),
                 viewModel.stateFlow.value,
             )
             coVerify {
@@ -3769,7 +3759,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             isPullToRefreshSettingEnabled = false,
             dialogState = null,
             autofillSelectionData = null,
-            shouldFinishOnComplete = false,
             policyDisablesSend = false,
             hasMasterPassword = true,
             fido2CredentialRequest = null,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the unused `shouldFinishOnComplete` property from the `VaultItemListingState` class. While this property was being set, it was never being referenced.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
