### PR TITLE
[PM-12739] adjusted generator length to not be lower than minimum length

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -507,7 +507,7 @@ private fun ColumnScope.PasswordTypeContent(
     BitwardenSlider(
         value = passwordTypeState.length,
         onValueChange = passwordHandlers.onPasswordSliderLengthChange,
-        range = passwordTypeState.minLength..passwordTypeState.maxLength,
+        range = passwordTypeState.computedMinimumLength..passwordTypeState.maxLength,
         sliderTag = "PasswordLengthSlider",
         valueTag = "PasswordLengthLabel",
     )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -2304,6 +2304,53 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 assertEquals(expectedState, viewModel.stateFlow.value)
             }
     }
+
+    @Test
+    fun `Password minimumLength should be at least as long as the sum of the minimums`() {
+        val password =
+            GeneratorState.MainType.Passcode.PasscodeType.Password(
+                length = 14,
+                minLength = 10,
+                useCapitals = true,
+                capitalsEnabled = false,
+                useLowercase = true,
+                lowercaseEnabled = false,
+                useNumbers = true,
+                numbersEnabled = false,
+                useSpecialChars = true,
+                specialCharsEnabled = false,
+                minNumbers = 9,
+                minNumbersAllowed = 3,
+                minSpecial = 9,
+                minSpecialAllowed = 3,
+                avoidAmbiguousChars = false,
+            )
+        // 9 numbers + 9 special + 1 lowercase + 1 uppercase
+        assertEquals(20, password.computedMinimumLength)
+    }
+
+    @Test
+    fun `Password minimumLength should use minLength if higher than sum of the minimums`() {
+        val password =
+            GeneratorState.MainType.Passcode.PasscodeType.Password(
+                length = 14,
+                minLength = 10,
+                useCapitals = true,
+                capitalsEnabled = false,
+                useLowercase = true,
+                lowercaseEnabled = false,
+                useNumbers = true,
+                numbersEnabled = false,
+                useSpecialChars = true,
+                specialCharsEnabled = false,
+                minNumbers = 1,
+                minNumbersAllowed = 3,
+                minSpecial = 1,
+                minSpecialAllowed = 3,
+                avoidAmbiguousChars = false,
+            )
+        assertEquals(10, password.computedMinimumLength)
+    }
     //region Helper Functions
 
     @Suppress("LongParameterList")


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-12739

## 📔 Objective

When the sum of minimum special, numbers, lowercase and uppercase exceeded the minimum length, the length was not being properly adjusted and was throwing an error on the SDK.
This should fix it by using the calculatedMinimumLength that takes variables that into consideration.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
