### PR TITLE
PM-11488: Add a switch to the autofill settings UI for enabling the accessibility service

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.core.os.LocaleListCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityActivityManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityCompletionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillActivityManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillCompletionManager
@@ -37,6 +38,9 @@ import javax.inject.Inject
 class MainActivity : AppCompatActivity() {
 
     private val mainViewModel: MainViewModel by viewModels()
+
+    @Inject
+    lateinit var accessibilityActivityManager: AccessibilityActivityManager
 
     @Inject
     lateinit var autofillActivityManager: AutofillActivityManager

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/di/AccessibilityModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/di/AccessibilityModule.kt
@@ -7,6 +7,8 @@ import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityAuto
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityAutofillManagerImpl
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityCompletionManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityCompletionManagerImpl
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManagerImpl
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.LauncherPackageNameManager
@@ -48,6 +50,11 @@ object AccessibilityModule {
     @Provides
     fun providesAccessibilityAutofillManager(): AccessibilityAutofillManager =
         AccessibilityAutofillManagerImpl()
+
+    @Singleton
+    @Provides
+    fun providesAccessibilityEnabledManager(): AccessibilityEnabledManager =
+        AccessibilityEnabledManagerImpl()
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/di/ActivityAccessibilityModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/di/ActivityAccessibilityModule.kt
@@ -1,0 +1,36 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.di
+
+import android.content.Context
+import androidx.lifecycle.LifecycleCoroutineScope
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityActivityManager
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityActivityManagerImpl
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
+import com.x8bit.bitwarden.data.platform.manager.AppForegroundManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ActivityScoped
+
+/**
+ * Provides dependencies within the accessibility package scoped to the activity.
+ */
+@Module
+@InstallIn(ActivityComponent::class)
+object ActivityAccessibilityModule {
+    @ActivityScoped
+    @Provides
+    fun providesAccessibilityActivityManager(
+        @ApplicationContext context: Context,
+        accessibilityEnabledManager: AccessibilityEnabledManager,
+        appForegroundManager: AppForegroundManager,
+        lifecycleScope: LifecycleCoroutineScope,
+    ): AccessibilityActivityManager =
+        AccessibilityActivityManagerImpl(
+            context = context,
+            accessibilityEnabledManager = accessibilityEnabledManager,
+            appForegroundManager = appForegroundManager,
+            lifecycleScope = lifecycleScope,
+        )
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManager.kt
@@ -1,0 +1,10 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+import android.app.Activity
+
+/**
+ * A helper for dealing with accessibility configuration that must be scoped to a specific
+ * [Activity]. In particular, this should be injected into an [Activity] to ensure that the
+ * [AccessibilityEnabledManager] reports correct values.
+ */
+interface AccessibilityActivityManager

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManagerImpl.kt
@@ -1,0 +1,53 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+import android.content.Context
+import android.provider.Settings
+import androidx.lifecycle.LifecycleCoroutineScope
+import com.x8bit.bitwarden.data.platform.manager.AppForegroundManager
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+/**
+ * The accessibility service name as it is known in the AndroidManifest.
+ *
+ * Note: This is not the name of the actual service but the name defined in the Android Manifest
+ * which matches the service in the Xamarin app.
+ */
+private const val LEGACY_ACCESSIBILITY_SERVICE_NAME =
+    "com.x8bit.bitwarden.Accessibility.AccessibilityService"
+
+/**
+ * The default implementation of the [AccessibilityActivityManager].
+ */
+class AccessibilityActivityManagerImpl(
+    private val context: Context,
+    private val accessibilityEnabledManager: AccessibilityEnabledManager,
+    appForegroundManager: AppForegroundManager,
+    lifecycleScope: LifecycleCoroutineScope,
+) : AccessibilityActivityManager {
+    private val isAccessibilityServiceEnabled: Boolean
+        get() {
+            val appContext = context.applicationContext
+            val accessibilityService = appContext
+                .packageName
+                ?.let { "$it/$LEGACY_ACCESSIBILITY_SERVICE_NAME" }
+                ?: return false
+            return Settings
+                .Secure
+                .getString(
+                    appContext.contentResolver,
+                    Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
+                )
+                ?.contains(accessibilityService)
+                ?: false
+        }
+
+    init {
+        appForegroundManager
+            .appForegroundStateFlow
+            .onEach {
+                accessibilityEnabledManager.isAccessibilityEnabled = isAccessibilityServiceEnabled
+            }
+            .launchIn(lifecycleScope)
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManager.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * A container for values specifying whether or not the accessibility service is enabled.
+ */
+interface AccessibilityEnabledManager {
+    /**
+     * Whether or not the accessibility service should be considered enabled.
+     *
+     * Note that changing this does not enable or disable autofill; it is only an indicator that
+     * this has occurred elsewhere.
+     */
+    var isAccessibilityEnabled: Boolean
+
+    /**
+     * Emits updates that track [isAccessibilityEnabled] values.
+     */
+    val isAccessibilityEnabledStateFlow: StateFlow<Boolean>
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManagerImpl.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * The default implementation of [AccessibilityEnabledManager].
+ */
+class AccessibilityEnabledManagerImpl : AccessibilityEnabledManager {
+    private val mutableIsAccessibilityEnabledStateFlow = MutableStateFlow(value = false)
+
+    override var isAccessibilityEnabled: Boolean
+        get() = mutableIsAccessibilityEnabledStateFlow.value
+        set(value) {
+            mutableIsAccessibilityEnabledStateFlow.value = value
+        }
+
+    override val isAccessibilityEnabledStateFlow: StateFlow<Boolean>
+        get() = mutableIsAccessibilityEnabledStateFlow.asStateFlow()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -134,6 +134,15 @@ interface SettingsRepository {
     var blockedAutofillUris: List<String>
 
     /**
+     * Emits updates whenever there is a change in the app's status for accessibility-based
+     * autofill.
+     *
+     * Note that the correct value is only populated upon subscription so calling [StateFlow.value]
+     * may result in an out-of-date value.
+     */
+    val isAccessibilityEnabledStateFlow: StateFlow<Boolean>
+
+    /**
      * Emits updates whenever there is a change in the app's status for supporting autofill.
      *
      * Note that the correct value is only populated upon subscription so calling [StateFlow.value]

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.UserFingerprintResult
 import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
@@ -49,6 +50,7 @@ class SettingsRepositoryImpl(
     private val settingsDiskSource: SettingsDiskSource,
     private val vaultSdkSource: VaultSdkSource,
     private val biometricsEncryptionManager: BiometricsEncryptionManager,
+    accessibilityEnabledManager: AccessibilityEnabledManager,
     policyManager: PolicyManager,
     dispatcherManager: DispatcherManager,
 ) : SettingsRepository {
@@ -292,6 +294,9 @@ class SettingsRepositoryImpl(
                 blockedAutofillUris = value,
             )
         }
+
+    override val isAccessibilityEnabledStateFlow: StateFlow<Boolean> =
+        accessibilityEnabledManager.isAccessibilityEnabledStateFlow
 
     override val isAutofillEnabledStateFlow: StateFlow<Boolean> =
         autofillEnabledManager.isAutofillEnabledStateFlow

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.repository.di
 
 import android.view.autofill.AutofillManager
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.ConfigDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.EnvironmentDiskSource
@@ -71,6 +72,7 @@ object PlatformRepositoryModule {
         settingsDiskSource: SettingsDiskSource,
         vaultSdkSource: VaultSdkSource,
         encryptionManager: BiometricsEncryptionManager,
+        accessibilityEnabledManager: AccessibilityEnabledManager,
         dispatcherManager: DispatcherManager,
         policyManager: PolicyManager,
     ): SettingsRepository =
@@ -81,6 +83,7 @@ object PlatformRepositoryModule {
             settingsDiskSource = settingsDiskSource,
             vaultSdkSource = vaultSdkSource,
             biometricsEncryptionManager = encryptionManager,
+            accessibilityEnabledManager = accessibilityEnabledManager,
             dispatcherManager = dispatcherManager,
             policyManager = policyManager,
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
@@ -36,6 +37,7 @@ import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
+import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenSelectionRow
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow
@@ -66,6 +68,10 @@ fun AutoFillScreen(
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             AutoFillEvent.NavigateBack -> onNavigateBack.invoke()
+
+            AutoFillEvent.NavigateToAccessibilitySettings -> {
+                intentManager.startSystemAccessibilitySettingsActivity()
+            }
 
             AutoFillEvent.NavigateToAutofillSettings -> {
                 val isSuccess = intentManager.startSystemAutofillSettingsActivity()
@@ -171,6 +177,15 @@ fun AutoFillScreen(
                     withDivider = false,
                 )
             }
+            AccessibilityAutofillSwitch(
+                isAccessibilityAutoFillEnabled = state.isAccessibilityAutofillEnabled,
+                onCheckedChange = remember(viewModel) {
+                    { viewModel.trySendAction(AutoFillAction.UseAccessibilityAutofillClick) }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            )
             Spacer(modifier = Modifier.height(16.dp))
             BitwardenListHeaderText(
                 label = stringResource(id = R.string.additional_options),
@@ -223,6 +238,45 @@ fun AutoFillScreen(
             )
             Spacer(modifier = Modifier.height(16.dp))
         }
+    }
+}
+
+@Composable
+private fun AccessibilityAutofillSwitch(
+    isAccessibilityAutoFillEnabled: Boolean,
+    onCheckedChange: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // TODO: This should be visible in all variants once the feature is complete (PM-12014)
+    if (!BuildConfig.DEBUG) return
+    var shouldShowDialog by rememberSaveable { mutableStateOf(value = false) }
+    BitwardenWideSwitch(
+        label = stringResource(id = R.string.accessibility),
+        description = stringResource(id = R.string.accessibility_description5),
+        isChecked = isAccessibilityAutoFillEnabled,
+        onCheckedChange = {
+            if (isAccessibilityAutoFillEnabled) {
+                onCheckedChange()
+            } else {
+                shouldShowDialog = true
+            }
+        },
+        modifier = modifier.testTag(tag = "AccessibilityAutofillSwitch"),
+    )
+
+    if (shouldShowDialog) {
+        BitwardenTwoButtonDialog(
+            title = stringResource(id = R.string.accessibility_service_disclosure),
+            message = stringResource(id = R.string.accessibility_disclosure_text),
+            confirmButtonText = stringResource(id = R.string.accept),
+            dismissButtonText = stringResource(id = R.string.decline),
+            onConfirmClick = {
+                onCheckedChange()
+                shouldShowDialog = false
+            },
+            onDismissClick = { shouldShowDialog = false },
+            onDismissRequest = { shouldShowDialog = false },
+        )
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -28,6 +28,11 @@ interface IntentManager {
     fun startCustomTabsActivity(uri: Uri)
 
     /**
+     * Attempts to start the system accessibility settings activity.
+     */
+    fun startSystemAccessibilitySettingsActivity()
+
+    /**
      * Attempts to start the system autofill settings activity. The return value indicates whether
      * or not this was successful.
      */

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -103,6 +103,10 @@ class IntentManagerImpl(
             .launchUrl(context, uri)
     }
 
+    override fun startSystemAccessibilitySettingsActivity() {
+        context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+    }
+
     override fun startSystemAutofillSettingsActivity(): Boolean =
         try {
             val intent = Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -542,6 +542,7 @@ Scanning will happen automatically.</string>
   <string name="accessibility_description2">Use the Bitwarden Accessibility Service to auto-fill your logins across apps and the web. (Requires Draw-Over to be turned on as well)</string>
   <string name="accessibility_description3">Use the Bitwarden Accessibility Service to use the Autofill Quick-Action Tile, and/or show a popup using Draw-Over (if turned on).</string>
   <string name="accessibility_description4">Required to use the Autofill Quick-Action Tile, or to augment the Autofill Service by using Draw-Over (if turned on).</string>
+  <string name="accessibility_description5">Required to use the Autofill Quick-Action Tile.</string>
   <string name="draw_over">Use draw-over</string>
   <string name="draw_over_description">Allows the Bitwarden Accessibility Service to display a popup when login fields are selected.</string>
   <string name="draw_over_description2">If turned on, the Bitwarden Accessibility Service will display a popup when login fields are selected to assist with auto-filling your logins.</string>

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManagerTest.kt
@@ -1,0 +1,95 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+import android.content.Context
+import android.provider.Settings
+import androidx.lifecycle.LifecycleCoroutineScope
+import app.cash.turbine.test
+import com.x8bit.bitwarden.data.platform.manager.AppForegroundManager
+import com.x8bit.bitwarden.data.platform.manager.model.AppForegroundState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccessibilityActivityManagerTest {
+    private val context: Context = mockk {
+        every { applicationContext } returns this
+        every { packageName } returns "com.x8bit.bitwarden"
+        every { contentResolver } returns mockk()
+    }
+    private val accessibilityEnabledManager: AccessibilityEnabledManager =
+        AccessibilityEnabledManagerImpl()
+    private val mutableAppForegroundStateFlow = MutableStateFlow(AppForegroundState.BACKGROUNDED)
+    private val appForegroundManager: AppForegroundManager = mockk {
+        every { appForegroundStateFlow } returns mutableAppForegroundStateFlow
+    }
+    private val lifecycleScope = mockk<LifecycleCoroutineScope> {
+        every { coroutineContext } returns UnconfinedTestDispatcher()
+    }
+
+    // We will construct an instance here just to hook the various dependencies together internally
+    @Suppress("unused")
+    private val autofillActivityManager: AccessibilityActivityManager =
+        AccessibilityActivityManagerImpl(
+            context = context,
+            accessibilityEnabledManager = accessibilityEnabledManager,
+            appForegroundManager = appForegroundManager,
+            lifecycleScope = lifecycleScope,
+        )
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(Settings.Secure::getString)
+        mockkSettingsSecureGetString(value = null)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Settings.Secure::getString)
+    }
+
+    @Test
+    fun `changes in app foreground status should update the AutofillEnabledManager as necessary`() =
+        runTest {
+            accessibilityEnabledManager.isAccessibilityEnabledStateFlow.test {
+                assertFalse(awaitItem())
+
+                // An update is received when both the accessibility state and foreground state
+                // change
+                @Suppress("MaxLineLength")
+                mockkSettingsSecureGetString(
+                    value = "com.x8bit.bitwarden/com.x8bit.bitwarden.Accessibility.AccessibilityService",
+                )
+                mutableAppForegroundStateFlow.value = AppForegroundState.FOREGROUNDED
+                assertTrue(awaitItem())
+
+                // An update is not received when only the foreground state changes
+                mutableAppForegroundStateFlow.value = AppForegroundState.BACKGROUNDED
+                expectNoEvents()
+
+                // An update is not received when only the accessibility state changes
+                mockkSettingsSecureGetString(value = "com.x8bit.bitwarden/AccessibilityService")
+                expectNoEvents()
+
+                // An update is received after both states have changed
+                mutableAppForegroundStateFlow.value = AppForegroundState.FOREGROUNDED
+                assertFalse(awaitItem())
+            }
+        }
+
+    private fun mockkSettingsSecureGetString(value: String?) {
+        every {
+            Settings.Secure.getString(any(), Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+        } returns value
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManagerTest.kt
@@ -1,0 +1,31 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.manager
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AccessibilityEnabledManagerTest {
+
+    private val accessibilityEnabledManager: AccessibilityEnabledManager =
+        AccessibilityEnabledManagerImpl()
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `isAccessibilityEnabledStateFlow should emit whenever isAccessibilityEnabled is set to a unique value`() =
+        runTest {
+            accessibilityEnabledManager.isAccessibilityEnabledStateFlow.test {
+                assertFalse(awaitItem())
+
+                accessibilityEnabledManager.isAccessibilityEnabled = true
+                assertTrue(awaitItem())
+
+                accessibilityEnabledManager.isAccessibilityEnabled = true
+                expectNoEvents()
+
+                accessibilityEnabledManager.isAccessibilityEnabled = false
+                assertFalse(awaitItem())
+            }
+        }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -11,6 +11,8 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.KdfTypeJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.UserDecryptionOptionsJson
 import com.x8bit.bitwarden.data.auth.repository.model.UserFingerprintResult
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManagerImpl
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManagerImpl
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
@@ -51,6 +53,8 @@ class SettingsRepositoryTest {
         every { disableAutofillServices() } just runs
     }
     private val autofillEnabledManager: AutofillEnabledManager = AutofillEnabledManagerImpl()
+    private val accessibilityEnabledManager: AccessibilityEnabledManager =
+        AccessibilityEnabledManagerImpl()
     private val fakeAuthDiskSource = FakeAuthDiskSource()
     private val fakeSettingsDiskSource = FakeSettingsDiskSource()
     private val vaultSdkSource: VaultSdkSource = mockk()
@@ -69,6 +73,7 @@ class SettingsRepositoryTest {
         settingsDiskSource = fakeSettingsDiskSource,
         vaultSdkSource = vaultSdkSource,
         biometricsEncryptionManager = biometricsEncryptionManager,
+        accessibilityEnabledManager = accessibilityEnabledManager,
         dispatcherManager = FakeDispatcherManager(),
         policyManager = policyManager,
     )
@@ -676,6 +681,21 @@ class SettingsRepositoryTest {
             fakeSettingsDiskSource.getBlockedAutofillUris(userId = USER_ID),
         )
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `isAccessibilityEnabledStateFlow should emit whenever the accessibilityEnabledManager does`() =
+        runTest {
+            settingsRepository.isAccessibilityEnabledStateFlow.test {
+                assertFalse(awaitItem())
+
+                accessibilityEnabledManager.isAccessibilityEnabled = true
+                assertTrue(awaitItem())
+
+                accessibilityEnabledManager.isAccessibilityEnabled = false
+                assertFalse(awaitItem())
+            }
+        }
 
     @Test
     fun `isAutofillEnabledStateFlow should emit whenever the AutofillEnabledManager does`() =


### PR DESCRIPTION
## 🎟️ Tracking

PM-11488

## 📔 Objective

This PR adds a switch to the autofill settings UI for enabling the accessibility service.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/f03d5088-7ffb-44fe-b6e2-1833152a4306" width="350" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
