### PR TITLE
BITAU-102 Return null BridgeService when API level is below 12

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/processor/BridgeServiceProcessorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/processor/BridgeServiceProcessorTest.kt
@@ -1,11 +1,15 @@
 package com.x8bit.bitwarden.data.platform.processor
 
+import android.os.Build
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class BridgeServiceProcessorTest {
@@ -16,15 +20,33 @@ class BridgeServiceProcessorTest {
         featureFlagManager = featureFlagManager,
     )
 
+    @BeforeEach
+    fun setup() {
+        mockkStatic(::isBuildVersionBelow)
+    }
+
     @Test
     fun `when AuthenticatorSync feature flag is off, should return null binder`() {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns false
         every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
         assertNull(bridgeServiceManager.binder)
     }
 
     @Test
-    fun `when AuthenticatorSync feature flag is on, should return non-null binder`() {
+    @Suppress("MaxLineLength")
+    fun `when AuthenticatorSync feature flag is on and running Android level greater than S, should return non-null binder`() {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns false
         every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns true
         assertNotNull(bridgeServiceManager.binder)
+    }
+
+    @Test
+    fun `when below Android level S, should never return a binder regardless of feature flag`() {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
+        every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
+        assertNull(bridgeServiceManager.binder)
+
+        every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns true
+        assertNull(bridgeServiceManager.binder)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-102

## 📔 Objective

Make sure we no-op all `BridgeService` calls under android API level 12.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
