### PR TITLE
PM-12296: Only match port when present on both uris

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ciphermatching/CipherMatchingManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ciphermatching/CipherMatchingManagerImpl.kt
@@ -7,8 +7,10 @@ import com.x8bit.bitwarden.data.platform.manager.ResourceCacheManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.util.firstWithTimeoutOrNull
 import com.x8bit.bitwarden.data.platform.util.getDomainOrNull
+import com.x8bit.bitwarden.data.platform.util.getHostOrNull
 import com.x8bit.bitwarden.data.platform.util.getHostWithPortOrNull
 import com.x8bit.bitwarden.data.platform.util.getWebHostFromAndroidUriOrNull
+import com.x8bit.bitwarden.data.platform.util.hasPort
 import com.x8bit.bitwarden.data.platform.util.isAndroidApp
 import com.x8bit.bitwarden.data.platform.util.regexOrNull
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
@@ -186,6 +188,7 @@ private fun checkForCipherMatch(
  * @param matchingDomains The set of domains that match the domain of [matchUri].
  * @param matchUri The uri that this [LoginUriView] is being matched to.
  */
+@Suppress("CyclomaticComplexMethod")
 private fun LoginUriView.checkForMatch(
     resourceCacheManager: ResourceCacheManager,
     defaultUriMatchType: UriMatchType,
@@ -210,9 +213,15 @@ private fun LoginUriView.checkForMatch(
             UriMatchType.EXACT -> exactIfTrue(loginViewUri == matchUri)
 
             UriMatchType.HOST -> {
-                val loginUriHost = loginViewUri.getHostWithPortOrNull()
-                val matchUriHost = matchUri.getHostWithPortOrNull()
-                exactIfTrue(matchUriHost != null && loginUriHost == matchUriHost)
+                if (loginViewUri.hasPort() && matchUri.hasPort()) {
+                    val loginUriHost = loginViewUri.getHostWithPortOrNull()
+                    val matchUriHost = matchUri.getHostWithPortOrNull()
+                    exactIfTrue(matchUriHost != null && loginUriHost == matchUriHost)
+                } else {
+                    val loginUriHost = loginViewUri.getHostOrNull()
+                    val matchUriHost = matchUri.getHostOrNull()
+                    exactIfTrue(matchUriHost != null && loginUriHost == matchUriHost)
+                }
             }
 
             UriMatchType.NEVER -> MatchResult.NONE

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
@@ -59,6 +59,21 @@ fun String.getDomainOrNull(resourceCacheManager: ResourceCacheManager): String? 
         ?.parseDomainOrNull(resourceCacheManager = resourceCacheManager)
 
 /**
+ * Returns `true` if the [String] uri has a port, `false` otherwise.
+ */
+@OmitFromCoverage
+fun String.hasPort(): Boolean {
+    val uri = this.toUriOrNull() ?: return false
+    return uri.port != -1
+}
+
+/**
+ * Extract the host from this [String] if possible, otherwise return null.
+ */
+@OmitFromCoverage
+fun String.getHostOrNull(): String? = this.toUriOrNull()?.host
+
+/**
  * Extract the host with optional port from this [String] if possible, otherwise return null.
  */
 @OmitFromCoverage


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12296](https://bitwarden.atlassian.net/browse/PM-12296)

## 📔 Objective

This PR updates the `HOST` matching logic to only match on port when both the source and the target have a port present.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12296]: https://bitwarden.atlassian.net/browse/PM-12296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ