### PR TITLE
BITAU-176 Filter out deleted ciphers from syncAccounts call

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
@@ -95,8 +95,8 @@ class AuthenticatorBridgeRepositoryImpl(
                 val totpUris = vaultDiskSource
                     .getCiphers(userId)
                     .first()
-                    // Filter out any ciphers without a totp item:
-                    .filter { it.login?.totp != null }
+                    // Filter out any ciphers without a totp item and also deleted ciphers:
+                    .filter { it.login?.totp != null && it.deletedDate == null }
                     .mapNotNull {
                         // Decrypt each cipher and take just totp codes:
                         vaultSdkSource

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 
 class AuthenticatorBridgeRepositoryTest {
 
@@ -183,7 +184,7 @@ class AuthenticatorBridgeRepositoryTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `syncAccounts when vault is locked for both users should unlock and re-lock vault for both users`() =
+    fun `syncAccounts when vault is locked for both users should unlock and re-lock vault for both users and filter out deleted ciphers`() =
         runTest {
             every { vaultRepository.isVaultUnlocked(USER_1_ID) } returns false
             coEvery {
@@ -382,10 +383,17 @@ private val USER_STATE = UserState(
 
 private val USER_1_TOTP_CIPHER = mockk<SyncResponseJson.Cipher> {
     every { login?.totp } returns "encryptedTotp1"
+    every { deletedDate } returns null
+}
+
+private val USER_1_DELETED_TOTP_CIPHER = mockk<SyncResponseJson.Cipher> {
+    every { login?.totp } returns "encryptedTotp1Deleted"
+    every { deletedDate } returns ZonedDateTime.now()
 }
 
 private val USER_2_TOTP_CIPHER = mockk<SyncResponseJson.Cipher> {
     every { login?.totp } returns "encryptedTotp2"
+    every { deletedDate } returns null
 }
 
 private val USER_1_ENCRYPTED_SDK_TOTP_CIPHER = mockk<Cipher>()
@@ -419,6 +427,7 @@ private val USER_2_SHARED_ACCOUNT = SharedAccountData.Account(
 
 private val USER_1_CIPHERS = listOf(
     USER_1_TOTP_CIPHER,
+    USER_1_DELETED_TOTP_CIPHER,
 )
 
 private val USER_2_CIPHERS = listOf(


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-176

## 📔 Objective

Make sure we don't show deleted ciphers when syncing with the authenticator app.

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
