### PR TITLE
Add logic to identify root cause of flakey test

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceTest.kt
@@ -311,7 +311,7 @@ class CiphersServiceTest : BaseServiceTest() {
         )
         assertEquals(
             createMockAttachment(number = 1),
-            result.getOrThrow(),
+            result.testGetOrThrow(),
         )
     }
 
@@ -335,6 +335,25 @@ private fun setupMockUri(
     every { Uri.parse(url) } returns mockUri
     return mockUri
 }
+
+/**
+ * A helper method to attempt validate that the the value is being boxed and causing test to
+ * inconsistently fail.
+ *
+ * This was modified from the code found here:
+ * * https://github.com/mockk/mockk/issues/485#issuecomment-1973170516
+ */
+@Suppress("INVISIBLE_REFERENCE", "UNCHECKED_CAST")
+private fun <T> Result<T>.testGetOrThrow(): T =
+    when (val unboxed: Any? = value) {
+        is Result.Failure -> throw unboxed.exception
+        !is Result<*> -> unboxed as T
+        else -> {
+            // This means the result is boxed, we could make this recursive to address the issue.
+            println("Unboxed value = $unboxed")
+            unboxed as T
+        }
+    }
 
 private const val CREATE_ATTACHMENT_SUCCESS_JSON = """
 {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds logic to log when a test is going to fail due to a boxed result coming from Retrofit.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
