### PR TITLE
PM-12631: Handle password re-prompt for accessibility autofill

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1122,8 +1122,19 @@ class VaultItemListingViewModel @Inject constructor(
         when (data) {
             is MasterPasswordRepromptData.Autofill -> {
                 // Complete the autofill selection flow
+                val autofillSelectionData = state.autofillSelectionData ?: return
                 val cipherView = getCipherViewOrNull(cipherId = data.cipherId) ?: return
-                autofillSelectionManager.emitAutofillSelection(cipherView = cipherView)
+                when (autofillSelectionData.framework) {
+                    AutofillSelectionData.Framework.ACCESSIBILITY -> {
+                        accessibilitySelectionManager.emitAccessibilitySelection(
+                            cipherView = cipherView,
+                        )
+                    }
+
+                    AutofillSelectionData.Framework.AUTOFILL -> {
+                        autofillSelectionManager.emitAutofillSelection(cipherView = cipherView)
+                    }
+                }
             }
 
             is MasterPasswordRepromptData.OverflowItem -> {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12631](https://bitwarden.atlassian.net/browse/PM-12631)

## 📔 Objective

This PR adds support for processing the accessibility autofill selection after a master password re-prompt.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/eb6688e1-4c91-4c57-ac58-1c6197176d1f" width="300" /> | <video src="https://github.com/user-attachments/assets/546d1a7e-8513-4f7d-97be-3efb430d3d03" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12631]: https://bitwarden.atlassian.net/browse/PM-12631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ