### PR TITLE
Disable stepper buttons when they reach the end of range

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -26,7 +26,7 @@ import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithAc
  * @param textFieldReadOnly whether or not the text field should be read only. The stepper
  * increment and decrement buttons function regardless of this value.
  */
-@Suppress("LongMethod")
+@Suppress("CyclomaticComplexMethod")
 @Composable
 fun BitwardenStepper(
     label: String,
@@ -45,45 +45,41 @@ fun BitwardenStepper(
     if (clampedValue != value && clampedValue != null) {
         onValueChange(clampedValue)
     }
+    val isAtRangeMinimum = clampedValue?.let { (it - 1) !in range } ?: true
+    val isAtRangeMaximum = clampedValue?.let { (it + 1) !in range } ?: false
     BitwardenTextFieldWithActions(
         label = label,
         // We use the zero width character instead of an empty string to make sure label is shown
         // small and above the input
-        value = clampedValue
-            ?.toString()
-            ?: ZERO_WIDTH_CHARACTER,
+        value = clampedValue?.toString() ?: ZERO_WIDTH_CHARACTER,
         actionsTestTag = stepperActionsTestTag,
         actions = {
             BitwardenFilledIconButton(
                 vectorIconRes = R.drawable.ic_minus,
                 contentDescription = "\u2212",
                 onClick = {
-                    val decrementedValue = ((value ?: 0) - 1).coerceIn(range)
-                    if (decrementedValue != value) {
+                    val decrementedValue = ((clampedValue ?: 0) - 1).coerceIn(range)
+                    if (decrementedValue != clampedValue) {
                         onValueChange(decrementedValue)
                     }
                 },
-                isEnabled = isDecrementEnabled,
+                isEnabled = isDecrementEnabled && !isAtRangeMinimum,
                 modifier = Modifier.semantics {
-                    if (decreaseButtonTestTag != null) {
-                        testTag = decreaseButtonTestTag
-                    }
+                    decreaseButtonTestTag?.let { testTag = it }
                 },
             )
             BitwardenFilledIconButton(
                 vectorIconRes = R.drawable.ic_plus,
                 contentDescription = "+",
                 onClick = {
-                    val incrementedValue = ((value ?: 0) + 1).coerceIn(range)
-                    if (incrementedValue != value) {
+                    val incrementedValue = ((clampedValue ?: 0) + 1).coerceIn(range)
+                    if (incrementedValue != clampedValue) {
                         onValueChange(incrementedValue)
                     }
                 },
-                isEnabled = isIncrementEnabled,
+                isEnabled = isIncrementEnabled && !isAtRangeMaximum,
                 modifier = Modifier.semantics {
-                    if (increaseButtonTestTag != null) {
-                        testTag = increaseButtonTestTag
-                    }
+                    increaseButtonTestTag?.let { testTag = it }
                 },
             )
         },
@@ -95,7 +91,7 @@ fun BitwardenStepper(
                     // Make sure the placeholder is gone, since it will mess up the int conversion
                     .replace(ZERO_WIDTH_CHARACTER, "")
                     .orNullIfBlank()
-                    ?.let { it.toIntOrNull()?.coerceIn(range) ?: value }
+                    ?.let { it.toIntOrNull()?.coerceIn(range) ?: clampedValue }
                     ?: range.start,
             )
         },


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR disables the stepper buttons when the values are at the end of the specified range.

## 📸 Screenshots

| Before | After |
| --- | -- |
| <video src="https://github.com/user-attachments/assets/f95c7c1d-80ba-424f-874d-91bf536dc263" width="300" /> | <video src="https://github.com/user-attachments/assets/7bf125e9-b5ed-41e6-b478-7a8412f459b2" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
