### PR TITLE
[PM-12408] Updating password revision date on password change

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
@@ -146,7 +146,7 @@ private fun VaultAddEditState.ViewState.Content.ItemType.toLoginView(
         LoginView(
             username = it.username.orNullIfBlank(),
             password = it.password.orNullIfBlank(),
-            passwordRevisionDate = getRevisionDate(common.originalCipher, it),
+            passwordRevisionDate = it.getRevisionDate(common.originalCipher),
             uris = it.uriList.toLoginUriView(),
             totp = it.totp,
             autofillOnPageLoad = common.originalCipher?.login?.autofillOnPageLoad,
@@ -215,13 +215,12 @@ private fun List<UriItem>?.toLoginUriView(): List<LoginUriView>? =
         ?.map { LoginUriView(uri = it.uri.orEmpty(), match = it.match, uriChecksum = null) }
         .takeUnless { it.isNullOrEmpty() }
 
-private fun getRevisionDate(
+private fun VaultAddEditState.ViewState.Content.ItemType.Login.getRevisionDate(
     originalCipher: CipherView?,
-    newLogin: VaultAddEditState.ViewState.Content.ItemType.Login,
 ): DateTime? {
     val isOriginalPasswordNull = originalCipher?.login?.password.isNullOrEmpty()
     val hasPasswordHistory = originalCipher?.passwordHistory?.any() ?: false
-    val isOriginalAndNewPasswordEqual = originalCipher?.login?.password == newLogin.password
+    val isOriginalAndNewPasswordEqual = originalCipher?.login?.password == this.password
     return if ((!isOriginalPasswordNull || hasPasswordHistory) && !isOriginalAndNewPasswordEqual) {
         Instant.now()
     } else {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
@@ -25,6 +25,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
@@ -728,6 +729,102 @@ class VaultAddItemStateExtensionsTest {
                 ),
             ),
             result,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toLoginView should update revision date when password differs`() {
+        mockkStatic(Instant::class)
+        every { Instant.now() } returns Instant.MAX
+
+        val cipherView = DEFAULT_LOGIN_CIPHER_VIEW
+
+        val viewState = VaultAddEditState.ViewState.Content(
+            common = VaultAddEditState.ViewState.Content.Common(
+                originalCipher = cipherView,
+                name = "mockName-1",
+                favorite = true,
+                masterPasswordReprompt = false,
+                customFieldData = emptyList(),
+            ),
+            isIndividualVaultDisabled = false,
+            type = VaultAddEditState.ViewState.Content.ItemType.Login(
+                username = "mockUsername-1",
+                password = "mockPassword-1",
+            ),
+        )
+
+        val result = viewState.toCipherView()
+
+        assertNotEquals(
+            viewState.common.originalCipher?.login?.passwordRevisionDate,
+            result.login?.passwordRevisionDate,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toLoginView should keep revision date when password is equal`() {
+        mockkStatic(Instant::class)
+        every { Instant.now() } returns Instant.MAX
+
+        val cipherView = DEFAULT_LOGIN_CIPHER_VIEW
+
+        val viewState = VaultAddEditState.ViewState.Content(
+            common = VaultAddEditState.ViewState.Content.Common(
+                originalCipher = cipherView,
+                name = "mockName-1",
+                favorite = true,
+                masterPasswordReprompt = false,
+                customFieldData = emptyList(),
+            ),
+            isIndividualVaultDisabled = false,
+            type = VaultAddEditState.ViewState.Content.ItemType.Login(
+                username = "mockUsername-1",
+                password = cipherView.login?.password ?: "",
+            ),
+        )
+
+        val result = viewState.toCipherView()
+
+        assertEquals(
+            viewState.common.originalCipher?.login?.passwordRevisionDate,
+            result.login?.passwordRevisionDate,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toLoginView should not update revision date when password is null and has no history`() {
+        mockkStatic(Instant::class)
+        every { Instant.now() } returns Instant.MAX
+
+        val cipherView = DEFAULT_LOGIN_CIPHER_VIEW.copy(
+            passwordHistory = null,
+            login = DEFAULT_LOGIN_CIPHER_VIEW.login?.copy(password = null),
+        )
+
+        val viewState = VaultAddEditState.ViewState.Content(
+            common = VaultAddEditState.ViewState.Content.Common(
+                originalCipher = cipherView,
+                name = "mockName-1",
+                favorite = true,
+                masterPasswordReprompt = false,
+                customFieldData = emptyList(),
+            ),
+            isIndividualVaultDisabled = false,
+            type = VaultAddEditState.ViewState.Content.ItemType.Login(
+                username = "mockUsername-1",
+                password = "updated password",
+            ),
+        )
+
+        val result = viewState.toCipherView()
+
+        assertEquals(
+            viewState.common.originalCipher?.login?.passwordRevisionDate,
+            result.login?.passwordRevisionDate,
         )
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
@@ -732,7 +732,6 @@ class VaultAddItemStateExtensionsTest {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `toLoginView should update revision date when password differs`() {
         mockkStatic(Instant::class)
@@ -763,7 +762,6 @@ class VaultAddItemStateExtensionsTest {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `toLoginView should keep revision date when password is equal`() {
         mockkStatic(Instant::class)
@@ -794,7 +792,6 @@ class VaultAddItemStateExtensionsTest {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `toLoginView should not update revision date when password is null and has no history`() {
         mockkStatic(Instant::class)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12408

## 📔 Objective

Password revision date should be updated when a cipher password is updated

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
