### PR TITLE
PM-12240: Remove unused permissions from the sync response

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
@@ -382,60 +382,16 @@ data class SyncResponseJson(
         /**
          * Represents permissions in the vault response.
          *
-         * @property shouldManageGroups If groups should be managed.
          * @property shouldManageResetPassword If reset password should be managed.
-         * @property shouldAccessReports If reports should be accessed.
          * @property shouldManagePolicies If policies should be managed.
-         * @property shouldDeleteAnyCollection If collections should be accessed.
-         * @property shouldManageSso If sso should be managed.
-         * @property shouldDeleteAssignedCollections If assigned collection should be deleted.
-         * @property shouldManageUsers If users should be managed.
-         * @property shouldAccessImportExport If import/export should be accessed.
-         * @property shouldEditAnyCollection If any collection should be edited.
-         * @property shouldAccessEventLogs If event logs should be accessed.
-         * @property shouldCreateNewCollections If new collections should be created.
-         * @property shouldEditAssignedCollections If assigned collections should be edited.
          */
         @Serializable
         data class Permissions(
-            @SerialName("manageGroups")
-            val shouldManageGroups: Boolean,
-
             @SerialName("manageResetPassword")
             val shouldManageResetPassword: Boolean,
 
-            @SerialName("accessReports")
-            val shouldAccessReports: Boolean,
-
             @SerialName("managePolicies")
             val shouldManagePolicies: Boolean,
-
-            @SerialName("deleteAnyCollection")
-            val shouldDeleteAnyCollection: Boolean,
-
-            @SerialName("manageSso")
-            val shouldManageSso: Boolean,
-
-            @SerialName("deleteAssignedCollections")
-            val shouldDeleteAssignedCollections: Boolean,
-
-            @SerialName("manageUsers")
-            val shouldManageUsers: Boolean,
-
-            @SerialName("accessImportExport")
-            val shouldAccessImportExport: Boolean,
-
-            @SerialName("editAnyCollection")
-            val shouldEditAnyCollection: Boolean,
-
-            @SerialName("accessEventLogs")
-            val shouldAccessEventLogs: Boolean,
-
-            @SerialName("createNewCollections")
-            val shouldCreateNewCollections: Boolean,
-
-            @SerialName("editAssignedCollections")
-            val shouldEditAssignedCollections: Boolean,
         )
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseProfileUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseProfileUtil.kt
@@ -83,19 +83,8 @@ fun createMockPermissions(
     shouldManageResetPassword: Boolean = false,
 ): SyncResponseJson.Profile.Permissions =
     SyncResponseJson.Profile.Permissions(
-        shouldManageGroups = false,
         shouldManageResetPassword = shouldManageResetPassword,
-        shouldAccessReports = false,
         shouldManagePolicies = false,
-        shouldDeleteAnyCollection = false,
-        shouldManageSso = false,
-        shouldDeleteAssignedCollections = false,
-        shouldManageUsers = false,
-        shouldAccessImportExport = false,
-        shouldEditAnyCollection = false,
-        shouldAccessEventLogs = false,
-        shouldCreateNewCollections = false,
-        shouldEditAssignedCollections = false,
     )
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12240](https://bitwarden.atlassian.net/browse/PM-12240)

## 📔 Objective

This PR removes all the unused fields from the Sync responses permissions block, this avoids a deserialization error that has occurred because some of the fields no longer exist.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12240]: https://bitwarden.atlassian.net/browse/PM-12240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ