### PR TITLE
[PM-13385] Remove unneeded confirmation after biometric authentication when using face unlock

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
@@ -133,6 +133,7 @@ class BiometricsManagerImpl(
                     .setDescription(activity.getString(R.string.biometrics_direction))
                     .setAllowedAuthenticators(Authenticators.BIOMETRIC_STRONG)
                     .setNegativeButtonText(activity.getString(R.string.cancel))
+                    .setConfirmationRequired(false)
                 biometricPrompt.authenticate(
                     promptInfoBuilder.build(),
                     BiometricPrompt.CryptoObject(it),
@@ -144,6 +145,7 @@ class BiometricsManagerImpl(
                     .setAllowedAuthenticators(
                         Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL,
                     )
+                    .setConfirmationRequired(false)
                 biometricPrompt.authenticate(promptInfoBuilder.build())
             }
     }


### PR DESCRIPTION
## 🎟️ Tracking

I opened this discussion explaining the change a few weeks ago:
https://github.com/orgs/bitwarden/discussions/11286

Got no response so far so I decided to go ahead and submit the PR. Hope that's ok!

## 📔 Objective

As explained in that discussion, by default the Biometrics API treats any authentication as if it were a high-risk operation (such as a purchase), and requires the user to press a "Confirm" button after successful authentication when using a passive biometric system (such as the secure face unlock present in newer Pixels).

But this doesn't really make sense for low-risk operations such as logging into an app, where you'd expect an iPhone-like authentication that seamlessly takes you to the app after success (I question whether it makes sense for the API to default to `true` here, but that's besides this PR).

This extremely simple PR just adds the `.setConfirmationRequired(false)` flag to the biometric prompt, which will greatly improve the user experience for people using devices with secure face unlock.

## 📸 Screenshots

The way it currently works, which requires pressing the "Confirm" button after successful face authentication:
![image](https://github.com/user-attachments/assets/687863fb-7e72-4bab-b690-54baec4d74b4)

The way it should work, showing the face unlock icon but requiring no user interaction to progress into the app activity:
![image](https://github.com/user-attachments/assets/557fbde5-fc00-4567-a80f-2509f4cbbe27)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
