### PR TITLE
PM-11714 record if a user has signed in on device before.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -129,6 +129,8 @@ class MainViewModel @Inject constructor(
             }
             .launchIn(viewModelScope)
 
+        // On app launch, mark all active users as having previously logged in.
+        // This covers any users who are active prior to this value being recorded.
         viewModelScope.launch {
             val userState = authRepository
                 .userStateFlow

--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -30,10 +30,12 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.time.Clock
 import javax.inject.Inject
@@ -126,6 +128,17 @@ class MainViewModel @Inject constructor(
                 }
             }
             .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            val userState = authRepository
+                .userStateFlow
+                .first()
+            userState
+                ?.accounts
+                ?.forEach {
+                    settingsRepository.storeUserHasLoggedInValue(it.userId)
+                }
+        }
     }
 
     override fun handleAction(action: MainAction) {

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -553,7 +553,7 @@ class AuthRepositoryImpl(
                 ),
             )
         }
-
+        settingsRepository.storeUserHasLoggedInValue(userId)
         vaultRepository.syncIfNecessary()
         return LoginResult.Success
     }
@@ -1560,6 +1560,7 @@ class AuthRepositoryImpl(
         resendEmailRequestJson = null
         twoFactorDeviceData = null
         settingsRepository.setDefaultsIfNecessary(userId = userId)
+        settingsRepository.storeUserHasLoggedInValue(userId)
         vaultRepository.syncIfNecessary()
         hasPendingAccountAddition = false
         LoginResult.Success

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -245,4 +245,17 @@ interface SettingsDiskSource {
      * Stores whether or not [isScreenCaptureAllowed] for the given [userId].
      */
     fun storeScreenCaptureAllowed(userId: String, isScreenCaptureAllowed: Boolean?)
+
+    /**
+     * Records a user sign in for the given [userId]. This data is expected to remain on
+     * disk until storage is cleared or the app is uninstalled.
+     */
+    fun storeUseHasLoggedInPreviously(userId: String)
+
+    /**
+     * Checks if a user has signed in previously for the given [userId].
+     *
+     * @see [storeUseHasLoggedInPreviously]
+     */
+    fun getUserHasSignedInPreviously(userId: String): Boolean
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -383,4 +383,16 @@ class SettingsDiskSourceImpl(
         )
         getMutableScreenCaptureAllowedFlow(userId).tryEmit(isScreenCaptureAllowed)
     }
+
+    override fun storeUseHasLoggedInPreviously(userId: String) {
+        putBoolean(
+            key = HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY.appendIdentifier(userId),
+            value = true,
+        )
+    }
+
+    override fun getUserHasSignedInPreviously(userId: String): Boolean =
+        getBoolean(
+            key = HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY.appendIdentifier(userId),
+        ) == true
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -233,4 +233,16 @@ interface SettingsRepository {
      * Clears any previously set unlock PIN for the current user.
      */
     fun clearUnlockPin()
+
+    /**
+     * Returns true if the given [userId] has already logged in on this device
+     *
+     * assuming the device storage has not be cleared since install.
+     */
+    fun getUserHasLoggedInValue(userId: String): Boolean
+
+    /**
+     * Record that a user has logged in on this device.
+     */
+    fun storeUserHasLoggedInValue(userId: String)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -235,9 +235,9 @@ interface SettingsRepository {
     fun clearUnlockPin()
 
     /**
-     * Returns true if the given [userId] has already logged in on this device
+     * Returns true if the given [userId] has previously logged in on this device.
      *
-     * assuming the device storage has not be cleared since install.
+     * This assumes the device storage has not been cleared since installation.
      */
     fun getUserHasLoggedInValue(userId: String): Boolean
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -494,6 +494,13 @@ class SettingsRepositoryImpl(
         }
     }
 
+    override fun getUserHasLoggedInValue(userId: String): Boolean =
+        settingsDiskSource.getUserHasSignedInPreviously(userId)
+
+    override fun storeUserHasLoggedInValue(userId: String) {
+        settingsDiskSource.storeUseHasLoggedInPreviously(userId)
+    }
+
     /**
      * Check the parameters of the vault unlock policy against the user's
      * settings to determine whether to update the user's settings.

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -164,6 +164,7 @@ class AuthRepositoryTest {
     private val settingsRepository: SettingsRepository = mockk {
         every { setDefaultsIfNecessary(any()) } just runs
         every { hasUserLoggedInOrCreatedAccount = true } just runs
+        every { storeUserHasLoggedInValue(any()) } just runs
     }
     private val authSdkSource = mockk<AuthSdkSource> {
         coEvery {
@@ -1345,6 +1346,7 @@ class AuthRepositoryTest {
                 organizationKeys = orgKeys,
             )
             vaultRepository.syncIfNecessary()
+            settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
         }
         assertEquals(LoginResult.Success, result)
     }
@@ -1393,6 +1395,7 @@ class AuthRepositoryTest {
         }
         coVerify(exactly = 0) {
             vaultRepository.syncIfNecessary()
+            settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
         }
         assertEquals(LoginResult.Error(errorMessage = null), result)
     }
@@ -1558,6 +1561,7 @@ class AuthRepositoryTest {
                     organizationKeys = null,
                 )
                 vaultRepository.syncIfNecessary()
+                settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
             }
             assertEquals(
                 SINGLE_USER_STATE_1,
@@ -1650,6 +1654,7 @@ class AuthRepositoryTest {
             coVerify(exactly = 0) {
                 vaultRepository.syncIfNecessary()
                 settingsRepository.setDefaultsIfNecessary(userId = USER_ID_1)
+                settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
             }
 
             assertEquals(
@@ -1715,6 +1720,7 @@ class AuthRepositoryTest {
                     uniqueAppId = UNIQUE_APP_ID,
                 )
                 vaultRepository.syncIfNecessary()
+                settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
             }
             assertEquals(
                 SINGLE_USER_STATE_1,
@@ -1813,6 +1819,7 @@ class AuthRepositoryTest {
                     organizationKeys = null,
                 )
                 vaultRepository.syncIfNecessary()
+                settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
             }
             assertEquals(
                 MULTI_USER_STATE,
@@ -2083,6 +2090,7 @@ class AuthRepositoryTest {
 
             coVerify(exactly = 0) {
                 vaultRepository.syncIfNecessary()
+                settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
             }
         }
 
@@ -2170,7 +2178,10 @@ class AuthRepositoryTest {
             SINGLE_USER_STATE_1,
             fakeAuthDiskSource.userState,
         )
-        verify { settingsRepository.setDefaultsIfNecessary(userId = USER_ID_1) }
+        verify {
+            settingsRepository.setDefaultsIfNecessary(userId = USER_ID_1)
+            settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
+        }
     }
 
     @Test
@@ -2355,12 +2366,13 @@ class AuthRepositoryTest {
                         ),
                     ),
                 )
+                settingsRepository.setDefaultsIfNecessary(userId = USER_ID_1)
+                settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
             }
             assertEquals(
                 SINGLE_USER_STATE_1,
                 fakeAuthDiskSource.userState,
             )
-            verify { settingsRepository.setDefaultsIfNecessary(userId = USER_ID_1) }
         }
 
     @Test
@@ -2789,6 +2801,7 @@ class AuthRepositoryTest {
                     uniqueAppId = UNIQUE_APP_ID,
                 )
                 vaultRepository.syncIfNecessary()
+                settingsRepository.storeUserHasLoggedInValue(userId = USER_ID_1)
             }
             assertEquals(
                 SINGLE_USER_STATE_1,

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1000,4 +1000,33 @@ class SettingsDiskSourceTest {
 
         assertFalse(fakeSharedPreferences.contains(initialAutofillDialogShownKey))
     }
+
+    @Test
+    fun `record user sign in adds value of true to shared preferences`() {
+        val keyPrefix = "bwPreferencesStorage:hasUserLoggedInOrCreatedAccount"
+        val mockUserId = "mockUserId"
+        settingsDiskSource.storeUseHasLoggedInPreviously(userId = mockUserId)
+
+        val actual = fakeSharedPreferences.getBoolean(
+            key = "${keyPrefix}_$mockUserId",
+            defaultValue = false,
+        )
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `hasUserSignedInPreviously returns true if value is present in shared preferences`() {
+        val mockUserId = "mockUserId"
+        fakeSharedPreferences.edit {
+            putBoolean("bwPreferencesStorage:hasUserLoggedInOrCreatedAccount_$mockUserId", true)
+        }
+
+        assertTrue(settingsDiskSource.getUserHasSignedInPreviously(userId = mockUserId))
+    }
+
+    @Test
+    fun `hasUserSignedInPreviously returns false if value is not present in shared preferences`() {
+        assertFalse(settingsDiskSource.getUserHasSignedInPreviously(userId = "haveNotSignedIn"))
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -60,6 +60,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val storedScreenCaptureAllowed = mutableMapOf<String, Boolean?>()
     private var storedSystemBiometricIntegritySource: String? = null
     private val storedAccountBiometricIntegrityValidity = mutableMapOf<String, Boolean?>()
+    private val userSignIns = mutableMapOf<String, Boolean>()
 
     override var appLanguage: AppLanguage? = null
 
@@ -276,6 +277,12 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         storedScreenCaptureAllowed[userId] = isScreenCaptureAllowed
         getMutableScreenCaptureAllowedFlow(userId).tryEmit(isScreenCaptureAllowed)
     }
+
+    override fun storeUseHasLoggedInPreviously(userId: String) {
+        userSignIns[userId] = true
+    }
+
+    override fun getUserHasSignedInPreviously(userId: String): Boolean = userSignIns[userId] == true
 
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {
         return mutableScreenCaptureAllowedFlowMap.getOrPut(userId) {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1026,6 +1026,25 @@ class SettingsRepositoryTest {
         settingsRepository.isAuthenticatorSyncEnabled = true
         assertTrue(settingsRepository.isAuthenticatorSyncEnabled)
     }
+
+    @Test
+    fun `getUserHasLoggedInValue should default to false if no value exists`() {
+        assertFalse(settingsRepository.getUserHasLoggedInValue(userId = "userId"))
+    }
+
+    @Test
+    fun `getUserHasLoggedInValue should return true if it exists`() {
+        val userId = "userId"
+        fakeSettingsDiskSource.storeUseHasLoggedInPreviously(userId = userId)
+        assertTrue(settingsRepository.getUserHasLoggedInValue(userId = userId))
+    }
+
+    @Test
+    fun `storeUserHasLoggedInValue should store value of true to disk`() {
+        val userId = "userId"
+        settingsRepository.storeUserHasLoggedInValue(userId = userId)
+        assertTrue(fakeSettingsDiskSource.getUserHasSignedInPreviously(userId = userId))
+    }
 }
 
 private const val USER_ID: String = "userId"


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-11714
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- record each user id that has logged in on the device to keep track of this on per userId basis.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
