### PR TITLE
[PM-10622] Handle the skip unlock step in the onboarding, storing when the user selects to do so.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -275,11 +275,11 @@ interface SettingsDiskSource {
      * Gets whether or not the given [userId] has signalled they want to enable unlock options
      * later, during onboarding.
      */
-    fun getShowUnlockSettingBadge(userId: String): Boolean
+    fun getShowUnlockSettingBadge(userId: String): Boolean?
 
     /**
      * Stores the given value for whether or not the given [userId] has signalled they want to
      * set up unlock options later, during onboarding.
      */
-    fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean)
+    fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean?)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -270,4 +270,16 @@ interface SettingsDiskSource {
      * enable autofill in onboarding.
      */
     fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?)
+
+    /**
+     * Gets whether or not the given [userId] has signalled they want to enable unlock options
+     * later, during onboarding.
+     */
+    fun getShowUnlockSettingBadge(userId: String): Boolean
+
+    /**
+     * Stores the given value for whether or not the given [userId] has signalled they want to
+     * set up unlock options later, during onboarding.
+     */
+    fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -409,12 +409,12 @@ class SettingsDiskSourceImpl(
             value = showBadge,
         )
 
-    override fun getShowUnlockSettingBadge(userId: String): Boolean =
+    override fun getShowUnlockSettingBadge(userId: String): Boolean? =
         getBoolean(
             key = SHOW_UNLOCK_SETTING_BADGE.appendIdentifier(userId),
-        ) == true
+        )
 
-    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean) =
+    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean?) =
         putBoolean(
             key = SHOW_UNLOCK_SETTING_BADGE.appendIdentifier(userId),
             value = showBadge,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -34,6 +34,7 @@ private const val CLEAR_CLIPBOARD_INTERVAL_KEY = "clearClipboard"
 private const val INITIAL_AUTOFILL_DIALOG_SHOWN = "addSitePromptShown"
 private const val HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY = "hasUserLoggedInOrCreatedAccount"
 private const val SHOW_AUTOFILL_SETTING_BADGE = "showAutofillSettingBadge"
+private const val SHOW_UNLOCK_SETTING_BADGE = "showUnlockSettingBadge"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -405,6 +406,17 @@ class SettingsDiskSourceImpl(
     override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?) =
         putBoolean(
             key = SHOW_AUTOFILL_SETTING_BADGE.appendIdentifier(userId),
+            value = showBadge,
+        )
+
+    override fun getShowUnlockSettingBadge(userId: String): Boolean =
+        getBoolean(
+            key = SHOW_UNLOCK_SETTING_BADGE.appendIdentifier(userId),
+        ) == true
+
+    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean) =
+        putBoolean(
+            key = SHOW_UNLOCK_SETTING_BADGE.appendIdentifier(userId),
             value = showBadge,
         )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -256,14 +256,26 @@ interface SettingsRepository {
     fun storeUserHasLoggedInValue(userId: String)
 
     /**
-     * Gets whether or not the given [userId] has signalled they want to enable autofill in
-     * onboarding.
+     * Gets whether or not the given [userId] has signalled they want to enable autofill
+     * later, during onboarding.
      */
     fun getShowAutoFillSettingBadge(userId: String): Boolean
 
     /**
      * Stores the given value for whether or not the given [userId] has signalled they want to
-     * enable autofill in onboarding.
+     * enable autofill later, during onboarding.
      */
     fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean)
+
+    /**
+     * Gets whether or not the given [userId] has signalled they want to enable unlock options
+     * later, during onboarding.
+     */
+    fun getShowUnlockSettingBadge(userId: String): Boolean
+
+    /**
+     * Stores the given value for whether or not the given [userId] has signalled they want to
+     * set up unlock options later, during onboarding.
+     */
+    fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -545,6 +545,13 @@ class SettingsRepositoryImpl(
         settingsDiskSource.storeShowAutoFillSettingBadge(userId, showBadge)
     }
 
+    override fun getShowUnlockSettingBadge(userId: String): Boolean =
+        settingsDiskSource.getShowUnlockSettingBadge(userId)
+
+    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean) {
+        settingsDiskSource.storeShowUnlockSettingBadge(userId, showBadge)
+    }
+
     /**
      * If there isn't already one generated, generate a symmetric sync key that would be used
      * for communicating via IPC.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -546,7 +546,7 @@ class SettingsRepositoryImpl(
     }
 
     override fun getShowUnlockSettingBadge(userId: String): Boolean =
-        settingsDiskSource.getShowUnlockSettingBadge(userId)
+        settingsDiskSource.getShowUnlockSettingBadge(userId) ?: false
 
     override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean) {
         settingsDiskSource.storeShowUnlockSettingBadge(userId, showBadge)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
@@ -95,6 +95,7 @@ class SetupUnlockViewModel @Inject constructor(
     }
 
     private fun handleSetUpLaterClick() {
+        settingsRepository.storeShowUnlockSettingBadge(state.userId, true)
         updateOnboardingStatusToNextStep()
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1053,4 +1053,28 @@ class SettingsDiskSourceTest {
 
         assertTrue(settingsDiskSource.getShowAutoFillSettingBadge(userId = mockUserId)!!)
     }
+
+    @Test
+    fun `storeShowUnlockSettingBadge should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val showUnlockSettingBadgeKey =
+            "bwPreferencesStorage:showUnlockSettingBadge_$mockUserId"
+        settingsDiskSource.storeShowUnlockSettingBadge(
+            userId = mockUserId,
+            showBadge = true,
+        )
+        assertTrue(fakeSharedPreferences.getBoolean(showUnlockSettingBadgeKey, false))
+    }
+
+    @Test
+    fun `getShowUnlockSettingBadge should pull value from shared preferences`() {
+        val mockUserId = "mockUserId"
+        val showUnlockSettingBadgeKey =
+            "bwPreferencesStorage:showUnlockSettingBadge_$mockUserId"
+        fakeSharedPreferences.edit {
+            putBoolean(showUnlockSettingBadgeKey, true)
+        }
+
+        assertTrue(settingsDiskSource.getShowUnlockSettingBadge(userId = mockUserId))
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1075,6 +1075,6 @@ class SettingsDiskSourceTest {
             putBoolean(showUnlockSettingBadgeKey, true)
         }
 
-        assertTrue(settingsDiskSource.getShowUnlockSettingBadge(userId = mockUserId))
+        assertTrue(settingsDiskSource.getShowUnlockSettingBadge(userId = mockUserId)!!)
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -62,7 +62,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val storedAccountBiometricIntegrityValidity = mutableMapOf<String, Boolean?>()
     private val userSignIns = mutableMapOf<String, Boolean>()
     private val userShowAutoFillBadge = mutableMapOf<String, Boolean?>()
-   private val userShowUnlockBadge = mutableMapOf<String, Boolean>()
+    private val userShowUnlockBadge = mutableMapOf<String, Boolean?>()
 
     override var appLanguage: AppLanguage? = null
 
@@ -293,10 +293,10 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         userShowAutoFillBadge[userId] = showBadge
     }
 
-    override fun getShowUnlockSettingBadge(userId: String): Boolean =
-        userShowUnlockBadge[userId] == true
+    override fun getShowUnlockSettingBadge(userId: String): Boolean? =
+        userShowUnlockBadge[userId]
 
-    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean) {
+    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean?) {
         userShowUnlockBadge[userId] = showBadge
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -62,6 +62,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val storedAccountBiometricIntegrityValidity = mutableMapOf<String, Boolean?>()
     private val userSignIns = mutableMapOf<String, Boolean>()
     private val userShowAutoFillBadge = mutableMapOf<String, Boolean?>()
+   private val userShowUnlockBadge = mutableMapOf<String, Boolean>()
 
     override var appLanguage: AppLanguage? = null
 
@@ -290,6 +291,13 @@ class FakeSettingsDiskSource : SettingsDiskSource {
 
     override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?) {
         userShowAutoFillBadge[userId] = showBadge
+    }
+
+    override fun getShowUnlockSettingBadge(userId: String): Boolean =
+        userShowUnlockBadge[userId] == true
+
+    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean) {
+        userShowUnlockBadge[userId] = showBadge
     }
 
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1177,6 +1177,20 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `storeShowUnlockSettingBadge should store value of false to disk`() {
+        val userId = "userId"
+        settingsRepository.storeShowUnlockSettingBadge(userId = userId, showBadge = false)
+        assertFalse(fakeSettingsDiskSource.getShowUnlockSettingBadge(userId = userId)!!)
+    }
+
+    @Test
+    fun `storeShowUnlockSettingBadge should store value of true to disk`() {
+        val userId = "userId"
+        settingsRepository.storeShowUnlockSettingBadge(userId = userId, showBadge = true)
+        assertTrue(fakeSettingsDiskSource.getShowUnlockSettingBadge(userId = userId)!!)
+    }
+
+    @Test
     fun `getUnlockSettingBadge get value of false if does not exist`() {
         val userId = "userId"
         assertFalse(settingsRepository.getShowUnlockSettingBadge(userId = userId))

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1175,6 +1175,19 @@ class SettingsRepositoryTest {
         fakeSettingsDiskSource.storeShowAutoFillSettingBadge(userId = userId, showBadge = true)
         assertTrue(settingsRepository.getShowAutoFillSettingBadge(userId = userId))
     }
+
+    @Test
+    fun `getUnlockSettingBadge get value of false if does not exist`() {
+        val userId = "userId"
+        assertFalse(settingsRepository.getShowUnlockSettingBadge(userId = userId))
+    }
+
+    @Test
+    fun `getShowUnlockSettingBadge should return the value saved to disk`() {
+        val userId = "userId"
+        fakeSettingsDiskSource.storeShowUnlockSettingBadge(userId = userId, showBadge = true)
+        assertTrue(settingsRepository.getShowUnlockSettingBadge(userId = userId))
+    }
 }
 
 private const val USER_ID: String = "userId"

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
@@ -40,6 +40,7 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
         every { isUnlockWithPinEnabled } returns false
         every { isUnlockWithBiometricsEnabled } returns false
         every { isAutofillEnabledStateFlow } returns mutableAutofillEnabledStateFlow
+        every { storeShowUnlockSettingBadge(any(), any()) } just runs
     }
     private val biometricsEncryptionManager: BiometricsEncryptionManager = mockk {
         every { getOrCreateCipher(userId = DEFAULT_USER_ID) } returns CIPHER
@@ -80,6 +81,7 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
                 userId = DEFAULT_USER_ID,
                 status = OnboardingStatus.AUTOFILL_SETUP,
             )
+            settingsRepository.storeShowUnlockSettingBadge(DEFAULT_USER_ID, true)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-10622
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- when the use selects to skip the onboarding step of setting up an unlock option, store that selection so we can show the badge on the settings later.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
