### PR TITLE
PM-10628: Update pin dialog title

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithPinSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithPinSwitch.kt
@@ -84,7 +84,7 @@ fun BitwardenUnlockWithPinSwitch(
 
         shouldShowPinConfirmationDialog -> {
             BitwardenTwoButtonDialog(
-                title = stringResource(id = R.string.unlock_with_pin),
+                title = stringResource(id = R.string.require_master_password_on_app_restart),
                 message = stringResource(id = R.string.pin_require_master_password_restart),
                 confirmButtonText = stringResource(id = R.string.yes),
                 dismissButtonText = stringResource(id = R.string.no),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,7 @@ Scanning will happen automatically.</string>
   <string name="copy_notes">Copy note</string>
   <string name="exit">Exit</string>
   <string name="exit_confirmation">Are you sure you want to exit Bitwarden?</string>
+  <string name="require_master_password_on_app_restart">Require master password on app restart?</string>
   <string name="pin_require_master_password_restart">Do you want to require unlocking with your master password when the application is restarted?</string>
   <string name="black">Black</string>
   <string name="nord">Nord</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
@@ -343,7 +343,7 @@ class SetupUnlockScreenTest : BaseComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText(text = "Unlock with PIN code")
+            .onAllNodesWithText(text = "Require master password on app restart?")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -370,7 +370,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText("Unlock with PIN code")
+            .onAllNodesWithText("Require master password on app restart?")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10628](https://bitwarden.atlassian.net/browse/PM-10628)

## 📔 Objective

This PR updates the title of the master password on restart dialog when enabling pin unlock.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/a8061b51-07f1-4178-982d-7c8e83f6c927" width="300" /> | <img src="https://github.com/user-attachments/assets/c6922406-b509-4131-a9c4-647566c36c11" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10628]: https://bitwarden.atlassian.net/browse/PM-10628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ