### PR TITLE
Update Slider UI after Compose BOM update

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -2,6 +2,7 @@
 
 package com.x8bit.bitwarden.ui.tools.feature.generator
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -49,6 +50,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -582,6 +584,7 @@ private fun ColumnScope.PasswordTypeContent(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Suppress("LongMethod")
 @Composable
 private fun PasswordLengthSliderItem(
@@ -646,6 +649,12 @@ private fun PasswordLengthSliderItem(
                 .width(16.dp + labelTextWidth + 16.dp),
         )
 
+        val colors = SliderDefaults.colors(
+            activeTickColor = Color.Transparent,
+            inactiveTickColor = Color.Transparent,
+            disabledActiveTickColor = Color.Transparent,
+            disabledInactiveTickColor = Color.Transparent,
+        )
         Slider(
             value = sliderValue.toFloat(),
             onValueChange = { newValue ->
@@ -656,16 +665,27 @@ private fun PasswordLengthSliderItem(
             },
             valueRange = sliderRange,
             steps = maxValue - 1,
-            colors = SliderDefaults.colors(
-                activeTickColor = Color.Transparent,
-                inactiveTickColor = Color.Transparent,
-                disabledActiveTickColor = Color.Transparent,
-                disabledInactiveTickColor = Color.Transparent,
-            ),
+            colors = colors,
+            thumb = {
+                SliderDefaults.Thumb(
+                    interactionSource = remember { MutableInteractionSource() },
+                    colors = colors,
+                    thumbSize = DpSize(width = 20.dp, height = 20.dp),
+                )
+            },
+            track = { sliderState ->
+                SliderDefaults.Track(
+                    modifier = Modifier.height(height = 4.dp),
+                    drawStopIndicator = null,
+                    colors = colors,
+                    sliderState = sliderState,
+                    thumbTrackGapSize = 0.dp,
+                )
+            },
             modifier = Modifier
                 .focusProperties { canFocus = false }
-                .testTag("PasswordLengthSlider")
-                .weight(1f),
+                .testTag(tag = "PasswordLengthSlider")
+                .weight(weight = 1f),
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes the Slider in the generator screen. The slider looked weird because of the recent Compose BOM update to 2024.09.00.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/b7c938a0-9d22-4f62-9b78-b974c4bf7f84" width="300" /> | <img src="https://github.com/user-attachments/assets/1c67e0e7-c2be-40bc-aeb0-c05c2bc20cf8" width="300" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
