### PR TITLE
BITAU-173 Return null symmetric key when no users have enabled Authen…

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepository.kt
@@ -10,7 +10,7 @@ interface AuthenticatorBridgeRepository {
 
     /**
      * The currently persisted authenticator sync symmetric key. This key is used for
-     * encrypting IPC traffic.
+     * encrypting IPC traffic. This will return null if no users have enabled authenticator sync.
      */
     val authenticatorSyncSymmetricKey: ByteArray?
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
@@ -334,7 +334,14 @@ class AuthenticatorBridgeRepositoryTest {
         }
 
     @Test
-    fun `authenticatorSyncSymmetricKey should read from authDiskSource`() {
+    @Suppress("MaxLineLength")
+    fun `authenticatorSyncSymmetricKey should read from authDiskSource when one user has authenticator sync enabled`() {
+        every { authRepository.userStateFlow } returns MutableStateFlow(USER_STATE)
+        fakeAuthDiskSource.storeAuthenticatorSyncUnlockKey(
+            userId = USER_1_ID,
+            authenticatorSyncUnlockKey = USER_1_UNLOCK_KEY,
+        )
+
         fakeAuthDiskSource.authenticatorSyncSymmetricKey = null
         assertNull(authenticatorBridgeRepository.authenticatorSyncSymmetricKey)
 
@@ -342,6 +349,29 @@ class AuthenticatorBridgeRepositoryTest {
         fakeAuthDiskSource.authenticatorSyncSymmetricKey = syncKey
 
         assertEquals(syncKey, authenticatorBridgeRepository.authenticatorSyncSymmetricKey)
+        verify { authRepository.userStateFlow }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `authenticatorSyncSymmetricKey should return null when no user has authenticator sync enabled`() {
+        every { authRepository.userStateFlow } returns MutableStateFlow(USER_STATE)
+        fakeAuthDiskSource.storeAuthenticatorSyncUnlockKey(
+            userId = USER_1_ID,
+            authenticatorSyncUnlockKey = null,
+        )
+        fakeAuthDiskSource.storeAuthenticatorSyncUnlockKey(
+            userId = USER_2_ID,
+            authenticatorSyncUnlockKey = null,
+        )
+
+        fakeAuthDiskSource.authenticatorSyncSymmetricKey = null
+        assertNull(authenticatorBridgeRepository.authenticatorSyncSymmetricKey)
+
+        val syncKey = generateSecretKey().getOrThrow().encoded
+        fakeAuthDiskSource.authenticatorSyncSymmetricKey = syncKey
+        assertNull(authenticatorBridgeRepository.authenticatorSyncSymmetricKey)
+        verify { authRepository.userStateFlow }
     }
 }
 


### PR DESCRIPTION
…ticator Sync

## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-173

## 📔 Objective

The goal here is to make a slight tweak to `AuthenticatorBridgeService`. We want to return null symmetric key info whenever there are no users who have enabled authenticator sync. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
