### PR TITLE
[PM-10118]  update selected generator type when returning to main tab.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -54,9 +54,11 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
+import com.x8bit.bitwarden.ui.platform.base.util.LivecycleEventEffect
 import com.x8bit.bitwarden.ui.platform.base.util.toDp
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenMediumTopAppBar
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
@@ -106,6 +108,16 @@ fun GeneratorScreen(
     val context = LocalContext.current
     val resources = context.resources
     val snackbarHostState = remember { SnackbarHostState() }
+
+    LivecycleEventEffect { _, event ->
+        when (event) {
+            Lifecycle.Event.ON_RESUME -> {
+                viewModel.trySendAction(GeneratorAction.LifecycleResume)
+            }
+
+            else -> Unit
+        }
+    }
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -140,7 +140,7 @@ class GeneratorViewModel @Inject constructor(
 
     private fun handleOnResumed() {
         // when the screen resumes we need to refresh the options for the current option from
-        // disk in the even they were changed while the screen was in the foreground.
+        // disk in the event they were changed while the screen was in the foreground.
         loadOptions(shouldUseStorageOptions = true)
     }
 
@@ -277,20 +277,28 @@ class GeneratorViewModel @Inject constructor(
     private fun loadOptions(shouldUseStorageOptions: Boolean = false) {
         when (val selectedType = state.selectedType) {
             is Passcode -> {
-                val savedOptionsType: Passcode.PasscodeType? = generatorRepository
-                    .getPasscodeGenerationOptions()
-                    ?.passcodeType
-                    .takeIf { shouldUseStorageOptions }
-                val mainType = savedOptionsType?.let { Passcode(it) } ?: selectedType
+                val mainType = if (shouldUseStorageOptions) {
+                    generatorRepository
+                        .getPasscodeGenerationOptions()
+                        ?.passcodeType
+                        ?.let { Passcode(it) }
+                        ?: selectedType
+                } else {
+                    selectedType
+                }
                 loadPasscodeOptions(selectedType = mainType)
             }
 
             is Username -> {
-                val savedOptionsType = generatorRepository
-                    .getUsernameGenerationOptions()
-                    ?.usernameType
-                    .takeIf { shouldUseStorageOptions }
-                val mainType = savedOptionsType?.let { Username(it) } ?: selectedType
+                val mainType = if (shouldUseStorageOptions) {
+                    generatorRepository
+                        .getUsernameGenerationOptions()
+                        ?.usernameType
+                        ?.let { Username(it) }
+                        ?: selectedType
+                } else {
+                    selectedType
+                }
                 loadUsernameOptions(
                     selectedType = mainType,
                     forceRegeneration = mainType.selectedType !is ForwardedEmailAlias,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -1690,6 +1690,11 @@ class GeneratorScreenTest : BaseComposeTest() {
         }
     }
 
+    @Test
+    fun `send LifecycleResumed action on screen resume`() {
+        verify { viewModel.trySendAction(GeneratorAction.LifecycleResume) }
+    }
+
     //endregion Random Word Tests
 
     private fun updateState(state: GeneratorState) {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -545,7 +545,8 @@ class GeneratorScreenTest : BaseComposeTest() {
             .performScrollTo()
             .performClick()
 
-        verify(exactly = 0) { viewModel.trySendAction(any()) }
+        verify(exactly = 1) { viewModel.trySendAction(GeneratorAction.LifecycleResume) }
+        verify(exactly = 1) { viewModel.trySendAction(any()) }
     }
 
     @Suppress("MaxLineLength")
@@ -573,7 +574,8 @@ class GeneratorScreenTest : BaseComposeTest() {
             .performScrollTo()
             .performClick()
 
-        verify(exactly = 0) { viewModel.trySendAction(any()) }
+        verify(exactly = 1) { viewModel.trySendAction(GeneratorAction.LifecycleResume) }
+        verify(exactly = 1) { viewModel.trySendAction(any()) }
     }
 
     @Suppress("MaxLineLength")
@@ -642,8 +644,8 @@ class GeneratorScreenTest : BaseComposeTest() {
             .filterToOne(hasContentDescription("\u2212"))
             .performScrollTo()
             .performClick()
-
-        verify(exactly = 0) { viewModel.trySendAction(any()) }
+        verify(exactly = 1) { viewModel.trySendAction(GeneratorAction.LifecycleResume) }
+        verify(exactly = 1) { viewModel.trySendAction(any()) }
     }
 
     @Suppress("MaxLineLength")
@@ -670,8 +672,8 @@ class GeneratorScreenTest : BaseComposeTest() {
             .filterToOne(hasContentDescription("+"))
             .performScrollTo()
             .performClick()
-
-        verify(exactly = 0) { viewModel.trySendAction(any()) }
+        verify(exactly = 1) { viewModel.trySendAction(GeneratorAction.LifecycleResume) }
+        verify(exactly = 1) { viewModel.trySendAction(any()) }
     }
 
     @Suppress("MaxLineLength")
@@ -1002,7 +1004,8 @@ class GeneratorScreenTest : BaseComposeTest() {
             .filterToOne(hasContentDescription("\u2212"))
             .performScrollTo()
             .performClick()
-        verify(exactly = 0) { viewModel.trySendAction(any()) }
+        verify(exactly = 1) { viewModel.trySendAction(GeneratorAction.LifecycleResume) }
+        verify(exactly = 1) { viewModel.trySendAction(any()) }
     }
 
     @Test
@@ -1030,7 +1033,8 @@ class GeneratorScreenTest : BaseComposeTest() {
             .filterToOne(hasContentDescription("+"))
             .performScrollTo()
             .performClick()
-        verify(exactly = 0) { viewModel.trySendAction(any()) }
+        verify(exactly = 1) { viewModel.trySendAction(GeneratorAction.LifecycleResume) }
+        verify(exactly = 1) { viewModel.trySendAction(any()) }
     }
 
     @Suppress("MaxLineLength")

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -886,6 +886,52 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `LifecycleResumedAction should use passcode storage options derived state over VM state`() {
+        val initialState = initialPasscodeState
+        val viewModel = createViewModel(initialState)
+        fakeGeneratorRepository.savePasscodeGenerationOptions(
+            PasscodeGenerationOptions(
+                type = PasscodeGenerationOptions.PasscodeType.PASSPHRASE,
+                length = 14,
+                allowAmbiguousChar = false,
+                hasNumbers = false,
+                minNumber = 3,
+                hasUppercase = false,
+                minUppercase = null,
+                hasLowercase = false,
+                minLowercase = null,
+                allowSpecial = false,
+                minSpecial = 0,
+                numWords = 3,
+                wordSeparator = "-",
+                allowCapitalize = false,
+                allowIncludeNumber = false,
+            ),
+        )
+        val expectedState = initialState.copy(
+            selectedType = GeneratorState.MainType.Passcode(
+                selectedType = GeneratorState.MainType.Passcode.PasscodeType.Passphrase(
+                    numWords = 3,
+                    minNumWords = 3,
+                    maxNumWords = 20,
+                    wordSeparator = '-',
+                    capitalize = false,
+                    capitalizeEnabled = true,
+                    includeNumber = false,
+                    includeNumberEnabled = true,
+
+                ),
+            ),
+            generatedText = "updatedPassphrase",
+        )
+        viewModel.trySendAction(GeneratorAction.LifecycleResume)
+        assertEquals(
+            expectedState,
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
     fun `No LifecycleResumedAction should use VM state options derived state over VM state`() {
         val initialState = initialUsernameState.copy(
             selectedType = GeneratorState.MainType.Username(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -936,7 +936,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
             val initialState = initialUsernameState.copy(
                 selectedType = GeneratorState.MainType.Username(
                     selectedType = GeneratorState.MainType.Username.UsernameType.PlusAddressedEmail(
-                        email = "email",
+                        email = "currentEmail",
                     ),
                 ),
             )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -946,7 +946,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
             viewModel.stateFlow.test {
                 assertEquals(
                     initialState.copy(generatedText = "email+abcd1234@address.com"),
-                    awaitItem()
+                    awaitItem(),
                 )
                 // Setting the repository options to RANDOM_WORD to show this does NOT get used.
                 fakeGeneratorRepository.saveUsernameGenerationOptions(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-10118
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- User selected generation type should be sync'd across all versions of generator screen.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/709a5d17-81ca-4057-ab41-2cad34337fa9


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
