### PR TITLE
PM-12014: Enable accessibility autofill outside of debug builds

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -3,44 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application tools:ignore="MissingApplicationIcon">
-        <!--
-        The AutofillTileService name below refers to the legacy Xamarin app's service name.
-        This must always match in order for the app to properly query if it is providing autofill
-        tile services.
-        -->
-        <!--suppress AndroidDomInspection -->
-        <service
-            android:name="com.x8bit.bitwarden.AutofillTileService"
-            android:exported="true"
-            android:icon="@drawable/ic_notification"
-            android:label="@string/autofill"
-            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
-            tools:ignore="MissingClass">
-            <intent-filter>
-                <action android:name="android.service.quicksettings.action.QS_TILE" />
-            </intent-filter>
-        </service>
-
-        <!--
-        The AccessibilityService name below refers to the legacy Xamarin app's service name. This
-        must always match in order for the app to properly query if it is providing accessibility
-        services.
-        -->
-        <!--suppress AndroidDomInspection -->
-        <service
-            android:name="com.x8bit.bitwarden.Accessibility.AccessibilityService"
-            android:exported="true"
-            android:label="@string/app_name"
-            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
-            tools:ignore="MissingClass">
-            <intent-filter>
-                <action android:name="android.accessibilityservice.AccessibilityService" />
-            </intent-filter>
-            <meta-data
-                android:name="android.accessibilityservice"
-                android:resource="@xml/accessibility_service" />
-        </service>
-
         <!-- Disable Crashlytics for debug builds -->
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -169,6 +169,26 @@
         </service>
 
         <!--
+        The AccessibilityService name below refers to the legacy Xamarin app's service name. This
+        must always match in order for the app to properly query if it is providing accessibility
+        services.
+        -->
+        <!--suppress AndroidDomInspection -->
+        <service
+            android:name="com.x8bit.bitwarden.Accessibility.AccessibilityService"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service" />
+        </service>
+
+        <!--
         The CredentialProviderService name below refers to the legacy Xamarin app's service name.
         This must always match in order for the app to properly query if it is providing credential
         services.
@@ -197,6 +217,24 @@
             <meta-data
                 android:name="autoStoreLocales"
                 android:value="true" />
+        </service>
+
+        <!--
+        The AutofillTileService name below refers to the legacy Xamarin app's service name.
+        This must always match in order for the app to properly query if it is providing autofill
+        tile services.
+        -->
+        <!--suppress AndroidDomInspection -->
+        <service
+            android:name="com.x8bit.bitwarden.AutofillTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_notification"
+            android:label="@string/autofill"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
         </service>
 
         <!--

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
@@ -247,8 +246,6 @@ private fun AccessibilityAutofillSwitch(
     onCheckedChange: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // TODO: This should be visible in all variants once the feature is complete (PM-12014)
-    if (!BuildConfig.DEBUG) return
     var shouldShowDialog by rememberSaveable { mutableStateOf(value = false) }
     BitwardenWideSwitch(
         label = stringResource(id = R.string.accessibility),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12014](https://bitwarden.atlassian.net/browse/PM-12014)

## 📔 Objective

This PR moves the manifest items for accessibility autofill from the debug manifest to the main manifest, allowing them to be used in all build variants. The UI switch for enabling accessibility autofill has also been enabled in non-debug builds.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12014]: https://bitwarden.atlassian.net/browse/PM-12014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ