### PR TITLE
[PM-12289] add onboarding status override to debug menu

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepository.kt
@@ -32,4 +32,9 @@ interface DebugMenuRepository {
      * Reset all feature flag overrides to their default values or values from the network.
      */
     fun resetFeatureFlagOverrides()
+
+    /**
+     * Resets the onboarding status to NOT_STARTED for the current active user, if applicable.
+     */
+    fun resetOnboardingStatusForCurrentUser()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.x8bit.bitwarden.data.platform.repository
 
 import com.x8bit.bitwarden.BuildConfig
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDiskSource
 import com.x8bit.bitwarden.data.platform.manager.getFlagValueOrDefault
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
@@ -14,6 +16,7 @@ import kotlinx.coroutines.flow.onSubscription
 class DebugMenuRepositoryImpl(
     private val featureFlagOverrideDiskSource: FeatureFlagOverrideDiskSource,
     private val serverConfigRepository: ServerConfigRepository,
+    private val authDiskSource: AuthDiskSource,
 ) : DebugMenuRepository {
 
     private val mutableOverridesUpdatedFlow = bufferedMutableSharedFlow<Unit>(replay = 1)
@@ -41,5 +44,13 @@ class DebugMenuRepositoryImpl(
                 currentServerConfig.getFlagValueOrDefault(flagKey),
             )
         }
+    }
+
+    override fun resetOnboardingStatusForCurrentUser() {
+        val currentUserId = authDiskSource.userState?.activeUserId ?: return
+        authDiskSource.storeOnboardingStatus(
+            userId = currentUserId,
+            onboardingStatus = OnboardingStatus.NOT_STARTED,
+        )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -93,8 +93,10 @@ object PlatformRepositoryModule {
     fun provideDebugMenuRepository(
         featureFlagOverrideDiskSource: FeatureFlagOverrideDiskSource,
         serverConfigRepository: ServerConfigRepository,
+        authDiskSource: AuthDiskSource,
     ): DebugMenuRepository = DebugMenuRepositoryImpl(
         featureFlagOverrideDiskSource = featureFlagOverrideDiskSource,
         serverConfigRepository = serverConfigRepository,
+        authDiskSource = authDiskSource,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
@@ -44,7 +44,12 @@ class DebugMenuViewModel @Inject constructor(
             is DebugMenuAction.Internal.UpdateFeatureFlagMap -> handleUpdateFeatureFlagMap(action)
             DebugMenuAction.NavigateBack -> handleNavigateBack()
             DebugMenuAction.ResetFeatureFlagValues -> handleResetFeatureFlagValues()
+            DebugMenuAction.ReStartOnboarding -> handleResetOnboardingStatus()
         }
+    }
+
+    private fun handleResetOnboardingStatus() {
+        debugMenuRepository.resetOnboardingStatusForCurrentUser()
     }
 
     private fun handleResetFeatureFlagValues() {
@@ -103,9 +108,14 @@ sealed class DebugMenuAction {
     data object NavigateBack : DebugMenuAction()
 
     /**
-     * The user has clicked "reset" button.
+     * The user has clicked "reset" button. For the feature flag section.
      */
     data object ResetFeatureFlagValues : DebugMenuAction()
+
+    /**
+     * The user has clicked the restart onboarding button for the onboarding section.
+     */
+    data object ReStartOnboarding : DebugMenuAction()
 
     /**
      * Internal actions not triggered from the UI.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
@@ -108,7 +108,7 @@ sealed class DebugMenuAction {
     data object NavigateBack : DebugMenuAction()
 
     /**
-     * The user has clicked "reset" button. For the feature flag section.
+     * The user has clicked "reset" button for the feature flag section.
      */
     data object ResetFeatureFlagValues : DebugMenuAction()
 

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -14,5 +14,8 @@
     <string name="feature_flags">Feature Flags:</string>
     <string name="debug_menu">Debug Menu</string>
     <string name="reset_values">Reset values</string>
+    <string name="onboarding_override">Onboarding Status Override</string>
+    <string name="restart_onboarding_cta">Restart Onboarding</string>
+    <string name="restart_onboarding_details">This will reset the onboarding status for the current user, if available. After clicking the button you will immediately be redirected to the onboarding flow. Onboarding flag must be enabled.</string>
     <!-- /Debug Menu -->
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
@@ -1,9 +1,12 @@
 package com.x8bit.bitwarden.ui.platform.feature.debugmenu
 
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.printToLog
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
@@ -100,8 +103,46 @@ class DebugMenuScreenTest : BaseComposeTest() {
     fun `reset feature flag values should send action when clicked`() {
         composeTestRule
             .onNodeWithText("Reset Values", ignoreCase = true)
+            .performScrollTo()
             .performClick()
 
         verify { viewModel.trySendAction(DebugMenuAction.ResetFeatureFlagValues) }
+    }
+
+    @Test
+    fun `restart onboarding should send action when clicked`() {
+        mutableStateFlow.tryEmit(
+            DebugMenuState(
+                featureFlags = mapOf(
+                    FlagKey.OnboardingFlow to true,
+                ),
+            ),
+        )
+        composeTestRule
+            .onNodeWithText("Restart Onboarding", ignoreCase = true)
+            .performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+
+        verify { viewModel.trySendAction(DebugMenuAction.ReStartOnboarding) }
+    }
+
+    @Test
+    fun `no restart onboarding should not send action when not enabled`() {
+        mutableStateFlow.tryEmit(
+            DebugMenuState(
+                featureFlags = mapOf(
+                    FlagKey.OnboardingFlow to false,
+                ),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithText("Restart Onboarding", ignoreCase = true)
+            .performScrollTo()
+            .assertIsNotEnabled()
+            .performClick()
+
+        verify(exactly = 0) { viewModel.trySendAction(DebugMenuAction.ReStartOnboarding) }
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -23,9 +23,10 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
         every { getFeatureFlagFlow<Boolean>(any()) } returns flowOf(true)
     }
 
-    private val mockDebugMenuRepository = mockk<DebugMenuRepository>(relaxed = true) {
+    private val mockDebugMenuRepository = mockk<DebugMenuRepository> {
         coEvery { resetFeatureFlagOverrides() } just runs
         every { updateFeatureFlag<Boolean>(any(), any()) } just runs
+        every { resetOnboardingStatusForCurrentUser() } just runs
     }
 
     @Test
@@ -67,6 +68,13 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
             DebugMenuAction.UpdateFeatureFlag(FlagKey.EmailVerification, false),
         )
         verify { mockDebugMenuRepository.updateFeatureFlag(FlagKey.EmailVerification, false) }
+    }
+
+    @Test
+    fun `handleResetOnboardingStatus should reset the onboarding status`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(DebugMenuAction.ReStartOnboarding)
+        verify { mockDebugMenuRepository.resetOnboardingStatusForCurrentUser() }
     }
 
     private fun createViewModel(): DebugMenuViewModel = DebugMenuViewModel(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12289
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- allow for a way to re-enter the onboarding flow outside of creating a new account or logging in a new user.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/8534e615-a81e-4e58-8b84-4f7b5d509a2b


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
