### PR TITLE
[PM-12592] & [PM-12593] bottom nav notification dot

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/badge/NotificationBadge.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/badge/NotificationBadge.kt
@@ -1,0 +1,63 @@
+package com.x8bit.bitwarden.ui.platform.components.badge
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Badge
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.x8bit.bitwarden.ui.platform.theme.LocalNonMaterialColors
+
+/**
+ * Reusable component for displaying a notification badge.
+ *
+ * @param notificationCount numeric value to display in center of the badge.
+ */
+@Composable
+fun NotificationBadge(
+    modifier: Modifier = Modifier,
+    notificationCount: Int,
+    backgroundColor: Color = LocalNonMaterialColors.current.fingerprint,
+    contentColor: Color = MaterialTheme.colorScheme.onSecondary,
+) {
+    Badge(
+        content = {
+            if (notificationCount > 0) {
+                Text(
+                    text = notificationCount.toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(horizontal = 5.dp, vertical = 2.dp),
+                )
+            }
+        },
+        modifier = modifier,
+        containerColor = backgroundColor,
+        contentColor = contentColor,
+    )
+}
+
+@Preview
+@Composable
+private fun NotificationBadge_preview() {
+    Column(
+        modifier = Modifier
+            .background(color = Color.White)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        NotificationBadge(notificationCount = 0, backgroundColor = Color.Red)
+        NotificationBadge(notificationCount = 4, backgroundColor = Color.Red)
+        NotificationBadge(notificationCount = 199, backgroundColor = Color.Green)
+        NotificationBadge(
+            notificationCount = 1999,
+            backgroundColor = Color.Blue,
+            contentColor = Color.Yellow,
+        )
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/badge/NotificationBadge.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/badge/NotificationBadge.kt
@@ -1,5 +1,10 @@
 package com.x8bit.bitwarden.ui.platform.components.badge
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,25 +26,30 @@ import com.x8bit.bitwarden.ui.platform.theme.LocalNonMaterialColors
  */
 @Composable
 fun NotificationBadge(
-    modifier: Modifier = Modifier,
     notificationCount: Int,
+    modifier: Modifier = Modifier,
+    isVisible: Boolean = true,
     backgroundColor: Color = LocalNonMaterialColors.current.fingerprint,
     contentColor: Color = MaterialTheme.colorScheme.onSecondary,
 ) {
-    Badge(
-        content = {
-            if (notificationCount > 0) {
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = slideInVertically() + fadeIn(),
+        exit = slideOutVertically() + fadeOut(),
+    ) {
+        Badge(
+            content = {
                 Text(
                     text = notificationCount.toString(),
                     style = MaterialTheme.typography.labelSmall,
                     modifier = Modifier.padding(horizontal = 5.dp, vertical = 2.dp),
                 )
-            }
-        },
-        modifier = modifier,
-        containerColor = backgroundColor,
-        contentColor = contentColor,
-    )
+            },
+            modifier = modifier,
+            containerColor = backgroundColor,
+            contentColor = contentColor,
+        )
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -2,8 +2,6 @@ package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -285,16 +285,10 @@ private fun VaultBottomAppBar(
                 icon = {
                     BadgedBox(
                         badge = {
-                            // Avoid using the RowScope.AnimatedVisibility inside BoxScope.
-                            androidx.compose.animation.AnimatedVisibility(
-                                visible = destination.notificationCount > 0,
-                                enter = slideInVertically() + fadeIn(),
-                                exit = slideOutVertically() + fadeOut(),
-                            ) {
-                                NotificationBadge(
-                                    notificationCount = destination.notificationCount,
-                                )
-                            }
+                            NotificationBadge(
+                                notificationCount = destination.notificationCount,
+                                isVisible = destination.notificationCount > 0,
+                            )
                         },
                     ) {
                         Icon(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
@@ -50,6 +50,11 @@ sealed class VaultUnlockedNavBarTab : Parcelable {
     abstract val testTag: String
 
     /**
+     * The amount of notifications for items that fall under this tab.
+     */
+    abstract val notificationCount: Int
+
+    /**
      * Show the Generator screen.
      */
     @Parcelize
@@ -60,6 +65,7 @@ sealed class VaultUnlockedNavBarTab : Parcelable {
         override val contentDescriptionRes get() = R.string.generator
         override val route get() = GENERATOR_GRAPH_ROUTE
         override val testTag get() = "GeneratorTab"
+        override val notificationCount get() = 0
     }
 
     /**
@@ -73,6 +79,7 @@ sealed class VaultUnlockedNavBarTab : Parcelable {
         override val contentDescriptionRes get() = R.string.send
         override val route get() = SEND_GRAPH_ROUTE
         override val testTag get() = "SendTab"
+        override val notificationCount get() = 0
     }
 
     /**
@@ -87,13 +94,16 @@ sealed class VaultUnlockedNavBarTab : Parcelable {
         override val iconRes get() = R.drawable.ic_vault
         override val route get() = VAULT_GRAPH_ROUTE
         override val testTag get() = "VaultTab"
+        override val notificationCount get() = 0
     }
 
     /**
      * Show the Settings screen.
      */
     @Parcelize
-    data object Settings : VaultUnlockedNavBarTab() {
+    data class Settings(
+        override val notificationCount: Int = 0,
+    ) : VaultUnlockedNavBarTab() {
         override val iconResSelected get() = R.drawable.ic_settings_filled
         override val iconRes get() = R.drawable.ic_settings
         override val labelRes get() = R.string.settings

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -11,6 +11,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import org.junit.Before
 import org.junit.Test
 
@@ -182,15 +183,47 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
             VaultUnlockedNavBarState(
                 vaultNavBarLabelRes = R.string.vaults,
                 vaultNavBarContentDescriptionRes = R.string.vaults,
+                notificationState = VaultUnlockedNavBarNotificationState(
+                    settingsTabNotificationCount = 0,
+                ),
             ),
         )
 
         composeTestRule.onNodeWithText("My vault").assertDoesNotExist()
         composeTestRule.onNodeWithText("Vaults").assertExists()
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `settings tab notification count should update according to state and show correct count`() {
+        mutableStateFlow.update {
+            it.copy(
+                notificationState = VaultUnlockedNavBarNotificationState(
+                    settingsTabNotificationCount = 1,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText("1", useUnmergedTree = true)
+            .assertExists()
+
+        mutableStateFlow.update {
+            it.copy(
+                notificationState = VaultUnlockedNavBarNotificationState(
+                    settingsTabNotificationCount = 0,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText("1", useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
 }
 
 private val DEFAULT_STATE = VaultUnlockedNavBarState(
     vaultNavBarLabelRes = R.string.my_vault,
     vaultNavBarContentDescriptionRes = R.string.my_vault,
+    notificationState = VaultUnlockedNavBarNotificationState(
+        settingsTabNotificationCount = 0,
+    ),
 )


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12592
https://bitwarden.atlassian.net/browse/PM-12593
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- show the count of "settings" notifications in a badge on the bottom nav bar.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/2494f010-b63a-4092-b850-88d76bf9e8e0


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
