### PR TITLE
PM-13648 Nav to new create account when email verification is on

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
@@ -133,6 +133,7 @@ fun NavGraphBuilder.authGraph(
         welcomeDestination(
             onNavigateToCreateAccount = { navController.navigateToCreateAccount() },
             onNavigateToLogin = { navController.navigateToLanding() },
+            onNavigateToStartRegistration = { navController.navigateToStartRegistration() },
         )
         loginDestination(
             onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeNavigation.kt
@@ -20,6 +20,7 @@ fun NavController.navigateToWelcome(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.welcomeDestination(
     onNavigateToCreateAccount: () -> Unit,
     onNavigateToLogin: () -> Unit,
+    onNavigateToStartRegistration: () -> Unit,
 ) {
     composableWithStayTransitions(
         route = WELCOME_ROUTE,
@@ -27,6 +28,7 @@ fun NavGraphBuilder.welcomeDestination(
         WelcomeScreen(
             onNavigateToCreateAccount = onNavigateToCreateAccount,
             onNavigateToLogin = onNavigateToLogin,
+            onNavigateToStartRegistration = onNavigateToStartRegistration,
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
@@ -59,6 +59,7 @@ private val LANDSCAPE_HORIZONTAL_MARGIN: Dp = 128.dp
 fun WelcomeScreen(
     onNavigateToCreateAccount: () -> Unit,
     onNavigateToLogin: () -> Unit,
+    onNavigateToStartRegistration: () -> Unit,
     viewModel: WelcomeViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
@@ -72,6 +73,7 @@ fun WelcomeScreen(
 
             WelcomeEvent.NavigateToCreateAccount -> onNavigateToCreateAccount()
             WelcomeEvent.NavigateToLogin -> onNavigateToLogin()
+            WelcomeEvent.NavigateToStartRegistration -> onNavigateToStartRegistration()
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeViewModel.kt
@@ -2,6 +2,8 @@ package com.x8bit.bitwarden.ui.auth.feature.welcome
 
 import android.os.Parcelable
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
@@ -12,7 +14,9 @@ import javax.inject.Inject
  * Manages application state for the welcome screen.
  */
 @HiltViewModel
-class WelcomeViewModel @Inject constructor() :
+class WelcomeViewModel @Inject constructor(
+    private val featureFlagManager: FeatureFlagManager,
+) :
     BaseViewModel<WelcomeState, WelcomeEvent, WelcomeAction>(
         initialState = WelcomeState(
             index = 0,
@@ -43,7 +47,12 @@ class WelcomeViewModel @Inject constructor() :
     }
 
     private fun handleCreateAccountClick() {
-        sendEvent(WelcomeEvent.NavigateToCreateAccount)
+        val event = if (featureFlagManager.getFeatureFlag(FlagKey.EmailVerification)) {
+            WelcomeEvent.NavigateToStartRegistration
+        } else {
+            WelcomeEvent.NavigateToCreateAccount
+        }
+        sendEvent(event)
     }
 
     private fun handleLoginClick() {
@@ -129,6 +138,11 @@ sealed class WelcomeEvent {
      * Navigates to the login screen.
      */
     data object NavigateToLogin : WelcomeEvent()
+
+    /**
+     * Navigates to the start registration screen.
+     */
+    data object NavigateToStartRegistration : WelcomeEvent()
 }
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreenTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.robolectric.annotation.Config
 
 class WelcomeScreenTest : BaseComposeTest() {
+    private var onNavigateToStartRegistrationCalled = false
     private var onNavigateToCreateAccountCalled = false
     private var onNavigateToLoginCalled = false
     private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
@@ -31,6 +32,7 @@ class WelcomeScreenTest : BaseComposeTest() {
             WelcomeScreen(
                 onNavigateToCreateAccount = { onNavigateToCreateAccountCalled = true },
                 onNavigateToLogin = { onNavigateToLoginCalled = true },
+                onNavigateToStartRegistration = { onNavigateToStartRegistrationCalled = true },
                 viewModel = viewModel,
             )
         }
@@ -112,6 +114,12 @@ class WelcomeScreenTest : BaseComposeTest() {
             .onNodeWithText("Log In")
             .performClick()
         verify { viewModel.trySendAction(WelcomeAction.LoginClick) }
+    }
+
+    @Test
+    fun `on NavigateToStartRegistration event should call onNavigateToStartRegistration`() {
+        mutableEventFlow.tryEmit(WelcomeEvent.NavigateToStartRegistration)
+        assertTrue(onNavigateToStartRegistrationCalled)
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeViewModelTest.kt
@@ -1,15 +1,22 @@
 package com.x8bit.bitwarden.ui.auth.feature.welcome
 
 import app.cash.turbine.test
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class WelcomeViewModelTest : BaseViewModelTest() {
+
+    private val featureFlagManager = mockk<FeatureFlagManager>()
+
     @Test
     fun `initial state should be correct`() = runTest {
-        val viewModel = WelcomeViewModel()
+        val viewModel = WelcomeViewModel(featureFlagManager = featureFlagManager)
 
         viewModel.stateFlow.test {
             assertEquals(
@@ -21,7 +28,7 @@ class WelcomeViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `PagerSwipe should update state`() = runTest {
-        val viewModel = WelcomeViewModel()
+        val viewModel = WelcomeViewModel(featureFlagManager = featureFlagManager)
         val newIndex = 2
 
         viewModel.trySendAction(WelcomeAction.PagerSwipe(index = newIndex))
@@ -36,7 +43,7 @@ class WelcomeViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `DotClick should update state and emit UpdatePager`() = runTest {
-        val viewModel = WelcomeViewModel()
+        val viewModel = WelcomeViewModel(featureFlagManager = featureFlagManager)
         val newIndex = 2
 
         viewModel.trySendAction(WelcomeAction.DotClick(index = newIndex))
@@ -55,10 +62,12 @@ class WelcomeViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `CreateAccountClick should emit NavigateToCreateAccount`() = runTest {
-        val viewModel = WelcomeViewModel()
-
+    fun `CreateAccountClick should emit NavigateToCreateAccount when email verification is disabled`() =
+        runTest {
+            val viewModel = WelcomeViewModel(featureFlagManager = featureFlagManager)
+            every { featureFlagManager.getFeatureFlag(FlagKey.EmailVerification) } returns false
         viewModel.trySendAction(WelcomeAction.CreateAccountClick)
 
         viewModel.eventFlow.test {
@@ -69,9 +78,25 @@ class WelcomeViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `CreateAccountClick should emit NavigateToStartRegistration when email verification is enabled`() =
+        runTest {
+            val viewModel = WelcomeViewModel(featureFlagManager = featureFlagManager)
+            every { featureFlagManager.getFeatureFlag(FlagKey.EmailVerification) } returns true
+            viewModel.trySendAction(WelcomeAction.CreateAccountClick)
+
+            viewModel.eventFlow.test {
+                assertEquals(
+                    WelcomeEvent.NavigateToStartRegistration,
+                    awaitItem(),
+                )
+            }
+        }
+
     @Test
     fun `LoginClick should emit NavigateToLogin`() = runTest {
-        val viewModel = WelcomeViewModel()
+        val viewModel = WelcomeViewModel(featureFlagManager = featureFlagManager)
 
         viewModel.trySendAction(WelcomeAction.LoginClick)
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13648
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- When the email verification flag is enabled we want to go to the new create account flow, this was not happening from the welcome carousel screen.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/3433a577-fd17-4191-af5d-68fcba769a95


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
