### PR TITLE
Add reusable icon button components

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -21,8 +21,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.TopAppBarDefaults
@@ -68,6 +66,7 @@ import com.x8bit.bitwarden.ui.platform.base.util.createAnnotatedString
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledButton
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.LoadingDialogState
@@ -264,18 +263,14 @@ private fun StartRegistrationContent(
                     .testTag("RegionSelectorDropdown"),
             )
             if (isNewOnboardingUiEnabled) {
-                IconButton(
+                BitwardenStandardIconButton(
+                    vectorIconRes = R.drawable.ic_tooltip_small,
+                    contentDescription = stringResource(R.string.help_with_server_geolocations),
                     onClick = handler.onServerGeologyHelpClick,
+                    contentColor = MaterialTheme.colorScheme.primary,
                     // Align with design but keep accessible touch target of IconButton.
                     modifier = Modifier.offset(y = (-8f).dp, x = 16.dp),
-                ) {
-                    Icon(
-                        painter = rememberVectorPainter(id = R.drawable.ic_tooltip_small),
-                        contentDescription = stringResource(R.string.help_with_server_geolocations),
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
+                )
             }
         }
         Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenMediumTopAppBar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenMediumTopAppBar.kt
@@ -2,8 +2,6 @@ package com.x8bit.bitwarden.ui.platform.components.appbar
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Text
@@ -15,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 
 /**
  * A custom Bitwarden-themed medium top app bar with support for actions.
@@ -73,13 +71,12 @@ private fun BitwardenMediumTopAppBar_preview() {
                     rememberTopAppBarState(),
                 ),
             actions = {
-                IconButton(onClick = { }) {
-                    Icon(
-                        painter = rememberVectorPainter(id = R.drawable.ic_more),
-                        contentDescription = "",
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    )
-                }
+                BitwardenStandardIconButton(
+                    vectorIconRes = R.drawable.ic_more,
+                    contentDescription = "",
+                    onClick = { },
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                )
             },
         )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenSearchTopAppBar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenSearchTopAppBar.kt
@@ -3,8 +3,6 @@ package com.x8bit.bitwarden.ui.platform.components.appbar
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -25,7 +23,7 @@ import androidx.compose.ui.text.input.ImeAction
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.x8bit.bitwarden.ui.platform.base.util.tabNavigation
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 
 /**
  * Represents a Bitwarden styled [TopAppBar] that assumes the following components:
@@ -58,16 +56,14 @@ fun BitwardenSearchTopAppBar(
         scrollBehavior = scrollBehavior,
         navigationIcon = {
             navigationIcon?.let {
-                IconButton(
+                BitwardenStandardIconButton(
+                    painter = it.navigationIcon,
+                    contentDescription = it.navigationIconContentDescription,
                     onClick = it.onNavigationIconClick,
-                    modifier = Modifier.testTag("CloseButton"),
-                ) {
-                    Icon(
-                        modifier = Modifier.mirrorIfRtl(),
-                        painter = it.navigationIcon,
-                        contentDescription = it.navigationIconContentDescription,
-                    )
-                }
+                    modifier = Modifier
+                        .testTag(tag = "CloseButton")
+                        .mirrorIfRtl(),
+                )
             }
         },
         title = {
@@ -83,14 +79,11 @@ fun BitwardenSearchTopAppBar(
                 singleLine = true,
                 onValueChange = onSearchTermChange,
                 trailingIcon = {
-                    IconButton(
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_close,
+                        contentDescription = stringResource(id = R.string.clear),
                         onClick = { onSearchTermChange("") },
-                    ) {
-                        Icon(
-                            painter = rememberVectorPainter(id = R.drawable.ic_close),
-                            contentDescription = stringResource(id = R.string.clear),
-                        )
-                    }
+                    )
                 },
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 modifier = Modifier

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
@@ -2,8 +2,6 @@ package com.x8bit.bitwarden.ui.platform.components.appbar
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Text
@@ -24,6 +22,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.mirrorIfRtl
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
@@ -90,16 +89,14 @@ fun BitwardenTopAppBar(
     val navigationIconContent: @Composable () -> Unit = remember(navigationIcon) {
         {
             navigationIcon?.let {
-                IconButton(
+                BitwardenStandardIconButton(
+                    painter = it.navigationIcon,
+                    contentDescription = it.navigationIconContentDescription,
                     onClick = it.onNavigationIconClick,
-                    modifier = Modifier.testTag("CloseButton"),
-                ) {
-                    Icon(
-                        modifier = Modifier.mirrorIfRtl(),
-                        painter = it.navigationIcon,
-                        contentDescription = it.navigationIconContentDescription,
-                    )
-                }
+                    modifier = Modifier
+                        .testTag(tag = "CloseButton")
+                        .mirrorIfRtl(),
+                )
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/action/BitwardenOverflowActionItem.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/action/BitwardenOverflowActionItem.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -26,7 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -53,15 +52,12 @@ fun BitwardenOverflowActionItem(
         contentAlignment = Alignment.Center,
         modifier = modifier,
     ) {
-        IconButton(
+        BitwardenStandardIconButton(
+            vectorIconRes = R.drawable.ic_more,
+            contentDescription = stringResource(id = R.string.more),
             onClick = { isOverflowMenuVisible = !isOverflowMenuVisible },
-            modifier = Modifier.testTag("HeaderBarOptionsButton"),
-        ) {
-            Icon(
-                painter = rememberVectorPainter(id = R.drawable.ic_more),
-                contentDescription = stringResource(id = R.string.more),
-            )
-        }
+            modifier = Modifier.testTag(tag = "HeaderBarOptionsButton"),
+        )
         DropdownMenu(
             expanded = isOverflowMenuVisible,
             onDismissRequest = { isOverflowMenuVisible = false },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/action/BitwardenSearchActionItem.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/action/BitwardenSearchActionItem.kt
@@ -1,13 +1,12 @@
 package com.x8bit.bitwarden.ui.platform.components.appbar.action
 
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 
 /**
  * Represents the Bitwarden search action item.
@@ -24,15 +23,12 @@ fun BitwardenSearchActionItem(
     contentDescription: String,
     onClick: () -> Unit,
 ) {
-    IconButton(
+    BitwardenStandardIconButton(
+        vectorIconRes = R.drawable.ic_search,
+        contentDescription = contentDescription,
         onClick = onClick,
-        modifier = Modifier.testTag("SearchButton"),
-    ) {
-        Icon(
-            painter = rememberVectorPainter(id = R.drawable.ic_search),
-            contentDescription = contentDescription,
-        )
-    }
+        modifier = Modifier.testTag(tag = "SearchButton"),
+    )
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenFilledIconButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenFilledIconButton.kt
@@ -1,29 +1,31 @@
-package com.x8bit.bitwarden.ui.platform.components.icon
+package com.x8bit.bitwarden.ui.platform.components.button
 
+import androidx.annotation.DrawableRes
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
- * An icon button that displays an icon from the provided [IconResource].
+ * A filled icon button that displays an icon.
  *
- * @param iconRes Icon to display on the button.
+ * @param vectorIconRes Icon to display on the button.
+ * @param contentDescription The content description for this icon button.
  * @param onClick Callback for when the icon button is clicked.
- * @param isEnabled Whether or not the button should be enabled.
  * @param modifier A [Modifier] for the composable.
+ * @param isEnabled Whether or not the button should be enabled.
  */
 @Composable
-fun BitwardenIconButtonWithResource(
-    iconRes: IconResource,
+fun BitwardenFilledIconButton(
+    @DrawableRes vectorIconRes: Int,
+    contentDescription: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     isEnabled: Boolean = true,
@@ -31,7 +33,7 @@ fun BitwardenIconButtonWithResource(
     FilledIconButton(
         modifier = modifier.semantics(mergeDescendants = true) {},
         onClick = onClick,
-        colors = IconButtonColors(
+        colors = IconButtonDefaults.filledIconButtonColors(
             containerColor = MaterialTheme.colorScheme.secondaryContainer,
             contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
             disabledContainerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .12f),
@@ -40,21 +42,19 @@ fun BitwardenIconButtonWithResource(
         enabled = isEnabled,
     ) {
         Icon(
-            painter = iconRes.iconPainter,
-            contentDescription = iconRes.contentDescription,
+            painter = rememberVectorPainter(id = vectorIconRes),
+            contentDescription = contentDescription,
         )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun BitwardenIconButtonWithResource_preview() {
+private fun BitwardenFilledIconButton_preview() {
     BitwardenTheme {
-        BitwardenIconButtonWithResource(
-            iconRes = IconResource(
-                iconPainter = rememberVectorPainter(id = R.drawable.ic_tooltip),
-                contentDescription = "Sample Icon",
-            ),
+        BitwardenFilledIconButton(
+            vectorIconRes = R.drawable.ic_tooltip,
+            contentDescription = "Sample Icon",
             onClick = {},
         )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenStandardIconButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenStandardIconButton.kt
@@ -1,0 +1,89 @@
+package com.x8bit.bitwarden.ui.platform.components.button
+
+import androidx.annotation.DrawableRes
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+
+/**
+ * A standard icon button that displays an icon.
+ *
+ * @param vectorIconRes Icon to display on the button.
+ * @param contentDescription The content description for this icon button.
+ * @param onClick Callback for when the icon button is clicked.
+ * @param modifier A [Modifier] for the composable.
+ * @param isEnabled Whether or not the button should be enabled.
+ */
+@Composable
+fun BitwardenStandardIconButton(
+    @DrawableRes vectorIconRes: Int,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
+    contentColor: Color = LocalContentColor.current,
+) {
+    BitwardenStandardIconButton(
+        painter = rememberVectorPainter(id = vectorIconRes),
+        contentDescription = contentDescription,
+        onClick = onClick,
+        modifier = modifier,
+        isEnabled = isEnabled,
+        contentColor = contentColor,
+    )
+}
+
+/**
+ * A standard icon button that displays an icon.
+ *
+ * @param painter Painter icon to display on the button.
+ * @param contentDescription The content description for this icon button.
+ * @param onClick Callback for when the icon button is clicked.
+ * @param modifier A [Modifier] for the composable.
+ * @param isEnabled Whether or not the button should be enabled.
+ */
+@Composable
+fun BitwardenStandardIconButton(
+    painter: Painter,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
+    contentColor: Color = LocalContentColor.current,
+) {
+    IconButton(
+        modifier = modifier.semantics(mergeDescendants = true) {},
+        onClick = onClick,
+        colors = IconButtonDefaults.iconButtonColors(
+            contentColor = contentColor,
+        ),
+        enabled = isEnabled,
+    ) {
+        Icon(
+            painter = painter,
+            contentDescription = contentDescription,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BitwardenStandardIconButton_preview() {
+    BitwardenTheme {
+        BitwardenStandardIconButton(
+            vectorIconRes = R.drawable.ic_tooltip,
+            contentDescription = "Sample Icon",
+            onClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenTimePickerDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenTimePickerDialog.kt
@@ -9,11 +9,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -38,7 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 
 /**
  * A custom composable representing a dialog that displays the time picker dialog.
@@ -91,21 +88,15 @@ fun BitwardenTimePickerDialog(
             }
         },
         inputToggleButton = {
-            IconButton(
-                modifier = Modifier.size(48.dp),
+            BitwardenStandardIconButton(
+                vectorIconRes = R.drawable.ic_keyboard,
+                contentDescription = stringResource(
+                    // TODO: Get our own string for this (BIT-1405)
+                    id = androidx.compose.material3.R.string.m3c_date_picker_switch_to_input_mode,
+                ),
                 onClick = { showTimeInput = !showTimeInput },
-            ) {
-                @Suppress("MaxLineLength")
-                Icon(
-                    modifier = Modifier.size(24.dp),
-                    painter = rememberVectorPainter(id = R.drawable.ic_keyboard),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    contentDescription = stringResource(
-                        // TODO: Get our own string for this (BIT-1405)
-                        id = androidx.compose.material3.R.string.m3c_date_picker_switch_to_input_mode,
-                    ),
-                )
-            }
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         },
     ) {
         val modifier = Modifier.weight(1f)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -32,6 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.asText
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenSelectionRow
 import com.x8bit.bitwarden.ui.platform.components.model.TooltipData
@@ -109,19 +108,14 @@ fun BitwardenMultiSelectButton(
                 )
                 tooltip?.let {
                     Spacer(modifier = Modifier.width(3.dp))
-                    IconButton(
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_tooltip_small,
+                        contentDescription = it.contentDescription,
                         onClick = it.onClick,
-                        enabled = isEnabled,
-                        colors = IconButtonDefaults.iconButtonColors(
-                            contentColor = MaterialTheme.colorScheme.primary,
-                        ),
+                        isEnabled = isEnabled,
+                        contentColor = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(16.dp),
-                    ) {
-                        Icon(
-                            painter = rememberVectorPainter(id = R.drawable.ic_tooltip_small),
-                            contentDescription = it.contentDescription,
-                        )
-                    }
+                    )
                 }
             }
         },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -1,11 +1,7 @@
 package com.x8bit.bitwarden.ui.platform.components.field
 
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -29,8 +25,8 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.tabNavigation
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.util.nonLetterColorVisualTransformation
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.LocalNonMaterialTypography
 
 /**
@@ -103,25 +99,19 @@ fun BitwardenPasswordField(
             }
         },
         trailingIcon = {
-            IconButton(
-                onClick = { showPasswordChange.invoke(!showPassword) },
-            ) {
-                @DrawableRes
-                val painterRes = if (showPassword) {
+            BitwardenStandardIconButton(
+                modifier = Modifier.semantics { showPasswordTestTag?.let { testTag = it } },
+                vectorIconRes = if (showPassword) {
                     R.drawable.ic_visibility_off
                 } else {
                     R.drawable.ic_visibility
-                }
-
-                @StringRes
-                val contentDescriptionRes = if (showPassword) R.string.hide else R.string.show
-                Icon(
-                    modifier = Modifier.semantics { showPasswordTestTag?.let { testTag = it } },
-                    painter = rememberVectorPainter(id = painterRes),
-                    contentDescription = stringResource(id = contentDescriptionRes),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+                },
+                contentDescription = stringResource(
+                    id = if (showPassword) R.string.hide else R.string.show,
+                ),
+                onClick = { showPasswordChange.invoke(!showPassword) },
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         },
     )
     if (autoFocus) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordFieldWithActions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordFieldWithActions.kt
@@ -15,9 +15,7 @@ import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
@@ -132,11 +130,9 @@ private fun BitwardenPasswordFieldWithActions_preview() {
             value = "samplePassword",
             onValueChange = {},
             actions = {
-                BitwardenIconButtonWithResource(
-                    iconRes = IconResource(
-                        iconPainter = rememberVectorPainter(id = R.drawable.ic_check_mark),
-                        contentDescription = "",
-                    ),
+                BitwardenFilledIconButton(
+                    vectorIconRes = R.drawable.ic_check_mark,
+                    contentDescription = "",
                     onClick = {},
                 )
             },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/listitem/BitwardenListItem.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/listitem/BitwardenListItem.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
@@ -31,12 +30,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenBasicDialogRow
 import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIcon
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 import com.x8bit.bitwarden.ui.platform.components.model.IconResource
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -151,17 +150,13 @@ fun BitwardenListItem(
         }
 
         if (selectionDataList.isNotEmpty()) {
-            IconButton(
+            BitwardenStandardIconButton(
+                vectorIconRes = R.drawable.ic_more_horizontal,
+                contentDescription = stringResource(id = R.string.options),
                 onClick = { shouldShowDialog = true },
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.semantics { optionsTestTag?.let { testTag = it } },
-            ) {
-                Icon(
-                    painter = rememberVectorPainter(id = R.drawable.ic_more_horizontal),
-                    contentDescription = stringResource(id = R.string.options),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(24.dp),
-                )
-            }
+            )
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -8,10 +8,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.ZERO_WIDTH_CHARACTER
 import com.x8bit.bitwarden.ui.platform.base.util.orNullIfBlank
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithActions
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 
 /**
  * Displays a stepper that allows the user to increment and decrement an int value.
@@ -56,11 +54,9 @@ fun BitwardenStepper(
             ?: ZERO_WIDTH_CHARACTER,
         actionsTestTag = stepperActionsTestTag,
         actions = {
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_minus),
-                    contentDescription = "\u2212",
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_minus,
+                contentDescription = "\u2212",
                 onClick = {
                     val decrementedValue = ((value ?: 0) - 1).coerceIn(range)
                     if (decrementedValue != value) {
@@ -74,11 +70,9 @@ fun BitwardenStepper(
                     }
                 },
             )
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_plus),
-                    contentDescription = "+",
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_plus,
+                contentDescription = "+",
                 onClick = {
                     val incrementedValue = ((value ?: 0) + 1).coerceIn(range)
                     if (incrementedValue != value) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenSwitchWithActions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenSwitchWithActions.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.ripple
@@ -20,8 +18,8 @@ import androidx.compose.ui.semantics.toggleableState
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.tooling.preview.Preview
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenRowOfActions
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
@@ -77,15 +75,13 @@ private fun BitwardenSwitchWithActions_preview() {
             isChecked = true,
             onCheckedChange = {},
             actions = {
-                IconButton(onClick = {}) {
-                    Icon(
-                        painter = rememberVectorPainter(id = R.drawable.ic_tooltip),
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        contentDescription = stringResource(
-                            id = R.string.master_password_re_prompt_help,
-                        ),
-                    )
-                }
+                BitwardenStandardIconButton(
+                    vectorIconRes = R.drawable.ic_tooltip,
+                    contentDescription = stringResource(
+                        id = R.string.master_password_re_prompt_help,
+                    ),
+                    onClick = {},
+                )
             },
         )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -64,14 +64,13 @@ import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenMediumTopAppBa
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.x8bit.bitwarden.ui.platform.components.appbar.action.BitwardenOverflowActionItem
 import com.x8bit.bitwarden.ui.platform.components.appbar.action.OverflowMenuItemData
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithActions
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
 import com.x8bit.bitwarden.ui.platform.components.model.TooltipData
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.stepper.BitwardenStepper
@@ -412,19 +411,15 @@ private fun GeneratedStringItem(
         value = generatedText,
         singleLine = false,
         actions = {
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                    contentDescription = stringResource(id = R.string.copy),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_copy,
+                contentDescription = stringResource(id = R.string.copy),
                 onClick = onCopyClick,
                 modifier = Modifier.testTag("CopyValueButton"),
             )
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_generator),
-                    contentDescription = stringResource(id = R.string.generate_password),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_generator,
+                contentDescription = stringResource(id = R.string.generate_password),
                 onClick = onRegenerateClick,
                 modifier = Modifier.testTag("RegenerateValueButton"),
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryListItem.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryListItem.kt
@@ -4,9 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,8 +21,8 @@ import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.withLineBreaksAtWidth
 import com.x8bit.bitwarden.ui.platform.base.util.withVisualTransformation
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.util.nonLetterColorVisualTransformation
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.ui.platform.theme.LocalNonMaterialTypography
 
@@ -77,18 +74,13 @@ fun PasswordHistoryListItem(
             )
         }
 
-        IconButton(
+        BitwardenStandardIconButton(
+            vectorIconRes = R.drawable.ic_copy,
+            contentDescription = stringResource(id = R.string.copy),
             onClick = onCopyClick,
-            colors = IconButtonDefaults.iconButtonColors(
-                contentColor = MaterialTheme.colorScheme.primary,
-            ),
-            modifier = Modifier.testTag("CopyPasswordValueButton"),
-        ) {
-            Icon(
-                painter = rememberVectorPainter(id = R.drawable.ic_copy),
-                contentDescription = stringResource(id = R.string.copy),
-            )
-        }
+            contentColor = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.testTag(tag = "CopyPasswordValueButton"),
+        )
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,13 +18,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitchWithActions
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.components.collectionItemsSelector
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCardTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCommonHandlers
@@ -225,15 +223,14 @@ fun LazyListScope.vaultAddEditCardItems(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 actions = {
-                    IconButton(onClick = commonHandlers.onTooltipClick) {
-                        Icon(
-                            painter = rememberVectorPainter(id = R.drawable.ic_tooltip),
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            contentDescription = stringResource(
-                                id = R.string.master_password_re_prompt_help,
-                            ),
-                        )
-                    }
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_tooltip,
+                        contentDescription = stringResource(
+                            id = R.string.master_password_re_prompt_help,
+                        ),
+                        onClick = commonHandlers.onTooltipClick,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    )
                 },
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomField.kt
@@ -12,17 +12,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTextEntryDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenBasicDialogRow
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordFieldWithActions
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithActions
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenRowOfActions
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenWideSwitch
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.CustomFieldAction
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
 import kotlinx.collections.immutable.ImmutableList
@@ -157,11 +155,9 @@ private fun CustomFieldBoolean(
 
         BitwardenRowOfActions(
             actions = {
-                BitwardenIconButtonWithResource(
-                    iconRes = IconResource(
-                        iconPainter = rememberVectorPainter(id = R.drawable.ic_settings),
-                        contentDescription = stringResource(id = R.string.edit),
-                    ),
+                BitwardenFilledIconButton(
+                    vectorIconRes = R.drawable.ic_settings,
+                    contentDescription = stringResource(id = R.string.edit),
                     onClick = onEditValue,
                 )
             },
@@ -194,11 +190,9 @@ private fun CustomFieldHiddenField(
         singleLine = true,
         modifier = modifier,
         actions = {
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_settings),
-                    contentDescription = stringResource(id = R.string.edit),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_settings,
+                contentDescription = stringResource(id = R.string.edit),
                 onClick = onEditValue,
             )
         },
@@ -223,11 +217,9 @@ private fun CustomFieldTextField(
         singleLine = true,
         modifier = modifier,
         actions = {
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_settings),
-                    contentDescription = stringResource(id = R.string.edit),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_settings,
+                contentDescription = stringResource(id = R.string.edit),
                 onClick = onEditValue,
             )
         },
@@ -270,11 +262,9 @@ private fun CustomFieldLinkedField(
 
         BitwardenRowOfActions(
             actions = {
-                BitwardenIconButtonWithResource(
-                    iconRes = IconResource(
-                        iconPainter = rememberVectorPainter(id = R.drawable.ic_settings),
-                        contentDescription = stringResource(id = R.string.edit),
-                    ),
+                BitwardenFilledIconButton(
+                    vectorIconRes = R.drawable.ic_settings,
+                    contentDescription = stringResource(id = R.string.edit),
                     onClick = onEditValue,
                 )
             },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,12 +14,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitchWithActions
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.components.collectionItemsSelector
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCommonHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditIdentityTypeHandlers
@@ -326,15 +324,14 @@ fun LazyListScope.vaultAddEditIdentityItems(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 actions = {
-                    IconButton(onClick = commonTypeHandlers.onTooltipClick) {
-                        Icon(
-                            painter = rememberVectorPainter(id = R.drawable.ic_tooltip),
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            contentDescription = stringResource(
-                                id = R.string.master_password_re_prompt_help,
-                            ),
-                        )
-                    }
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_tooltip,
+                        contentDescription = stringResource(
+                            id = R.string.master_password_re_prompt_help,
+                        ),
+                        onClick = commonTypeHandlers.onTooltipClick,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    )
                 },
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,8 +19,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.Text
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledTonalButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledTonalButtonWithIcon
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenHiddenPasswordField
@@ -30,8 +30,6 @@ import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordFieldWi
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithActions
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitchWithActions
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
@@ -117,33 +115,26 @@ fun LazyListScope.vaultAddEditLoginItems(
                 label = stringResource(id = R.string.totp),
                 value = loginState.totp,
                 trailingIconContent = {
-                    IconButton(
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_close,
+                        contentDescription = stringResource(id = R.string.delete),
                         onClick = loginItemTypeHandlers.onClearTotpKeyClick,
-                    ) {
-                        Icon(
-                            painter = rememberVectorPainter(id = R.drawable.ic_close),
-                            contentDescription = stringResource(id = R.string.delete),
-                        )
-                    }
+                    )
                 },
                 onValueChange = {},
                 readOnly = true,
                 singleLine = true,
                 actions = {
-                    BitwardenIconButtonWithResource(
-                        iconRes = IconResource(
-                            iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                            contentDescription = stringResource(id = R.string.copy_totp),
-                        ),
+                    BitwardenFilledIconButton(
+                        vectorIconRes = R.drawable.ic_copy,
+                        contentDescription = stringResource(id = R.string.copy_totp),
                         onClick = {
                             loginItemTypeHandlers.onCopyTotpKeyClick(loginState.totp)
                         },
                     )
-                    BitwardenIconButtonWithResource(
-                        iconRes = IconResource(
-                            iconPainter = rememberVectorPainter(id = R.drawable.ic_camera),
-                            contentDescription = stringResource(id = R.string.camera),
-                        ),
+                    BitwardenFilledIconButton(
+                        vectorIconRes = R.drawable.ic_camera,
+                        contentDescription = stringResource(id = R.string.camera),
                         onClick = onTotpSetupClick,
                     )
                 },
@@ -254,15 +245,14 @@ fun LazyListScope.vaultAddEditLoginItems(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 actions = {
-                    IconButton(onClick = commonActionHandler.onTooltipClick) {
-                        Icon(
-                            painter = rememberVectorPainter(id = R.drawable.ic_tooltip),
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            contentDescription = stringResource(
-                                id = R.string.master_password_re_prompt_help,
-                            ),
-                        )
-                    }
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_tooltip,
+                        contentDescription = stringResource(
+                            id = R.string.master_password_re_prompt_help,
+                        ),
+                        onClick = commonActionHandler.onTooltipClick,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    )
                 },
             )
         }
@@ -388,11 +378,9 @@ private fun UsernameRow(
         value = username,
         onValueChange = loginItemTypeHandlers.onUsernameTextChange,
         actions = {
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_generator),
-                    contentDescription = stringResource(id = R.string.generate_username),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_generator,
+                contentDescription = stringResource(id = R.string.generate_username),
                 onClick = {
                     if (username.isEmpty()) {
                         loginItemTypeHandlers.onOpenUsernameGeneratorClick()
@@ -400,7 +388,7 @@ private fun UsernameRow(
                         shouldShowDialog = true
                     }
                 },
-                modifier = Modifier.testTag("GenerateUsernameButton"),
+                modifier = Modifier.testTag(tag = "GenerateUsernameButton"),
             )
         },
         modifier = Modifier
@@ -457,20 +445,15 @@ private fun PasswordRow(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
         ) {
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_check_mark),
-                    contentDescription = stringResource(id = R.string.check_password),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_check_mark,
+                contentDescription = stringResource(id = R.string.check_password),
                 onClick = loginItemTypeHandlers.onPasswordCheckerClick,
-                modifier = Modifier
-                    .testTag("CheckPasswordButton"),
+                modifier = Modifier.testTag(tag = "CheckPasswordButton"),
             )
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_generator),
-                    contentDescription = stringResource(id = R.string.generate_password),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_generator,
+                contentDescription = stringResource(id = R.string.generate_password),
                 onClick = {
                     if (password.isEmpty()) {
                         loginItemTypeHandlers.onOpenPasswordGeneratorClick()
@@ -478,8 +461,7 @@ private fun PasswordRow(
                         shouldShowDialog = true
                     }
                 },
-                modifier = Modifier
-                    .testTag("RegeneratePasswordButton"),
+                modifier = Modifier.testTag(tag = "RegeneratePasswordButton"),
             )
 
             if (shouldShowDialog) {
@@ -532,14 +514,11 @@ private fun PasskeyField(
         modifier = modifier,
         actions = {
             if (canRemovePasskey) {
-                BitwardenIconButtonWithResource(
-                    iconRes = IconResource(
-                        iconPainter = rememberVectorPainter(id = R.drawable.ic_minus),
-                        contentDescription = stringResource(id = R.string.remove_passkey),
-                    ),
+                BitwardenFilledIconButton(
+                    vectorIconRes = R.drawable.ic_minus,
+                    contentDescription = stringResource(id = R.string.remove_passkey),
                     onClick = loginItemTypeHandlers.onClearFido2CredentialClick,
-                    modifier = Modifier
-                        .testTag("RemovePasskeyButton"),
+                    modifier = Modifier.testTag(tag = "RemovePasskeyButton"),
                 )
             }
         },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSecureNotesItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSecureNotesItems.kt
@@ -6,20 +6,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitchWithActions
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.components.collectionItemsSelector
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCommonHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.CustomFieldType
@@ -105,15 +103,14 @@ fun LazyListScope.vaultAddEditSecureNotesItems(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 actions = {
-                    IconButton(onClick = commonTypeHandlers.onTooltipClick) {
-                        Icon(
-                            painter = rememberVectorPainter(id = R.drawable.ic_tooltip),
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            contentDescription = stringResource(
-                                id = R.string.master_password_re_prompt_help,
-                            ),
-                        )
-                    }
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_tooltip,
+                        contentDescription = stringResource(
+                            id = R.string.master_password_re_prompt_help,
+                        ),
+                        onClick = commonTypeHandlers.onTooltipClick,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    )
                 },
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditUriItem.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditUriItem.kt
@@ -11,13 +11,11 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenBasicDialogRow
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenSelectionRow
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithActions
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriMatchDisplayType
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.toDisplayMatchType
@@ -41,13 +39,11 @@ fun VaultAddEditUriItem(
         value = uriItem.uri.orEmpty(),
         onValueChange = { onUriValueChange(uriItem.copy(uri = it)) },
         actions = {
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_settings),
-                    contentDescription = stringResource(id = R.string.options),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_settings,
+                contentDescription = stringResource(id = R.string.options),
                 onClick = { shouldShowOptionsDialog = true },
-                modifier = Modifier.testTag("LoginUriOptionsButton"),
+                modifier = Modifier.testTag(tag = "LoginUriOptionsButton"),
             )
         },
         modifier = Modifier

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsContent.kt
@@ -7,12 +7,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,9 +27,9 @@ import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.bottomDivider
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledTonalButton
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.feature.attachments.handlers.AttachmentsHandlers
 
 /**
@@ -179,16 +176,11 @@ private fun AttachmentListEntry(
 
         Spacer(modifier = Modifier.width(8.dp))
 
-        IconButton(
+        BitwardenStandardIconButton(
+            vectorIconRes = R.drawable.ic_trash,
+            contentDescription = stringResource(id = R.string.delete),
             onClick = { shouldShowDeleteDialog = true },
-            modifier = Modifier,
-        ) {
-            Icon(
-                painter = rememberVectorPainter(id = R.drawable.ic_trash),
-                contentDescription = stringResource(id = R.string.delete),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(24.dp),
-            )
-        }
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemAttachmentContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemAttachmentContent.kt
@@ -4,11 +4,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,9 +20,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.bottomDivider
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 
 /**
  * Attachment UI common for all item types.
@@ -68,29 +65,24 @@ fun AttachmentItemContent(
 
         Spacer(modifier = Modifier.width(8.dp))
 
-        IconButton(
+        BitwardenStandardIconButton(
+            vectorIconRes = R.drawable.ic_download,
+            contentDescription = stringResource(id = R.string.download),
             onClick = {
                 if (!attachmentItem.isDownloadAllowed) {
                     shouldShowPremiumWarningDialog = true
-                    return@IconButton
+                    return@BitwardenStandardIconButton
                 }
 
                 if (attachmentItem.isLargeFile) {
                     shouldShowSizeWarningDialog = true
-                    return@IconButton
+                    return@BitwardenStandardIconButton
                 }
 
                 onAttachmentDownloadClick(attachmentItem)
             },
-            modifier = Modifier,
-        ) {
-            Icon(
-                painter = rememberVectorPainter(id = R.drawable.ic_download),
-                contentDescription = stringResource(id = R.string.download),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(24.dp),
-            )
-        }
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 
     if (shouldShowPremiumWarningDialog) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
@@ -13,12 +13,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordFieldWithActions
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.feature.item.handlers.VaultCardItemTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.item.handlers.VaultCommonItemTypeHandlers
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
@@ -87,13 +85,11 @@ fun VaultItemCardContent(
                     readOnly = true,
                     singleLine = false,
                     actions = {
-                        BitwardenIconButtonWithResource(
-                            iconRes = IconResource(
-                                iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                                contentDescription = stringResource(id = R.string.copy_number),
-                            ),
+                        BitwardenFilledIconButton(
+                            vectorIconRes = R.drawable.ic_copy,
+                            contentDescription = stringResource(id = R.string.copy_number),
                             onClick = vaultCardItemTypeHandlers.onCopyNumberClick,
-                            modifier = Modifier.testTag("CardCopyNumberButton"),
+                            modifier = Modifier.testTag(tag = "CardCopyNumberButton"),
                         )
                     },
                     passwordFieldTestTag = "CardNumberEntry",
@@ -151,16 +147,11 @@ fun VaultItemCardContent(
                     readOnly = true,
                     singleLine = false,
                     actions = {
-                        BitwardenIconButtonWithResource(
-                            iconRes = IconResource(
-                                iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                                contentDescription = stringResource(
-                                    id = R.string.copy_security_code,
-                                ),
-                            ),
+                        BitwardenFilledIconButton(
+                            vectorIconRes = R.drawable.ic_copy,
+                            contentDescription = stringResource(id = R.string.copy_security_code),
                             onClick = vaultCardItemTypeHandlers.onCopySecurityCodeClick,
-                            modifier = Modifier
-                                .testTag("CardCopySecurityCodeButton"),
+                            modifier = Modifier.testTag(tag = "CardCopySecurityCodeButton"),
                         )
                     },
                     modifier = Modifier

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCustomField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCustomField.kt
@@ -4,10 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordFieldWithActions
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithActions
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
 import com.x8bit.bitwarden.ui.platform.components.model.IconResource
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenWideSwitch
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
@@ -47,14 +47,10 @@ fun CustomField(
                 modifier = modifier,
                 actions = {
                     if (customField.isCopyable) {
-                        BitwardenIconButtonWithResource(
-                            iconRes = IconResource(
-                                iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                                contentDescription = stringResource(id = R.string.copy),
-                            ),
-                            onClick = {
-                                onCopyCustomHiddenField(customField.value)
-                            },
+                        BitwardenFilledIconButton(
+                            vectorIconRes = R.drawable.ic_copy,
+                            contentDescription = stringResource(id = R.string.copy),
+                            onClick = { onCopyCustomHiddenField(customField.value) },
                         )
                     }
                 },
@@ -86,11 +82,9 @@ fun CustomField(
                 modifier = modifier,
                 actions = {
                     if (customField.isCopyable) {
-                        BitwardenIconButtonWithResource(
-                            iconRes = IconResource(
-                                iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                                contentDescription = stringResource(id = R.string.copy),
-                            ),
+                        BitwardenFilledIconButton(
+                            vectorIconRes = R.drawable.ic_copy,
+                            contentDescription = stringResource(id = R.string.copy),
                             onClick = { onCopyCustomTextField(customField.value) },
                         )
                     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
@@ -18,15 +18,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenHiddenPasswordField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordFieldWithActions
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithActions
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
-import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIconButtonWithResource
 import com.x8bit.bitwarden.ui.platform.components.indicator.BitwardenCircularCountdownIndicator
-import com.x8bit.bitwarden.ui.platform.components.model.IconResource
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.feature.item.handlers.VaultCommonItemTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.item.handlers.VaultLoginItemTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.item.model.TotpCodeItemData
@@ -306,23 +304,19 @@ private fun PasswordField(
             readOnly = true,
             singleLine = false,
             actions = {
-                BitwardenIconButtonWithResource(
-                    iconRes = IconResource(
-                        iconPainter = rememberVectorPainter(id = R.drawable.ic_check_mark),
-                        contentDescription = stringResource(
-                            id = R.string.check_known_data_breaches_for_this_password,
-                        ),
+                BitwardenFilledIconButton(
+                    vectorIconRes = R.drawable.ic_check_mark,
+                    contentDescription = stringResource(
+                        id = R.string.check_known_data_breaches_for_this_password,
                     ),
                     onClick = onCheckForBreachClick,
-                    modifier = Modifier.testTag("LoginCheckPasswordButton"),
+                    modifier = Modifier.testTag(tag = "LoginCheckPasswordButton"),
                 )
-                BitwardenIconButtonWithResource(
-                    iconRes = IconResource(
-                        iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                        contentDescription = stringResource(id = R.string.copy_password),
-                    ),
+                BitwardenFilledIconButton(
+                    vectorIconRes = R.drawable.ic_copy,
+                    contentDescription = stringResource(id = R.string.copy_password),
                     onClick = onCopyPasswordClick,
-                    modifier = Modifier.testTag("LoginCopyPasswordButton"),
+                    modifier = Modifier.testTag(tag = "LoginCopyPasswordButton"),
                 )
             },
             modifier = modifier,
@@ -384,13 +378,11 @@ private fun TotpField(
                         timeLeftSeconds = totpCodeItemData.timeLeftSeconds,
                         periodSeconds = totpCodeItemData.periodSeconds,
                     )
-                    BitwardenIconButtonWithResource(
-                        iconRes = IconResource(
-                            iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                            contentDescription = stringResource(id = R.string.copy_totp),
-                        ),
+                    BitwardenFilledIconButton(
+                        vectorIconRes = R.drawable.ic_copy,
+                        contentDescription = stringResource(id = R.string.copy_totp),
                         onClick = onCopyTotpClick,
-                        modifier = Modifier.testTag("LoginCopyTotpButton"),
+                        modifier = Modifier.testTag(tag = "LoginCopyTotpButton"),
                     )
                 },
                 modifier = modifier,
@@ -425,23 +417,19 @@ private fun UriField(
         singleLine = false,
         actions = {
             if (uriData.isLaunchable) {
-                BitwardenIconButtonWithResource(
-                    iconRes = IconResource(
-                        iconPainter = rememberVectorPainter(id = R.drawable.ic_launch),
-                        contentDescription = stringResource(id = R.string.launch),
-                    ),
+                BitwardenFilledIconButton(
+                    vectorIconRes = R.drawable.ic_launch,
+                    contentDescription = stringResource(id = R.string.launch),
                     onClick = { onLaunchUriClick(uriData.uri) },
-                    modifier = Modifier.testTag("LoginLaunchUriButton"),
+                    modifier = Modifier.testTag(tag = "LoginLaunchUriButton"),
                 )
             }
             if (uriData.isCopyable) {
-                BitwardenIconButtonWithResource(
-                    iconRes = IconResource(
-                        iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                        contentDescription = stringResource(id = R.string.copy),
-                    ),
+                BitwardenFilledIconButton(
+                    vectorIconRes = R.drawable.ic_copy,
+                    contentDescription = stringResource(id = R.string.copy),
                     onClick = { onCopyUriClick(uriData.uri) },
-                    modifier = Modifier.testTag("LoginCopyUriButton"),
+                    modifier = Modifier.testTag(tag = "LoginCopyUriButton"),
                 )
             }
         },
@@ -463,13 +451,11 @@ private fun UsernameField(
         readOnly = true,
         singleLine = false,
         actions = {
-            BitwardenIconButtonWithResource(
-                iconRes = IconResource(
-                    iconPainter = rememberVectorPainter(id = R.drawable.ic_copy),
-                    contentDescription = stringResource(id = R.string.copy_username),
-                ),
+            BitwardenFilledIconButton(
+                vectorIconRes = R.drawable.ic_copy,
+                contentDescription = stringResource(id = R.string.copy_username),
                 onClick = onCopyUsernameClick,
-                modifier = Modifier.testTag("LoginCopyUsernameButton"),
+                modifier = Modifier.testTag(tag = "LoginCopyUsernameButton"),
             )
         },
         modifier = modifier,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultFilter.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultFilter.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -23,9 +21,9 @@ import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.bottomDivider
 import com.x8bit.bitwarden.ui.platform.base.util.scrolledContainerBackground
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenSelectionRow
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 import kotlinx.collections.immutable.ImmutableList
 
@@ -92,15 +90,12 @@ fun VaultFilter(
 
         Spacer(modifier = Modifier.width(16.dp))
 
-        IconButton(
+        BitwardenStandardIconButton(
+            vectorIconRes = R.drawable.ic_more_horizontal,
+            contentDescription = stringResource(id = R.string.filter_by_vault),
             onClick = { shouldShowSelectionDialog = true },
-            modifier = Modifier.testTag("OpenOrgFilter"),
-        ) {
-            Icon(
-                painter = rememberVectorPainter(id = R.drawable.ic_more_horizontal),
-                contentDescription = stringResource(id = R.string.filter_by_vault),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag(tag = "OpenOrgFilter"),
+        )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeItem.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeItem.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
@@ -22,10 +20,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIcon
 import com.x8bit.bitwarden.ui.platform.components.indicator.BitwardenCircularCountdownIndicator
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
@@ -112,16 +110,12 @@ fun VaultVerificationCodeItem(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
-            IconButton(
+            BitwardenStandardIconButton(
+                vectorIconRes = R.drawable.ic_copy,
+                contentDescription = stringResource(id = R.string.copy),
                 onClick = onCopyClick,
-            ) {
-                Icon(
-                    painter = rememberVectorPainter(id = R.drawable.ic_copy),
-                    contentDescription = stringResource(id = R.string.copy),
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp),
-                )
-            }
+                contentColor = MaterialTheme.colorScheme.primary,
+            )
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds reusable icon button components.

No visual or functional changes were made in this PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
