### PR TITLE
BITAU-105 Add support for deep link to account security

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,6 +98,11 @@
                 <data android:scheme="otpauth" />
                 <data android:host="totp" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="bitwarden" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -30,6 +30,7 @@ import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.x8bit.bitwarden.ui.platform.util.isAccountSecurityShortcut
 import com.x8bit.bitwarden.ui.platform.util.isMyVaultShortcut
 import com.x8bit.bitwarden.ui.platform.util.isPasswordGeneratorShortcut
 import com.x8bit.bitwarden.ui.vault.util.getTotpDataOrNull
@@ -236,6 +237,7 @@ class MainViewModel @Inject constructor(
         val totpData = intent.getTotpDataOrNull()
         val hasGeneratorShortcut = intent.isPasswordGeneratorShortcut
         val hasVaultShortcut = intent.isMyVaultShortcut
+        val hasAccountSecurityShortcut = intent.isAccountSecurityShortcut
         val fido2CredentialRequestData = intent.getFido2CredentialRequestOrNull()
         val completeRegistrationData = intent.getCompleteRegistrationDataIntentOrNull()
         val fido2CredentialAssertionRequest = intent.getFido2AssertionRequestOrNull()
@@ -329,6 +331,11 @@ class MainViewModel @Inject constructor(
 
             hasVaultShortcut -> {
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.VaultShortcut
+            }
+
+            hasAccountSecurityShortcut -> {
+                specialCircumstanceManager.specialCircumstance =
+                    SpecialCircumstance.AccountSecurityShortcut
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
@@ -99,6 +99,12 @@ sealed class SpecialCircumstance : Parcelable {
     data object VaultShortcut : SpecialCircumstance()
 
     /**
+     * The app was launched via deeplink to the account security screen.
+     */
+    @Parcelize
+    data object AccountSecurityShortcut : SpecialCircumstance()
+
+    /**
      * A subset of [SpecialCircumstance] that are only relevant in a pre-login state and should be
      * cleared after a successful login.
      */

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -151,6 +151,7 @@ class RootNavViewModel @Inject constructor(
                         )
                     }
 
+                    SpecialCircumstance.AccountSecurityShortcut,
                     SpecialCircumstance.GeneratorShortcut,
                     SpecialCircumstance.VaultShortcut,
                     null,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
@@ -67,6 +67,7 @@ fun SettingsScreen(
             SettingsEvent.NavigateAutoFill -> onNavigateToAutoFill()
             SettingsEvent.NavigateOther -> onNavigateToOther()
             SettingsEvent.NavigateVault -> onNavigateToVault()
+            SettingsEvent.NavigateAccountSecurityShortcut -> onNavigateToAccountSecurity()
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
@@ -3,8 +3,11 @@ package com.x8bit.bitwarden.ui.platform.feature.settings
 import androidx.compose.material3.Text
 import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
+import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
+import com.x8bit.bitwarden.ui.platform.base.util.BackgroundEvent
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,6 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     settingsRepository: SettingsRepository,
+    specialCircumstanceManager: SpecialCircumstanceManager,
 ) : BaseViewModel<SettingsState, SettingsEvent, SettingsAction>(
     initialState = SettingsState(
         securityCount = settingsRepository.allSecuritySettingsBadgeCountFlow.value,
@@ -39,6 +43,15 @@ class SettingsViewModel @Inject constructor(
         }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
+
+        when (specialCircumstanceManager.specialCircumstance) {
+            SpecialCircumstance.AccountSecurityShortcut -> {
+                sendEvent(SettingsEvent.NavigateAccountSecurityShortcut)
+                specialCircumstanceManager.specialCircumstance = null
+            }
+
+            else -> Unit
+        }
     }
 
     override fun handleAction(action: SettingsAction): Unit = when (action) {
@@ -114,6 +127,11 @@ sealed class SettingsEvent {
      * Navigate to the account security screen.
      */
     data object NavigateAccountSecurity : SettingsEvent()
+
+    /**
+     * Navigate to the account security screen.
+     */
+    data object NavigateAccountSecurityShortcut : SettingsEvent(), BackgroundEvent
 
     /**
      * Navigate to the appearance screen.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -58,7 +58,7 @@ import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 /**
  * Top level composable for the Vault Unlocked Screen.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 fun VaultUnlockedNavBarScreen(
     viewModel: VaultUnlockedNavBarViewModel = hiltViewModel(),
@@ -102,6 +102,10 @@ fun VaultUnlockedNavBarScreen(
                 }
 
                 VaultUnlockedNavBarEvent.NavigateToSettingsScreen -> {
+                    navigateToSettingsGraph(navOptions)
+                }
+
+                VaultUnlockedNavBarEvent.Shortcut.NavigateToSettingsScreen -> {
                     navigateToSettingsGraph(navOptions)
                 }
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModel.kt
@@ -65,6 +65,10 @@ class VaultUnlockedNavBarViewModel @Inject constructor(
                 specialCircumstancesManager.specialCircumstance = null
             }
 
+            SpecialCircumstance.AccountSecurityShortcut -> {
+                sendEvent(VaultUnlockedNavBarEvent.Shortcut.NavigateToSettingsScreen)
+            }
+
             else -> Unit
         }
     }
@@ -282,6 +286,13 @@ sealed class VaultUnlockedNavBarEvent {
                 labelRes = labelRes,
                 contentDescriptionRes = contentDescRes,
             )
+        }
+
+        /**
+         * Navigate to the Settings Screen.
+         */
+        data object NavigateToSettingsScreen : Shortcut() {
+            override val tab: VaultUnlockedNavBarTab = VaultUnlockedNavBarTab.Settings()
         }
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/ShortcutUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/ShortcutUtils.kt
@@ -13,3 +13,9 @@ val Intent.isMyVaultShortcut: Boolean
  */
 val Intent.isPasswordGeneratorShortcut: Boolean
     get() = dataString?.equals("bitwarden://password_generator") == true
+
+/**
+ * Returns `true` if the [Intent] is a deeplink to the account security screen, `false` otherwise.
+ */
+val Intent.isAccountSecurityShortcut: Boolean
+    get() = dataString?.equals("bitwarden://settings/account_security") == true

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -48,6 +48,7 @@ import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.x8bit.bitwarden.ui.platform.util.isAccountSecurityShortcut
 import com.x8bit.bitwarden.ui.platform.util.isMyVaultShortcut
 import com.x8bit.bitwarden.ui.platform.util.isPasswordGeneratorShortcut
 import com.x8bit.bitwarden.ui.vault.model.TotpData
@@ -131,6 +132,7 @@ class MainViewModelTest : BaseViewModelTest() {
         mockkStatic(
             Intent::isMyVaultShortcut,
             Intent::isPasswordGeneratorShortcut,
+            Intent::isAccountSecurityShortcut,
         )
     }
 
@@ -146,6 +148,7 @@ class MainViewModelTest : BaseViewModelTest() {
         unmockkStatic(
             Intent::isMyVaultShortcut,
             Intent::isPasswordGeneratorShortcut,
+            Intent::isAccountSecurityShortcut,
         )
     }
 
@@ -312,6 +315,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(MainAction.ReceiveFirstIntent(intent = mockIntent))
         assertEquals(
@@ -334,6 +338,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns shareData
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(
             MainAction.ReceiveFirstIntent(
@@ -363,6 +368,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(
             MainAction.ReceiveFirstIntent(
@@ -394,6 +400,7 @@ class MainViewModelTest : BaseViewModelTest() {
             every { getAutofillSelectionDataOrNull() } returns null
             every { isMyVaultShortcut } returns false
             every { isPasswordGeneratorShortcut } returns false
+            every { isAccountSecurityShortcut } returns false
         }
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { authRepository.activeUserId } returns null
@@ -430,6 +437,7 @@ class MainViewModelTest : BaseViewModelTest() {
             every { getAutofillSelectionDataOrNull() } returns null
             every { isMyVaultShortcut } returns false
             every { isPasswordGeneratorShortcut } returns false
+            every { isAccountSecurityShortcut } returns false
         }
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { authRepository.activeUserId } returns "activeId"
@@ -468,6 +476,7 @@ class MainViewModelTest : BaseViewModelTest() {
             every { getAutofillSelectionDataOrNull() } returns null
             every { isMyVaultShortcut } returns false
             every { isPasswordGeneratorShortcut } returns false
+            every { isAccountSecurityShortcut } returns false
         }
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { authRepository.activeUserId } returns null
@@ -508,6 +517,7 @@ class MainViewModelTest : BaseViewModelTest() {
                 every { getAutofillSelectionDataOrNull() } returns null
                 every { isMyVaultShortcut } returns false
                 every { isPasswordGeneratorShortcut } returns false
+                every { isAccountSecurityShortcut } returns false
             }
             every { intentManager.getShareDataFromIntent(mockIntent) } returns null
             every { authRepository.activeUserId } returns null
@@ -550,6 +560,7 @@ class MainViewModelTest : BaseViewModelTest() {
                 every { getAutofillSelectionDataOrNull() } returns null
                 every { isMyVaultShortcut } returns false
                 every { isPasswordGeneratorShortcut } returns false
+                every { isAccountSecurityShortcut } returns false
             }
             every { intentManager.getShareDataFromIntent(mockIntent) } returns null
             every { authRepository.activeUserId } returns null
@@ -589,6 +600,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(
             MainAction.ReceiveFirstIntent(
@@ -619,6 +631,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(
             MainAction.ReceiveFirstIntent(
@@ -706,6 +719,7 @@ class MainViewModelTest : BaseViewModelTest() {
             every { getCompleteRegistrationDataIntentOrNull() } returns null
             every { isMyVaultShortcut } returns false
             every { isPasswordGeneratorShortcut } returns false
+            every { isAccountSecurityShortcut } returns false
         }
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         coEvery {
@@ -744,6 +758,7 @@ class MainViewModelTest : BaseViewModelTest() {
             every { getCompleteRegistrationDataIntentOrNull() } returns null
             every { isMyVaultShortcut } returns false
             every { isPasswordGeneratorShortcut } returns false
+            every { isAccountSecurityShortcut } returns false
         }
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         coEvery {
@@ -818,6 +833,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns shareData
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(
             MainAction.ReceiveNewIntent(
@@ -847,6 +863,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(MainAction.ReceiveNewIntent(intent = mockIntent))
         assertEquals(
@@ -869,6 +886,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(
             MainAction.ReceiveNewIntent(
@@ -898,6 +916,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(
             MainAction.ReceiveNewIntent(
@@ -928,6 +947,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
 
         viewModel.trySendAction(
             MainAction.ReceiveNewIntent(
@@ -955,6 +975,7 @@ class MainViewModelTest : BaseViewModelTest() {
             every { getCompleteRegistrationDataIntentOrNull() } returns null
             every { isMyVaultShortcut } returns true
             every { isPasswordGeneratorShortcut } returns false
+            every { isAccountSecurityShortcut } returns false
         }
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
 
@@ -971,6 +992,33 @@ class MainViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `on ReceiveNewIntent with account security deeplink data should set the special circumstance to AccountSecurityShortcut `() {
+        val viewModel = createViewModel()
+        val mockIntent = mockk<Intent> {
+            every { getTotpDataOrNull() } returns null
+            every { getPasswordlessRequestDataIntentOrNull() } returns null
+            every { getAutofillSaveItemOrNull() } returns null
+            every { getAutofillSelectionDataOrNull() } returns null
+            every { getCompleteRegistrationDataIntentOrNull() } returns null
+            every { isMyVaultShortcut } returns false
+            every { isPasswordGeneratorShortcut } returns false
+            every { isAccountSecurityShortcut } returns true
+        }
+        every { intentManager.getShareDataFromIntent(mockIntent) } returns null
+
+        viewModel.trySendAction(
+            MainAction.ReceiveNewIntent(
+                intent = mockIntent,
+            ),
+        )
+        assertEquals(
+            SpecialCircumstance.AccountSecurityShortcut,
+            specialCircumstanceManager.specialCircumstance,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `on ReceiveNewIntent with a password generator deeplink data should set the special circumstance to GeneratorShortcut`() {
         val viewModel = createViewModel()
         val mockIntent = mockk<Intent> {
@@ -981,6 +1029,7 @@ class MainViewModelTest : BaseViewModelTest() {
             every { getCompleteRegistrationDataIntentOrNull() } returns null
             every { isMyVaultShortcut } returns false
             every { isPasswordGeneratorShortcut } returns true
+            every { isAccountSecurityShortcut } returns false
         }
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
 
@@ -1070,6 +1119,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { intentManager.getShareDataFromIntent(mockIntent) } returns null
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
+        every { mockIntent.isAccountSecurityShortcut } returns false
         every { passwordlessRequestData.userId } returns "userId"
 
         viewModel.trySendAction(
@@ -1152,6 +1202,7 @@ private fun createMockFido2RegistrationIntent(
     every { getCompleteRegistrationDataIntentOrNull() } returns null
     every { isMyVaultShortcut } returns false
     every { isPasswordGeneratorShortcut } returns false
+    every { isAccountSecurityShortcut } returns false
 }
 
 private fun createMockFido2AssertionIntent(
@@ -1166,6 +1217,7 @@ private fun createMockFido2AssertionIntent(
     every { getCompleteRegistrationDataIntentOrNull() } returns null
     every { isMyVaultShortcut } returns false
     every { isPasswordGeneratorShortcut } returns false
+    every { isAccountSecurityShortcut } returns false
 }
 
 private fun createMockFido2GetCredentialsIntent(
@@ -1183,6 +1235,7 @@ private fun createMockFido2GetCredentialsIntent(
     every { getCompleteRegistrationDataIntentOrNull() } returns null
     every { isMyVaultShortcut } returns false
     every { isPasswordGeneratorShortcut } returns false
+    every { isAccountSecurityShortcut } returns false
 }
 
 private val FIXED_CLOCK: Clock = Clock.fixed(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -483,6 +483,44 @@ class RootNavViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `when the active user has an unlocked vault but there is an AccountSecurityShortcut special circumstance the nav state should be VaultUnlocked`() {
+        specialCircumstanceManager.specialCircumstance =
+            SpecialCircumstance.AccountSecurityShortcut
+        mutableUserStateFlow.tryEmit(
+            UserState(
+                activeUserId = "activeUserId",
+                accounts = listOf(
+                    UserState.Account(
+                        userId = "activeUserId",
+                        name = "name",
+                        email = "email",
+                        avatarColorHex = "avatarColorHex",
+                        environment = Environment.Us,
+                        isPremium = true,
+                        isLoggedIn = true,
+                        isVaultUnlocked = true,
+                        needsPasswordReset = false,
+                        isBiometricsEnabled = false,
+                        organizations = emptyList(),
+                        needsMasterPassword = false,
+                        trustedDevice = null,
+                        hasMasterPassword = true,
+                        isUsingKeyConnector = false,
+                        firstTimeState = UserState.FirstTimeState(false),
+                        onboardingStatus = OnboardingStatus.COMPLETE,
+                    ),
+                ),
+            ),
+        )
+        val viewModel = createViewModel()
+        assertEquals(
+            RootNavState.VaultUnlocked(activeUserId = "activeUserId"),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `when the active user has an unlocked vault but the is a ShareNewSend special circumstance the nav state should be VaultUnlockedForNewSend`() {
         specialCircumstanceManager.specialCircumstance =
             SpecialCircumstance.ShareNewSend(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -261,6 +261,25 @@ class SettingsScreenTest : BaseComposeTest() {
     }
 
     @Test
+    fun `on NavigateAccountSecurityShortcut should call onNavigateToAccountSecurity`() {
+        var haveCalledNavigateToAccountSecurity = false
+        composeTestRule.setContent {
+            SettingsScreen(
+                viewModel = viewModel,
+                onNavigateToAbout = { },
+                onNavigateToAccountSecurity = { haveCalledNavigateToAccountSecurity = true },
+                onNavigateToAppearance = { },
+                onNavigateToAutoFill = { },
+                onNavigateToOther = { },
+                onNavigateToVault = {
+                },
+            )
+        }
+        mutableEventFlow.tryEmit(SettingsEvent.NavigateAccountSecurityShortcut)
+        assertTrue(haveCalledNavigateToAccountSecurity)
+    }
+
+    @Test
     fun `Settings screen should show correct number of notification badges based on state`() {
         composeTestRule.setContent {
             SettingsScreen(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -104,6 +104,21 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
     }
 
     @Test
+    fun `NavigateToSettingsScreen shortcut event should navigate to SettingsScreen`() {
+        mutableEventFlow.tryEmit(VaultUnlockedNavBarEvent.NavigateToSendScreen)
+        composeTestRule.runOnIdle { fakeNavHostController.assertCurrentRoute("send_graph") }
+        mutableEventFlow.tryEmit(
+            VaultUnlockedNavBarEvent.Shortcut.NavigateToSettingsScreen,
+        )
+        composeTestRule.runOnIdle {
+            fakeNavHostController.assertLastNavigation(
+                route = "settings_graph",
+                navOptions = expectedNavOptions,
+            )
+        }
+    }
+
+    @Test
     fun `send tab click should send SendTabClick action`() {
         composeTestRule.onNodeWithText("Send").performClick()
         verify { viewModel.trySendAction(VaultUnlockedNavBarAction.SendTabClick) }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarViewModelTest.kt
@@ -80,6 +80,27 @@ class VaultUnlockedNavBarViewModelTest : BaseViewModelTest() {
             }
         }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on init with AccountSecurityShortcut special circumstance should navigate to the settings screen with shortcut event`() =
+        runTest {
+            every {
+                specialCircumstancesManager.specialCircumstance
+            } returns SpecialCircumstance.AccountSecurityShortcut
+
+            val viewModel = createViewModel()
+
+            viewModel.eventFlow.test {
+                assertEquals(
+                    VaultUnlockedNavBarEvent.Shortcut.NavigateToSettingsScreen,
+                    awaitItem(),
+                )
+            }
+            verify(exactly = 1) {
+                specialCircumstancesManager.specialCircumstance
+            }
+        }
+
     @Test
     fun `on init with no shortcut special circumstance should do nothing`() = runTest {
         every { specialCircumstancesManager.specialCircumstance } returns null


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-105

## 📔 Objective

The goal of this PR is to add a deep link to account security settings that will be used by the Authenticator app.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/660b6d3a-f9b1-4d62-b111-902919ff1804" width="300" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
