### PR TITLE
[PM-13074] Explicitly sync FIDO2 credentials

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
@@ -24,6 +24,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
+import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.TotpCodeResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateFolderResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateSendResult
@@ -115,6 +116,12 @@ interface VaultRepository : CipherManager, VaultLockManager {
      * data for the current user.
      */
     fun syncIfNecessary()
+
+    /**
+     * Syncs the user's FIDO 2 credentials. This is an explicit request to sync and is not dependent
+     * on whether the last sync time was sufficiently in the past.
+     */
+    suspend fun syncFido2Credentials(): SyncVaultDataResult
 
     /**
      * Flow that represents the data for a specific vault item as found by ID. This may emit `null`

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/SyncVaultDataResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/SyncVaultDataResult.kt
@@ -1,0 +1,18 @@
+package com.x8bit.bitwarden.data.vault.repository.model
+
+/**
+ * Represents the result of a sync operation.
+ */
+sealed class SyncVaultDataResult {
+    /**
+     * Indicates a successful sync operation.
+     */
+    data object Success : SyncVaultDataResult()
+
+    /**
+     * Indicates a failed sync operation.
+     *
+     * @property throwable The exception that caused the failure, if any.
+     */
+    data class Error(val throwable: Throwable?) : SyncVaultDataResult()
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13074

## 📔 Objective

This commit introduces an explicit sync for FIDO2 credentials, ensuring they are up-to-date when accessed. It modifies the `Fido2CredentialStoreImpl` to call `syncFido2Credentials` instead of the  generic `sync` method.

Additionally, it adds a new `syncFido2Credentials` method to the `VaultRepository` interface and implements it in `VaultRepositoryImpl`,  allowing for targeted FIDO2 credential synchronization. A new sealed class, `SyncFido2CredentialsResult`, is introduced to represent the outcome of this sync operation.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
