### PR TITLE
Create reusable isAccessibilityServiceEnabled extension

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityActivityManagerImpl.kt
@@ -1,9 +1,8 @@
 package com.x8bit.bitwarden.data.autofill.accessibility.manager
 
 import android.content.Context
-import android.provider.Settings
 import androidx.lifecycle.LifecycleCoroutineScope
-import com.x8bit.bitwarden.LEGACY_ACCESSIBILITY_SERVICE_NAME
+import com.x8bit.bitwarden.data.autofill.accessibility.util.isAccessibilityServiceEnabled
 import com.x8bit.bitwarden.data.platform.manager.AppForegroundManager
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -17,28 +16,12 @@ class AccessibilityActivityManagerImpl(
     appForegroundManager: AppForegroundManager,
     lifecycleScope: LifecycleCoroutineScope,
 ) : AccessibilityActivityManager {
-    private val isAccessibilityServiceEnabled: Boolean
-        get() {
-            val appContext = context.applicationContext
-            val accessibilityService = appContext
-                .packageName
-                ?.let { "$it/$LEGACY_ACCESSIBILITY_SERVICE_NAME" }
-                ?: return false
-            return Settings
-                .Secure
-                .getString(
-                    appContext.contentResolver,
-                    Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
-                )
-                ?.contains(accessibilityService)
-                ?: false
-        }
-
     init {
         appForegroundManager
             .appForegroundStateFlow
             .onEach {
-                accessibilityEnabledManager.isAccessibilityEnabled = isAccessibilityServiceEnabled
+                accessibilityEnabledManager.isAccessibilityEnabled =
+                    context.isAccessibilityServiceEnabled
             }
             .launchIn(lifecycleScope)
     }

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/ContextExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/ContextExtensions.kt
@@ -1,0 +1,26 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.util
+
+import android.content.Context
+import android.provider.Settings
+import com.x8bit.bitwarden.LEGACY_ACCESSIBILITY_SERVICE_NAME
+import com.x8bit.bitwarden.data.autofill.accessibility.BitwardenAccessibilityService
+
+/**
+ * Helper method to determine if the [BitwardenAccessibilityService] is enabled.
+ */
+val Context.isAccessibilityServiceEnabled: Boolean
+    get() {
+        val appContext = this.applicationContext
+        val accessibilityServiceName = appContext
+            .packageName
+            ?.let { "$it/$LEGACY_ACCESSIBILITY_SERVICE_NAME" }
+            ?: return false
+        return Settings
+            .Secure
+            .getString(
+                appContext.contentResolver,
+                Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
+            )
+            ?.contains(accessibilityServiceName)
+            ?: false
+    }

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/util/ContextExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/util/ContextExtensionsTest.kt
@@ -1,0 +1,83 @@
+package com.x8bit.bitwarden.data.autofill.accessibility.util
+
+import android.content.Context
+import android.provider.Settings
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ContextExtensionsTest {
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(Settings.Secure::getString)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Settings.Secure::getString)
+    }
+
+    @Test
+    fun `isAccessibilityServiceEnabled with null package name returns false`() {
+        val context: Context = mockk {
+            every { applicationContext } returns this
+            every { packageName } returns null
+        }
+
+        assertFalse(context.isAccessibilityServiceEnabled)
+    }
+
+    @Test
+    fun `isAccessibilityServiceEnabled with null secure string returns false`() {
+        val context: Context = mockk {
+            every { applicationContext } returns this
+            every { packageName } returns "com.x8bit.bitwarden"
+            every { contentResolver } returns mockk()
+        }
+        mockkSettingsSecureGetString(value = null)
+
+        assertFalse(context.isAccessibilityServiceEnabled)
+    }
+
+    @Test
+    fun `isAccessibilityServiceEnabled with incorrect secure string returns false`() {
+        val context: Context = mockk {
+            every { applicationContext } returns this
+            every { packageName } returns "com.x8bit.bitwarden"
+            every { contentResolver } returns mockk()
+        }
+        @Suppress("MaxLineLength")
+        mockkSettingsSecureGetString(
+            value = "com.x8bit.bitwarden.dev/com.x8bit.bitwarden.Accessibility.AccessibilityService",
+        )
+
+        assertFalse(context.isAccessibilityServiceEnabled)
+    }
+
+    @Test
+    fun `isAccessibilityServiceEnabled with correct secure string returns true`() {
+        val context: Context = mockk {
+            every { applicationContext } returns this
+            every { packageName } returns "com.x8bit.bitwarden"
+            every { contentResolver } returns mockk()
+        }
+        mockkSettingsSecureGetString(
+            value = "com.x8bit.bitwarden/com.x8bit.bitwarden.Accessibility.AccessibilityService",
+        )
+
+        assertTrue(context.isAccessibilityServiceEnabled)
+    }
+
+    private fun mockkSettingsSecureGetString(value: String?) {
+        every {
+            Settings.Secure.getString(any(), Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+        } returns value
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR creates a reusable extension for determining if the accessibility service is enabled. It is currently only used in one spot but will be used in other places soon.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
