### PR TITLE
Add BitwardenOutlinedErrorButton and rename BitwardenErrorButton

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenFilledErrorButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenFilledErrorButton.kt
@@ -21,7 +21,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * @param isEnabled Whether or not the button is enabled.
  */
 @Composable
-fun BitwardenErrorButton(
+fun BitwardenFilledErrorButton(
     label: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -51,7 +51,7 @@ fun BitwardenErrorButton(
 @Composable
 private fun BitwardenErrorButton_preview_isEnabled() {
     BitwardenTheme {
-        BitwardenErrorButton(
+        BitwardenFilledErrorButton(
             label = "Label",
             onClick = {},
             isEnabled = true,
@@ -63,7 +63,7 @@ private fun BitwardenErrorButton_preview_isEnabled() {
 @Composable
 private fun BitwardenErrorButton_preview_isNotEnabled() {
     BitwardenTheme {
-        BitwardenErrorButton(
+        BitwardenFilledErrorButton(
             label = "Label",
             onClick = {},
             isEnabled = false,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenOutlinedErrorButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenOutlinedErrorButton.kt
@@ -1,0 +1,73 @@
+package com.x8bit.bitwarden.ui.platform.components.button
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * Represents a Bitwarden-styled filled [OutlinedButton] for error states.
+ *
+ * @param label The label for the button.
+ * @param onClick The callback when the button is clicked.
+ * @param modifier The [Modifier] to be applied to the button.
+ * @param isEnabled Whether or not the button is enabled.
+ */
+@Composable
+fun BitwardenOutlinedErrorButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
+) {
+    OutlinedButton(
+        modifier = modifier.semantics(mergeDescendants = true) { },
+        onClick = onClick,
+        enabled = isEnabled,
+        contentPadding = PaddingValues(
+            vertical = 10.dp,
+            horizontal = 24.dp,
+        ),
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = MaterialTheme.colorScheme.error,
+        ),
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.error.copy(
+                alpha = if (isEnabled) 1f else 0.12f,
+            ),
+        ),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BitwardenOutlinedErrorButton_preview_isEnabled() {
+    BitwardenOutlinedErrorButton(
+        label = "Label",
+        onClick = {},
+        isEnabled = true,
+    )
+}
+
+@Preview
+@Composable
+private fun BBitwardenOutlinedErrorButton_preview_isNotEnabled() {
+    BitwardenOutlinedErrorButton(
+        label = "Label",
+        onClick = {},
+        isEnabled = false,
+    )
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreen.kt
@@ -34,7 +34,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
-import com.x8bit.bitwarden.ui.platform.components.button.BitwardenErrorButton
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledErrorButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
@@ -203,7 +203,7 @@ private fun DeleteAccountButton(
         )
     }
 
-    BitwardenErrorButton(
+    BitwardenFilledErrorButton(
         label = stringResource(id = R.string.delete_account),
         onClick = {
             if (isUnlockWithPasswordEnabled) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreen.kt
@@ -32,7 +32,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
-import com.x8bit.bitwarden.ui.platform.components.button.BitwardenErrorButton
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledErrorButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
@@ -176,7 +176,7 @@ private fun DeleteAccountConfirmationContent(
                 .fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(12.dp))
-        BitwardenErrorButton(
+        BitwardenFilledErrorButton(
             label = stringResource(id = R.string.delete_account),
             onClick = onDeleteAccountClick,
             isEnabled = state.verificationCode.isNotBlank(),


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR renames the `BitwardenErrorButton` to `BitwardenFilledErrorButton` to be more inline with the naming conventions and adds a new `BitwardenOutlinedErrorButton` which will be used in the future.

No functional or visual changes were made in this PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
