### PR TITLE
Clean up text field typography

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenSearchTopAppBar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenSearchTopAppBar.kt
@@ -24,6 +24,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.x8bit.bitwarden.ui.platform.base.util.tabNavigation
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
  * Represents a Bitwarden styled [TopAppBar] that assumes the following components:
@@ -74,6 +75,7 @@ fun BitwardenSearchTopAppBar(
                     focusedIndicatorColor = Color.Transparent,
                     unfocusedIndicatorColor = Color.Transparent,
                 ),
+                textStyle = BitwardenTheme.typography.bodyLarge,
                 placeholder = { Text(text = placeholder) },
                 value = searchTerm,
                 singleLine = true,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenHiddenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenHiddenPasswordField.kt
@@ -27,7 +27,7 @@ fun BitwardenHiddenPasswordField(
 ) {
     OutlinedTextField(
         modifier = modifier,
-        textStyle = BitwardenTheme.typography.bodyLarge,
+        textStyle = BitwardenTheme.typography.sensitiveInfoSmall,
         label = { Text(text = label) },
         value = value,
         onValueChange = { },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.ui.platform.components.field
 
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -61,7 +60,7 @@ fun BitwardenTextField(
     singleLine: Boolean = true,
     readOnly: Boolean = false,
     enabled: Boolean = true,
-    textStyle: TextStyle? = null,
+    textStyle: TextStyle = BitwardenTheme.typography.bodyLarge,
     shouldAddCustomLineBreaks: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
     isError: Boolean = false,
@@ -70,12 +69,11 @@ fun BitwardenTextField(
 ) {
     var widthPx by remember { mutableIntStateOf(0) }
     val focusRequester = remember { FocusRequester() }
-    val currentTextStyle = textStyle ?: LocalTextStyle.current
     val formattedText = if (shouldAddCustomLineBreaks) {
         value.withLineBreaksAtWidth(
             // Adjust for built in padding
             widthPx = widthPx - 16.dp.toPx(),
-            monospacedTextStyle = currentTextStyle,
+            monospacedTextStyle = textStyle,
         )
     } else {
         value
@@ -114,7 +112,7 @@ fun BitwardenTextField(
         onValueChange = onValueChange,
         singleLine = singleLine,
         readOnly = readOnly,
-        textStyle = currentTextStyle,
+        textStyle = textStyle,
         keyboardOptions = KeyboardOptions.Default.copy(keyboardType = keyboardType),
         isError = isError,
         visualTransformation = visualTransformation,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextFieldWithActions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextFieldWithActions.kt
@@ -49,7 +49,7 @@ fun BitwardenTextFieldWithActions(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    textStyle: TextStyle? = null,
+    textStyle: TextStyle = BitwardenTheme.typography.bodyLarge,
     shouldAddCustomLineBreaks: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     readOnly: Boolean = false,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/slider/BitwardenSlider.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/slider/BitwardenSlider.kt
@@ -74,6 +74,7 @@ fun BitwardenSlider(
     ) {
         OutlinedTextField(
             value = sliderValue.toString(),
+            textStyle = BitwardenTheme.typography.bodyLarge,
             readOnly = true,
             onValueChange = { },
             label = {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the text field typography in the app for consistency.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/7259b2bd-941a-4d5c-b2e4-eb693fa0932c" width="300" /> | <img src="https://github.com/user-attachments/assets/e410e0ee-44a4-414d-8531-0220843aabf6" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
