### PR TITLE
Pin the segmented control to toolbar in AddSendScreen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
@@ -21,10 +21,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.base.util.bottomDivider
 import com.x8bit.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.x8bit.bitwarden.ui.platform.base.util.scrolledContainerBottomDivider
 import com.x8bit.bitwarden.ui.platform.components.appbar.color.bitwardenTopAppBarColors
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
+import com.x8bit.bitwarden.ui.platform.components.model.TopAppBarDividerStyle
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
@@ -47,6 +49,7 @@ fun BitwardenTopAppBar(
     navigationIconContentDescription: String,
     onNavigationIconClick: () -> Unit,
     modifier: Modifier = Modifier,
+    dividerStyle: TopAppBarDividerStyle = TopAppBarDividerStyle.ON_SCROLL,
     actions: @Composable RowScope.() -> Unit = { },
 ) {
     BitwardenTopAppBar(
@@ -58,6 +61,7 @@ fun BitwardenTopAppBar(
             onNavigationIconClick = onNavigationIconClick,
         ),
         modifier = modifier,
+        dividerStyle = dividerStyle,
         actions = actions,
     )
 }
@@ -82,6 +86,7 @@ fun BitwardenTopAppBar(
     scrollBehavior: TopAppBarScrollBehavior,
     navigationIcon: NavigationIcon?,
     modifier: Modifier = Modifier,
+    dividerStyle: TopAppBarDividerStyle = TopAppBarDividerStyle.ON_SCROLL,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     var titleTextHasOverflow by remember {
@@ -102,6 +107,24 @@ fun BitwardenTopAppBar(
             }
         }
     }
+    val customModifier = modifier
+        .testTag(tag = "HeaderBarComponent")
+        .scrolledContainerBottomDivider(
+            topAppBarScrollBehavior = scrollBehavior,
+            enabled = when (dividerStyle) {
+                TopAppBarDividerStyle.NONE -> false
+                TopAppBarDividerStyle.STATIC -> false
+                TopAppBarDividerStyle.ON_SCROLL -> true
+            },
+        )
+        .bottomDivider(
+            enabled = when (dividerStyle) {
+                TopAppBarDividerStyle.NONE -> false
+                TopAppBarDividerStyle.STATIC -> true
+                TopAppBarDividerStyle.ON_SCROLL -> false
+            },
+            thickness = (0.5).dp,
+        )
 
     if (titleTextHasOverflow) {
         MediumTopAppBar(
@@ -120,9 +143,7 @@ fun BitwardenTopAppBar(
                     modifier = Modifier.testTag(tag = "PageTitleLabel"),
                 )
             },
-            modifier = modifier
-                .testTag(tag = "HeaderBarComponent")
-                .scrolledContainerBottomDivider(topAppBarScrollBehavior = scrollBehavior),
+            modifier = customModifier,
             actions = actions,
         )
     } else {
@@ -144,9 +165,7 @@ fun BitwardenTopAppBar(
                     },
                 )
             },
-            modifier = modifier
-                .testTag(tag = "HeaderBarComponent")
-                .scrolledContainerBottomDivider(topAppBarScrollBehavior = scrollBehavior),
+            modifier = customModifier,
             actions = actions,
         )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreen.kt
@@ -35,6 +35,7 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.LoadingDialogState
+import com.x8bit.bitwarden.ui.platform.components.model.TopAppBarDividerStyle
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.composition.LocalExitManager
@@ -137,6 +138,7 @@ fun AddSendScreen(
                     },
                 )
                     .takeUnless { state.isShared },
+                dividerStyle = TopAppBarDividerStyle.NONE,
                 scrollBehavior = scrollBehavior,
                 actions = {
                     BitwardenTextButton(
@@ -194,6 +196,7 @@ fun AddSendScreen(
         when (val viewState = state.viewState) {
             is AddSendState.ViewState.Content -> AddSendContent(
                 state = viewState,
+                scrollBehavior = scrollBehavior,
                 policyDisablesSend = state.policyDisablesSend,
                 policySendOptionsInEffect = state.shouldDisplayPolicyWarning,
                 isAddMode = state.isAddMode,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
@@ -376,12 +376,10 @@ class AddSendScreenTest : BaseComposeTest() {
         composeTestRule
             .onAllNodesWithText("File")
             .filterToOne(!isEditableText)
-            .performScrollTo()
             .assertIsDisplayed()
         composeTestRule
             .onAllNodesWithText("Text")
             .filterToOne(!isEditableText)
-            .performScrollTo()
             .assertIsDisplayed()
 
         mutableStateFlow.update {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR pins the segmented control to toolbar in AddSendScreen.

## 📸 Screenshots

| Before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a960f4be-eaf7-417b-b9eb-22034d088511" width="300" /> | <video src="https://github.com/user-attachments/assets/151a2c97-6cbb-44f9-9392-edfbbfce9209" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
