### PR TITLE
PM-12594 Add observable flows to observe badge count changes when corresponding settings update

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -272,6 +272,11 @@ interface SettingsDiskSource {
     fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?)
 
     /**
+     * Emits updates that track [getShowAutoFillSettingBadge] for the given [userId].
+     */
+    fun getShowAutoFillSettingBadgeFlow(userId: String): Flow<Boolean?>
+
+    /**
      * Gets whether or not the given [userId] has signalled they want to enable unlock options
      * later, during onboarding.
      */
@@ -282,4 +287,9 @@ interface SettingsDiskSource {
      * set up unlock options later, during onboarding.
      */
     fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean?)
+
+    /**
+     * Emits updates that track [getShowUnlockSettingBadge] for the given [userId].
+     */
+    fun getShowUnlockSettingBadgeFlow(userId: String): Flow<Boolean?>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -58,6 +58,12 @@ class SettingsDiskSourceImpl(
     private val mutablePullToRefreshEnabledFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
+    private val mutableShowAutoFillSettingBadgeFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutableShowUnlockSettingBadgeFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
     private val mutableIsIconLoadingDisabledFlow = bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableIsCrashLoggingEnabledFlow = bufferedMutableSharedFlow<Boolean?>()
@@ -334,39 +340,6 @@ class SettingsDiskSourceImpl(
         )
     }
 
-    private fun getMutableLastSyncFlow(
-        userId: String,
-    ): MutableSharedFlow<Instant?> =
-        mutableLastSyncFlowMap.getOrPut(userId) {
-            bufferedMutableSharedFlow(replay = 1)
-        }
-
-    private fun getMutableVaultTimeoutActionFlow(
-        userId: String,
-    ): MutableSharedFlow<VaultTimeoutAction?> =
-        mutableVaultTimeoutActionFlowMap.getOrPut(userId) {
-            bufferedMutableSharedFlow(replay = 1)
-        }
-
-    private fun getMutableVaultTimeoutInMinutesFlow(
-        userId: String,
-    ): MutableSharedFlow<Int?> =
-        mutableVaultTimeoutInMinutesFlowMap.getOrPut(userId) {
-            bufferedMutableSharedFlow(replay = 1)
-        }
-
-    private fun getMutablePullToRefreshEnabledFlowMap(
-        userId: String,
-    ): MutableSharedFlow<Boolean?> =
-        mutablePullToRefreshEnabledFlowMap.getOrPut(userId) {
-            bufferedMutableSharedFlow(replay = 1)
-        }
-
-    private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> =
-        mutableScreenCaptureAllowedFlowMap.getOrPut(userId) {
-            bufferedMutableSharedFlow(replay = 1)
-        }
-
     override fun getScreenCaptureAllowed(userId: String): Boolean? {
         return getBoolean(key = SCREEN_CAPTURE_ALLOW_KEY.appendIdentifier(userId))
     }
@@ -403,20 +376,76 @@ class SettingsDiskSourceImpl(
             key = SHOW_AUTOFILL_SETTING_BADGE.appendIdentifier(userId),
         )
 
-    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?) =
+    override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?) {
         putBoolean(
             key = SHOW_AUTOFILL_SETTING_BADGE.appendIdentifier(userId),
             value = showBadge,
         )
+        getMutableShowAutoFillSettingBadgeFlow(userId).tryEmit(showBadge)
+    }
+
+    override fun getShowAutoFillSettingBadgeFlow(userId: String): Flow<Boolean?> =
+        getMutableShowAutoFillSettingBadgeFlow(userId)
+            .onSubscription { emit(getShowAutoFillSettingBadge(userId)) }
 
     override fun getShowUnlockSettingBadge(userId: String): Boolean? =
         getBoolean(
             key = SHOW_UNLOCK_SETTING_BADGE.appendIdentifier(userId),
         )
 
-    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean?) =
+    override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean?) {
         putBoolean(
             key = SHOW_UNLOCK_SETTING_BADGE.appendIdentifier(userId),
             value = showBadge,
         )
+        getMutableShowUnlockSettingBadgeFlow(userId).tryEmit(showBadge)
+    }
+
+    override fun getShowUnlockSettingBadgeFlow(userId: String): Flow<Boolean?> =
+        getMutableShowUnlockSettingBadgeFlow(userId = userId)
+            .onSubscription { emit(getShowUnlockSettingBadge(userId)) }
+
+    private fun getMutableLastSyncFlow(
+        userId: String,
+    ): MutableSharedFlow<Instant?> =
+        mutableLastSyncFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutableVaultTimeoutActionFlow(
+        userId: String,
+    ): MutableSharedFlow<VaultTimeoutAction?> =
+        mutableVaultTimeoutActionFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutableVaultTimeoutInMinutesFlow(
+        userId: String,
+    ): MutableSharedFlow<Int?> =
+        mutableVaultTimeoutInMinutesFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutablePullToRefreshEnabledFlowMap(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> =
+        mutablePullToRefreshEnabledFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> =
+        mutableScreenCaptureAllowedFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutableShowAutoFillSettingBadgeFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> = mutableShowAutoFillSettingBadgeFlowMap.getOrPut(userId) {
+        bufferedMutableSharedFlow(replay = 1)
+    }
+
+    private fun getMutableShowUnlockSettingBadgeFlow(userId: String): MutableSharedFlow<Boolean?> =
+        mutableShowUnlockSettingBadgeFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -161,6 +161,24 @@ interface SettingsRepository {
     val isScreenCaptureAllowedStateFlow: StateFlow<Boolean>
 
     /**
+     * Returns an observable count of the number of settings items that have a badge to display
+     * for the current active user.
+     */
+    val allSettingsBadgeCountFlow: StateFlow<Int>
+
+    /**
+     * Returns an observable count of the number of security settings items that have a badge to
+     * display for the current active user.
+     */
+    val allSecuritySettingsBadgeCountFlow: StateFlow<Int>
+
+    /**
+     * Returns an observable count of the number of autofill settings items that have a badge to
+     * display for the current active user.
+     */
+    val allAutofillSettingsBadgeCountFlow: StateFlow<Int>
+
+    /**
      * Disables autofill if it is currently enabled.
      */
     fun disableAutofill()
@@ -278,4 +296,14 @@ interface SettingsRepository {
      * set up unlock options later, during onboarding.
      */
     fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean)
+
+    /**
+     * Gets whether or not the given [userId] has signalled they want to enable autofill
+     */
+    fun getShowAutofillBadgeFlow(userId: String): Flow<Boolean>
+
+    /**
+     * Gets whether or not the given [userId] has signalled they want to enable unlock options
+     */
+    fun getShowUnlockBadgeFlow(userId: String): Flow<Boolean>
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1055,6 +1055,23 @@ class SettingsDiskSourceTest {
     }
 
     @Test
+    fun `storeShowAutoFillSettingBadge should update the flow value`() = runTest {
+        val mockUserId = "mockUserId"
+        settingsDiskSource.storeShowAutoFillSettingBadge(mockUserId, true)
+        settingsDiskSource.getShowAutoFillSettingBadgeFlow(userId = mockUserId).test {
+            // The initial values of the Flow are in sync
+            assertTrue(awaitItem() ?: false)
+            assertTrue(awaitItem() ?: false)
+
+            // update the value to false
+            settingsDiskSource.storeShowAutoFillSettingBadge(
+                userId = mockUserId, false,
+            )
+            assertFalse(awaitItem() ?: true)
+        }
+    }
+
+    @Test
     fun `storeShowUnlockSettingBadge should update SharedPreferences`() {
         val mockUserId = "mockUserId"
         val showUnlockSettingBadgeKey =
@@ -1076,5 +1093,22 @@ class SettingsDiskSourceTest {
         }
 
         assertTrue(settingsDiskSource.getShowUnlockSettingBadge(userId = mockUserId)!!)
+    }
+
+    @Test
+    fun `storeShowUnlockSettingsBadge should update the flow value`() = runTest {
+        val mockUserId = "mockUserId"
+        settingsDiskSource.storeShowUnlockSettingBadge(mockUserId, true)
+        settingsDiskSource.getShowUnlockSettingBadgeFlow(userId = mockUserId).test {
+            // The initial values of the Flow are in sync
+            assertTrue(awaitItem() ?: false)
+            assertTrue(awaitItem() ?: false)
+
+            // update the value to false
+            settingsDiskSource.storeShowUnlockSettingBadge(
+                userId = mockUserId, false,
+            )
+            assertFalse(awaitItem() ?: true)
+        }
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -64,6 +64,12 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val userShowAutoFillBadge = mutableMapOf<String, Boolean?>()
     private val userShowUnlockBadge = mutableMapOf<String, Boolean?>()
 
+    private val mutableShowAutoFillSettingBadgeFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutableShowUnlockSettingBadgeFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
     override var appLanguage: AppLanguage? = null
 
     override var appTheme: AppTheme
@@ -291,22 +297,33 @@ class FakeSettingsDiskSource : SettingsDiskSource {
 
     override fun storeShowAutoFillSettingBadge(userId: String, showBadge: Boolean?) {
         userShowAutoFillBadge[userId] = showBadge
+        getMutableShowAutoFillSettingBadgeFlow(userId).tryEmit(showBadge)
     }
+
+    override fun getShowAutoFillSettingBadgeFlow(userId: String): Flow<Boolean?> =
+        getMutableShowAutoFillSettingBadgeFlow(userId = userId).onSubscription {
+            emit(getShowAutoFillSettingBadge(userId = userId))
+        }
 
     override fun getShowUnlockSettingBadge(userId: String): Boolean? =
         userShowUnlockBadge[userId]
 
     override fun storeShowUnlockSettingBadge(userId: String, showBadge: Boolean?) {
         userShowUnlockBadge[userId] = showBadge
+        getMutableShowUnlockSettingBadgeFlow(userId).tryEmit(showBadge)
     }
 
+    override fun getShowUnlockSettingBadgeFlow(userId: String): Flow<Boolean?> =
+        getMutableShowUnlockSettingBadgeFlow(userId = userId).onSubscription {
+            emit(getShowUnlockSettingBadge(userId = userId))
+        }
+
+    //region Private helper functions
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {
         return mutableScreenCaptureAllowedFlowMap.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
     }
-
-    //region Private helper functions
 
     private fun getMutableLastSyncTimeFlow(
         userId: String,
@@ -333,6 +350,16 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         userId: String,
     ): MutableSharedFlow<Boolean?> =
         mutablePullToRefreshEnabledFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+    private fun getMutableShowAutoFillSettingBadgeFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> = mutableShowAutoFillSettingBadgeFlowMap.getOrPut(userId) {
+        bufferedMutableSharedFlow(replay = 1)
+    }
+
+    private fun getMutableShowUnlockSettingBadgeFlow(userId: String): MutableSharedFlow<Boolean?> =
+        mutableShowUnlockSettingBadgeFlowMap.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1202,6 +1202,101 @@ class SettingsRepositoryTest {
         fakeSettingsDiskSource.storeShowUnlockSettingBadge(userId = userId, showBadge = true)
         assertTrue(settingsRepository.getShowUnlockSettingBadge(userId = userId))
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getShowAutoFillBadgeFlow should emit the values saved to disk and update when they change`() =
+        runTest {
+            val userId = "userId"
+            settingsRepository.getShowAutofillBadgeFlow(userId).test {
+                assertFalse(awaitItem())
+                fakeSettingsDiskSource.storeShowAutoFillSettingBadge(
+                    userId = userId,
+                    showBadge = true,
+                )
+                assertTrue(awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getShowUnlockBadgeFlow should emit the values saved to disk and update when they change`() =
+        runTest {
+            val userId = "userId"
+            settingsRepository.getShowUnlockBadgeFlow(userId).test {
+                assertFalse(awaitItem())
+                fakeSettingsDiskSource.storeShowUnlockSettingBadge(
+                    userId = userId,
+                    showBadge = true,
+                )
+                assertTrue(awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `allAutoFillSettingsBadgeCountFlow should emit the value of flags set to true and update when changed`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            settingsRepository.allAutofillSettingsBadgeCountFlow.test {
+                assertEquals(0, awaitItem())
+                fakeSettingsDiskSource.storeShowAutoFillSettingBadge(
+                    userId = USER_ID,
+                    showBadge = true,
+                )
+                assertEquals(1, awaitItem())
+                fakeSettingsDiskSource.storeShowAutoFillSettingBadge(
+                    userId = USER_ID,
+                    showBadge = false,
+                )
+                assertEquals(0, awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `allSecuritySettingsBadgeCountFlow should emit the value of flags set to true and update when changed`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            settingsRepository.allSecuritySettingsBadgeCountFlow.test {
+                assertEquals(0, awaitItem())
+                fakeSettingsDiskSource.storeShowUnlockSettingBadge(
+                    userId = USER_ID,
+                    showBadge = true,
+                )
+                assertEquals(1, awaitItem())
+                fakeSettingsDiskSource.storeShowUnlockSettingBadge(
+                    userId = USER_ID,
+                    showBadge = false,
+                )
+                assertEquals(0, awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `allSettingsBadgeCountFlow should emit the value of all flags set to true and update when changed`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            settingsRepository.allSettingsBadgeCountFlow.test {
+                assertEquals(0, awaitItem())
+                fakeSettingsDiskSource.storeShowAutoFillSettingBadge(
+                    userId = USER_ID,
+                    showBadge = true,
+                )
+                assertEquals(1, awaitItem())
+                fakeSettingsDiskSource.storeShowUnlockSettingBadge(
+                    userId = USER_ID,
+                    showBadge = true,
+                )
+                assertEquals(2, awaitItem())
+                fakeSettingsDiskSource.storeShowAutoFillSettingBadge(
+                    userId = USER_ID,
+                    showBadge = false,
+                )
+                assertEquals(1, awaitItem())
+            }
+        }
 }
 
 private const val USER_ID: String = "userId"


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12594
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Setup logic for showing badges on the main settings tabs and the nested settings menus
- Set up so the changes are observable and update when the values change.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
