### PR TITLE
PM-11176: Update generator to use segmented control

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
@@ -46,6 +46,7 @@ fun BitwardenSegmentedButton(
         ) {
             options.forEachIndexed { index, option ->
                 SegmentedButton(
+                    enabled = option.isEnabled,
                     selected = option.isChecked,
                     onClick = option.onClick,
                     colors = bitwardenSegmentedButtonColors(),
@@ -74,5 +75,6 @@ data class SegmentedButtonState(
     val text: String,
     val onClick: () -> Unit,
     val isChecked: Boolean,
+    val isEnabled: Boolean = true,
     val testTag: String? = null,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/color/BitwardenSegmentedButtonColors.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/color/BitwardenSegmentedButtonColors.kt
@@ -20,6 +20,6 @@ fun bitwardenSegmentedButtonColors(): SegmentedButtonColors = SegmentedButtonCol
     disabledActiveContentColor = BitwardenTheme.colorScheme.filledButton.foregroundDisabled,
     disabledActiveBorderColor = Color.Transparent,
     disabledInactiveContainerColor = BitwardenTheme.colorScheme.background.primary,
-    disabledInactiveContentColor = BitwardenTheme.colorScheme.filledButton.foregroundDisabled,
+    disabledInactiveContentColor = BitwardenTheme.colorScheme.stroke.divider,
     disabledInactiveBorderColor = Color.Transparent,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -205,48 +205,12 @@ class GeneratorScreenTest : BaseComposeTest() {
     fun `clicking a MainStateOption should send MainTypeOptionSelect action`() {
         // Opens the menu
         composeTestRule
-            .onNodeWithContentDescription(label = "Password. What would you like to generate?")
-            .performClick()
-
-        // Choose the option from the menu
-        composeTestRule
-            .onAllNodesWithText(text = "Password")
-            .onLast()
-            .performScrollTo()
-            .assert(hasAnyAncestor(isDialog()))
+            .onNodeWithText(text = "Password")
             .performClick()
 
         verify {
             viewModel.trySendAction(
                 GeneratorAction.MainTypeOptionSelect(GeneratorState.MainTypeOption.PASSWORD),
-            )
-        }
-
-        // Make sure dialog is hidden:
-        composeTestRule
-            .onNode(isDialog())
-            .assertDoesNotExist()
-    }
-
-    @Test
-    fun `clicking a PasscodeOption should send PasscodeTypeOption action`() {
-        // Opens the menu
-        composeTestRule
-            .onNodeWithContentDescription(label = "Password. Password type")
-            .performClick()
-
-        // Choose the option from the menu
-        composeTestRule
-            .onAllNodesWithText(text = "Passphrase")
-            .onLast()
-            .assert(hasAnyAncestor(isDialog()))
-            .performClick()
-
-        verify {
-            viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeTypeOptionSelect(
-                    GeneratorState.MainType.Passcode.PasscodeTypeOption.PASSPHRASE,
-                ),
             )
         }
 
@@ -262,11 +226,7 @@ class GeneratorScreenTest : BaseComposeTest() {
         updateState(
             DEFAULT_STATE.copy(
                 selectedType = GeneratorState.MainType.Username(
-                    GeneratorState
-                        .MainType
-                        .Username
-                        .UsernameType
-                        .PlusAddressedEmail(),
+                    GeneratorState.MainType.Username.UsernameType.PlusAddressedEmail(),
                 ),
             ),
         )
@@ -302,15 +262,7 @@ class GeneratorScreenTest : BaseComposeTest() {
     //region Passcode Password Tests
 
     @Test
-    fun `in Passcode_Password state, the ViewModel state should update the UI correctly`() {
-        composeTestRule
-            .onNodeWithContentDescription(label = "Password. What would you like to generate?")
-            .assertIsDisplayed()
-
-        composeTestRule
-            .onNodeWithContentDescription(label = "Password. Password type")
-            .assertIsDisplayed()
-
+    fun `in Password state, the ViewModel state should update the UI correctly`() {
         composeTestRule
             .onNode(
                 expectValue(
@@ -363,7 +315,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, adjusting the slider should send SliderLengthChange action with length not equal to default`() {
+    fun `in Password state, adjusting the slider should send SliderLengthChange action with length not equal to default`() {
         composeTestRule
             .onNodeWithText("Length")
             .onSiblings()
@@ -383,7 +335,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.SliderLengthChange(
+                GeneratorAction.MainType.Password.SliderLengthChange(
                     length = 128,
                     isUserInteracting = true,
                 ),
@@ -396,7 +348,7 @@ class GeneratorScreenTest : BaseComposeTest() {
         // actually get updated from its original value, and thus will be its original value of 14.
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.SliderLengthChange(
+                GeneratorAction.MainType.Password.SliderLengthChange(
                     length = 14,
                     isUserInteracting = false,
                 ),
@@ -406,14 +358,14 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, toggling the capital letters toggle should send ToggleCapitalLettersChange action`() {
+    fun `in Password state, toggling the capital letters toggle should send ToggleCapitalLettersChange action`() {
         composeTestRule.onNodeWithText("A—Z")
             .performScrollTo()
             .performClick()
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.ToggleCapitalLettersChange(
+                GeneratorAction.MainType.Password.ToggleCapitalLettersChange(
                     useCapitals = false,
                 ),
             )
@@ -422,36 +374,15 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, toggling the use lowercase toggle should send ToggleLowercaseLettersChange action`() {
+    fun `in Password state, toggling the use lowercase toggle should send ToggleLowercaseLettersChange action`() {
         composeTestRule.onNodeWithText("a—z")
             .performScrollTo()
             .performClick()
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleLowercaseLettersChange(
-                        useLowercase = false,
-                    ),
-            )
-        }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `in Passcode_Password state, toggling the use numbers toggle should send ToggleNumbersChange action`() {
-        composeTestRule.onNodeWithText("0-9")
-            .performScrollTo()
-            .performClick()
-
-        verify {
-            viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.ToggleNumbersChange(
-                    useNumbers = false,
+                GeneratorAction.MainType.Password.ToggleLowercaseLettersChange(
+                    useLowercase = false,
                 ),
             )
         }
@@ -459,28 +390,37 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, toggling the use special characters toggle should send ToggleSpecialCharactersChange action`() {
-        composeTestRule.onNodeWithText("!@#$%^&*")
+    fun `in Password state, toggling the use numbers toggle should send ToggleNumbersChange action`() {
+        composeTestRule.onNodeWithText("0-9")
             .performScrollTo()
             .performClick()
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleSpecialCharactersChange(
-                        useSpecialChars = true,
-                    ),
+                GeneratorAction.MainType.Password.ToggleNumbersChange(useNumbers = false),
             )
         }
     }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, decrementing the minimum numbers counter should send MinNumbersCounterChange action`() {
+    fun `in Password state, toggling the use special characters toggle should send ToggleSpecialCharactersChange action`() {
+        composeTestRule.onNodeWithText("!@#$%^&*")
+            .performScrollTo()
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                GeneratorAction.MainType.Password.ToggleSpecialCharactersChange(
+                    useSpecialChars = true,
+                ),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in Password state, decrementing the minimum numbers counter should send MinNumbersCounterChange action`() {
         val initialMinNumbers = 1
 
         composeTestRule.onNodeWithText("Minimum numbers")
@@ -492,7 +432,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.MinNumbersCounterChange(
+                GeneratorAction.MainType.Password.MinNumbersCounterChange(
                     minNumbers = initialMinNumbers - 1,
                 ),
             )
@@ -501,7 +441,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, incrementing the minimum numbers counter should send MinNumbersCounterChange action`() {
+    fun `in Password state, incrementing the minimum numbers counter should send MinNumbersCounterChange action`() {
         val initialMinNumbers = 1
 
         composeTestRule.onNodeWithText("Minimum numbers")
@@ -513,28 +453,19 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.MinNumbersCounterChange(
+                GeneratorAction.MainType.Password.MinNumbersCounterChange(
                     minNumbers = initialMinNumbers + 1,
                 ),
             )
         }
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, decrementing the minimum numbers counter below 0 should do nothing`() {
+    fun `in Password state, decrementing the minimum numbers counter below 0 should do nothing`() {
         val initialMinNumbers = 0
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            minNumbers = initialMinNumbers,
-                        ),
-                ),
+                selectedType = GeneratorState.MainType.Password(minNumbers = initialMinNumbers),
             ),
         )
 
@@ -549,21 +480,12 @@ class GeneratorScreenTest : BaseComposeTest() {
         verify(exactly = 1) { viewModel.trySendAction(any()) }
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, incrementing the minimum numbers counter above 9 should do nothing`() {
+    fun `in Password state, incrementing the minimum numbers counter above 9 should do nothing`() {
         val initialMinNumbers = 9
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            minNumbers = initialMinNumbers,
-                        ),
-                ),
+                selectedType = GeneratorState.MainType.Password(minNumbers = initialMinNumbers),
             ),
         )
 
@@ -580,7 +502,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, decrementing the minimum special characters counter should send MinSpecialCharactersChange action`() {
+    fun `in Password state, decrementing the minimum special characters counter should send MinSpecialCharactersChange action`() {
         val initialSpecialChars = 1
 
         composeTestRule.onNodeWithText("Minimum special")
@@ -592,7 +514,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.MinSpecialCharactersChange(
+                GeneratorAction.MainType.Password.MinSpecialCharactersChange(
                     minSpecial = initialSpecialChars - 1,
                 ),
             )
@@ -601,7 +523,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, incrementing the minimum special characters counter should send MinSpecialCharactersChange action`() {
+    fun `in Password state, incrementing the minimum special characters counter should send MinSpecialCharactersChange action`() {
         val initialSpecialChars = 1
 
         composeTestRule.onNodeWithText("Minimum special")
@@ -613,7 +535,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.MinSpecialCharactersChange(
+                GeneratorAction.MainType.Password.MinSpecialCharactersChange(
                     minSpecial = initialSpecialChars + 1,
                 ),
             )
@@ -622,19 +544,11 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, decrementing the minimum special characters below 0 should do nothing`() {
+    fun `in Password state, decrementing the minimum special characters below 0 should do nothing`() {
         val initialSpecialChars = 0
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            minSpecial = initialSpecialChars,
-                        ),
-                ),
+                selectedType = GeneratorState.MainType.Password(minSpecial = initialSpecialChars),
             ),
         )
 
@@ -650,19 +564,11 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, decrementing the minimum special characters above 9 should do nothing`() {
+    fun `in Password state, decrementing the minimum special characters above 9 should do nothing`() {
         val initialSpecialChars = 9
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            minSpecial = initialSpecialChars,
-                        ),
-                ),
+                selectedType = GeneratorState.MainType.Password(minSpecial = initialSpecialChars),
             ),
         )
 
@@ -678,41 +584,30 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, toggling the use avoid ambiguous characters toggle should send ToggleSpecialCharactersChange action`() {
+    fun `in Password state, toggling the use avoid ambiguous characters toggle should send ToggleSpecialCharactersChange action`() {
         composeTestRule.onNodeWithText("Avoid ambiguous characters")
             .performScrollTo()
             .performClick()
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleAvoidAmbigousCharactersChange(
-                        avoidAmbiguousChars = true,
-                    ),
+                GeneratorAction.MainType.Password.ToggleAvoidAmbigousCharactersChange(
+                    avoidAmbiguousChars = true,
+                ),
             )
         }
     }
 
     @Test
-    fun `in Passcode_Password state, disabled elements should not send events`() {
+    fun `in Password state, disabled elements should not send events`() {
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            capitalsEnabled = false,
-                            lowercaseEnabled = false,
-                            numbersEnabled = false,
-                            specialCharsEnabled = false,
-                            ambiguousCharsEnabled = false,
-                        ),
+                selectedType = GeneratorState.MainType.Password(
+                    capitalsEnabled = false,
+                    lowercaseEnabled = false,
+                    numbersEnabled = false,
+                    specialCharsEnabled = false,
+                    ambiguousCharsEnabled = false,
                 ),
             ),
         )
@@ -735,72 +630,37 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify(exactly = 0) {
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleCapitalLettersChange(
-                        useCapitals = false,
-                    ),
+                GeneratorAction.MainType.Password.ToggleCapitalLettersChange(useCapitals = false),
             )
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleLowercaseLettersChange(
-                        useLowercase = false,
-                    ),
+                GeneratorAction.MainType.Password.ToggleLowercaseLettersChange(
+                    useLowercase = false,
+                ),
             )
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleNumbersChange(
-                        useNumbers = false,
-                    ),
+                GeneratorAction.MainType.Password.ToggleNumbersChange(useNumbers = false),
             )
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleSpecialCharactersChange(
-                        useSpecialChars = true,
-                    ),
+                GeneratorAction.MainType.Password.ToggleSpecialCharactersChange(
+                    useSpecialChars = true,
+                ),
             )
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleAvoidAmbigousCharactersChange(
-                        avoidAmbiguousChars = true,
-                    ),
+                GeneratorAction.MainType.Password.ToggleAvoidAmbigousCharactersChange(
+                    avoidAmbiguousChars = true,
+                ),
             )
         }
     }
 
     @Test
-    fun `in Passcode_Password state, minimum numbers cannot go below minimum threshold`() {
+    fun `in Password state, minimum numbers cannot go below minimum threshold`() {
         val initialMinNumbers = 5
 
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            minNumbersAllowed = initialMinNumbers,
-                        ),
+                selectedType = GeneratorState.MainType.Password(
+                    minNumbersAllowed = initialMinNumbers,
                 ),
             ),
         )
@@ -814,7 +674,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify(exactly = 0) {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.MinNumbersCounterChange(
+                GeneratorAction.MainType.Password.MinNumbersCounterChange(
                     minNumbers = 4,
                 ),
             )
@@ -822,21 +682,15 @@ class GeneratorScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `in Passcode_Password state, maximum numbers should match minimum if lower`() {
+    fun `in Password state, maximum numbers should match minimum if lower`() {
         val initialMinNumbers = 7
         val initialMaxNumbers = 5
 
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            minNumbersAllowed = initialMinNumbers,
-                            maxNumbersAllowed = initialMaxNumbers,
-                        ),
+                selectedType = GeneratorState.MainType.Password(
+                    minNumbersAllowed = initialMinNumbers,
+                    maxNumbersAllowed = initialMaxNumbers,
                 ),
             ),
         )
@@ -850,21 +704,14 @@ class GeneratorScreenTest : BaseComposeTest() {
             .assertIsDisplayed()
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Password state, minimum special characters cannot go below minimum threshold`() {
+    fun `in Password state, minimum special characters cannot go below minimum threshold`() {
         val initialMinSpecials = 5
 
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            minSpecialAllowed = initialMinSpecials,
-                        ),
+                selectedType = GeneratorState.MainType.Password(
+                    minSpecialAllowed = initialMinSpecials,
                 ),
             ),
         )
@@ -878,7 +725,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify(exactly = 0) {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.MinSpecialCharactersChange(
+                GeneratorAction.MainType.Password.MinSpecialCharactersChange(
                     minSpecial = 4,
                 ),
             )
@@ -886,21 +733,15 @@ class GeneratorScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `in Passcode_Password state, maximum special should match minimum if lower `() {
+    fun `in Password state, maximum special should match minimum if lower `() {
         val initialMinSpecials = 7
         val initialMaxSpecials = 5
 
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password(
-                            minSpecialAllowed = initialMinSpecials,
-                            maxSpecialAllowed = initialMaxSpecials,
-                        ),
+                selectedType = GeneratorState.MainType.Password(
+                    minSpecialAllowed = initialMinSpecials,
+                    maxSpecialAllowed = initialMaxSpecials,
                 ),
             ),
         )
@@ -914,18 +755,12 @@ class GeneratorScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `in Passcode_Passphrase state, disabled elements should not send events`() {
+    fun `in Passphrase state, disabled elements should not send events`() {
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(
-                            capitalizeEnabled = false,
-                            includeNumberEnabled = false,
-                        ),
+                selectedType = GeneratorState.MainType.Passphrase(
+                    capitalizeEnabled = false,
+                    includeNumberEnabled = false,
                 ),
             ),
         )
@@ -939,44 +774,25 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify(exactly = 0) {
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Passphrase
-                    .ToggleCapitalizeChange(
-                        capitalize = true,
-                    ),
+                GeneratorAction.MainType.Passphrase.ToggleCapitalizeChange(
+                    capitalize = true,
+                ),
             )
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Passphrase
-                    .ToggleIncludeNumberChange(
-                        includeNumber = true,
-                    ),
+                GeneratorAction.MainType.Passphrase.ToggleIncludeNumberChange(
+                    includeNumber = true,
+                ),
             )
         }
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_passphrase state, minimum number of words cannot go below minimum threshold`() {
+    fun `in Passphrase state, minimum number of words cannot go below minimum threshold`() {
         val initialMinWords = 5
 
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(
-                            minNumWords = initialMinWords,
-                        ),
-                ),
+                selectedType = GeneratorState.MainType.Passphrase(minNumWords = initialMinWords),
             ),
         )
 
@@ -989,9 +805,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify(exactly = 0) {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Passphrase.NumWordsCounterChange(
-                    numWords = 4,
-                ),
+                GeneratorAction.MainType.Passphrase.NumWordsCounterChange(numWords = 4),
             )
         }
     }
@@ -1002,19 +816,11 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Passphrase state, decrementing number of words should send NumWordsCounterChange action with decremented value`() {
+    fun `in Passphrase state, decrementing number of words should send NumWordsCounterChange action with decremented value`() {
         val initialNumWords = 4
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(
-                            numWords = initialNumWords,
-                        ),
-                ),
+                selectedType = GeneratorState.MainType.Passphrase(numWords = initialNumWords),
             ),
         )
 
@@ -1029,7 +835,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Passphrase.NumWordsCounterChange(
+                GeneratorAction.MainType.Passphrase.NumWordsCounterChange(
                     numWords = initialNumWords - 1,
                 ),
             )
@@ -1037,19 +843,11 @@ class GeneratorScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `in Passcode_Passphrase state, decrementing number of words under 3 should do nothing`() {
+    fun `in Passphrase state, decrementing number of words under 3 should do nothing`() {
         val initialNumWords = 3
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(
-                            numWords = initialNumWords,
-                        ),
-                ),
+                selectedType = GeneratorState.MainType.Passphrase(numWords = initialNumWords),
             ),
         )
 
@@ -1066,19 +864,11 @@ class GeneratorScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `in Passcode_Passphrase state, incrementing number of words over 20 should do nothing`() {
+    fun `in Passphrase state, incrementing number of words over 20 should do nothing`() {
         val initialNumWords = 20
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(
-                            numWords = initialNumWords,
-                        ),
-                ),
+                selectedType = GeneratorState.MainType.Passphrase(numWords = initialNumWords),
             ),
         )
 
@@ -1096,17 +886,11 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Passphrase state, incrementing number of words should send NumWordsCounterChange action with incremented value`() {
+    fun `in Passphrase state, incrementing number of words should send NumWordsCounterChange action with incremented value`() {
         val initialNumWords = 3
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(),
-                ),
+                selectedType = GeneratorState.MainType.Passphrase(),
             ),
         )
 
@@ -1120,25 +904,18 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Passphrase.NumWordsCounterChange(
+                GeneratorAction.MainType.Passphrase.NumWordsCounterChange(
                     numWords = initialNumWords + 1,
                 ),
             )
         }
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Passphrase state, toggling capitalize should send ToggleCapitalizeChange action`() {
+    fun `in Passphrase state, toggling capitalize should send ToggleCapitalizeChange action`() {
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(),
-                ),
+                selectedType = GeneratorState.MainType.Passphrase(),
             ),
         )
 
@@ -1149,7 +926,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Passphrase.ToggleCapitalizeChange(
+                GeneratorAction.MainType.Passphrase.ToggleCapitalizeChange(
                     capitalize = true,
                 ),
             )
@@ -1158,16 +935,10 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Passphrase state, toggling the include number toggle should send ToggleIncludeNumberChange action`() {
+    fun `in Passphrase state, toggling the include number toggle should send ToggleIncludeNumberChange action`() {
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(),
-                ),
+                selectedType = GeneratorState.MainType.Passphrase(),
             ),
         )
 
@@ -1177,7 +948,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Passphrase.ToggleIncludeNumberChange(
+                GeneratorAction.MainType.Passphrase.ToggleIncludeNumberChange(
                     includeNumber = true,
                 ),
             )
@@ -1186,16 +957,10 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in Passcode_Passphrase state, updating text in word separator should send WordSeparatorTextChange action`() {
+    fun `in Passphrase state, updating text in word separator should send WordSeparatorTextChange action`() {
         updateState(
             DEFAULT_STATE.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase(),
-                ),
+                selectedType = GeneratorState.MainType.Passphrase(),
             ),
         )
 
@@ -1206,7 +971,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
         verify {
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Passphrase.WordSeparatorTextChange(
+                GeneratorAction.MainType.Passphrase.WordSeparatorTextChange(
                     wordSeparator = 'a',
                 ),
             )
@@ -1765,8 +1530,6 @@ class GeneratorScreenTest : BaseComposeTest() {
 
 private val DEFAULT_STATE = GeneratorState(
     generatedText = "",
-    selectedType = GeneratorState.MainType.Passcode(
-        GeneratorState.MainType.Passcode.PasscodeType.Password(),
-    ),
+    selectedType = GeneratorState.MainType.Password(),
     currentEmailAddress = "currentEmail",
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -163,9 +163,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         fakeGeneratorRepository.savePasscodeGenerationOptions(passcodeGenerationOptions)
         val expected = GeneratorState(
             generatedText = "updatedPassphrase",
-            selectedType = GeneratorState.MainType.Passcode(
-                selectedType = GeneratorState.MainType.Passcode.PasscodeType.Passphrase(),
-            ),
+            selectedType = GeneratorState.MainType.Passphrase(),
             generatorMode = GeneratorMode.Modal.Password,
             currentEmailAddress = "currentEmail",
             isUnderPolicy = false,
@@ -213,29 +211,27 @@ class GeneratorViewModelTest : BaseViewModelTest() {
             mutablePolicyFlow.tryEmit(value = policies)
             assertEquals(
                 initialPasscodeState.copy(
-                    selectedType = GeneratorState.MainType.Passcode(
-                        selectedType = GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 14,
-                            minLength = 10,
-                            maxLength = 128,
-                            useCapitals = true,
-                            capitalsEnabled = false,
-                            useLowercase = true,
-                            lowercaseEnabled = false,
-                            useNumbers = true,
-                            numbersEnabled = false,
-                            useSpecialChars = true,
-                            specialCharsEnabled = false,
-                            minNumbers = 3,
-                            minNumbersAllowed = 3,
-                            maxNumbersAllowed = 9,
-                            minSpecial = 3,
-                            minSpecialAllowed = 3,
-                            maxSpecialAllowed = 9,
-                            avoidAmbiguousChars = false,
-                            ambiguousCharsEnabled = true,
-                            isUserInteracting = false,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 14,
+                        minLength = 10,
+                        maxLength = 128,
+                        useCapitals = true,
+                        capitalsEnabled = false,
+                        useLowercase = true,
+                        lowercaseEnabled = false,
+                        useNumbers = true,
+                        numbersEnabled = false,
+                        useSpecialChars = true,
+                        specialCharsEnabled = false,
+                        minNumbers = 3,
+                        minNumbersAllowed = 3,
+                        maxNumbersAllowed = 9,
+                        minSpecial = 3,
+                        minSpecialAllowed = 3,
+                        maxSpecialAllowed = 9,
+                        avoidAmbiguousChars = false,
+                        ambiguousCharsEnabled = true,
+                        isUserInteracting = false,
                     ),
                     isUnderPolicy = true,
                 ),
@@ -247,29 +243,27 @@ class GeneratorViewModelTest : BaseViewModelTest() {
             mutablePolicyFlow.tryEmit(value = emptyList())
             assertEquals(
                 initialPasscodeState.copy(
-                    selectedType = GeneratorState.MainType.Passcode(
-                        selectedType = GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 14,
-                            minLength = 5,
-                            maxLength = 128,
-                            useCapitals = true,
-                            capitalsEnabled = true,
-                            useLowercase = true,
-                            lowercaseEnabled = true,
-                            useNumbers = true,
-                            numbersEnabled = true,
-                            useSpecialChars = true,
-                            specialCharsEnabled = true,
-                            minNumbers = 3,
-                            minNumbersAllowed = 0,
-                            maxNumbersAllowed = 9,
-                            minSpecial = 3,
-                            minSpecialAllowed = 0,
-                            maxSpecialAllowed = 9,
-                            avoidAmbiguousChars = false,
-                            ambiguousCharsEnabled = true,
-                            isUserInteracting = false,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 14,
+                        minLength = 5,
+                        maxLength = 128,
+                        useCapitals = true,
+                        capitalsEnabled = true,
+                        useLowercase = true,
+                        lowercaseEnabled = true,
+                        useNumbers = true,
+                        numbersEnabled = true,
+                        useSpecialChars = true,
+                        specialCharsEnabled = true,
+                        minNumbers = 3,
+                        minNumbersAllowed = 0,
+                        maxNumbersAllowed = 9,
+                        minSpecial = 3,
+                        minSpecialAllowed = 0,
+                        maxSpecialAllowed = 9,
+                        avoidAmbiguousChars = false,
+                        ambiguousCharsEnabled = true,
+                        isUserInteracting = false,
                     ),
                     isUnderPolicy = false,
                 ),
@@ -562,24 +556,22 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         assertEquals(
             initialPasscodeState.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState.MainType.Passcode.PasscodeType.Password(
-                        length = 14,
-                        minLength = 10,
-                        useCapitals = true,
-                        capitalsEnabled = false,
-                        useLowercase = true,
-                        lowercaseEnabled = false,
-                        useNumbers = true,
-                        numbersEnabled = false,
-                        useSpecialChars = true,
-                        specialCharsEnabled = false,
-                        minNumbers = 3,
-                        minNumbersAllowed = 3,
-                        minSpecial = 3,
-                        minSpecialAllowed = 3,
-                        avoidAmbiguousChars = false,
-                    ),
+                selectedType = GeneratorState.MainType.Password(
+                    length = 14,
+                    minLength = 10,
+                    useCapitals = true,
+                    capitalsEnabled = false,
+                    useLowercase = true,
+                    lowercaseEnabled = false,
+                    useNumbers = true,
+                    numbersEnabled = false,
+                    useSpecialChars = true,
+                    specialCharsEnabled = false,
+                    minNumbers = 3,
+                    minNumbersAllowed = 3,
+                    minSpecial = 3,
+                    minSpecialAllowed = 3,
+                    avoidAmbiguousChars = false,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -613,8 +605,8 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         } returns listOf(policy)
 
         val viewModel = createViewModel()
-        val action = GeneratorAction.MainType.Passcode.PasscodeTypeOptionSelect(
-            passcodeTypeOption = GeneratorState.MainType.Passcode.PasscodeTypeOption.PASSPHRASE,
+        val action = GeneratorAction.MainTypeOptionSelect(
+            mainTypeOption = GeneratorState.MainTypeOption.PASSPHRASE,
         )
 
         viewModel.trySendAction(action)
@@ -622,16 +614,14 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         assertEquals(
             initialPasscodeState.copy(
                 generatedText = "updatedPassphrase",
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState.MainType.Passcode.PasscodeType.Passphrase(
-                        numWords = 5,
-                        minNumWords = 5,
-                        maxNumWords = 20,
-                        capitalize = true,
-                        capitalizeEnabled = false,
-                        includeNumber = true,
-                        includeNumberEnabled = false,
-                    ),
+                selectedType = GeneratorState.MainType.Passphrase(
+                    numWords = 5,
+                    minNumWords = 5,
+                    maxNumWords = 20,
+                    capitalize = true,
+                    capitalizeEnabled = false,
+                    includeNumber = true,
+                    includeNumberEnabled = false,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -659,10 +649,8 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         assertEquals(
             initialPasscodeState.copy(
                 generatedText = "updatedPassphrase",
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState.MainType.Passcode.PasscodeType.Passphrase(),
-                ),
-                overridePassword = true,
+                selectedType = GeneratorState.MainType.Passphrase(),
+                passcodePolicyOverride = GeneratorState.PasscodePolicyOverride.PASSPHRASE,
             ),
             viewModel.stateFlow.value,
         )
@@ -701,10 +689,8 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         assertEquals(
             initialPasscodeState.copy(
                 generatedText = "defaultPassword",
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState.MainType.Passcode.PasscodeType.Password(),
-                ),
-                overridePassword = true,
+                selectedType = GeneratorState.MainType.Password(),
+                passcodePolicyOverride = GeneratorState.PasscodePolicyOverride.PASSWORD,
             ),
             viewModel.stateFlow.value,
         )
@@ -721,11 +707,10 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(action)
 
-        val expectedState =
-            initialPasscodeState.copy(
-                selectedType = GeneratorState.MainType.Passcode(),
-                generatedText = "updatedText",
-            )
+        val expectedState = initialPasscodeState.copy(
+            selectedType = GeneratorState.MainType.Password(),
+            generatedText = "updatedText",
+        )
 
         assertEquals(expectedState, viewModel.stateFlow.value)
     }
@@ -750,54 +735,6 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                     ),
                 ),
             )
-
-        assertEquals(expectedState, viewModel.stateFlow.value)
-    }
-
-    @Test
-    fun `PasscodeTypeOptionSelect PASSWORD should switch to PasswordType`() = runTest {
-        val viewModel = createViewModel()
-        fakeGeneratorRepository.setMockGeneratePasswordResult(
-            GeneratedPasswordResult.Success("updatedText"),
-        )
-
-        val action = GeneratorAction.MainType.Passcode.PasscodeTypeOptionSelect(
-            passcodeTypeOption = GeneratorState.MainType.Passcode.PasscodeTypeOption.PASSWORD,
-        )
-
-        viewModel.trySendAction(action)
-
-        val expectedState = initialPasscodeState.copy(
-            selectedType = GeneratorState.MainType.Passcode(
-                selectedType = GeneratorState.MainType.Passcode.PasscodeType.Password(),
-            ),
-            generatedText = "updatedText",
-        )
-
-        assertEquals(expectedState, viewModel.stateFlow.value)
-    }
-
-    @Test
-    fun `PasscodeTypeOptionSelect PASSPHRASE should switch to PassphraseType`() = runTest {
-        val viewModel = createViewModel()
-        val updatedText = "updatedPassphrase"
-
-        fakeGeneratorRepository.setMockGeneratePasswordResult(
-            GeneratedPasswordResult.Success(updatedText),
-        )
-
-        val action = GeneratorAction.MainType.Passcode.PasscodeTypeOptionSelect(
-            passcodeTypeOption = GeneratorState.MainType.Passcode.PasscodeTypeOption.PASSPHRASE,
-        )
-
-        viewModel.trySendAction(action)
-
-        val expectedState = initialPasscodeState.copy(
-            generatedText = updatedText,
-            selectedType = GeneratorState.MainType.Passcode(
-                selectedType = GeneratorState.MainType.Passcode.PasscodeType.Passphrase(),
-            ),
-        )
 
         assertEquals(expectedState, viewModel.stateFlow.value)
     }
@@ -975,17 +912,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
             ),
         )
         val expectedState = initialState.copy(
-            selectedType = GeneratorState.MainType.Passcode(
-                selectedType = GeneratorState.MainType.Passcode.PasscodeType.Passphrase(
-                    numWords = 3,
-                    minNumWords = 3,
-                    maxNumWords = 20,
-                    wordSeparator = '-',
-                    capitalize = false,
-                    capitalizeEnabled = true,
-                    includeNumber = false,
-                    includeNumberEnabled = true,
-                ),
+            selectedType = GeneratorState.MainType.Passphrase(
+                numWords = 3,
+                minNumWords = 3,
+                maxNumWords = 20,
+                wordSeparator = '-',
+                capitalize = false,
+                capitalizeEnabled = true,
+                includeNumber = false,
+                includeNumberEnabled = true,
             ),
             generatedText = "updatedPassphrase",
         )
@@ -1055,7 +990,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 val newLength = 16
 
                 viewModel.trySendAction(
-                    GeneratorAction.MainType.Passcode.PasscodeType.Password.SliderLengthChange(
+                    GeneratorAction.MainType.Password.SliderLengthChange(
                         length = newLength,
                         isUserInteracting = false,
                     ),
@@ -1063,11 +998,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 val expectedState = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = newLength,
-                        ),
-                    ),
+                    selectedType = GeneratorState.MainType.Password(length = newLength),
                 )
 
                 assertEquals(expectedState, viewModel.stateFlow.value)
@@ -1084,7 +1015,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 // Update the length to something small enough that it updates on capitals toggle.
                 viewModel.trySendAction(
-                    GeneratorAction.MainType.Passcode.PasscodeType.Password.SliderLengthChange(
+                    GeneratorAction.MainType.Password.SliderLengthChange(
                         length = 5,
                         isUserInteracting = false,
                     ),
@@ -1092,31 +1023,24 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 // Set useCapitals to false initially to ensure length change is reflected.
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleCapitalLettersChange(
-                            useCapitals = false,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleCapitalLettersChange(
+                        useCapitals = false,
+                    ),
                 )
 
                 // Verify useCapitals is reflected and initial length is correct.
                 val expectedState1 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 5,
-                            useCapitals = false,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 5,
+                        useCapitals = false,
                     ),
                 )
                 assertEquals(expectedState1, viewModel.stateFlow.value)
 
                 // Update minNumbers so that length will exceed 5 when useCapitals is enabled.
                 viewModel.trySendAction(
-                    GeneratorAction.MainType.Passcode.PasscodeType.Password.MinNumbersCounterChange(
+                    GeneratorAction.MainType.Password.MinNumbersCounterChange(
                         minNumbers = 4,
                     ),
                 )
@@ -1124,38 +1048,29 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 // Verify length is still 5, minNumbers is updated, and useCapital is still false.
                 val expectedState2 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 5, // 0 uppercase + 1 lowercase + 4 numbers + 0 special chars
-                            minNumbers = 4,
-                            useCapitals = false,
-                            useNumbers = true,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 5, // 0 uppercase + 1 lowercase + 4 numbers + 0 special chars
+                        minNumbers = 4,
+                        useCapitals = false,
+                        useNumbers = true,
                     ),
                 )
                 assertEquals(expectedState2, viewModel.stateFlow.value)
 
                 // Enable useCapitals.
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleCapitalLettersChange(
-                            useCapitals = true,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleCapitalLettersChange(
+                        useCapitals = true,
+                    ),
                 )
 
                 // Verify this has caused length to increase.
                 val expectedState3 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 6, // 1 uppercase + 1 lowercase + 4 numbers + 0 special chars
-                            minNumbers = 4,
-                            useCapitals = true,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 6, // 1 uppercase + 1 lowercase + 4 numbers + 0 special chars
+                        minNumbers = 4,
+                        useCapitals = true,
                     ),
                 )
                 assertEquals(expectedState3, viewModel.stateFlow.value)
@@ -1172,7 +1087,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 // Update the length to something small enough that it updates on lowercase toggle.
                 viewModel.trySendAction(
-                    GeneratorAction.MainType.Passcode.PasscodeType.Password.SliderLengthChange(
+                    GeneratorAction.MainType.Password.SliderLengthChange(
                         length = 5,
                         isUserInteracting = false,
                     ),
@@ -1180,31 +1095,24 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 // Set useLowercase to false initially to ensure length change is reflected.
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleLowercaseLettersChange(
-                            useLowercase = false,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleLowercaseLettersChange(
+                        useLowercase = false,
+                    ),
                 )
 
                 // Verify useLowercase is reflected and initial length is correct.
                 val expectedState1 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 5,
-                            useLowercase = false,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 5,
+                        useLowercase = false,
                     ),
                 )
                 assertEquals(expectedState1, viewModel.stateFlow.value)
 
                 // Update minNumbers so that length will exceed 5 when useLowercase is enabled.
                 viewModel.trySendAction(
-                    GeneratorAction.MainType.Passcode.PasscodeType.Password.MinNumbersCounterChange(
+                    GeneratorAction.MainType.Password.MinNumbersCounterChange(
                         minNumbers = 4,
                     ),
                 )
@@ -1212,38 +1120,29 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 // Verify length is still 5, minNumbers is updated, and useLowercase is still false.
                 val expectedState2 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 5, // 1 uppercase + 0 lowercase + 4 numbers + 0 special chars
-                            minNumbers = 4,
-                            useLowercase = false,
-                            useNumbers = true,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 5, // 1 uppercase + 0 lowercase + 4 numbers + 0 special chars
+                        minNumbers = 4,
+                        useLowercase = false,
+                        useNumbers = true,
                     ),
                 )
                 assertEquals(expectedState2, viewModel.stateFlow.value)
 
                 // Enable useLowercase.
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleLowercaseLettersChange(
-                            useLowercase = true,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleLowercaseLettersChange(
+                        useLowercase = true,
+                    ),
                 )
 
                 // Verify this has caused length to increase.
                 val expectedState3 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 6, // 1 uppercase + 1 lowercase + 4 numbers + 0 special chars
-                            minNumbers = 4,
-                            useLowercase = true,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 6, // 1 uppercase + 1 lowercase + 4 numbers + 0 special chars
+                        minNumbers = 4,
+                        useLowercase = true,
                     ),
                 )
                 assertEquals(expectedState3, viewModel.stateFlow.value)
@@ -1259,17 +1158,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
             val useNumbers = true
 
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.ToggleNumbersChange(
+                GeneratorAction.MainType.Password.ToggleNumbersChange(
                     useNumbers = useNumbers,
                 ),
             )
 
             val expectedState = defaultPasswordState.copy(
                 generatedText = updatedGeneratedPassword,
-                selectedType = GeneratorState.MainType.Passcode(
-                    GeneratorState.MainType.Passcode.PasscodeType.Password(
-                        useNumbers = useNumbers,
-                    ),
+                selectedType = GeneratorState.MainType.Password(
+                    useNumbers = useNumbers,
                 ),
             )
 
@@ -1288,22 +1185,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 val useSpecialChars = true
 
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleSpecialCharactersChange(
-                            useSpecialChars = useSpecialChars,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleSpecialCharactersChange(
+                        useSpecialChars = useSpecialChars,
+                    ),
                 )
 
                 val expectedState = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            useSpecialChars = useSpecialChars,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        useSpecialChars = useSpecialChars,
                     ),
                 )
 
@@ -1320,19 +1210,14 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 // Toggle numbers to false initially so we can verify length changes appropriately.
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleNumbersChange(
-                            useNumbers = false,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleNumbersChange(
+                        useNumbers = false,
+                    ),
                 )
 
                 // Update the length to something small enough that it's updated on numbers toggle.
                 viewModel.trySendAction(
-                    GeneratorAction.MainType.Passcode.PasscodeType.Password.SliderLengthChange(
+                    GeneratorAction.MainType.Password.SliderLengthChange(
                         length = 5,
                         isUserInteracting = false,
                     ),
@@ -1340,43 +1225,34 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 val minNumbers = 5
                 viewModel.trySendAction(
-                    GeneratorAction.MainType.Passcode.PasscodeType.Password.MinNumbersCounterChange(
+                    GeneratorAction.MainType.Password.MinNumbersCounterChange(
                         minNumbers = minNumbers,
                     ),
                 )
 
                 val expectedState1 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 5, // the current slider value, which the min doesn't exceed
-                            minNumbers = minNumbers,
-                            useNumbers = false,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 5, // the current slider value, which the min doesn't exceed
+                        minNumbers = minNumbers,
+                        useNumbers = false,
                     ),
                 )
                 assertEquals(expectedState1, viewModel.stateFlow.value)
 
                 // Toggle numbers to true so we can verify length changes appropriately.
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleNumbersChange(
-                            useNumbers = true,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleNumbersChange(
+                        useNumbers = true,
+                    ),
                 )
 
                 val expectedState2 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 7, // 1 uppercase + 1 lowercase + 5 numbers + 0 special
-                            minNumbers = minNumbers,
-                            useNumbers = true,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 7, // 1 uppercase + 1 lowercase + 5 numbers + 0 special
+                        minNumbers = minNumbers,
+                        useNumbers = true,
                     ),
                 )
                 assertEquals(expectedState2, viewModel.stateFlow.value)
@@ -1393,7 +1269,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 // Update the length to something small enough that it's updated on toggle.
                 viewModel.trySendAction(
-                    GeneratorAction.MainType.Passcode.PasscodeType.Password.SliderLengthChange(
+                    GeneratorAction.MainType.Password.SliderLengthChange(
                         length = 5,
                         isUserInteracting = false,
                     ),
@@ -1402,49 +1278,35 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 val minSpecial = 5
 
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .MinSpecialCharactersChange(
-                            minSpecial = minSpecial,
-                        ),
+                    GeneratorAction.MainType.Password.MinSpecialCharactersChange(
+                        minSpecial = minSpecial,
+                    ),
                 )
 
                 // Length should still be 5 because special characters are not enabled.
                 val expectedState1 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 5,
-                            minSpecial = minSpecial,
-                            useSpecialChars = false,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 5,
+                        minSpecial = minSpecial,
+                        useSpecialChars = false,
                     ),
                 )
                 assertEquals(expectedState1, viewModel.stateFlow.value)
 
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleSpecialCharactersChange(
-                            useSpecialChars = true,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleSpecialCharactersChange(
+                        useSpecialChars = true,
+                    ),
                 )
 
                 // Length should update to 7 because special characters are now enabled.
                 val expectedState2 = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            length = 8, // 1 uppercase + 1 lowercase + 1 number + 5 special chars
-                            minSpecial = minSpecial,
-                            useSpecialChars = true,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        length = 8, // 1 uppercase + 1 lowercase + 1 number + 5 special chars
+                        minSpecial = minSpecial,
+                        useSpecialChars = true,
                     ),
                 )
                 assertEquals(expectedState2, viewModel.stateFlow.value)
@@ -1462,22 +1324,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 val avoidAmbiguousChars = true
 
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Password
-                        .ToggleAvoidAmbigousCharactersChange(
-                            avoidAmbiguousChars = avoidAmbiguousChars,
-                        ),
+                    GeneratorAction.MainType.Password.ToggleAvoidAmbigousCharactersChange(
+                        avoidAmbiguousChars = avoidAmbiguousChars,
+                    ),
                 )
 
                 val expectedState = defaultPasswordState.copy(
                     generatedText = updatedGeneratedPassword,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Password(
-                            avoidAmbiguousChars = avoidAmbiguousChars,
-                        ),
+                    selectedType = GeneratorState.MainType.Password(
+                        avoidAmbiguousChars = avoidAmbiguousChars,
                     ),
                 )
 
@@ -1493,60 +1348,45 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
             // Initially turn on all toggles
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.ToggleCapitalLettersChange(
+                GeneratorAction.MainType.Password.ToggleCapitalLettersChange(
                     useCapitals = true,
                 ),
             )
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleLowercaseLettersChange(
-                        useLowercase = true,
-                    ),
+                GeneratorAction.MainType.Password.ToggleLowercaseLettersChange(
+                    useLowercase = true,
+                ),
             )
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.ToggleNumbersChange(
+                GeneratorAction.MainType.Password.ToggleNumbersChange(
                     useNumbers = true,
                 ),
             )
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleSpecialCharactersChange(
-                        useSpecialChars = true,
-                    ),
+                GeneratorAction.MainType.Password.ToggleSpecialCharactersChange(
+                    useSpecialChars = true,
+                ),
             )
 
             // Attempt to turn off all toggles
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.ToggleCapitalLettersChange(
+                GeneratorAction.MainType.Password.ToggleCapitalLettersChange(
                     useCapitals = false,
                 ),
             )
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleLowercaseLettersChange(
-                        useLowercase = false,
-                    ),
+                GeneratorAction.MainType.Password.ToggleLowercaseLettersChange(
+                    useLowercase = false,
+                ),
             )
             viewModel.trySendAction(
-                GeneratorAction.MainType.Passcode.PasscodeType.Password.ToggleNumbersChange(
+                GeneratorAction.MainType.Password.ToggleNumbersChange(
                     useNumbers = false,
                 ),
             )
 
             // Check the state with only one toggle (useSpecialChars) left on
-            val intermediatePasswordState = GeneratorState.MainType.Passcode.PasscodeType.Password(
+            val intermediatePasswordState = GeneratorState.MainType.Password(
                 useCapitals = false,
                 useLowercase = false,
                 useNumbers = false,
@@ -1555,31 +1395,22 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
             val intermediateState = defaultPasswordState.copy(
                 generatedText = updatedGeneratedPassword,
-                selectedType = GeneratorState.MainType.Passcode(
-                    selectedType = intermediatePasswordState,
-                ),
+                selectedType = intermediatePasswordState,
             )
 
             assertEquals(intermediateState, viewModel.stateFlow.value)
 
             viewModel.trySendAction(
-                GeneratorAction
-                    .MainType
-                    .Passcode
-                    .PasscodeType
-                    .Password
-                    .ToggleSpecialCharactersChange(
-                        useSpecialChars = false,
-                    ),
+                GeneratorAction.MainType.Password.ToggleSpecialCharactersChange(
+                    useSpecialChars = false,
+                ),
             )
 
             // Check if useLowercase is turned on automatically
             val expectedState = intermediateState.copy(
-                selectedType = GeneratorState.MainType.Passcode(
-                    selectedType = intermediatePasswordState.copy(
-                        useLowercase = true,
-                        useSpecialChars = false,
-                    ),
+                selectedType = intermediatePasswordState.copy(
+                    useLowercase = true,
+                    useSpecialChars = false,
                 ),
             )
 
@@ -1611,22 +1442,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
                 val newNumWords = 4
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase
-                        .NumWordsCounterChange(
-                            numWords = newNumWords,
-                        ),
+                    GeneratorAction.MainType.Passphrase.NumWordsCounterChange(
+                        numWords = newNumWords,
+                    ),
                 )
 
                 val expectedState = defaultPassphraseState.copy(
                     generatedText = updatedGeneratedPassphrase,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Passphrase(
-                            numWords = newNumWords,
-                        ),
+                    selectedType = GeneratorState.MainType.Passphrase(
+                        numWords = newNumWords,
                     ),
                 )
 
@@ -1644,21 +1468,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 val newWordSeparatorChar = '_'
 
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType.Passphrase
-                        .WordSeparatorTextChange(
-                            wordSeparator = newWordSeparatorChar,
-                        ),
+                    GeneratorAction.MainType.Passphrase.WordSeparatorTextChange(
+                        wordSeparator = newWordSeparatorChar,
+                    ),
                 )
 
                 val expectedState = defaultPassphraseState.copy(
                     generatedText = updatedGeneratedPassphrase,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Passphrase(
-                            wordSeparator = newWordSeparatorChar,
-                        ),
+                    selectedType = GeneratorState.MainType.Passphrase(
+                        wordSeparator = newWordSeparatorChar,
                     ),
                 )
 
@@ -1674,22 +1492,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 )
 
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase
-                        .ToggleIncludeNumberChange(
-                            includeNumber = true,
-                        ),
+                    GeneratorAction.MainType.Passphrase.ToggleIncludeNumberChange(
+                        includeNumber = true,
+                    ),
                 )
 
                 val expectedState = defaultPassphraseState.copy(
                     generatedText = updatedGeneratedPassphrase,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        selectedType = GeneratorState.MainType.Passcode.PasscodeType.Passphrase(
-                            includeNumber = true,
-                        ),
+                    selectedType = GeneratorState.MainType.Passphrase(
+                        includeNumber = true,
                     ),
                 )
 
@@ -1705,22 +1516,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 )
 
                 viewModel.trySendAction(
-                    GeneratorAction
-                        .MainType
-                        .Passcode
-                        .PasscodeType
-                        .Passphrase
-                        .ToggleCapitalizeChange(
-                            capitalize = true,
-                        ),
+                    GeneratorAction.MainType.Passphrase.ToggleCapitalizeChange(
+                        capitalize = true,
+                    ),
                 )
 
                 val expectedState = defaultPassphraseState.copy(
                     generatedText = updatedGeneratedPassphrase,
-                    selectedType = GeneratorState.MainType.Passcode(
-                        GeneratorState.MainType.Passcode.PasscodeType.Passphrase(
-                            capitalize = true,
-                        ),
+                    selectedType = GeneratorState.MainType.Passphrase(
+                        capitalize = true,
                     ),
                 )
 
@@ -2307,48 +2111,46 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `Password minimumLength should be at least as long as the sum of the minimums`() {
-        val password =
-            GeneratorState.MainType.Passcode.PasscodeType.Password(
-                length = 14,
-                minLength = 10,
-                useCapitals = true,
-                capitalsEnabled = false,
-                useLowercase = true,
-                lowercaseEnabled = false,
-                useNumbers = true,
-                numbersEnabled = false,
-                useSpecialChars = true,
-                specialCharsEnabled = false,
-                minNumbers = 9,
-                minNumbersAllowed = 3,
-                minSpecial = 9,
-                minSpecialAllowed = 3,
-                avoidAmbiguousChars = false,
-            )
+        val password = GeneratorState.MainType.Password(
+            length = 14,
+            minLength = 10,
+            useCapitals = true,
+            capitalsEnabled = false,
+            useLowercase = true,
+            lowercaseEnabled = false,
+            useNumbers = true,
+            numbersEnabled = false,
+            useSpecialChars = true,
+            specialCharsEnabled = false,
+            minNumbers = 9,
+            minNumbersAllowed = 3,
+            minSpecial = 9,
+            minSpecialAllowed = 3,
+            avoidAmbiguousChars = false,
+        )
         // 9 numbers + 9 special + 1 lowercase + 1 uppercase
         assertEquals(20, password.computedMinimumLength)
     }
 
     @Test
     fun `Password minimumLength should use minLength if higher than sum of the minimums`() {
-        val password =
-            GeneratorState.MainType.Passcode.PasscodeType.Password(
-                length = 14,
-                minLength = 10,
-                useCapitals = true,
-                capitalsEnabled = false,
-                useLowercase = true,
-                lowercaseEnabled = false,
-                useNumbers = true,
-                numbersEnabled = false,
-                useSpecialChars = true,
-                specialCharsEnabled = false,
-                minNumbers = 1,
-                minNumbersAllowed = 3,
-                minSpecial = 1,
-                minSpecialAllowed = 3,
-                avoidAmbiguousChars = false,
-            )
+        val password = GeneratorState.MainType.Password(
+            length = 14,
+            minLength = 10,
+            useCapitals = true,
+            capitalsEnabled = false,
+            useLowercase = true,
+            lowercaseEnabled = false,
+            useNumbers = true,
+            numbersEnabled = false,
+            useSpecialChars = true,
+            specialCharsEnabled = false,
+            minNumbers = 1,
+            minNumbersAllowed = 3,
+            minSpecial = 1,
+            minSpecialAllowed = 3,
+            avoidAmbiguousChars = false,
+        )
         assertEquals(10, password.computedMinimumLength)
     }
     //region Helper Functions
@@ -2367,17 +2169,15 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     ): GeneratorState =
         GeneratorState(
             generatedText = generatedText,
-            selectedType = GeneratorState.MainType.Passcode(
-                GeneratorState.MainType.Passcode.PasscodeType.Password(
-                    length = length,
-                    useCapitals = useCapitals,
-                    useLowercase = useLowercase,
-                    useNumbers = useNumbers,
-                    useSpecialChars = useSpecialChars,
-                    minNumbers = minNumbers,
-                    minSpecial = minSpecial,
-                    avoidAmbiguousChars = avoidAmbiguousChars,
-                ),
+            selectedType = GeneratorState.MainType.Password(
+                length = length,
+                useCapitals = useCapitals,
+                useLowercase = useLowercase,
+                useNumbers = useNumbers,
+                useSpecialChars = useSpecialChars,
+                minNumbers = minNumbers,
+                minSpecial = minSpecial,
+                avoidAmbiguousChars = avoidAmbiguousChars,
             ),
             currentEmailAddress = "currentEmail",
         )
@@ -2391,13 +2191,11 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     ): GeneratorState =
         GeneratorState(
             generatedText = generatedText,
-            selectedType = GeneratorState.MainType.Passcode(
-                GeneratorState.MainType.Passcode.PasscodeType.Passphrase(
-                    numWords = numWords,
-                    wordSeparator = wordSeparator,
-                    capitalize = capitalize,
-                    includeNumber = includeNumber,
-                ),
+            selectedType = GeneratorState.MainType.Passphrase(
+                numWords = numWords,
+                wordSeparator = wordSeparator,
+                capitalize = capitalize,
+                includeNumber = includeNumber,
             ),
             currentEmailAddress = "currentEmail",
         )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11176](https://bitwarden.atlassian.net/browse/PM-11176)

## 📔 Objective

This PR updates the Generator Screen to use a Segmented Control for top level navigation.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/78f1bc2d-5e52-4b79-979b-7505073e058a" width="300" /> | <img src="https://github.com/user-attachments/assets/8321ebde-31be-4512-848b-77d8883a9973" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11176]: https://bitwarden.atlassian.net/browse/PM-11176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ