### PR TITLE
Update switch to represent disabled state

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenWideSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenWideSwitch.kt
@@ -99,6 +99,7 @@ fun BitwardenWideSwitch(
         Switch(
             modifier = Modifier
                 .height(56.dp),
+            enabled = enabled,
             checked = isChecked,
             onCheckedChange = null,
         )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR update the `BitwardenWideSwitch` to display the disabled state when needed.

This change is purely cosmetic, the rows were not clickable.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/cd9bb5ee-1b79-484f-b69c-91b4a9d3f99b" width="300" /> | <img src="https://github.com/user-attachments/assets/43a39f68-5834-4ef3-88e9-64c00aa6fdde" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
