### PR TITLE
BITAU-99 Expose and protect `AuthenticatorBridgeService`

### DIFF
--- a/app/src/beta/res/values/manifest.xml
+++ b/app/src/beta/res/values/manifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- For beta variant, we don't have a matching variant of the Bitwarden Authenticator app.
+    Therefore, we leave the known app cert null here so that no clients can connect to
+    AuthenticatorBridgeService in the beta variant. If later another variant of the
+    Bitwarden Authenticator app is added, a SHA-256 digest of that variant's APK can be added here.
+    -->
+    <string name="known_authenticator_app_cert">@null</string>
+</resources>

--- a/app/src/debug/res/values/manifest.xml
+++ b/app/src/debug/res/values/manifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- This is the SHA-256 digest for the Authenticator App debug variant:-->
+    <string name="known_authenticator_app_cert">13144ab52af797a88c2fe292674461ef1715e0e1e4f5f538f63f1c174696f476</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,20 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Protect access to AuthenticatorBridgeService using this custom permission.
+
+    Note that each build type uses a different value for knownCerts.
+
+    This in effect means that the only application that can connect to the debug/release/etc
+    variant AuthenticatorBridgeService is the debug/release/etc variant Bitwarden Authenticator
+    app. -->
+    <permission
+        android:name="${applicationId}.permission.AUTHENTICATOR_BRIDGE_SERVICE"
+        android:knownCerts="@string/known_authenticator_app_cert"
+        android:label="Bitwarden Bridge"
+        android:protectionLevel="signature|knownSigner"
+        tools:targetApi="s" />
+
     <application
         android:name=".BitwardenApplication"
         android:allowBackup="false"
@@ -276,6 +290,11 @@
         <meta-data
             android:name="android.content.APP_RESTRICTIONS"
             android:resource="@xml/app_restrictions" />
+
+        <service
+            android:name="com.x8bit.bitwarden.data.platform.service.AuthenticatorBridgeService"
+            android:exported="true"
+            android:permission="${applicationId}.permission.AUTHENTICATOR_BRIDGE_SERVICE" />
 
     </application>
 

--- a/app/src/release/res/values/manifest.xml
+++ b/app/src/release/res/values/manifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- This is the SHA-256 digest for the Authenticator App Release variant:-->
+    <string name="known_authenticator_app_cert">45bd689eb1493eaef19c346dc1385197ddbb53ddc5d09476db4895df75b9b53b</string>
+</resources>

--- a/app/src/release/res/values/manifest.xml
+++ b/app/src/release/res/values/manifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- This is the SHA-256 digest for the Authenticator App Release variant:-->
+    <!-- This is the SHA-256 digest for Google Play signing key of theAuthenticator App Release
+    variant: -->
     <string name="known_authenticator_app_cert">45bd689eb1493eaef19c346dc1385197ddbb53ddc5d09476db4895df75b9b53b</string>
 </resources>

--- a/app/src/release/res/values/manifest.xml
+++ b/app/src/release/res/values/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- This is the SHA-256 digest for Google Play signing key of theAuthenticator App Release
+    <!-- This is the SHA-256 digest for Google Play signing key of the Authenticator App Release
     variant: -->
     <string name="known_authenticator_app_cert">45bd689eb1493eaef19c346dc1385197ddbb53ddc5d09476db4895df75b9b53b</string>
 </resources>


### PR DESCRIPTION
> [!NOTE]
> I tested these two cases:

[X] does this work for release <> release variant communication. 

I tested this with two one-off builds:
- [Main App Build](https://github.com/bitwarden/android/actions/runs/11151653148)
- [Authenticator App Build](https://github.com/bitwarden/authenticator-android/actions/runs/11148769402)

By clicking on the build links, you can see the commit that was build to see what changes are required by the authenticator app. 

[X] what happens under android version S?

- The coroutines wrapper returns an error in this case because we cannot connect to the bridge service. I'm going to add code to the wrapper to handle this expicitly and return a `OSVersionNotSupported` as part of BITAU-69.

## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-99

## 📔 Objective

The goal of this PR is to expose access to authenticator bridge service behind a permission that is scoped so that only the bitwarden authenticator app may use the service.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
