### PR TITLE
[PM-12739] Updated generator maximum number and specials

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -68,6 +68,7 @@ import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlin.math.max
 
 /**
  * Top level composable for the generator screen.
@@ -550,7 +551,7 @@ private fun ColumnScope.PasswordTypeContent(
         minNumbers = passwordTypeState.minNumbers,
         onPasswordMinNumbersCounterChange =
         passwordHandlers.onPasswordMinNumbersCounterChange,
-        maxValue = passwordTypeState.maxNumbersAllowed,
+        maxValue = max(passwordTypeState.maxNumbersAllowed, passwordTypeState.minNumbersAllowed),
         minValue = passwordTypeState.minNumbersAllowed,
     )
 
@@ -560,7 +561,7 @@ private fun ColumnScope.PasswordTypeContent(
         minSpecial = passwordTypeState.minSpecial,
         onPasswordMinSpecialCharactersChange =
         passwordHandlers.onPasswordMinSpecialCharactersChange,
-        maxValue = passwordTypeState.maxSpecialAllowed,
+        maxValue = max(passwordTypeState.maxSpecialAllowed, passwordTypeState.minSpecialAllowed),
         minValue = passwordTypeState.minSpecialAllowed,
     )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -1862,7 +1862,7 @@ data class GeneratorState(
                         const val PASSWORD_LENGTH_SLIDER_MIN: Int = 5
                         const val PASSWORD_LENGTH_SLIDER_MAX: Int = 128
                         const val PASSWORD_COUNTER_MIN: Int = 0
-                        const val PASSWORD_COUNTER_MAX: Int = 5
+                        const val PASSWORD_COUNTER_MAX: Int = 9
                     }
                 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -31,6 +31,7 @@ import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFl
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Passcode.PasscodeType.Password.Companion.PASSWORD_COUNTER_MAX
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
 import io.mockk.every
 import io.mockk.just
@@ -551,8 +552,8 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, incrementing the minimum numbers counter above 5 should do nothing`() {
-        val initialMinNumbers = 5
+    fun `in Passcode_Password state, incrementing the minimum numbers counter above PASSWORD_COUNTER_MAX should do nothing`() {
+        val initialMinNumbers = PASSWORD_COUNTER_MAX
         updateState(
             DEFAULT_STATE.copy(
                 selectedType = GeneratorState.MainType.Passcode(
@@ -650,8 +651,8 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, decrementing the minimum special characters above 5 should do nothing`() {
-        val initialSpecialChars = 5
+    fun `in Passcode_Password state, decrementing the minimum special characters above PASSWORD_COUNTER_MAX should do nothing`() {
+        val initialSpecialChars = PASSWORD_COUNTER_MAX
         updateState(
             DEFAULT_STATE.copy(
                 selectedType = GeneratorState.MainType.Passcode(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -821,6 +821,35 @@ class GeneratorScreenTest : BaseComposeTest() {
         }
     }
 
+    @Test
+    fun `in Passcode_Password state, maximum numbers should match minimum if lower`() {
+        val initialMinNumbers = 7
+        val initialMaxNumbers = 5
+
+        updateState(
+            DEFAULT_STATE.copy(
+                selectedType = GeneratorState.MainType.Passcode(
+                    GeneratorState
+                        .MainType
+                        .Passcode
+                        .PasscodeType
+                        .Password(
+                            minNumbersAllowed = initialMinNumbers,
+                            maxNumbersAllowed = initialMaxNumbers,
+                        ),
+                ),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithText("Minimum numbers")
+            .assertTextEquals("Minimum numbers", "7")
+            .onSiblings()
+            .filterToOne(hasContentDescription("\u2212"))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
     @Suppress("MaxLineLength")
     @Test
     fun `in Passcode_Password state, minimum special characters cannot go below minimum threshold`() {
@@ -854,6 +883,34 @@ class GeneratorScreenTest : BaseComposeTest() {
                 ),
             )
         }
+    }
+
+    @Test
+    fun `in Passcode_Password state, maximum special should match minimum if lower `() {
+        val initialMinSpecials = 7
+        val initialMaxSpecials = 5
+
+        updateState(
+            DEFAULT_STATE.copy(
+                selectedType = GeneratorState.MainType.Passcode(
+                    GeneratorState
+                        .MainType
+                        .Passcode
+                        .PasscodeType
+                        .Password(
+                            minSpecialAllowed = initialMinSpecials,
+                            maxSpecialAllowed = initialMaxSpecials,
+                        ),
+                ),
+            ),
+        )
+
+        composeTestRule.onNodeWithText("Minimum special")
+            .assertTextEquals("Minimum special", "7")
+            .onSiblings()
+            .filterToOne(hasContentDescription("\u2212"))
+            .performScrollTo()
+            .performClick()
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -31,7 +31,6 @@ import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFl
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
-import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Passcode.PasscodeType.Password.Companion.PASSWORD_COUNTER_MAX
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
 import io.mockk.every
 import io.mockk.just
@@ -552,8 +551,8 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, incrementing the minimum numbers counter above PASSWORD_COUNTER_MAX should do nothing`() {
-        val initialMinNumbers = PASSWORD_COUNTER_MAX
+    fun `in Passcode_Password state, incrementing the minimum numbers counter above 9 should do nothing`() {
+        val initialMinNumbers = 9
         updateState(
             DEFAULT_STATE.copy(
                 selectedType = GeneratorState.MainType.Passcode(
@@ -651,8 +650,8 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, decrementing the minimum special characters above PASSWORD_COUNTER_MAX should do nothing`() {
-        val initialSpecialChars = PASSWORD_COUNTER_MAX
+    fun `in Passcode_Password state, decrementing the minimum special characters above 9 should do nothing`() {
+        val initialSpecialChars = 9
         updateState(
             DEFAULT_STATE.copy(
                 selectedType = GeneratorState.MainType.Passcode(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -26,6 +26,7 @@ import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockPolicy
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
+import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Passcode.PasscodeType.Password.Companion.PASSWORD_COUNTER_MAX
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Username.UsernameType.ForwardedEmailAlias.ServiceType
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Username.UsernameType.ForwardedEmailAlias.ServiceTypeOption
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
@@ -228,10 +229,10 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                             specialCharsEnabled = false,
                             minNumbers = 3,
                             minNumbersAllowed = 3,
-                            maxNumbersAllowed = 5,
+                            maxNumbersAllowed = PASSWORD_COUNTER_MAX,
                             minSpecial = 3,
                             minSpecialAllowed = 3,
-                            maxSpecialAllowed = 5,
+                            maxSpecialAllowed = PASSWORD_COUNTER_MAX,
                             avoidAmbiguousChars = false,
                             ambiguousCharsEnabled = true,
                             isUserInteracting = false,
@@ -262,10 +263,10 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                             specialCharsEnabled = true,
                             minNumbers = 3,
                             minNumbersAllowed = 0,
-                            maxNumbersAllowed = 5,
+                            maxNumbersAllowed = PASSWORD_COUNTER_MAX,
                             minSpecial = 3,
                             minSpecialAllowed = 0,
-                            maxSpecialAllowed = 5,
+                            maxSpecialAllowed = PASSWORD_COUNTER_MAX,
                             avoidAmbiguousChars = false,
                             ambiguousCharsEnabled = true,
                             isUserInteracting = false,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -26,7 +26,6 @@ import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockPolicy
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
-import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Passcode.PasscodeType.Password.Companion.PASSWORD_COUNTER_MAX
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Username.UsernameType.ForwardedEmailAlias.ServiceType
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Username.UsernameType.ForwardedEmailAlias.ServiceTypeOption
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
@@ -229,10 +228,10 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                             specialCharsEnabled = false,
                             minNumbers = 3,
                             minNumbersAllowed = 3,
-                            maxNumbersAllowed = PASSWORD_COUNTER_MAX,
+                            maxNumbersAllowed = 9,
                             minSpecial = 3,
                             minSpecialAllowed = 3,
-                            maxSpecialAllowed = PASSWORD_COUNTER_MAX,
+                            maxSpecialAllowed = 9,
                             avoidAmbiguousChars = false,
                             ambiguousCharsEnabled = true,
                             isUserInteracting = false,
@@ -263,10 +262,10 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                             specialCharsEnabled = true,
                             minNumbers = 3,
                             minNumbersAllowed = 0,
-                            maxNumbersAllowed = PASSWORD_COUNTER_MAX,
+                            maxNumbersAllowed = 9,
                             minSpecial = 3,
                             minSpecialAllowed = 0,
-                            maxSpecialAllowed = PASSWORD_COUNTER_MAX,
+                            maxSpecialAllowed = 9,
                             avoidAmbiguousChars = false,
                             ambiguousCharsEnabled = true,
                             isUserInteracting = false,
@@ -986,7 +985,6 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                     capitalizeEnabled = true,
                     includeNumber = false,
                     includeNumberEnabled = true,
-
                 ),
             ),
             generatedText = "updatedPassphrase",


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12739

## 📔 Objective

Updated maximum number and specials to match [other clients](https://github.com/bitwarden/clients/blob/main/libs/tools/generator/core/src/data/default-password-boundaries.ts) and server 
If minimum value is higher than maximum, set it as new maximum in order to avoid the app to crash in a scenario minimum is higher than maximum
Added tests

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
