### PR TITLE
PM-10631 store when the user selects to turn auto fill on later

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -258,4 +258,16 @@ interface SettingsDiskSource {
      * @see [storeUseHasLoggedInPreviously]
      */
     fun getUserHasSignedInPreviously(userId: String): Boolean
+
+    /**
+     * Gets whether or not the given [userId] has signalled they want to enable autofill in
+     * onboarding.
+     */
+    fun getShowAutoFillSettingBadge(userId: String): Boolean
+
+    /**
+     * Stores the given value for whether or not the given [userId] has signalled they want to
+     * enable autofill in onboarding.
+     */
+    fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -263,11 +263,11 @@ interface SettingsDiskSource {
      * Gets whether or not the given [userId] has signalled they want to enable autofill in
      * onboarding.
      */
-    fun getShowAutoFillSettingBadge(userId: String): Boolean
+    fun getShowAutoFillSettingBadge(userId: String): Boolean?
 
     /**
      * Stores the given value for whether or not the given [userId] has signalled they want to
      * enable autofill in onboarding.
      */
-    fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean)
+    fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -397,12 +397,12 @@ class SettingsDiskSourceImpl(
             key = HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY.appendIdentifier(userId),
         ) == true
 
-    override fun getShowAutoFillSettingBadge(userId: String): Boolean =
+    override fun getShowAutoFillSettingBadge(userId: String): Boolean? =
         getBoolean(
             key = SHOW_AUTOFILL_SETTING_BADGE.appendIdentifier(userId),
-        ) == true
+        )
 
-    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean) =
+    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?) =
         putBoolean(
             key = SHOW_AUTOFILL_SETTING_BADGE.appendIdentifier(userId),
             value = showBadge,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -33,6 +33,7 @@ private const val CRASH_LOGGING_ENABLED_KEY = "crashLoggingEnabled"
 private const val CLEAR_CLIPBOARD_INTERVAL_KEY = "clearClipboard"
 private const val INITIAL_AUTOFILL_DIALOG_SHOWN = "addSitePromptShown"
 private const val HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY = "hasUserLoggedInOrCreatedAccount"
+private const val SHOW_AUTOFILL_SETTING_BADGE = "showAutofillSettingBadge"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -395,4 +396,15 @@ class SettingsDiskSourceImpl(
         getBoolean(
             key = HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY.appendIdentifier(userId),
         ) == true
+
+    override fun getShowAutoFillSettingBadge(userId: String): Boolean =
+        getBoolean(
+            key = SHOW_AUTOFILL_SETTING_BADGE.appendIdentifier(userId),
+        ) == true
+
+    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean) =
+        putBoolean(
+            key = SHOW_AUTOFILL_SETTING_BADGE.appendIdentifier(userId),
+            value = showBadge,
+        )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -254,4 +254,16 @@ interface SettingsRepository {
      * Record that a user has logged in on this device.
      */
     fun storeUserHasLoggedInValue(userId: String)
+
+    /**
+     * Gets whether or not the given [userId] has signalled they want to enable autofill in
+     * onboarding.
+     */
+    fun getShowAutoFillSettingBadge(userId: String): Boolean
+
+    /**
+     * Stores the given value for whether or not the given [userId] has signalled they want to
+     * enable autofill in onboarding.
+     */
+    fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -538,6 +538,13 @@ class SettingsRepositoryImpl(
         settingsDiskSource.storeUseHasLoggedInPreviously(userId)
     }
 
+    override fun getShowAutoFillSettingBadge(userId: String): Boolean =
+        settingsDiskSource.getShowAutoFillSettingBadge(userId)
+
+    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean) {
+        settingsDiskSource.storeShowAutoFillSettingBadge(userId, showBadge)
+    }
+
     /**
      * If there isn't already one generated, generate a symmetric sync key that would be used
      * for communicating via IPC.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -539,7 +539,7 @@ class SettingsRepositoryImpl(
     }
 
     override fun getShowAutoFillSettingBadge(userId: String): Boolean =
-        settingsDiskSource.getShowAutoFillSettingBadge(userId)
+        settingsDiskSource.getShowAutoFillSettingBadge(userId) ?: false
 
     override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean) {
         settingsDiskSource.storeShowAutoFillSettingBadge(userId, showBadge)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
@@ -78,7 +78,7 @@ class SetupAutoFillViewModel @Inject constructor(
     }
 
     private fun handleTurnOnLaterConfirmClick() {
-        // TODO PM-10631 record user chose to turn on later for settings badging.
+        settingsRepository.storeShowAutoFillSettingBadge(state.userId, true)
         updateOnboardingStatusToNextStep()
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1051,6 +1051,6 @@ class SettingsDiskSourceTest {
             putBoolean(showAutofillSettingBadgeKey, true)
         }
 
-        assertTrue(settingsDiskSource.getShowAutoFillSettingBadge(userId = mockUserId))
+        assertTrue(settingsDiskSource.getShowAutoFillSettingBadge(userId = mockUserId)!!)
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1029,4 +1029,28 @@ class SettingsDiskSourceTest {
     fun `hasUserSignedInPreviously returns false if value is not present in shared preferences`() {
         assertFalse(settingsDiskSource.getUserHasSignedInPreviously(userId = "haveNotSignedIn"))
     }
+
+    @Test
+    fun `storeShowAutoFillSettingBadge should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val showAutofillSettingBadgeKey =
+            "bwPreferencesStorage:showAutofillSettingBadge_$mockUserId"
+        settingsDiskSource.storeShowAutoFillSettingBadge(
+            userId = mockUserId,
+            showBadge = true,
+        )
+        assertTrue(fakeSharedPreferences.getBoolean(showAutofillSettingBadgeKey, false))
+    }
+
+    @Test
+    fun `getShowAutoFillSettingBadge should pull value from shared preferences`() {
+        val mockUserId = "mockUserId"
+        val showAutofillSettingBadgeKey =
+            "bwPreferencesStorage:showAutofillSettingBadge_$mockUserId"
+        fakeSharedPreferences.edit {
+            putBoolean(showAutofillSettingBadgeKey, true)
+        }
+
+        assertTrue(settingsDiskSource.getShowAutoFillSettingBadge(userId = mockUserId))
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -61,6 +61,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private var storedSystemBiometricIntegritySource: String? = null
     private val storedAccountBiometricIntegrityValidity = mutableMapOf<String, Boolean?>()
     private val userSignIns = mutableMapOf<String, Boolean>()
+    private val userShowAutoFillBadge = mutableMapOf<String, Boolean>()
 
     override var appLanguage: AppLanguage? = null
 
@@ -283,6 +284,13 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     }
 
     override fun getUserHasSignedInPreviously(userId: String): Boolean = userSignIns[userId] == true
+
+    override fun getShowAutoFillSettingBadge(userId: String): Boolean =
+        userShowAutoFillBadge[userId] == true
+
+    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean) {
+        userShowAutoFillBadge[userId] = showBadge
+    }
 
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {
         return mutableScreenCaptureAllowedFlowMap.getOrPut(userId) {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -61,7 +61,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private var storedSystemBiometricIntegritySource: String? = null
     private val storedAccountBiometricIntegrityValidity = mutableMapOf<String, Boolean?>()
     private val userSignIns = mutableMapOf<String, Boolean>()
-    private val userShowAutoFillBadge = mutableMapOf<String, Boolean>()
+    private val userShowAutoFillBadge = mutableMapOf<String, Boolean?>()
 
     override var appLanguage: AppLanguage? = null
 
@@ -289,9 +289,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         userShowAutoFillBadge[userId]
 
     override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?) {
-        showBadge?.let {
-            userShowAutoFillBadge[userId] = it
-        }
+        userShowAutoFillBadge[userId] = showBadge
     }
 
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -285,11 +285,13 @@ class FakeSettingsDiskSource : SettingsDiskSource {
 
     override fun getUserHasSignedInPreviously(userId: String): Boolean = userSignIns[userId] == true
 
-    override fun getShowAutoFillSettingBadge(userId: String): Boolean =
-        userShowAutoFillBadge[userId] == true
+    override fun getShowAutoFillSettingBadge(userId: String): Boolean? =
+        userShowAutoFillBadge[userId]
 
-    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean) {
-        userShowAutoFillBadge[userId] = showBadge
+    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?) {
+        showBadge?.let {
+            userShowAutoFillBadge[userId] = it
+        }
     }
 
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1153,14 +1153,14 @@ class SettingsRepositoryTest {
     fun `storeShowAutoFillSettingBadge should store value of false to disk`() {
         val userId = "userId"
         settingsRepository.storeShowAutoFillSettingBadge(userId = userId, showBadge = false)
-        assertFalse(fakeSettingsDiskSource.getShowAutoFillSettingBadge(userId = userId))
+        assertFalse(fakeSettingsDiskSource.getShowAutoFillSettingBadge(userId = userId)!!)
     }
 
     @Test
     fun `storeShowAutoFillSettingBadge should store value of true to disk`() {
         val userId = "userId"
         settingsRepository.storeShowAutoFillSettingBadge(userId = userId, showBadge = true)
-        assertTrue(fakeSettingsDiskSource.getShowAutoFillSettingBadge(userId = userId))
+        assertTrue(fakeSettingsDiskSource.getShowAutoFillSettingBadge(userId = userId)!!)
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1148,6 +1148,33 @@ class SettingsRepositoryTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             assertFalse(settingsRepository.isAuthenticatorSyncEnabled)
         }
+
+    @Test
+    fun `storeShowAutoFillSettingBadge should store value of false to disk`() {
+        val userId = "userId"
+        settingsRepository.storeShowAutoFillSettingBadge(userId = userId, showBadge = false)
+        assertFalse(fakeSettingsDiskSource.getShowAutoFillSettingBadge(userId = userId))
+    }
+
+    @Test
+    fun `storeShowAutoFillSettingBadge should store value of true to disk`() {
+        val userId = "userId"
+        settingsRepository.storeShowAutoFillSettingBadge(userId = userId, showBadge = true)
+        assertTrue(fakeSettingsDiskSource.getShowAutoFillSettingBadge(userId = userId))
+    }
+
+    @Test
+    fun `getShowAutoFillSettingBadge get value of false if does not exist`() {
+        val userId = "userId"
+        assertFalse(settingsRepository.getShowAutoFillSettingBadge(userId = userId))
+    }
+
+    @Test
+    fun `getShowAutoFillSettingBadge should return the value saved to disk`() {
+        val userId = "userId"
+        fakeSettingsDiskSource.storeShowAutoFillSettingBadge(userId = userId, showBadge = true)
+        assertTrue(settingsRepository.getShowAutoFillSettingBadge(userId = userId))
+    }
 }
 
 private const val USER_ID: String = "userId"

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
@@ -4,7 +4,6 @@ import app.cash.turbine.test
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
-import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
@@ -27,15 +26,6 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
         every { isAutofillEnabledStateFlow } returns mutableAutoFillEnabledStateFlow
         every { disableAutofill() } just runs
         every { storeShowAutoFillSettingBadge(any(), any()) } just runs
-    }
-
-    private val mockUserState = mockk<UserState> {
-        every { activeUserId } returns DEFAULT_USER_ID
-    }
-    private val mutableUserStateFlow = MutableStateFlow<UserState?>(mockUserState)
-    private val authRepository: AuthRepository = mockk {
-        every { userStateFlow } returns mutableUserStateFlow
-        every { setOnboardingStatus(any(), any()) } just runs
     }
 
     private val mockUserState = mockk<UserState> {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
@@ -22,9 +23,19 @@ import org.junit.jupiter.api.Test
 class SetupAutoFillViewModelTest : BaseViewModelTest() {
 
     private val mutableAutoFillEnabledStateFlow = MutableStateFlow(false)
-    private val settingsRepository = mockk<SettingsRepository>(relaxed = true) {
+    private val settingsRepository = mockk<SettingsRepository> {
         every { isAutofillEnabledStateFlow } returns mutableAutoFillEnabledStateFlow
         every { disableAutofill() } just runs
+        every { storeShowAutoFillSettingBadge(any(), any()) } just runs
+    }
+
+    private val mockUserState = mockk<UserState> {
+        every { activeUserId } returns DEFAULT_USER_ID
+    }
+    private val mutableUserStateFlow = MutableStateFlow<UserState?>(mockUserState)
+    private val authRepository: AuthRepository = mockk {
+        every { userStateFlow } returns mutableUserStateFlow
+        every { setOnboardingStatus(any(), any()) } just runs
     }
 
     private val mockUserState = mockk<UserState> {
@@ -127,8 +138,22 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
             )
         }
     }
+    @Test
+    fun `handleTurnOnLaterConfirmClick sets showAutoFillSettingBadge to true`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(SetupAutoFillAction.TurnOnLaterConfirmClick)
+        verify {
+            settingsRepository.storeShowAutoFillSettingBadge(
+                userId = DEFAULT_USER_ID,
+                showBadge = true,
+            )
+        }
+    }
 
-    private fun createViewModel() = SetupAutoFillViewModel(settingsRepository, authRepository)
+    private fun createViewModel() = SetupAutoFillViewModel(
+        settingsRepository = settingsRepository,
+        authRepository = authRepository,
+    )
 }
 
 private const val DEFAULT_USER_ID = "userId"


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-10631
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- when a user clicks the "turn on later" option on the autofill setup screen, if they confirm we want to keep track of that to show the badge later.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
