### PR TITLE
Add missing SerialName annotations

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/model/ServerConfig.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/model/ServerConfig.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk.model
 
 import com.x8bit.bitwarden.data.platform.datasource.network.model.ConfigResponseJson
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -13,6 +14,9 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ServerConfig(
+    @SerialName("lastSync")
     val lastSync: Long,
+
+    @SerialName("serverData")
     val serverData: ConfigResponseJson,
 )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds the missing `SerialName` annotations to the `ServerConfig` class.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
