### PR TITLE
PM-11485: Add routing logic to handle searching during accessibility autofill

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -11,6 +11,8 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManager
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
@@ -75,6 +77,8 @@ import java.time.ZoneOffset
 @Suppress("LargeClass")
 class SearchViewModelTest : BaseViewModelTest() {
 
+    private val accessibilitySelectionManager: AccessibilitySelectionManager =
+        AccessibilitySelectionManagerImpl()
     private val autofillSelectionManager: AutofillSelectionManager =
         AutofillSelectionManagerImpl()
 
@@ -206,7 +210,23 @@ class SearchViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `AutofillItemClick should emit NavigateToViewCipher`() = runTest {
+    fun `AutofillItemClick should call emitAccessibilitySelection`() = runTest {
+        val cipherView = setupForAutofill(
+            autofillSelectionData = AUTOFILL_SELECTION_DATA.copy(
+                framework = AutofillSelectionData.Framework.ACCESSIBILITY,
+            ),
+        )
+        val cipherId = CIPHER_ID
+        val viewModel = createViewModel()
+
+        accessibilitySelectionManager.accessibilitySelectionFlow.test {
+            viewModel.trySendAction(SearchAction.AutofillItemClick(itemId = cipherId))
+            assertEquals(cipherView, awaitItem())
+        }
+    }
+
+    @Test
+    fun `AutofillItemClick should call emitAutofillSelection`() = runTest {
         val cipherView = setupForAutofill()
         val cipherId = CIPHER_ID
         val viewModel = createViewModel()
@@ -267,6 +287,64 @@ class SearchViewModelTest : BaseViewModelTest() {
             )
         }
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `AutofillAndSaveItemClick with request success should post to the AccessibilitySelectionManager`() =
+        runTest {
+            val autofillSelectionData = AUTOFILL_SELECTION_DATA.copy(
+                framework = AutofillSelectionData.Framework.ACCESSIBILITY,
+            )
+            val cipherView = setupForAutofill(autofillSelectionData = autofillSelectionData)
+            val cipherId = CIPHER_ID
+            val updatedCipherView = cipherView.copy(
+                login = createMockLoginView(number = 1, clock = clock).copy(
+                    uris = listOf(createMockUriView(number = 1)) +
+                        LoginUriView(
+                            uri = AUTOFILL_URI,
+                            match = null,
+                            uriChecksum = null,
+                        ),
+                ),
+            )
+            val initialState = INITIAL_STATE_FOR_AUTOFILL.copy(
+                autofillSelectionData = autofillSelectionData,
+            )
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.updateCipher(
+                    cipherId = cipherId,
+                    cipherView = updatedCipherView,
+                )
+            } returns UpdateCipherResult.Success
+
+            turbineScope {
+                val stateTurbine = viewModel
+                    .stateFlow
+                    .testIn(backgroundScope)
+                val selectionTurbine = accessibilitySelectionManager
+                    .accessibilitySelectionFlow
+                    .testIn(backgroundScope)
+
+                assertEquals(initialState, stateTurbine.awaitItem())
+
+                viewModel.trySendAction(SearchAction.AutofillAndSaveItemClick(itemId = cipherId))
+
+                assertEquals(
+                    initialState.copy(
+                        dialogState = SearchState.DialogState.Loading(
+                            message = R.string.loading.asText(),
+                        ),
+                    ),
+                    stateTurbine.awaitItem(),
+                )
+
+                assertEquals(initialState, stateTurbine.awaitItem())
+
+                // Autofill flow is completed
+                assertEquals(cipherView, selectionTurbine.awaitItem())
+            }
+        }
 
     @Suppress("MaxLineLength")
     @Test
@@ -395,6 +473,36 @@ class SearchViewModelTest : BaseViewModelTest() {
                 ),
                 viewModel.stateFlow.value,
             )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `MasterPasswordRepromptSubmit for a request Success with a valid password for autofill should post to the AccessibilitySelectionManager`() =
+        runTest {
+            setupMockUri()
+            val cipherView = setupForAutofill(
+                autofillSelectionData = AUTOFILL_SELECTION_DATA.copy(
+                    framework = AutofillSelectionData.Framework.ACCESSIBILITY,
+                ),
+            )
+            val cipherId = CIPHER_ID
+            val password = "password"
+            coEvery {
+                authRepository.validatePassword(password = password)
+            } returns ValidatePasswordResult.Success(isValid = true)
+            val viewModel = createViewModel()
+
+            accessibilitySelectionManager.accessibilitySelectionFlow.test {
+                viewModel.trySendAction(
+                    SearchAction.MasterPasswordRepromptSubmit(
+                        password = password,
+                        masterPasswordRepromptData = MasterPasswordRepromptData.Autofill(
+                            cipherId = cipherId,
+                        ),
+                    ),
+                )
+                assertEquals(cipherView, awaitItem())
+            }
         }
 
     @Suppress("MaxLineLength")
@@ -1333,6 +1441,7 @@ class SearchViewModelTest : BaseViewModelTest() {
         clipboardManager = clipboardManager,
         policyManager = policyManager,
         specialCircumstanceManager = specialCircumstanceManager,
+        accessibilitySelectionManager = accessibilitySelectionManager,
         autofillSelectionManager = autofillSelectionManager,
         organizationEventManager = organizationEventManager,
     )
@@ -1341,9 +1450,11 @@ class SearchViewModelTest : BaseViewModelTest() {
      * Generates and returns [CipherView] to be populated for autofill testing and sets up the
      * state to return that item.
      */
-    private fun setupForAutofill(): CipherView {
+    private fun setupForAutofill(
+        autofillSelectionData: AutofillSelectionData = AUTOFILL_SELECTION_DATA,
+    ): CipherView {
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.AutofillSelection(
-            autofillSelectionData = AUTOFILL_SELECTION_DATA,
+            autofillSelectionData = autofillSelectionData,
             shouldFinishWhenComplete = true,
         )
         val cipherView = createMockCipherView(


### PR DESCRIPTION
## 🎟️ Tracking

PM-11485

## 📔 Objective

This PR adds additional routing logic for accessibility-base autofill in the app. This new logic supports searching for a cipher when using accessibility autofill.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
