### PR TITLE
BITAU-108 Add unlockWithAuthenticatorSyncKey to VaultRepository 

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
@@ -172,11 +172,11 @@ interface VaultRepository : CipherManager, VaultLockManager {
      * given user.
      *
      * @param userId ID of the user's vault to unlock.
-     * @param decryptedAuthenticatorSyncKey The authenticator sync unlock key for the user.
+     * @param decryptedUserKey The authenticator sync unlock key for the user.
      */
     suspend fun unlockVaultWithAuthenticatorSyncKey(
         userId: String,
-        decryptedAuthenticatorSyncKey: String,
+        decryptedUserKey: String,
     ): VaultUnlockResult
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
@@ -168,6 +168,18 @@ interface VaultRepository : CipherManager, VaultLockManager {
     fun emitTotpCodeResult(totpCodeResult: TotpCodeResult)
 
     /**
+     * Attempt to unlock the vault using the stored authenticator sync unlock key for the
+     * given user.
+     *
+     * @param userId ID of the user's vault to unlock.
+     * @param decryptedAuthenticatorSyncKey The authenticator sync unlock key for the user.
+     */
+    suspend fun unlockVaultWithAuthenticatorSyncKey(
+        userId: String,
+        decryptedAuthenticatorSyncKey: String,
+    ): VaultUnlockResult
+
+    /**
      * Attempt to unlock the vault using the stored biometric key for the currently active user.
      */
     suspend fun unlockVaultWithBiometrics(): VaultUnlockResult

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
@@ -168,13 +168,13 @@ interface VaultRepository : CipherManager, VaultLockManager {
     fun emitTotpCodeResult(totpCodeResult: TotpCodeResult)
 
     /**
-     * Attempt to unlock the vault using the stored authenticator sync unlock key for the
-     * given user.
+     * Attempt to unlock the vault using a user unlock key.
      *
      * @param userId ID of the user's vault to unlock.
-     * @param decryptedUserKey The authenticator sync unlock key for the user.
+     * @param decryptedUserKey A decrypted unlock key for the user (ex: their authenticator
+     * sync unlock key)
      */
-    suspend fun unlockVaultWithAuthenticatorSyncKey(
+    suspend fun unlockVaultWithDecryptedUserKey(
         userId: String,
         decryptedUserKey: String,
     ): VaultUnlockResult

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -553,6 +553,23 @@ class VaultRepositoryImpl(
         mutableTotpCodeResultFlow.tryEmit(totpCodeResult)
     }
 
+    override suspend fun unlockVaultWithAuthenticatorSyncKey(
+        userId: String,
+        decryptedAuthenticatorSyncKey: String,
+    ): VaultUnlockResult {
+        return unlockVaultForUser(
+            userId = userId,
+            initUserCryptoMethod = InitUserCryptoMethod.DecryptedKey(
+                decryptedUserKey = decryptedAuthenticatorSyncKey,
+            ),
+        )
+            .also {
+                if (it is VaultUnlockResult.Success) {
+                    deriveTemporaryPinProtectedUserKeyIfNecessary(userId = userId)
+                }
+            }
+    }
+
     override suspend fun unlockVaultWithBiometrics(): VaultUnlockResult {
         val userId = activeUserId ?: return VaultUnlockResult.InvalidStateError
         val biometricsKey = authDiskSource

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -555,12 +555,12 @@ class VaultRepositoryImpl(
 
     override suspend fun unlockVaultWithAuthenticatorSyncKey(
         userId: String,
-        decryptedAuthenticatorSyncKey: String,
+        decryptedUserKey: String,
     ): VaultUnlockResult {
         return unlockVaultForUser(
             userId = userId,
             initUserCryptoMethod = InitUserCryptoMethod.DecryptedKey(
-                decryptedUserKey = decryptedAuthenticatorSyncKey,
+                decryptedUserKey = decryptedUserKey,
             ),
         )
             .also {

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -553,7 +553,7 @@ class VaultRepositoryImpl(
         mutableTotpCodeResultFlow.tryEmit(totpCodeResult)
     }
 
-    override suspend fun unlockVaultWithAuthenticatorSyncKey(
+    override suspend fun unlockVaultWithDecryptedUserKey(
         userId: String,
         decryptedUserKey: String,
     ): VaultUnlockResult = unlockVaultForUser(

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -556,19 +556,12 @@ class VaultRepositoryImpl(
     override suspend fun unlockVaultWithAuthenticatorSyncKey(
         userId: String,
         decryptedUserKey: String,
-    ): VaultUnlockResult {
-        return unlockVaultForUser(
-            userId = userId,
-            initUserCryptoMethod = InitUserCryptoMethod.DecryptedKey(
-                decryptedUserKey = decryptedUserKey,
-            ),
-        )
-            .also {
-                if (it is VaultUnlockResult.Success) {
-                    deriveTemporaryPinProtectedUserKeyIfNecessary(userId = userId)
-                }
-            }
-    }
+    ): VaultUnlockResult = unlockVaultForUser(
+        userId = userId,
+        initUserCryptoMethod = InitUserCryptoMethod.DecryptedKey(
+            decryptedUserKey = decryptedUserKey,
+        ),
+    )
 
     override suspend fun unlockVaultWithBiometrics(): VaultUnlockResult {
         val userId = activeUserId ?: return VaultUnlockResult.InvalidStateError

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -1245,7 +1245,7 @@ class VaultRepositoryTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `unlockVaultWithAuthenticatorSyncKey with VaultLockManager Success should return Success`() =
+    fun `unlockVaultWithDecryptedUserKey with VaultLockManager Success should return Success`() =
         runTest {
             val userId = MOCK_USER_STATE.activeUserId
             val authenticatorSyncUnlockKey = "asdf1234"
@@ -1292,7 +1292,7 @@ class VaultRepositoryTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `unlockVaultWithAuthenticatorSyncKey with VaultLockManager InvalidStateError should return InvalidStateError`() =
+    fun `unlockVaultWithDecryptedUserKey with VaultLockManager InvalidStateError should return InvalidStateError`() =
         runTest {
             val userId = MOCK_USER_STATE.activeUserId
             val authenticatorSyncUnlockKey = "asdf1234"

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -1287,7 +1287,7 @@ class VaultRepositoryTest {
 
             val result = vaultRepository.unlockVaultWithAuthenticatorSyncKey(
                 userId = userId,
-                decryptedAuthenticatorSyncKey = authenticatorSyncUnlockKey,
+                decryptedUserKey = authenticatorSyncUnlockKey,
             )
 
             assertEquals(VaultUnlockResult.Success, result)
@@ -1346,7 +1346,7 @@ class VaultRepositoryTest {
 
             val result = vaultRepository.unlockVaultWithAuthenticatorSyncKey(
                 userId = userId,
-                decryptedAuthenticatorSyncKey = authenticatorSyncUnlockKey,
+                decryptedUserKey = authenticatorSyncUnlockKey,
             )
 
             assertEquals(VaultUnlockResult.Success, result)

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -1271,7 +1271,7 @@ class VaultRepositoryTest {
                 storePrivateKey(userId = userId, privateKey = privateKey)
             }
 
-            val result = vaultRepository.unlockVaultWithAuthenticatorSyncKey(
+            val result = vaultRepository.unlockVaultWithDecryptedUserKey(
                 userId = userId,
                 decryptedUserKey = authenticatorSyncUnlockKey,
             )
@@ -1318,7 +1318,7 @@ class VaultRepositoryTest {
                 storePrivateKey(userId = userId, privateKey = privateKey)
             }
 
-            val result = vaultRepository.unlockVaultWithAuthenticatorSyncKey(
+            val result = vaultRepository.unlockVaultWithDecryptedUserKey(
                 userId = userId,
                 decryptedUserKey = authenticatorSyncUnlockKey,
             )


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-108

## 📔 Objective

I had previously missed this requirement for this ticket:

 "A function is added to `VaultRepository` / `VaultLockManager` that allows for this per-user key to be used to unlock a particular user's vault."

## 📸 Screenshots

N/A


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
