### PR TITLE
[PM-12319] Skip Auto-fill setup if already enabled.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
@@ -176,7 +176,12 @@ class SetupUnlockViewModel @Inject constructor(
     }
 
     private fun updateOnboardingStatusToNextStep() {
-        authRepository.setOnboardingStatus(state.userId, OnboardingStatus.AUTOFILL_SETUP)
+        val nextStep = if (settingsRepository.isAutofillEnabledStateFlow.value) {
+            OnboardingStatus.FINAL_STEP
+        } else {
+            OnboardingStatus.AUTOFILL_SETUP
+        }
+        authRepository.setOnboardingStatus(state.userId, nextStep)
     }
 }
 


### PR DESCRIPTION

## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12319
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- If the auto fill service is already enabled on the device a user is onboarding on, we should skip that step in the onboarding flow.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/b4a73be7-bf83-4dae-8f4c-89d79488be6a


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
