### PR TITLE
PM-12760 Add way to re-show the onboarding carousel via debug menu

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepository.kt
@@ -37,4 +37,11 @@ interface DebugMenuRepository {
      * Resets the onboarding status to NOT_STARTED for the current active user, if applicable.
      */
     fun resetOnboardingStatusForCurrentUser()
+
+    /**
+     * Manipulates the state to force showing the onboarding carousel.
+     *
+     * @param userStateUpdateTrigger A passable lambda to trigger a user state update.
+     */
+    fun modifyStateToShowOnboardingCarousel(userStateUpdateTrigger: () -> Unit)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDiskSource
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.getFlagValueOrDefault
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.onSubscription
 class DebugMenuRepositoryImpl(
     private val featureFlagOverrideDiskSource: FeatureFlagOverrideDiskSource,
     private val serverConfigRepository: ServerConfigRepository,
+    private val settingsDiskSource: SettingsDiskSource,
     private val authDiskSource: AuthDiskSource,
 ) : DebugMenuRepository {
 
@@ -52,5 +54,12 @@ class DebugMenuRepositoryImpl(
             userId = currentUserId,
             onboardingStatus = OnboardingStatus.NOT_STARTED,
         )
+    }
+
+    override fun modifyStateToShowOnboardingCarousel(
+        userStateUpdateTrigger: () -> Unit,
+    ) {
+        settingsDiskSource.hasUserLoggedInOrCreatedAccount = false
+        userStateUpdateTrigger.invoke()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -117,9 +117,11 @@ object PlatformRepositoryModule {
         featureFlagOverrideDiskSource: FeatureFlagOverrideDiskSource,
         serverConfigRepository: ServerConfigRepository,
         authDiskSource: AuthDiskSource,
+        settingsDiskSource: SettingsDiskSource,
     ): DebugMenuRepository = DebugMenuRepositoryImpl(
         featureFlagOverrideDiskSource = featureFlagOverrideDiskSource,
         serverConfigRepository = serverConfigRepository,
         authDiskSource = authDiskSource,
+        settingsDiskSource = settingsDiskSource,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -159,7 +159,7 @@ private fun FeatureFlagContent(
  * The content for the onboarding override feature flag.
  */
 @Composable
-fun OnboardingOverrideContent(
+private fun OnboardingOverrideContent(
     isRestartOnboardingEnabled: Boolean,
     onStartOnboarding: () -> Unit,
     isCarouselOverrideEnabled: Boolean,
@@ -207,7 +207,7 @@ fun OnboardingOverrideContent(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .standardHorizontalMargin(),
-            style = MaterialTheme.typography.bodySmall,
+            style = BitwardenTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -42,6 +42,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * Top level screen for the debug menu.
  */
 @OptIn(ExperimentalMaterial3Api::class)
+@Suppress("LongMethod")
 @Composable
 fun DebugMenuScreen(
     onNavigateBack: () -> Unit,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -95,11 +95,21 @@ fun DebugMenuScreen(
                 },
             )
             Spacer(Modifier.height(12.dp))
+            // Pulled these into variable to avoid over-nested formatting in the composable call.
+            val isRestartOnboardingEnabled = state.featureFlags[FlagKey.OnboardingFlow] as? Boolean
+            val isRestartOnboardingCarouselEnabled = state
+                .featureFlags[FlagKey.OnboardingCarousel] as? Boolean
             OnboardingOverrideContent(
-                enabled = (state.featureFlags[FlagKey.OnboardingFlow] as? Boolean) == true,
+                isRestartOnboardingEnabled = isRestartOnboardingEnabled == true,
                 onStartOnboarding = remember(viewModel) {
                     {
-                        viewModel.trySendAction(DebugMenuAction.ReStartOnboarding)
+                        viewModel.trySendAction(DebugMenuAction.RestartOnboarding)
+                    }
+                },
+                isCarouselOverrideEnabled = isRestartOnboardingCarouselEnabled == true,
+                onStartOnboardingCarousel = remember(viewModel) {
+                    {
+                        viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel)
                     }
                 },
             )
@@ -144,10 +154,15 @@ private fun FeatureFlagContent(
     }
 }
 
+/**
+ * The content for the onboarding override feature flag.
+ */
 @Composable
-private fun OnboardingOverrideContent(
-    enabled: Boolean,
+fun OnboardingOverrideContent(
+    isRestartOnboardingEnabled: Boolean,
     onStartOnboarding: () -> Unit,
+    isCarouselOverrideEnabled: Boolean,
+    onStartOnboardingCarousel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -161,7 +176,7 @@ private fun OnboardingOverrideContent(
         BitwardenFilledButton(
             label = stringResource(R.string.restart_onboarding_cta),
             onClick = onStartOnboarding,
-            isEnabled = enabled,
+            isEnabled = isRestartOnboardingEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
@@ -173,6 +188,25 @@ private fun OnboardingOverrideContent(
                 .align(Alignment.CenterHorizontally)
                 .standardHorizontalMargin(),
             style = BitwardenTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(16.dp))
+        BitwardenFilledButton(
+            label = stringResource(R.string.restart_onboarding_carousel),
+            onClick = onStartOnboardingCarousel,
+            isEnabled = isCarouselOverrideEnabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.restart_onboarding_carousel_details),
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .standardHorizontalMargin(),
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
@@ -199,6 +233,11 @@ private fun FeatureFlagContent_preview() {
 @Composable
 private fun OnboardingOverrideContent_preview() {
     BitwardenTheme {
-        OnboardingOverrideContent(onStartOnboarding = {}, enabled = true)
+        OnboardingOverrideContent(
+            onStartOnboarding = {},
+            isRestartOnboardingEnabled = true,
+            onStartOnboardingCarousel = {},
+            isCarouselOverrideEnabled = true,
+        )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.platform.feature.debugmenu
 
 import androidx.lifecycle.viewModelScope
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.DebugMenuRepository
@@ -22,6 +23,7 @@ import javax.inject.Inject
 class DebugMenuViewModel @Inject constructor(
     featureFlagManager: FeatureFlagManager,
     private val debugMenuRepository: DebugMenuRepository,
+    private val authRepository: AuthRepository,
 ) : BaseViewModel<DebugMenuState, DebugMenuEvent, DebugMenuAction>(
     initialState = DebugMenuState(featureFlags = emptyMap()),
 ) {
@@ -44,8 +46,17 @@ class DebugMenuViewModel @Inject constructor(
             is DebugMenuAction.Internal.UpdateFeatureFlagMap -> handleUpdateFeatureFlagMap(action)
             DebugMenuAction.NavigateBack -> handleNavigateBack()
             DebugMenuAction.ResetFeatureFlagValues -> handleResetFeatureFlagValues()
-            DebugMenuAction.ReStartOnboarding -> handleResetOnboardingStatus()
+            DebugMenuAction.RestartOnboarding -> handleResetOnboardingStatus()
+            DebugMenuAction.RestartOnboardingCarousel -> handleResetOnboardingCarousel()
         }
+    }
+
+    private fun handleResetOnboardingCarousel() {
+        debugMenuRepository.modifyStateToShowOnboardingCarousel(
+            userStateUpdateTrigger = {
+                authRepository.hasPendingAccountAddition = true
+            },
+        )
     }
 
     private fun handleResetOnboardingStatus() {
@@ -115,7 +126,12 @@ sealed class DebugMenuAction {
     /**
      * The user has clicked the restart onboarding button for the onboarding section.
      */
-    data object ReStartOnboarding : DebugMenuAction()
+    data object RestartOnboarding : DebugMenuAction()
+
+    /**
+     * The user has clicked the restart onboarding button for the onboarding section.
+     */
+    data object RestartOnboardingCarousel : DebugMenuAction()
 
     /**
      * Internal actions not triggered from the UI.

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -17,5 +17,7 @@
     <string name="onboarding_override">Onboarding Status Override</string>
     <string name="restart_onboarding_cta">Restart Onboarding</string>
     <string name="restart_onboarding_details">This will reset the onboarding status for the current user, if available. After clicking the button you will immediately be redirected to the onboarding flow. Onboarding flag must be enabled.</string>
+    <string name="restart_onboarding_carousel">Show Onboarding Carousel</string>
+    <string name="restart_onboarding_carousel_details">This will force the change to app state which will cause the first time carousel to show. The carousel will continue to show for any \"new\" account until a login is completed. May need to exit debug menu manually.</string>
     <!-- /Debug Menu -->
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
@@ -110,7 +110,7 @@ class DebugMenuScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `restart onboarding should send action when clicked`() {
+    fun `restart onboarding should send action when enabled and clicked`() {
         mutableStateFlow.tryEmit(
             DebugMenuState(
                 featureFlags = mapOf(
@@ -124,11 +124,11 @@ class DebugMenuScreenTest : BaseComposeTest() {
             .assertIsEnabled()
             .performClick()
 
-        verify { viewModel.trySendAction(DebugMenuAction.ReStartOnboarding) }
+        verify { viewModel.trySendAction(DebugMenuAction.RestartOnboarding) }
     }
 
     @Test
-    fun `no restart onboarding should not send action when not enabled`() {
+    fun `restart onboarding should not send action when not enabled`() {
         mutableStateFlow.tryEmit(
             DebugMenuState(
                 featureFlags = mapOf(
@@ -143,6 +143,43 @@ class DebugMenuScreenTest : BaseComposeTest() {
             .assertIsNotEnabled()
             .performClick()
 
-        verify(exactly = 0) { viewModel.trySendAction(DebugMenuAction.ReStartOnboarding) }
+        verify(exactly = 0) { viewModel.trySendAction(DebugMenuAction.RestartOnboarding) }
+    }
+
+    @Test
+    fun `Show onboarding carousel should send action when enabled and clicked`() {
+        mutableStateFlow.tryEmit(
+            DebugMenuState(
+                featureFlags = mapOf(
+                    FlagKey.OnboardingCarousel to true,
+                ),
+            ),
+        )
+        composeTestRule
+            .onNodeWithText("Show Onboarding Carousel", ignoreCase = true)
+            .performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+
+        verify { viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel) }
+    }
+
+    @Test
+    fun `show onboarding carousel should not send action when not enabled`() {
+        mutableStateFlow.tryEmit(
+            DebugMenuState(
+                featureFlags = mapOf(
+                    FlagKey.OnboardingCarousel to false,
+                ),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithText("Show Onboarding Carousel", ignoreCase = true)
+            .performScrollTo()
+            .assertIsNotEnabled()
+            .performClick()
+
+        verify(exactly = 0) { viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel) }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12760
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Allow users of debug menu the ability to revisit the Onboarding carousel flow after already logging in.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/e7aebd95-3fe8-4067-81e6-25c0863fc1ac


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
