### PR TITLE
Add reusable radio button

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/row/BitwardenSelectionRow.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/row/BitwardenSelectionRow.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,6 +13,7 @@ import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.ui.platform.base.util.Text
+import com.x8bit.bitwarden.ui.platform.components.radio.BitwardenRadioButton
 
 /**
  * A clickable item that displays a radio button and text.
@@ -38,9 +38,9 @@ fun BitwardenSelectionRow(
             },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        RadioButton(
+        BitwardenRadioButton(
             modifier = Modifier.padding(16.dp),
-            selected = isSelected,
+            isSelected = isSelected,
             onClick = null,
         )
         Text(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/radio/BitwardenRadioButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/radio/BitwardenRadioButton.kt
@@ -1,0 +1,27 @@
+package com.x8bit.bitwarden.ui.platform.components.radio
+
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * A custom Bitwarden-themed radio button.
+ *
+ * @param isSelected Whether this radio button is selected or not.
+ * @param onClick The lambda to be invoked when the item is clicked.
+ * @param modifier The [Modifier] to be applied to this radio button.
+ */
+@Composable
+fun BitwardenRadioButton(
+    isSelected: Boolean,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    RadioButton(
+        modifier = modifier,
+        selected = isSelected,
+        onClick = onClick,
+        colors = RadioButtonDefaults.colors(),
+    )
+}


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds a reusable `BitwardenRadioButton` that can have custom theming applied to it.

There are no functional changes in this PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
