### PR TITLE
BITAU-108 Store Authenticator Sync Key

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
@@ -46,6 +46,18 @@ interface AuthDiskSource {
     fun clearData(userId: String)
 
     /**
+     * Get the authenticator sync unlock key. Null means there is no key, which means the user
+     * has not enabled authenticator syncing
+     */
+    fun getAuthenticatorSyncUnlockKey(userId: String): String?
+
+    /**
+     * Store the authenticator sync unlock key. Storing a null key effectively disables
+     * authenticator syncing.
+     */
+    fun storeAuthenticatorSyncUnlockKey(userId: String, authenticatorSyncUnlockKey: String?)
+
+    /**
      * Retrieves the state indicating that the user should use a key connector.
      */
     fun getShouldUseKeyConnector(userId: String): Boolean?

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
@@ -18,6 +18,7 @@ import java.util.UUID
 
 // These keys should be encrypted
 private const val ACCOUNT_TOKENS_KEY = "accountTokens"
+private const val AUTHENTICATOR_SYNC_UNLOCK_KEY = "authenticatorSyncUnlock"
 private const val BIOMETRICS_UNLOCK_KEY = "userKeyBiometricUnlock"
 private const val USER_AUTO_UNLOCK_KEY_KEY = "userKeyAutoUnlock"
 private const val DEVICE_KEY_KEY = "deviceKey"
@@ -128,9 +129,23 @@ class AuthDiskSourceImpl(
         storeAccountTokens(userId = userId, accountTokens = null)
         storeShouldUseKeyConnector(userId = userId, shouldUseKeyConnector = null)
         storeIsTdeLoginComplete(userId = userId, isTdeLoginComplete = null)
+        storeAuthenticatorSyncUnlockKey(userId = userId, authenticatorSyncUnlockKey = null)
 
         // Do not remove the DeviceKey or PendingAuthRequest on logout, these are persisted
         // indefinitely unless the TDE flow explicitly removes them.
+    }
+
+    override fun getAuthenticatorSyncUnlockKey(userId: String): String? =
+        getEncryptedString(AUTHENTICATOR_SYNC_UNLOCK_KEY.appendIdentifier(userId))
+
+    override fun storeAuthenticatorSyncUnlockKey(
+        userId: String,
+        authenticatorSyncUnlockKey: String?,
+    ) {
+        putEncryptedString(
+            key = AUTHENTICATOR_SYNC_UNLOCK_KEY.appendIdentifier(userId),
+            value = authenticatorSyncUnlockKey,
+        )
     }
 
     override fun getShouldUseKeyConnectorFlow(userId: String): Flow<Boolean?> =

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -295,6 +295,10 @@ class AuthDiskSourceTest {
         )
         authDiskSource.storeEncryptedPin(userId = userId, encryptedPin = "encryptedPin")
         authDiskSource.storeMasterPasswordHash(userId = userId, passwordHash = "passwordHash")
+        authDiskSource.storeAuthenticatorSyncUnlockKey(
+            userId = userId,
+            authenticatorSyncUnlockKey = "authenticatorSyncUnlockKey",
+        )
 
         authDiskSource.clearData(userId = userId)
 
@@ -318,6 +322,7 @@ class AuthDiskSourceTest {
         assertNull(authDiskSource.getMasterPasswordHash(userId = userId))
         assertNull(authDiskSource.getShouldUseKeyConnector(userId = userId))
         assertNull(authDiskSource.getIsTdeLoginComplete(userId = userId))
+        assertNull(authDiskSource.getAuthenticatorSyncUnlockKey(userId = userId))
     }
 
     @Test
@@ -1038,6 +1043,45 @@ class AuthDiskSourceTest {
         assertEquals(
             json.encodeToJsonElement(accountTokens),
             json.parseToJsonElement(requireNotNull(actual)),
+        )
+    }
+
+    @Test
+    fun `getAuthenticatorSyncUnlockKey should pull from SharedPreferences`() {
+        val authenticatorSyncUnlockKey = "bwSecureStorage:authenticatorSyncUnlock"
+        val mockUserId = "mockUserId"
+        val mockAuthenticatorSyncUnlockKey = "mockAuthSyncUnlockKey"
+        fakeEncryptedSharedPreferences
+            .edit {
+                putString(
+                    "${authenticatorSyncUnlockKey}_$mockUserId",
+                    mockAuthenticatorSyncUnlockKey,
+                )
+            }
+        val actual = authDiskSource.getAuthenticatorSyncUnlockKey(userId = mockUserId)
+        assertEquals(
+            mockAuthenticatorSyncUnlockKey,
+            actual,
+        )
+    }
+
+    @Test
+    fun `storeAuthenticatorSyncUnlockKey should update SharedPreferences`() {
+        val authenticatorSyncUnlockKey = "bwSecureStorage:authenticatorSyncUnlock"
+        val mockUserId = "mockUserId"
+        val mockAuthenticatorSyncUnlockKey = "mockAuthSyncUnlockKey"
+        authDiskSource.storeAuthenticatorSyncUnlockKey(
+            userId = mockUserId,
+            authenticatorSyncUnlockKey = mockAuthenticatorSyncUnlockKey,
+        )
+
+        val actual = fakeEncryptedSharedPreferences.getString(
+            key = "${authenticatorSyncUnlockKey}_$mockUserId",
+            defaultValue = null,
+        )
+        assertEquals(
+            mockAuthenticatorSyncUnlockKey,
+            actual,
         )
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
@@ -46,6 +46,7 @@ class FakeAuthDiskSource : AuthDiskSource {
     private val storedPendingAuthRequests = mutableMapOf<String, PendingAuthRequestJson?>()
     private val storedBiometricKeys = mutableMapOf<String, String?>()
     private val storedMasterPasswordHashes = mutableMapOf<String, String?>()
+    private val storedAuthenticationSyncKeys = mutableMapOf<String, String?>()
     private val storedPolicies = mutableMapOf<String, List<SyncResponseJson.Policy>?>()
 
     override var userState: UserStateJson? = null
@@ -213,6 +214,16 @@ class FakeAuthDiskSource : AuthDiskSource {
 
     override fun storeMasterPasswordHash(userId: String, passwordHash: String?) {
         storedMasterPasswordHashes[userId] = passwordHash
+    }
+
+    override fun getAuthenticatorSyncUnlockKey(userId: String): String? =
+        storedAuthenticationSyncKeys[userId]
+
+    override fun storeAuthenticatorSyncUnlockKey(
+        userId: String,
+        authenticatorSyncUnlockKey: String?,
+    ) {
+        storedAuthenticationSyncKeys[userId] = authenticatorSyncUnlockKey
     }
 
     override fun getPolicies(


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-108

## 📔 Objective

The goal here is to generate and store a user specific encryption key whenever the user enables authenticator syncing. 

The presence of this key is how other services will know whether or not to share the user's TOTP URIs via `BridgeService`.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
