### PR TITLE
Simplify text field color and textstyles

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenDateSelectButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenDateSelectButton.kt
@@ -94,7 +94,6 @@ fun BitwardenDateSelectButton(
             Icon(
                 painter = rememberVectorPainter(id = R.drawable.ic_down_triangle),
                 contentDescription = null,
-                tint = BitwardenTheme.colorScheme.icon.primary,
             )
         },
         colors = bitwardenTextFieldButtonColors(),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenTimeSelectButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenTimeSelectButton.kt
@@ -79,7 +79,6 @@ fun BitwardenTimeSelectButton(
             Icon(
                 painter = rememberVectorPainter(id = R.drawable.ic_down_triangle),
                 contentDescription = null,
-                tint = BitwardenTheme.colorScheme.icon.primary,
             )
         },
         colors = bitwardenTextFieldButtonColors(),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
@@ -128,7 +128,6 @@ fun BitwardenMultiSelectButton(
             Icon(
                 painter = rememberVectorPainter(id = R.drawable.ic_down_triangle),
                 contentDescription = null,
-                tint = BitwardenTheme.colorScheme.icon.primary,
             )
         },
         colors = bitwardenTextFieldButtonColors(),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -92,7 +92,6 @@ fun BitwardenTextField(
                 Icon(
                     painter = iconResource.iconPainter,
                     contentDescription = iconResource.contentDescription,
-                    tint = BitwardenTheme.colorScheme.icon.primary,
                 )
             }
         },
@@ -101,7 +100,7 @@ fun BitwardenTextField(
             {
                 Text(
                     text = it,
-                    color = BitwardenTheme.colorScheme.text.primary,
+                    style = textStyle,
                 )
             }
         },


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR simplifies the styling of the Text Fields in the app and allows the underlying color scheme to handle it.

The main thing is fixing the placeholder text color.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/69e2fcbe-b286-4e1b-9df9-61b24114386b" width="300" /> | <img src="https://github.com/user-attachments/assets/bb0763c0-afa9-41eb-b31e-a81235265c71" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
