### PR TITLE
PM-12076 remaining state based navigation linkup for onboarding

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteNavigation.kt
@@ -1,0 +1,29 @@
+package com.x8bit.bitwarden.ui.auth.feature.accountsetup
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+
+/**
+ * Route name for [SetupCompleteScreen].
+ */
+const val SETUP_COMPLETE_ROUTE = "setup_complete"
+
+/**
+ * Navigate to the setup complete screen.
+ */
+fun NavController.navigateToSetupCompleteScreen(navOptions: NavOptions? = null) {
+    this.navigate(SETUP_COMPLETE_ROUTE, navOptions)
+}
+
+/**
+ * Add the setup complete screen to the nav graph.
+ */
+fun NavGraphBuilder.setupCompleteDestination() {
+    composableWithPushTransitions(
+        route = SETUP_COMPLETE_ROUTE,
+    ) {
+        SetupCompleteScreen()
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -16,10 +16,13 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_AUTO_FILL_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_COMPLETE_ROUTE
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_UNLOCK_ROUTE
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupAutoFillScreen
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupCompleteScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupUnlockScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupAutoFillDestination
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupCompleteDestination
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupUnlockDestination
 import com.x8bit.bitwarden.ui.auth.feature.auth.AUTH_GRAPH_ROUTE
 import com.x8bit.bitwarden.ui.auth.feature.auth.authGraph
@@ -98,6 +101,7 @@ fun RootNavScreen(
         setupDebugMenuDestination(onNavigateBack = { navController.popBackStack() })
         setupUnlockDestination()
         setupAutoFillDestination()
+        setupCompleteDestination()
     }
 
     val targetRoute = when (state) {
@@ -125,6 +129,7 @@ fun RootNavScreen(
 
         RootNavState.OnboardingAccountLockSetup -> SETUP_UNLOCK_ROUTE
         RootNavState.OnboardingAutoFillSetup -> SETUP_AUTO_FILL_ROUTE
+        RootNavState.OnboardingStepsComplete -> SETUP_COMPLETE_ROUTE
     }
     val currentRoute = navController.currentDestination?.rootLevelRoute()
 
@@ -235,6 +240,10 @@ fun RootNavScreen(
 
             RootNavState.OnboardingAutoFillSetup -> {
                 navController.navigateToSetupAutoFillScreen(rootNavOptions)
+            }
+
+            RootNavState.OnboardingStepsComplete -> {
+                navController.navigateToSetupCompleteScreen(rootNavOptions)
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -97,8 +97,8 @@ class RootNavViewModel @Inject constructor(
                     OnboardingStatus.ACCOUNT_LOCK_SETUP,
                     -> RootNavState.OnboardingAccountLockSetup
                     OnboardingStatus.AUTOFILL_SETUP -> RootNavState.OnboardingAutoFillSetup
+                    OnboardingStatus.FINAL_STEP -> RootNavState.OnboardingStepsComplete
                     OnboardingStatus.COMPLETE -> throw IllegalStateException("Should not have entered here.")
-                    OnboardingStatus.FINAL_STEP -> TODO("PM-12076 complete navigation wiring")
                 }
             }
 
@@ -345,6 +345,12 @@ sealed class RootNavState : Parcelable {
      */
     @Parcelize
     data object OnboardingAutoFillSetup : RootNavState()
+
+    /**
+     * App should show the onboarding steps complete screen.
+     */
+    @Parcelize
+    data object OnboardingStepsComplete : RootNavState()
 }
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.x8bit.bitwarden.ui.auth.feature.accountsetup
 
 import app.cash.turbine.test
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
@@ -22,6 +25,15 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
     private val settingsRepository = mockk<SettingsRepository>(relaxed = true) {
         every { isAutofillEnabledStateFlow } returns mutableAutoFillEnabledStateFlow
         every { disableAutofill() } just runs
+    }
+
+    private val mockUserState = mockk<UserState> {
+        every { activeUserId } returns DEFAULT_USER_ID
+    }
+    private val mutableUserStateFlow = MutableStateFlow<UserState?>(mockUserState)
+    private val authRepository: AuthRepository = mockk {
+        every { userStateFlow } returns mutableUserStateFlow
+        every { setOnboardingStatus(any(), any()) } just runs
     }
 
     @Test
@@ -92,5 +104,31 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
         )
     }
 
-    private fun createViewModel() = SetupAutoFillViewModel(settingsRepository)
+    @Test
+    fun `handleTurnOnLaterConfirmClick sets onboarding status to FINAL_STEP`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(SetupAutoFillAction.TurnOnLaterConfirmClick)
+        verify {
+            authRepository.setOnboardingStatus(
+                DEFAULT_USER_ID,
+                OnboardingStatus.FINAL_STEP,
+            )
+        }
+    }
+
+    @Test
+    fun `handleContinueClick sets onboarding status to FINAL_STEP`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(SetupAutoFillAction.ContinueClick)
+        verify {
+            authRepository.setOnboardingStatus(
+                DEFAULT_USER_ID,
+                OnboardingStatus.FINAL_STEP,
+            )
+        }
+    }
+
+    private fun createViewModel() = SetupAutoFillViewModel(settingsRepository, authRepository)
 }
+
+private const val DEFAULT_USER_ID = "userId"

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
@@ -208,4 +208,8 @@ class SetupAutofillScreenTest : BaseComposeTest() {
     }
 }
 
-private val DEFAULT_STATE = SetupAutoFillState(dialogState = null, autofillEnabled = false)
+private val DEFAULT_STATE = SetupAutoFillState(
+    userId = "userId",
+    dialogState = null,
+    autofillEnabled = false,
+)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteViewModelTest.kt
@@ -5,7 +5,9 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -18,8 +20,9 @@ class SetupCompleteViewModelTest : BaseViewModelTest() {
         every { activeUserId } returns DEFAULT_USER_ID
     }
     private val mutableUserStateFlow = MutableStateFlow<UserState?>(mockUserState)
-    private val authRepository: AuthRepository = mockk(relaxed = true) {
+    private val authRepository: AuthRepository = mockk {
         every { userStateFlow } returns mutableUserStateFlow
+        every { setOnboardingStatus(any(), any()) } just runs
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -226,12 +226,32 @@ class RootNavScreenTest : BaseComposeTest() {
                 )
             }
 
-        // Make sure navigating to onboarding graph works as expected:
+        // Make sure navigating to account lock setup works as expected:
         rootNavStateFlow.value =
             RootNavState.OnboardingAccountLockSetup
         composeTestRule.runOnIdle {
             fakeNavHostController.assertLastNavigation(
                 route = "setup_unlock",
+                navOptions = expectedNavOptions,
+            )
+        }
+
+        // Make sure navigating to account autofill setup works as expected:
+        rootNavStateFlow.value =
+            RootNavState.OnboardingAutoFillSetup
+        composeTestRule.runOnIdle {
+            fakeNavHostController.assertLastNavigation(
+                route = "setup_auto_fill",
+                navOptions = expectedNavOptions,
+            )
+        }
+
+        // Make sure navigating to account setup complete works as expected:
+        rootNavStateFlow.value =
+            RootNavState.OnboardingStepsComplete
+        composeTestRule.runOnIdle {
+            fakeNavHostController.assertLastNavigation(
+                route = "setup_complete",
                 navOptions = expectedNavOptions,
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -1034,6 +1034,41 @@ class RootNavViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `when the active user has an unlocked vault and they have a OnboardingStatus of FINAL_STEP the nav state should be OnboardingAutoFillSetup`() {
+        mutableUserStateFlow.tryEmit(
+            UserState(
+                activeUserId = "activeUserId",
+                accounts = listOf(
+                    UserState.Account(
+                        userId = "activeUserId",
+                        name = "name",
+                        email = "email",
+                        avatarColorHex = "avatarColorHex",
+                        environment = Environment.Us,
+                        isPremium = true,
+                        isLoggedIn = true,
+                        isVaultUnlocked = true,
+                        needsPasswordReset = false,
+                        isBiometricsEnabled = false,
+                        organizations = emptyList(),
+                        needsMasterPassword = false,
+                        trustedDevice = null,
+                        hasMasterPassword = true,
+                        isUsingKeyConnector = false,
+                        onboardingStatus = OnboardingStatus.FINAL_STEP,
+                    ),
+                ),
+            ),
+        )
+        val viewModel = createViewModel()
+        assertEquals(
+            RootNavState.OnboardingStepsComplete,
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `when the active user has an locked vault and they have a OnboardingStatus of NOT_STARTED the nav state should be VaultLocked`() {
         mutableUserStateFlow.tryEmit(
             UserState(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12076
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Add remaining areas for updating onboarding status to complete successful navigation of onboarding flow
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
builds on #3921 

## 📸 Screenshots

<!-- Required for any UI 
Demo: of full flow with some branching to demo other parts not on happy path:
https://github.com/user-attachments/assets/63cf8102-eb5f-425c-bb13-f4671656e8bd

changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
