### PR TITLE
PM-12297: Add accessibility service alert for autofill tile

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/tiles/BitwardenAutofillTileService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tiles/BitwardenAutofillTileService.kt
@@ -1,14 +1,18 @@
 package com.x8bit.bitwarden.data.tiles
 
 import android.annotation.SuppressLint
+import android.app.AlertDialog
+import android.app.Dialog
 import android.app.PendingIntent
 import android.content.Intent
 import android.os.Build
 import android.service.quicksettings.TileService
 import androidx.annotation.Keep
 import com.x8bit.bitwarden.AccessibilityActivity
+import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityAutofillManager
 import com.x8bit.bitwarden.data.autofill.accessibility.model.AccessibilityAction
+import com.x8bit.bitwarden.data.autofill.accessibility.util.isAccessibilityServiceEnabled
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,6 +38,10 @@ class BitwardenAutofillTileService : TileService() {
 
     @SuppressLint("StartActivityAndCollapseDeprecated")
     private fun launchAutofill() {
+        if (!applicationContext.isAccessibilityServiceEnabled) {
+            showDialog(getAccessibilityServiceRequiredDialog())
+            return
+        }
         accessibilityAutofillManager.accessibilityAction = AccessibilityAction.AttemptParseUri
         val intent = Intent(applicationContext, AccessibilityActivity::class.java)
         if (isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
@@ -50,4 +58,11 @@ class BitwardenAutofillTileService : TileService() {
             )
         }
     }
+
+    private fun getAccessibilityServiceRequiredDialog(): Dialog =
+        AlertDialog.Builder(this)
+            .setMessage(R.string.autofill_tile_accessibility_required)
+            .setCancelable(true)
+            .setPositiveButton(R.string.ok) { dialog, _ -> dialog.cancel() }
+            .create()
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12297](https://bitwarden.atlassian.net/browse/PM-12297)

## 📔 Objective

This PR adds a alert dialog to the `BitwardenAutofillTileService` whenever a user attempts to invoke the service but the `BitwardenAccessibilityService` is not enabled.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/0963f4e8-f5d3-4226-9328-647dc9225330" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12297]: https://bitwarden.atlassian.net/browse/PM-12297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ