### PR TITLE
PM-13464 show notification badge for vault settings if the showImport…

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDisk
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.network.service.ConfigService
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.AuthenticatorBridgeRepository
@@ -96,6 +97,8 @@ object PlatformRepositoryModule {
         accessibilityEnabledManager: AccessibilityEnabledManager,
         dispatcherManager: DispatcherManager,
         policyManager: PolicyManager,
+        featureFlagManager: FeatureFlagManager,
+        vaultDiskSource: VaultDiskSource,
     ): SettingsRepository =
         SettingsRepositoryImpl(
             autofillManager = autofillManager,
@@ -107,6 +110,8 @@ object PlatformRepositoryModule {
             accessibilityEnabledManager = accessibilityEnabledManager,
             dispatcherManager = dispatcherManager,
             policyManager = policyManager,
+            featureFlagManager = featureFlagManager,
+            vaultDiskSource = vaultDiskSource,
         )
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -11,7 +11,6 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDisk
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.network.service.ConfigService
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.AuthenticatorBridgeRepository
@@ -97,8 +96,6 @@ object PlatformRepositoryModule {
         accessibilityEnabledManager: AccessibilityEnabledManager,
         dispatcherManager: DispatcherManager,
         policyManager: PolicyManager,
-        featureFlagManager: FeatureFlagManager,
-        vaultDiskSource: VaultDiskSource,
     ): SettingsRepository =
         SettingsRepositoryImpl(
             autofillManager = autofillManager,
@@ -110,8 +107,6 @@ object PlatformRepositoryModule {
             accessibilityEnabledManager = accessibilityEnabledManager,
             dispatcherManager = dispatcherManager,
             policyManager = policyManager,
-            featureFlagManager = featureFlagManager,
-            vaultDiskSource = vaultDiskSource,
         )
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
@@ -28,6 +28,7 @@ class SettingsViewModel @Inject constructor(
     initialState = SettingsState(
         securityCount = firstTimeActionManager.allSecuritySettingsBadgeCountFlow.value,
         autoFillCount = firstTimeActionManager.allAutofillSettingsBadgeCountFlow.value,
+        vaultCount = firstTimeActionManager.allVaultSettingsBadgeCountFlow.value,
     ),
 ) {
 
@@ -35,10 +36,12 @@ class SettingsViewModel @Inject constructor(
         combine(
             firstTimeActionManager.allSecuritySettingsBadgeCountFlow,
             firstTimeActionManager.allAutofillSettingsBadgeCountFlow,
-        ) { securityCount, autofillCount ->
+            firstTimeActionManager.allVaultSettingsBadgeCountFlow,
+        ) { securityCount, autofillCount, vaultCount ->
             SettingsAction.Internal.SettingsNotificationCountUpdate(
                 securityCount = securityCount,
                 autoFillCount = autofillCount,
+                vaultCount = vaultCount,
             )
         }
             .onEach(::sendAction)
@@ -68,6 +71,7 @@ class SettingsViewModel @Inject constructor(
             it.copy(
                 autoFillCount = action.autoFillCount,
                 securityCount = action.securityCount,
+                vaultCount = action.vaultCount,
             )
         }
     }
@@ -107,10 +111,12 @@ class SettingsViewModel @Inject constructor(
 data class SettingsState(
     private val autoFillCount: Int,
     private val securityCount: Int,
+    private val vaultCount: Int,
 ) {
     val notificationBadgeCountMap: Map<Settings, Int> = mapOf(
         Settings.ACCOUNT_SECURITY to securityCount,
         Settings.AUTO_FILL to autoFillCount,
+        Settings.VAULT to vaultCount,
     )
 }
 
@@ -175,6 +181,7 @@ sealed class SettingsAction {
         data class SettingsNotificationCountUpdate(
             val autoFillCount: Int,
             val securityCount: Int,
+            val vaultCount: Int,
         ) : Internal()
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -312,10 +312,25 @@ class SettingsScreenTest : BaseComposeTest() {
         composeTestRule
             .onAllNodesWithText(text = "1", useUnmergedTree = true)[1]
             .assertExists()
+
+        mutableStateFlow.update { it.copy(vaultCount = 1) }
+
+        composeTestRule
+            .onAllNodesWithText(text = "1", useUnmergedTree = true)[0]
+            .assertExists()
+
+        composeTestRule
+            .onAllNodesWithText(text = "1", useUnmergedTree = true)[1]
+            .assertExists()
+
+        composeTestRule
+            .onAllNodesWithText(text = "1", useUnmergedTree = true)[2]
+            .assertExists()
     }
 }
 
 private val DEFAULT_STATE = SettingsState(
     securityCount = 0,
     autoFillCount = 0,
+    vaultCount = 0,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.Test
 class SettingsViewModelTest : BaseViewModelTest() {
 
     private val mutableAutofillBadgeCountFlow = MutableStateFlow(0)
+    private val mutableVaultBadgeCountFlow = MutableStateFlow(0)
     private val mutableSecurityBadgeCountFlow = MutableStateFlow(0)
     private val firstTimeManager = mockk<FirstTimeActionManager> {
         every { allSecuritySettingsBadgeCountFlow } returns mutableSecurityBadgeCountFlow
         every { allAutofillSettingsBadgeCountFlow } returns mutableAutofillBadgeCountFlow
+        every { allVaultSettingsBadgeCountFlow } returns mutableVaultBadgeCountFlow
     }
     private val specialCircumstanceManager: SpecialCircumstanceManager = mockk {
         every { specialCircumstance } returns null
@@ -86,11 +88,13 @@ class SettingsViewModelTest : BaseViewModelTest() {
     fun `initial state reflects the current state of the repository`() {
         mutableAutofillBadgeCountFlow.update { 1 }
         mutableSecurityBadgeCountFlow.update { 2 }
+        mutableVaultBadgeCountFlow.update { 3 }
         val viewModel = createViewModel()
         assertEquals(
             SettingsState(
                 autoFillCount = 1,
                 securityCount = 2,
+                vaultCount = 3,
             ),
             viewModel.stateFlow.value,
         )
@@ -104,6 +108,7 @@ class SettingsViewModelTest : BaseViewModelTest() {
                 SettingsState(
                     autoFillCount = 0,
                     securityCount = 0,
+                    vaultCount = 0,
                 ),
                 awaitItem(),
             )
@@ -113,6 +118,7 @@ class SettingsViewModelTest : BaseViewModelTest() {
                 SettingsState(
                     autoFillCount = 0,
                     securityCount = 2,
+                    vaultCount = 0,
                 ),
                 awaitItem(),
             )
@@ -122,6 +128,17 @@ class SettingsViewModelTest : BaseViewModelTest() {
                 SettingsState(
                     autoFillCount = 1,
                     securityCount = 2,
+                    vaultCount = 0,
+                ),
+                awaitItem(),
+            )
+
+            mutableVaultBadgeCountFlow.update { 3 }
+            assertEquals(
+                SettingsState(
+                    autoFillCount = 1,
+                    securityCount = 2,
+                    vaultCount = 3,
                 ),
                 awaitItem(),
             )


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13634
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Show settings notification badge for when the showImportLogins flag is set to true.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/99754683-dcac-46b2-9a2c-9c78aaab6154


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
