### PR TITLE
PM-11741 add password modal to root nav for generator shortcut specia…

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -47,6 +47,8 @@ import com.x8bit.bitwarden.ui.platform.feature.vaultunlocked.vaultUnlockedGraph
 import com.x8bit.bitwarden.ui.platform.theme.NonNullEnterTransitionProvider
 import com.x8bit.bitwarden.ui.platform.theme.NonNullExitTransitionProvider
 import com.x8bit.bitwarden.ui.platform.theme.RootTransitionProviders
+import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
+import com.x8bit.bitwarden.ui.tools.feature.generator.navigateToGeneratorModal
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.model.AddSendType
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.navigateToAddSend
 import com.x8bit.bitwarden.ui.vault.feature.addedit.navigateToVaultAddEdit
@@ -113,6 +115,7 @@ fun RootNavScreen(
         is RootNavState.VaultUnlockedForFido2Save,
         is RootNavState.VaultUnlockedForFido2Assertion,
         is RootNavState.VaultUnlockedForFido2GetCredentials,
+        is RootNavState.GeneratorShortcut,
         -> VAULT_UNLOCKED_GRAPH_ROUTE
     }
     val currentRoute = navController.currentDestination?.rootLevelRoute()
@@ -216,6 +219,11 @@ fun RootNavScreen(
                     vaultItemListingType = VaultItemListingType.Login,
                     navOptions = rootNavOptions,
                 )
+            }
+
+            RootNavState.GeneratorShortcut -> {
+                navController.navigateToVaultUnlockedGraph(rootNavOptions)
+                navController.navigateToGeneratorModal(mode = GeneratorMode.Modal.Password)
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -131,7 +131,9 @@ class RootNavViewModel @Inject constructor(
                         )
                     }
 
-                    SpecialCircumstance.GeneratorShortcut,
+                    SpecialCircumstance.GeneratorShortcut -> {
+                        RootNavState.GeneratorShortcut
+                    }
                     SpecialCircumstance.VaultShortcut,
                     null,
                     -> RootNavState.VaultUnlocked(activeUserId = userState.activeAccount.userId)
@@ -320,6 +322,12 @@ sealed class RootNavState : Parcelable {
      */
     @Parcelize
     data object ExpiredRegistrationLink : RootNavState()
+
+    /**
+     * App should show the password generator modal.
+     */
+    @Parcelize
+    data object GeneratorShortcut : RootNavState()
 }
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -225,6 +225,15 @@ class RootNavScreenTest : BaseComposeTest() {
                     navOptions = expectedNavOptions,
                 )
             }
+
+        // Make sure navigating to the generator shortcut works as expected:
+        rootNavStateFlow.value = RootNavState.GeneratorShortcut
+        composeTestRule
+            .runOnIdle {
+                fakeNavHostController.assertLastNavigation(
+                    route = "generator_modal/password_generator",
+                )
+            }
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -905,6 +905,97 @@ class RootNavViewModelTest : BaseViewModelTest() {
         assertEquals(RootNavState.VaultLocked, viewModel.stateFlow.value)
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when there are no accounts but there is a GeneratorShortcut special circumstance the nav state should be Auth`() {
+        every { authRepository.hasPendingAccountAddition } returns false
+
+        specialCircumstanceManager.specialCircumstance =
+            SpecialCircumstance.GeneratorShortcut
+        mutableUserStateFlow.tryEmit(null)
+        val viewModel = createViewModel()
+        assertEquals(
+            RootNavState.Auth,
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when the active user has an unlocked vault and there is a GeneratorShortcut special circumstance the nav state should be GeneratorShortcut`() {
+        every { authRepository.hasPendingAccountAddition } returns true
+
+        specialCircumstanceManager.specialCircumstance =
+            SpecialCircumstance.GeneratorShortcut
+        mutableUserStateFlow.tryEmit(
+            UserState(
+                activeUserId = "activeUserId",
+                accounts = listOf(
+                    UserState.Account(
+                        userId = "activeUserId",
+                        name = "name",
+                        email = "email",
+                        avatarColorHex = "avatarHexColor",
+                        environment = Environment.Us,
+                        isPremium = true,
+                        isLoggedIn = true,
+                        isVaultUnlocked = true,
+                        needsPasswordReset = false,
+                        isBiometricsEnabled = false,
+                        organizations = emptyList(),
+                        needsMasterPassword = false,
+                        trustedDevice = null,
+                        hasMasterPassword = true,
+                        isUsingKeyConnector = false,
+                    ),
+                ),
+            ),
+        )
+        val viewModel = createViewModel()
+        assertEquals(
+            RootNavState.GeneratorShortcut,
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when the active user has a locked vault and there is a GeneratorShortcut special circumstance the nav state should be VaultLocked`() {
+        every { authRepository.hasPendingAccountAddition } returns true
+
+        specialCircumstanceManager.specialCircumstance =
+            SpecialCircumstance.GeneratorShortcut
+        mutableUserStateFlow.tryEmit(
+            UserState(
+                activeUserId = "activeUserId",
+                accounts = listOf(
+                    UserState.Account(
+                        userId = "activeUserId",
+                        name = "name",
+                        email = "email",
+                        avatarColorHex = "avatarColorHex",
+                        environment = Environment.Us,
+                        isPremium = true,
+                        isLoggedIn = true,
+                        isVaultUnlocked = false,
+                        needsPasswordReset = false,
+                        isBiometricsEnabled = false,
+                        organizations = emptyList(),
+                        needsMasterPassword = false,
+                        trustedDevice = null,
+                        hasMasterPassword = true,
+                        isUsingKeyConnector = false,
+                    ),
+                ),
+            ),
+        )
+        val viewModel = createViewModel()
+        assertEquals(
+            RootNavState.VaultLocked,
+            viewModel.stateFlow.value,
+        )
+    }
+
     private fun createViewModel(): RootNavViewModel =
         RootNavViewModel(
             authRepository = authRepository,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-11741
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- When a use adds the "Password generator" shortcut, and its selected from outside the app the password generator should display if their account is unlocked.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/335f5912-4838-460f-915b-0b995ae1172c


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
