### PR TITLE
Add BitwardenLegacyAppComponents for legacy app component names

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/BitwardenAppComponentFactory.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/BitwardenAppComponentFactory.kt
@@ -13,15 +13,6 @@ import com.x8bit.bitwarden.data.tiles.BitwardenAutofillTileService
 import com.x8bit.bitwarden.data.tiles.BitwardenGeneratorTileService
 import com.x8bit.bitwarden.data.tiles.BitwardenVaultTileService
 
-private const val LEGACY_ACCESSIBILITY_SERVICE_NAME =
-    "com.x8bit.bitwarden.Accessibility.AccessibilityService"
-private const val LEGACY_AUTOFILL_SERVICE_NAME = "com.x8bit.bitwarden.Autofill.AutofillService"
-private const val LEGACY_CREDENTIAL_SERVICE_NAME =
-    "com.x8bit.bitwarden.Autofill.CredentialProviderService"
-private const val LEGACY_AUTOFILL_TILE_SERVICE_NAME = "com.x8bit.bitwarden.AutofillTileService"
-private const val LEGACY_VAULT_TILE_SERVICE_NAME = "com.x8bit.bitwarden.MyVaultTileService"
-private const val LEGACY_GENERATOR_TILE_SERVICE_NAME = "com.x8bit.bitwarden.GeneratorTileService"
-
 /**
  * A factory class that allows us to intercept when a manifest element is being instantiated
  * and modify various characteristics before initialization.

--- a/app/src/main/java/com/x8bit/bitwarden/BitwardenLegacyAppComponents.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/BitwardenLegacyAppComponents.kt
@@ -1,0 +1,33 @@
+package com.x8bit.bitwarden
+
+/**
+ * The legacy name for the accessibility service.
+ */
+const val LEGACY_ACCESSIBILITY_SERVICE_NAME: String =
+    "com.x8bit.bitwarden.Accessibility.AccessibilityService"
+
+/**
+ * The legacy name for the autofill service.
+ */
+const val LEGACY_AUTOFILL_SERVICE_NAME: String = "com.x8bit.bitwarden.Autofill.AutofillService"
+
+/**
+ * The legacy name for the accessibility autofill tile service.
+ */
+const val LEGACY_AUTOFILL_TILE_SERVICE_NAME: String = "com.x8bit.bitwarden.AutofillTileService"
+
+/**
+ * The legacy name for the credential service.
+ */
+const val LEGACY_CREDENTIAL_SERVICE_NAME: String =
+    "com.x8bit.bitwarden.Autofill.CredentialProviderService"
+
+/**
+ * The legacy name for the generator tile service.
+ */
+const val LEGACY_GENERATOR_TILE_SERVICE_NAME: String = "com.x8bit.bitwarden.GeneratorTileService"
+
+/**
+ * The legacy name for the vault tile service.
+ */
+const val LEGACY_VAULT_TILE_SERVICE_NAME: String = "com.x8bit.bitwarden.MyVaultTileService"

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManagerImpl.kt
@@ -3,18 +3,10 @@ package com.x8bit.bitwarden.data.autofill.accessibility.manager
 import android.content.Context
 import android.provider.Settings
 import androidx.lifecycle.LifecycleCoroutineScope
+import com.x8bit.bitwarden.LEGACY_ACCESSIBILITY_SERVICE_NAME
 import com.x8bit.bitwarden.data.platform.manager.AppForegroundManager
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-
-/**
- * The accessibility service name as it is known in the AndroidManifest.
- *
- * Note: This is not the name of the actual service but the name defined in the Android Manifest
- * which matches the service in the Xamarin app.
- */
-private const val LEGACY_ACCESSIBILITY_SERVICE_NAME =
-    "com.x8bit.bitwarden.Accessibility.AccessibilityService"
 
 /**
  * The default implementation of the [AccessibilityActivityManager].


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds the `BitwardenLegacyAppComponents` for legacy app component names.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
