### PR TITLE
[PM-10678] Rename VaultUnlockDialog.Error to UnlockError

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -118,7 +118,7 @@ fun VaultUnlockScreen(
 
     // Dynamic dialogs
     when (val dialog = state.dialog) {
-        is VaultUnlockState.VaultUnlockDialog.Error -> BitwardenBasicDialog(
+        is VaultUnlockState.VaultUnlockDialog.UnlockError -> BitwardenBasicDialog(
             visibilityState = BasicDialogState.Shown(
                 title = R.string.an_error_has_occurred.asText(),
                 message = dialog.message,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -205,7 +205,7 @@ class VaultUnlockViewModel @Inject constructor(
         if (state.input.isEmpty()) {
             mutableStateFlow.update {
                 it.copy(
-                    dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                    dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                         it.vaultUnlockType.emptyInputDialogMessage,
                     ),
                 )
@@ -268,7 +268,7 @@ class VaultUnlockViewModel @Inject constructor(
             is VaultUnlockResult.AuthenticationError -> {
                 mutableStateFlow.update {
                     it.copy(
-                        dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                        dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                             if (action.isBiometricLogin) {
                                 R.string.generic_error_message.asText()
                             } else {
@@ -284,7 +284,7 @@ class VaultUnlockViewModel @Inject constructor(
             -> {
                 mutableStateFlow.update {
                     it.copy(
-                        dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                        dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                             R.string.generic_error_message.asText(),
                         ),
                     )
@@ -385,10 +385,10 @@ data class VaultUnlockState(
      */
     sealed class VaultUnlockDialog : Parcelable {
         /**
-         * Represents an error dialog.
+         * Represents a generic unlock error dialog.
          */
         @Parcelize
-        data class Error(
+        data class UnlockError(
             val message: Text,
         ) : VaultUnlockDialog()
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -505,7 +505,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.validation_field_required.asText(
                         initialState.vaultUnlockType.unlockScreenInputLabel,
                     ),
@@ -530,7 +530,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.invalid_master_password.asText(),
                 ),
             ),
@@ -556,7 +556,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.generic_error_message.asText(),
                 ),
             ),
@@ -582,7 +582,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.generic_error_message.asText(),
                 ),
             ),
@@ -664,7 +664,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.validation_field_required.asText(
                         initialState.vaultUnlockType.unlockScreenInputLabel,
                     ),
@@ -689,7 +689,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.invalid_pin.asText(),
                 ),
             ),
@@ -715,7 +715,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.generic_error_message.asText(),
                 ),
             ),
@@ -741,7 +741,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.generic_error_message.asText(),
                 ),
             ),
@@ -839,7 +839,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.generic_error_message.asText(),
                 ),
             ),
@@ -866,7 +866,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.generic_error_message.asText(),
                 ),
             ),
@@ -893,7 +893,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             initialState.copy(
-                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                dialog = VaultUnlockState.VaultUnlockDialog.UnlockError(
                     R.string.generic_error_message.asText(),
                 ),
             ),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10678

## 📔 Objective

This commit renames `VaultUnlockDialog.Error` to `VaultUnlockDialog.UnlockError` for clarity and to avoid potential naming conflicts in the future. Specifically the addition of error dialogs when processing FIDO 2 requests.

There are no functional changes in this PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
