### PR TITLE
BITAU-69 Check for OS version in AuthenticatorBridgeManager

### DIFF
--- a/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerImpl.kt
+++ b/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerImpl.kt
@@ -60,12 +60,10 @@ internal class AuthenticatorBridgeManagerImpl(
      */
     private val mutableSharedAccountsStateFlow: MutableStateFlow<AccountSyncState> =
         MutableStateFlow(
-            if (isBuildVersionBelow(Build.VERSION_CODES.S)) {
-                AccountSyncState.OSVersionNotSupported
-            } else if (isBitwardenAppInstalled()) {
-                AccountSyncState.Loading
-            } else {
-                AccountSyncState.AppNotInstalled
+            when {
+                isBuildVersionBelow(Build.VERSION_CODES.S) -> AccountSyncState.OSVersionNotSupported
+                !isBitwardenAppInstalled() -> AccountSyncState.AppNotInstalled
+                else -> AccountSyncState.Loading
             }
         )
 

--- a/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerImpl.kt
+++ b/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerImpl.kt
@@ -61,7 +61,7 @@ internal class AuthenticatorBridgeManagerImpl(
     private val mutableSharedAccountsStateFlow: MutableStateFlow<AccountSyncState> =
         MutableStateFlow(
             when {
-                isBuildVersionBelow(Build.VERSION_CODES.S) -> AccountSyncState.OSVersionNotSupported
+                isBuildVersionBelow(Build.VERSION_CODES.S) -> AccountSyncState.OsVersionNotSupported
                 !isBitwardenAppInstalled() -> AccountSyncState.AppNotInstalled
                 else -> AccountSyncState.Loading
             }
@@ -105,7 +105,7 @@ internal class AuthenticatorBridgeManagerImpl(
 
     private fun bindService() {
         if (isBuildVersionBelow(Build.VERSION_CODES.S)) {
-            mutableSharedAccountsStateFlow.value = AccountSyncState.OSVersionNotSupported
+            mutableSharedAccountsStateFlow.value = AccountSyncState.OsVersionNotSupported
             return
         }
         if (!isBitwardenAppInstalled()) {

--- a/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/manager/model/AccountSyncState.kt
+++ b/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/manager/model/AccountSyncState.kt
@@ -30,7 +30,7 @@ sealed class AccountSyncState {
     /**
      * OS version can't support account syncing.
      */
-    data object OSVersionNotSupported: AccountSyncState()
+    data object OsVersionNotSupported: AccountSyncState()
 
     /**
      * Accounts successfully synced.

--- a/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/manager/model/AccountSyncState.kt
+++ b/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/manager/model/AccountSyncState.kt
@@ -28,6 +28,11 @@ sealed class AccountSyncState {
     data object Loading : AccountSyncState()
 
     /**
+     * OS version can't support account syncing.
+     */
+    data object OSVersionNotSupported: AccountSyncState()
+
+    /**
      * Accounts successfully synced.
      */
     data class Success(val accounts: List<SharedAccountData.Account>) : AccountSyncState()

--- a/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/util/AndroidBuildUtils.kt
+++ b/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/util/AndroidBuildUtils.kt
@@ -1,0 +1,10 @@
+package com.bitwarden.authenticatorbridge.util
+
+import android.os.Build
+
+/**
+ * Returns true if the current OS build version is below the provided [version].
+ *
+ * @see Build.VERSION_CODES
+ */
+fun isBuildVersionBelow(version: Int): Boolean = version > Build.VERSION.SDK_INT

--- a/authenticatorbridge/src/test/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerTest.kt
+++ b/authenticatorbridge/src/test/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerTest.kt
@@ -107,7 +107,7 @@ class AuthenticatorBridgeManagerTest {
     }
 
     @Test
-    fun `onStart when OS level is below S should set state to OsNotSupported`() {
+    fun `onStart when OS level is below S should set state to OsVersionNotSupported`() {
         every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
         fakeLifecycleOwner.lifecycle.dispatchOnStart()
         assertEquals(AccountSyncState.OsVersionNotSupported, manager.accountSyncStateFlow.value)

--- a/authenticatorbridge/src/test/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerTest.kt
+++ b/authenticatorbridge/src/test/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerTest.kt
@@ -94,7 +94,7 @@ class AuthenticatorBridgeManagerTest {
     }
 
     @Test
-    fun `initial AccountSyncState should be OSVersionNotSupported when OS level is below S`() {
+    fun `initial AccountSyncState should be OsVersionNotSupported when OS level is below S`() {
         every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
         val manager = AuthenticatorBridgeManagerImpl(
             context = context,
@@ -103,14 +103,14 @@ class AuthenticatorBridgeManagerTest {
             callbackProvider = testAuthenticatorBridgeCallbackProvider,
             processLifecycleOwner = fakeLifecycleOwner,
         )
-        assertEquals(AccountSyncState.OSVersionNotSupported, manager.accountSyncStateFlow.value)
+        assertEquals(AccountSyncState.OsVersionNotSupported, manager.accountSyncStateFlow.value)
     }
 
     @Test
-    fun `onStart when OS level is below S should set state to OS`() {
+    fun `onStart when OS level is below S should set state to OsNotSupported`() {
         every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
         fakeLifecycleOwner.lifecycle.dispatchOnStart()
-        assertEquals(AccountSyncState.OSVersionNotSupported, manager.accountSyncStateFlow.value)
+        assertEquals(AccountSyncState.OsVersionNotSupported, manager.accountSyncStateFlow.value)
     }
 
     @Test

--- a/authenticatorbridge/src/test/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerTest.kt
+++ b/authenticatorbridge/src/test/java/com/bitwarden/authenticatorbridge/manager/AuthenticatorBridgeManagerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.content.pm.PackageManager.NameNotFoundException
+import android.os.Build
 import com.bitwarden.authenticatorbridge.IAuthenticatorBridgeService
 import com.bitwarden.authenticatorbridge.IAuthenticatorBridgeServiceCallback
 import com.bitwarden.authenticatorbridge.manager.model.AccountSyncState
@@ -15,6 +16,7 @@ import com.bitwarden.authenticatorbridge.util.FakeSymmetricKeyStorageProvider
 import com.bitwarden.authenticatorbridge.util.TestAuthenticatorBridgeCallbackProvider
 import com.bitwarden.authenticatorbridge.util.decrypt
 import com.bitwarden.authenticatorbridge.util.generateSecretKey
+import com.bitwarden.authenticatorbridge.util.isBuildVersionBelow
 import com.bitwarden.authenticatorbridge.util.toFingerprint
 import com.bitwarden.authenticatorbridge.util.toSymmetricEncryptionKeyData
 import io.mockk.every
@@ -45,23 +47,27 @@ class AuthenticatorBridgeManagerTest {
     private val fakeSymmetricKeyStorageProvider = FakeSymmetricKeyStorageProvider()
     private val testAuthenticatorBridgeCallbackProvider = TestAuthenticatorBridgeCallbackProvider()
 
-    private val manager: AuthenticatorBridgeManagerImpl = AuthenticatorBridgeManagerImpl(
-        context = context,
-        connectionType = AuthenticatorBridgeConnectionType.DEV,
-        symmetricKeyStorageProvider = fakeSymmetricKeyStorageProvider,
-        callbackProvider = testAuthenticatorBridgeCallbackProvider,
-        processLifecycleOwner = fakeLifecycleOwner,
-    )
+    private lateinit var manager: AuthenticatorBridgeManagerImpl
 
     @BeforeEach
     fun setup() {
+        mockkStatic(::isBuildVersionBelow)
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns false
         mockkConstructor(Intent::class)
         mockkStatic(IAuthenticatorBridgeService.Stub::class)
         mockkStatic(EncryptedSharedAccountData::decrypt)
+        manager = AuthenticatorBridgeManagerImpl(
+            context = context,
+            connectionType = AuthenticatorBridgeConnectionType.DEV,
+            symmetricKeyStorageProvider = fakeSymmetricKeyStorageProvider,
+            callbackProvider = testAuthenticatorBridgeCallbackProvider,
+            processLifecycleOwner = fakeLifecycleOwner,
+        )
     }
 
     @AfterEach
     fun teardown() {
+        mockkStatic(::isBuildVersionBelow)
         unmockkConstructor(Intent::class)
         unmockkStatic(IAuthenticatorBridgeService.Stub::class)
         unmockkStatic(EncryptedSharedAccountData::decrypt)
@@ -85,6 +91,26 @@ class AuthenticatorBridgeManagerTest {
             processLifecycleOwner = fakeLifecycleOwner,
         )
         assertEquals(AccountSyncState.AppNotInstalled, manager.accountSyncStateFlow.value)
+    }
+
+    @Test
+    fun `initial AccountSyncState should be OSVersionNotSupported when OS level is below S`() {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
+        val manager = AuthenticatorBridgeManagerImpl(
+            context = context,
+            connectionType = AuthenticatorBridgeConnectionType.DEV,
+            symmetricKeyStorageProvider = fakeSymmetricKeyStorageProvider,
+            callbackProvider = testAuthenticatorBridgeCallbackProvider,
+            processLifecycleOwner = fakeLifecycleOwner,
+        )
+        assertEquals(AccountSyncState.OSVersionNotSupported, manager.accountSyncStateFlow.value)
+    }
+
+    @Test
+    fun `onStart when OS level is below S should set state to OS`() {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
+        fakeLifecycleOwner.lifecycle.dispatchOnStart()
+        assertEquals(AccountSyncState.OSVersionNotSupported, manager.accountSyncStateFlow.value)
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-69

## 📔 Objective

The goal of this PR is to add a check for OS version to the bridge coroutines wrapper. 

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
