### PR TITLE
PM-13068 Navigate from settings to setup autofill screen.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillNavigation.kt
@@ -1,29 +1,77 @@
 package com.x8bit.bitwarden.ui.auth.feature.accountsetup
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 
 /**
- * Route name for [SetupAutoFillScreen].
+ * Route constant for navigating to the [SetupAutoFillScreen].
  */
-const val SETUP_AUTO_FILL_ROUTE = "setup_auto_fill"
+private const val SETUP_AUTO_FILL_PREFIX = "setup_auto_fill"
+private const val SETUP_AUTO_FILL_AS_ROOT_PREFIX = "${SETUP_AUTO_FILL_PREFIX}_as_root"
+private const val SETUP_AUTO_FILL_NAV_ARG = "isInitialSetup"
+private const val SETUP_AUTO_FILL_ROUTE = "$SETUP_AUTO_FILL_PREFIX/{$SETUP_AUTO_FILL_NAV_ARG}"
+const val SETUP_AUTO_FILL_AS_ROOT_ROUTE =
+    "$SETUP_AUTO_FILL_AS_ROOT_PREFIX/{$SETUP_AUTO_FILL_NAV_ARG}"
+
+/**
+ * Arguments for the [SetupAutoFillScreen] using [SavedStateHandle].
+ */
+data class SetupAutoFillScreenArgs(val isInitialSetup: Boolean) {
+    constructor(savedStateHandle: SavedStateHandle) : this(
+        isInitialSetup = requireNotNull(savedStateHandle[SETUP_AUTO_FILL_NAV_ARG]),
+    )
+}
 
 /**
  * Navigate to the setup auto-fill screen.
  */
 fun NavController.navigateToSetupAutoFillScreen(navOptions: NavOptions? = null) {
-    this.navigate(SETUP_AUTO_FILL_ROUTE, navOptions)
+    this.navigate("$SETUP_AUTO_FILL_PREFIX/false", navOptions)
+}
+
+/**
+ * Navigate to the setup auto-fill screen as the root.
+ */
+fun NavController.navigateToSetupAutoFillAsRootScreen(navOptions: NavOptions? = null) {
+    this.navigate("$SETUP_AUTO_FILL_AS_ROOT_PREFIX/true", navOptions)
 }
 
 /**
  * Add the setup auto-fil screen to the nav graph.
  */
-fun NavGraphBuilder.setupAutoFillDestination() {
-    composableWithPushTransitions(
+fun NavGraphBuilder.setupAutoFillDestination(onNavigateBack: () -> Unit) {
+    composableWithSlideTransitions(
         route = SETUP_AUTO_FILL_ROUTE,
+        arguments = setupAutofillNavArgs,
     ) {
-        SetupAutoFillScreen()
+        SetupAutoFillScreen(onNavigateBack = onNavigateBack)
     }
 }
+
+/**
+ * Add the setup autofil screen to the root nav graph.
+ */
+fun NavGraphBuilder.setupAutoFillDestinationAsRoot() {
+    composableWithPushTransitions(
+        route = SETUP_AUTO_FILL_AS_ROOT_ROUTE,
+        arguments = setupAutofillNavArgs,
+    ) {
+        SetupAutoFillScreen(
+            onNavigateBack = {
+                // No-Op
+            },
+        )
+    }
+}
+
+private val setupAutofillNavArgs = listOf(
+    navArgument(SETUP_AUTO_FILL_NAV_ARG) {
+        type = NavType.BoolType
+    },
+)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
+import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 
@@ -22,6 +23,7 @@ const val SETUP_AUTO_FILL_AS_ROOT_ROUTE =
 /**
  * Arguments for the [SetupAutoFillScreen] using [SavedStateHandle].
  */
+@OmitFromCoverage
 data class SetupAutoFillScreenArgs(val isInitialSetup: Boolean) {
     constructor(savedStateHandle: SavedStateHandle) : this(
         isInitialSetup = requireNotNull(savedStateHandle[SETUP_AUTO_FILL_NAV_ARG]),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
@@ -1,5 +1,7 @@
 package com.x8bit.bitwarden.ui.auth.feature.accountsetup
 
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -10,20 +12,30 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+
+private const val KEY_STATE = "state"
 
 /**
  * View model for the Auto-fill setup screen.
  */
 @HiltViewModel
 class SetupAutoFillViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val settingsRepository: SettingsRepository,
     private val authRepository: AuthRepository,
 ) :
     BaseViewModel<SetupAutoFillState, SetupAutoFillEvent, SetupAutoFillAction>(
-        initialState = run {
+        initialState = savedStateHandle[KEY_STATE] ?: run {
             val userId = requireNotNull(authRepository.userStateFlow.value).activeUserId
-            SetupAutoFillState(userId = userId, dialogState = null, autofillEnabled = false)
+            val isInitialSetup = SetupAutoFillScreenArgs(savedStateHandle).isInitialSetup
+            SetupAutoFillState(
+                userId = userId,
+                dialogState = null,
+                autofillEnabled = false,
+                isInitialSetup = isInitialSetup,
+            )
         },
     ) {
 
@@ -34,6 +46,12 @@ class SetupAutoFillViewModel @Inject constructor(
                 SetupAutoFillAction.Internal.AutofillEnabledUpdateReceive(isAutofillEnabled = it)
             }
             .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        stateFlow
+            .onEach {
+                savedStateHandle[KEY_STATE] = it
+            }
             .launchIn(viewModelScope)
     }
 
@@ -48,7 +66,13 @@ class SetupAutoFillViewModel @Inject constructor(
             is SetupAutoFillAction.Internal.AutofillEnabledUpdateReceive -> {
                 handleAutofillEnabledUpdateReceive(action)
             }
+
+            SetupAutoFillAction.CloseClick -> handleCloseClick()
         }
+    }
+
+    private fun handleCloseClick() {
+        sendEvent(SetupAutoFillEvent.NavigateBack)
     }
 
     private fun handleAutofillEnabledUpdateReceive(
@@ -83,7 +107,11 @@ class SetupAutoFillViewModel @Inject constructor(
     }
 
     private fun handleContinueClick() {
-        updateOnboardingStatusToNextStep()
+        if (state.isInitialSetup) {
+            updateOnboardingStatusToNextStep()
+        } else {
+            sendEvent(SetupAutoFillEvent.NavigateBack)
+        }
     }
 
     private fun handleAutofillServiceChanged(action: SetupAutoFillAction.AutofillServiceChanged) {
@@ -105,24 +133,28 @@ class SetupAutoFillViewModel @Inject constructor(
 /**
  * UI State for the Auto-fill setup screen.
  */
+@Parcelize
 data class SetupAutoFillState(
     val userId: String,
     val dialogState: SetupAutoFillDialogState?,
     val autofillEnabled: Boolean,
-)
+    val isInitialSetup: Boolean,
+) : Parcelable
 
 /**
  * Dialog states for the Auto-fill setup screen.
  */
-sealed class SetupAutoFillDialogState {
+sealed class SetupAutoFillDialogState : Parcelable {
     /**
      * Represents the turn on later dialog.
      */
+    @Parcelize
     data object TurnOnLaterDialog : SetupAutoFillDialogState()
 
     /**
      * Represents the autofill fallback dialog.
      */
+    @Parcelize
     data object AutoFillFallbackDialog : SetupAutoFillDialogState()
 }
 
@@ -135,6 +167,11 @@ sealed class SetupAutoFillEvent {
      * Navigate to the autofill settings screen.
      */
     data object NavigateToAutofillSettings : SetupAutoFillEvent()
+
+    /**
+     * Navigate back.
+     */
+    data object NavigateBack : SetupAutoFillEvent()
 }
 
 /**
@@ -172,6 +209,11 @@ sealed class SetupAutoFillAction {
      * Autofill service fallback has occurred.
      */
     data object AutoFillServiceFallback : SetupAutoFillAction()
+
+    /**
+     * The user has clicked the close button.
+     */
+    data object CloseClick : SetupAutoFillAction()
 
     /**
      * Internal actions not send through UI.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
@@ -27,6 +27,7 @@ class SetupAutoFillViewModel @Inject constructor(
     private val authRepository: AuthRepository,
 ) :
     BaseViewModel<SetupAutoFillState, SetupAutoFillEvent, SetupAutoFillAction>(
+        // We load the state from the savedStateHandle for testing purposes.
         initialState = savedStateHandle[KEY_STATE] ?: run {
             val userId = requireNotNull(authRepository.userStateFlow.value).activeUserId
             val isInitialSetup = SetupAutoFillScreenArgs(savedStateHandle).isInitialSetup
@@ -46,12 +47,6 @@ class SetupAutoFillViewModel @Inject constructor(
                 SetupAutoFillAction.Internal.AutofillEnabledUpdateReceive(isAutofillEnabled = it)
             }
             .onEach(::sendAction)
-            .launchIn(viewModelScope)
-
-        stateFlow
-            .onEach {
-                savedStateHandle[KEY_STATE] = it
-            }
             .launchIn(viewModelScope)
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
@@ -33,6 +33,7 @@ class SetupUnlockViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val biometricsEncryptionManager: BiometricsEncryptionManager,
 ) : BaseViewModel<SetupUnlockState, SetupUnlockEvent, SetupUnlockAction>(
+    // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE] ?: run {
         val userId = requireNotNull(authRepository.userStateFlow.value).activeUserId
         val isBiometricsValid = biometricsEncryptionManager.isBiometricIntegrityValid(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -15,13 +15,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
-import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_AUTO_FILL_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_AUTO_FILL_AS_ROOT_ROUTE
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_COMPLETE_ROUTE
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_UNLOCK_AS_ROOT_ROUTE
-import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupAutoFillScreen
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupAutoFillAsRootScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupCompleteScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupUnlockScreenAsRoot
-import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupAutoFillDestination
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupAutoFillDestinationAsRoot
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupCompleteDestination
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupUnlockDestinationAsRoot
 import com.x8bit.bitwarden.ui.auth.feature.auth.AUTH_GRAPH_ROUTE
@@ -100,7 +100,7 @@ fun RootNavScreen(
         vaultUnlockedGraph(navController)
         setupDebugMenuDestination(onNavigateBack = { navController.popBackStack() })
         setupUnlockDestinationAsRoot()
-        setupAutoFillDestination()
+        setupAutoFillDestinationAsRoot()
         setupCompleteDestination()
     }
 
@@ -128,7 +128,7 @@ fun RootNavScreen(
         -> VAULT_UNLOCKED_GRAPH_ROUTE
 
         RootNavState.OnboardingAccountLockSetup -> SETUP_UNLOCK_AS_ROOT_ROUTE
-        RootNavState.OnboardingAutoFillSetup -> SETUP_AUTO_FILL_ROUTE
+        RootNavState.OnboardingAutoFillSetup -> SETUP_AUTO_FILL_AS_ROOT_ROUTE
         RootNavState.OnboardingStepsComplete -> SETUP_COMPLETE_ROUTE
     }
     val currentRoute = navController.currentDestination?.rootLevelRoute()
@@ -239,7 +239,7 @@ fun RootNavScreen(
             }
 
             RootNavState.OnboardingAutoFillSetup -> {
-                navController.navigateToSetupAutoFillScreen(rootNavOptions)
+                navController.navigateToSetupAutoFillAsRootScreen(rootNavOptions)
             }
 
             RootNavState.OnboardingStepsComplete -> {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsNavigation.kt
@@ -4,7 +4,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.navigation
-import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupUnlockScreen
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithRootPushTransitions
 import com.x8bit.bitwarden.ui.platform.feature.settings.about.aboutDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.about.navigateToAbout
@@ -34,6 +33,8 @@ fun NavGraphBuilder.settingsGraph(
     onNavigateToExportVault: () -> Unit,
     onNavigateToFolders: () -> Unit,
     onNavigateToPendingRequests: () -> Unit,
+    onNavigateToSetupUnlockScreen: () -> Unit,
+    onNavigateToSetupAutoFillScreen: () -> Unit,
 ) {
     navigation(
         startDestination = SETTINGS_ROUTE,
@@ -56,12 +57,13 @@ fun NavGraphBuilder.settingsGraph(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToDeleteAccount = onNavigateToDeleteAccount,
             onNavigateToPendingRequests = onNavigateToPendingRequests,
-            onNavigateToSetupUnlockScreen = { navController.navigateToSetupUnlockScreen() },
+            onNavigateToSetupUnlockScreen = onNavigateToSetupUnlockScreen,
         )
         appearanceDestination(onNavigateBack = { navController.popBackStack() })
         autoFillDestination(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToBlockAutoFillScreen = { navController.navigateToBlockAutoFillScreen() },
+            onNavigateToSetupAutofill = onNavigateToSetupAutoFillScreen,
         )
         otherDestination(onNavigateBack = { navController.popBackStack() })
         vaultSettingsDestination(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillNavigation.kt
@@ -13,6 +13,7 @@ private const val AUTO_FILL_ROUTE = "settings_auto_fill"
 fun NavGraphBuilder.autoFillDestination(
     onNavigateBack: () -> Unit,
     onNavigateToBlockAutoFillScreen: () -> Unit,
+    onNavigateToSetupAutofill: () -> Unit,
 ) {
     composableWithPushTransitions(
         route = AUTO_FILL_ROUTE,
@@ -20,6 +21,7 @@ fun NavGraphBuilder.autoFillDestination(
         AutoFillScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToBlockAutoFillScreen = onNavigateToBlockAutoFillScreen,
+            onNavigateToSetupAutofill = onNavigateToSetupAutofill,
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -64,6 +64,7 @@ fun AutoFillScreen(
     viewModel: AutoFillViewModel = hiltViewModel(),
     intentManager: IntentManager = LocalIntentManager.current,
     onNavigateToBlockAutoFillScreen: () -> Unit,
+    onNavigateToSetupAutofill: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -94,6 +95,8 @@ fun AutoFillScreen(
             AutoFillEvent.NavigateToSettings -> {
                 intentManager.startCredentialManagerSettings(context)
             }
+
+            AutoFillEvent.NavigateToSetupAutofill -> onNavigateToSetupAutofill()
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -118,7 +118,7 @@ class AutoFillViewModel @Inject constructor(
 
     private fun handleAutoFillActionCardCtClick() {
         dismissShowAutofillActionCard()
-        // TODO PM-13068 navigate to auto fill setup screen
+        sendEvent(AutoFillEvent.NavigateToSetupAutofill)
     }
 
     private fun handleUpdateShowAutofillActionCard(
@@ -261,6 +261,11 @@ sealed class AutoFillEvent {
     data class ShowToast(
         val text: Text,
     ) : AutoFillEvent()
+
+    /**
+     * Navigates to the setup autofill screen.
+     */
+    data object NavigateToSetupAutofill : AutoFillEvent()
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -4,6 +4,10 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.navigation
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupAutoFillScreen
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupUnlockScreen
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupAutoFillDestination
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupUnlockDestination
 import com.x8bit.bitwarden.ui.platform.feature.search.navigateToSearch
 import com.x8bit.bitwarden.ui.platform.feature.search.searchDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.deleteaccount.deleteAccountDestination
@@ -98,6 +102,8 @@ fun NavGraphBuilder.vaultUnlockedGraph(
                     passwordHistoryMode = GeneratorPasswordHistoryMode.Default,
                 )
             },
+            onNavigateToSetupUnlockScreen = { navController.navigateToSetupUnlockScreen() },
+            onNavigateToSetupAutoFillScreen = { navController.navigateToSetupAutoFillScreen() },
         )
         deleteAccountDestination(
             onNavigateBack = { navController.popBackStack() },
@@ -199,6 +205,16 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         )
         attachmentDestination(
             onNavigateBack = { navController.popBackStack() },
+        )
+        setupUnlockDestination(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
+        )
+        setupAutoFillDestination(
+            onNavigateBack = {
+                navController.popBackStack()
+            },
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
@@ -36,6 +36,8 @@ fun NavGraphBuilder.vaultUnlockedNavBarDestination(
     onNavigateToFolders: () -> Unit,
     onNavigateToPendingRequests: () -> Unit,
     onNavigateToPasswordHistory: () -> Unit,
+    onNavigateToSetupUnlockScreen: () -> Unit,
+    onNavigateToSetupAutoFillScreen: () -> Unit,
 ) {
     composableWithStayTransitions(
         route = VAULT_UNLOCKED_NAV_BAR_ROUTE,
@@ -53,6 +55,8 @@ fun NavGraphBuilder.vaultUnlockedNavBarDestination(
             onNavigateToFolders = onNavigateToFolders,
             onNavigateToPendingRequests = onNavigateToPendingRequests,
             onNavigateToPasswordHistory = onNavigateToPasswordHistory,
+            onNavigateToSetupUnlockScreen = onNavigateToSetupUnlockScreen,
+            onNavigateToSetupAutoFillScreen = onNavigateToSetupAutoFillScreen,
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -34,7 +34,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
-import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupUnlockDestination
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.base.util.max
 import com.x8bit.bitwarden.ui.platform.base.util.toDp
@@ -76,6 +75,8 @@ fun VaultUnlockedNavBarScreen(
     onNavigateToFolders: () -> Unit,
     onNavigateToPendingRequests: () -> Unit,
     onNavigateToPasswordHistory: () -> Unit,
+    onNavigateToSetupUnlockScreen: () -> Unit,
+    onNavigateToSetupAutoFillScreen: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
@@ -133,6 +134,8 @@ fun VaultUnlockedNavBarScreen(
         settingsTabClickedAction = remember(viewModel) {
             { viewModel.trySendAction(VaultUnlockedNavBarAction.SettingsTabClick) }
         },
+        onNavigateToSetupUnlockScreen = onNavigateToSetupUnlockScreen,
+        onNavigateToSetupAutoFillScreen = onNavigateToSetupAutoFillScreen,
     )
 }
 
@@ -160,6 +163,8 @@ private fun VaultUnlockedNavBarScaffold(
     navigateToFolders: () -> Unit,
     navigateToPendingRequests: () -> Unit,
     navigateToPasswordHistory: () -> Unit,
+    onNavigateToSetupUnlockScreen: () -> Unit,
+    onNavigateToSetupAutoFillScreen: () -> Unit,
 ) {
     var shouldDimNavBar by remember { mutableStateOf(false) }
 
@@ -235,11 +240,8 @@ private fun VaultUnlockedNavBarScaffold(
                 onNavigateToExportVault = navigateToExportVault,
                 onNavigateToFolders = navigateToFolders,
                 onNavigateToPendingRequests = navigateToPendingRequests,
-            )
-            setupUnlockDestination(
-                onNavigateBack = {
-                    navController.popBackStack()
-                },
+                onNavigateToSetupUnlockScreen = onNavigateToSetupUnlockScreen,
+                onNavigateToSetupAutoFillScreen = onNavigateToSetupAutoFillScreen,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -241,7 +241,7 @@ class RootNavScreenTest : BaseComposeTest() {
             RootNavState.OnboardingAutoFillSetup
         composeTestRule.runOnIdle {
             fakeNavHostController.assertLastNavigation(
-                route = "setup_auto_fill",
+                route = "setup_auto_fill_as_root/true",
                 navOptions = expectedNavOptions,
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -35,6 +35,7 @@ class AutoFillScreenTest : BaseComposeTest() {
     private var isSystemSettingsRequestSuccess = false
     private var onNavigateBackCalled = false
     private var onNavigateToBlockAutoFillScreenCalled = false
+    private var onNavigateToSetupAutoFillScreenCalled = false
 
     private val mutableEventFlow = bufferedMutableSharedFlow<AutoFillEvent>()
     private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
@@ -56,6 +57,7 @@ class AutoFillScreenTest : BaseComposeTest() {
                 onNavigateToBlockAutoFillScreen = { onNavigateToBlockAutoFillScreenCalled = true },
                 viewModel = viewModel,
                 intentManager = intentManager,
+                onNavigateToSetupAutofill = { onNavigateToSetupAutoFillScreenCalled = true },
             )
         }
     }
@@ -497,6 +499,12 @@ class AutoFillScreenTest : BaseComposeTest() {
             .performScrollTo()
             .performClick()
         verify { viewModel.trySendAction(AutoFillAction.DismissShowAutofillActionCard) }
+    }
+
+    @Test
+    fun `when NavigateToSetupAutofill event is sent should call onNavigateToSetupAutofill`() {
+        mutableEventFlow.tryEmit(AutoFillEvent.NavigateToSetupAutofill)
+        assertTrue(onNavigateToSetupAutoFillScreenCalled)
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -321,10 +321,17 @@ class AutoFillViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `when AutoFillActionCardCtaClick action is sent should update show autofill in repository`() {
+    fun `when AutoFillActionCardCtaClick action is sent should update show autofill in repository and send NavigateToSetupAutofill event`() =
+        runTest {
         mutableShowAutofillActionCardFlow.update { true }
         val viewModel = createViewModel()
-        viewModel.trySendAction(AutoFillAction.AutoFillActionCardCtaClick)
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(AutoFillAction.AutoFillActionCardCtaClick)
+                assertEquals(
+                    AutoFillEvent.NavigateToSetupAutofill,
+                    awaitItem(),
+                )
+            }
         verify {
             settingsRepository.storeShowAutoFillSettingBadge(
                 DEFAULT_STATE.activeUserId,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -53,6 +53,8 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
                     onNavigateToPendingRequests = {},
                     onNavigateToSearchVault = {},
                     onNavigateToSearchSend = {},
+                    onNavigateToSetupAutoFillScreen = {},
+                    onNavigateToSetupUnlockScreen = {},
                 )
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13068
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Navigate from the autofill settings to the setup autofill screen if there is the action card.
- Show the setup autofill screen with "non root" UI and behavior.
- This is the final piece to the badging related to the onboarding setup.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/085a08e2-3f38-4829-88aa-5e9de7f36f85


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
