### PR TITLE
PM-13382 show contextual message for the level of Biometrics available

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreen.kt
@@ -161,7 +161,7 @@ private fun SetupUnlockScreenContent(
 
         Spacer(modifier = Modifier.height(height = 24.dp))
         BitwardenUnlockWithBiometricsSwitch(
-            isBiometricsSupported = biometricsManager.isBiometricsSupported,
+            biometricSupportStatus = biometricsManager.biometricSupportStatus,
             isChecked = state.isUnlockWithBiometricsEnabled || showBiometricsPrompt,
             onDisableBiometrics = handler.onDisableBiometrics,
             onEnableBiometrics = handler.onEnableBiometrics,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
@@ -10,8 +10,7 @@ import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricSupportStatus
  * Displays a switch for enabling or disabling unlock with biometrics functionality.
  *
  * @param isChecked Indicates that the switch should be checked or not.
- * @param isBiometricsSupported Indicates if biometrics is supported and we should display the
- * switch.
+ * @param biometricSupportStatus Indicates what type of biometrics are supported on device.
  * @param onDisableBiometrics Callback invoked when the toggle has be turned off.
  * @param onEnableBiometrics Callback invoked when the toggle has be turned on.
  * @param modifier The [Modifier] to be applied to the switch.
@@ -24,7 +23,6 @@ fun BitwardenUnlockWithBiometricsSwitch(
     onEnableBiometrics: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (biometricSupportStatus == BiometricSupportStatus.NOT_SUPPORTED) return
     val biometricsDescription: String = when (biometricSupportStatus) {
         BiometricSupportStatus.CLASS_3_SUPPORTED -> {
             stringResource(R.string.class_3_biometrics_description)
@@ -33,9 +31,7 @@ fun BitwardenUnlockWithBiometricsSwitch(
             stringResource(R.string.class_2_biometrics_description)
         }
 
-        BiometricSupportStatus.NOT_SUPPORTED -> error(
-            "Should not be called when BiometricSupportStatus is NOT_SUPPORTED",
-        )
+        BiometricSupportStatus.NOT_SUPPORTED -> return
     }
     BitwardenWideSwitch(
         modifier = modifier,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.components.toggle
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -38,22 +37,21 @@ fun BitwardenUnlockWithBiometricsSwitch(
             "Should not be called when BiometricSupportStatus is NOT_SUPPORTED",
         )
     }
-    Column(modifier = modifier) {
-        BitwardenWideSwitch(
-            label = stringResource(
-                id = R.string.unlock_with,
-                stringResource(id = R.string.biometrics),
-            ),
-            isChecked = isChecked,
-            onCheckedChange = { toggled ->
-                if (toggled) {
-                    onEnableBiometrics()
-                } else {
-                    onDisableBiometrics()
-                }
-            },
-            enabled = biometricSupportStatus == BiometricSupportStatus.CLASS_3_SUPPORTED,
-            description = biometricsDescription,
-        )
-    }
+    BitwardenWideSwitch(
+        modifier = modifier,
+        label = stringResource(
+            id = R.string.unlock_with,
+            stringResource(id = R.string.biometrics),
+        ),
+        isChecked = isChecked,
+        onCheckedChange = { toggled ->
+            if (toggled) {
+                onEnableBiometrics()
+            } else {
+                onDisableBiometrics()
+            }
+        },
+        enabled = biometricSupportStatus == BiometricSupportStatus.CLASS_3_SUPPORTED,
+        description = biometricsDescription,
+    )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
@@ -1,9 +1,16 @@
 package com.x8bit.bitwarden.ui.platform.components.toggle
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricSupportStatus
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
  * Displays a switch for enabling or disabling unlock with biometrics functionality.
@@ -17,23 +24,46 @@ import com.x8bit.bitwarden.R
  */
 @Composable
 fun BitwardenUnlockWithBiometricsSwitch(
-    isBiometricsSupported: Boolean,
+    biometricSupportStatus: BiometricSupportStatus,
     isChecked: Boolean,
     onDisableBiometrics: () -> Unit,
     onEnableBiometrics: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (!isBiometricsSupported) return
-    BitwardenWideSwitch(
-        modifier = modifier,
-        label = stringResource(id = R.string.unlock_with, stringResource(id = R.string.biometrics)),
-        isChecked = isChecked,
-        onCheckedChange = { toggled ->
-            if (toggled) {
-                onEnableBiometrics()
-            } else {
-                onDisableBiometrics()
+    if (biometricSupportStatus == BiometricSupportStatus.NOT_SUPPORTED) return
+    Column(modifier = modifier) {
+        BitwardenWideSwitch(
+            label = stringResource(
+                id = R.string.unlock_with,
+                stringResource(id = R.string.biometrics),
+            ),
+            isChecked = isChecked,
+            onCheckedChange = { toggled ->
+                if (toggled) {
+                    onEnableBiometrics()
+                } else {
+                    onDisableBiometrics()
+                }
+            },
+            enabled = biometricSupportStatus == BiometricSupportStatus.CLASS_3_SUPPORTED,
+        )
+        val biometricsDescription: String = when (biometricSupportStatus) {
+            BiometricSupportStatus.CLASS_3_SUPPORTED -> {
+                stringResource(R.string.class_3_biometrics_description)
             }
-        },
-    )
+            BiometricSupportStatus.CLASS_2_SUPPORTED -> {
+                stringResource(R.string.class_2_biometrics_description)
+            }
+
+            BiometricSupportStatus.NOT_SUPPORTED -> error(
+                "Should not be called when BiometricSupportStatus is NOT_SUPPORTED",
+            )
+        }
+        Text(
+            text = biometricsDescription,
+            style = BitwardenTheme.typography.labelSmall,
+            color = BitwardenTheme.colorScheme.text.secondary,
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+    }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
@@ -31,6 +31,18 @@ fun BitwardenUnlockWithBiometricsSwitch(
     modifier: Modifier = Modifier,
 ) {
     if (biometricSupportStatus == BiometricSupportStatus.NOT_SUPPORTED) return
+    val biometricsDescription: String = when (biometricSupportStatus) {
+        BiometricSupportStatus.CLASS_3_SUPPORTED -> {
+            stringResource(R.string.class_3_biometrics_description)
+        }
+        BiometricSupportStatus.CLASS_2_SUPPORTED -> {
+            stringResource(R.string.class_2_biometrics_description)
+        }
+
+        BiometricSupportStatus.NOT_SUPPORTED -> error(
+            "Should not be called when BiometricSupportStatus is NOT_SUPPORTED",
+        )
+    }
     Column(modifier = modifier) {
         BitwardenWideSwitch(
             label = stringResource(
@@ -46,24 +58,7 @@ fun BitwardenUnlockWithBiometricsSwitch(
                 }
             },
             enabled = biometricSupportStatus == BiometricSupportStatus.CLASS_3_SUPPORTED,
+            description = biometricsDescription,
         )
-        val biometricsDescription: String = when (biometricSupportStatus) {
-            BiometricSupportStatus.CLASS_3_SUPPORTED -> {
-                stringResource(R.string.class_3_biometrics_description)
-            }
-            BiometricSupportStatus.CLASS_2_SUPPORTED -> {
-                stringResource(R.string.class_2_biometrics_description)
-            }
-
-            BiometricSupportStatus.NOT_SUPPORTED -> error(
-                "Should not be called when BiometricSupportStatus is NOT_SUPPORTED",
-            )
-        }
-        Text(
-            text = biometricsDescription,
-            style = BitwardenTheme.typography.labelSmall,
-            color = BitwardenTheme.colorScheme.text.secondary,
-        )
-        Spacer(modifier = Modifier.height(2.dp))
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithBiometricsSwitch.kt
@@ -1,16 +1,11 @@
 package com.x8bit.bitwarden.ui.platform.components.toggle
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricSupportStatus
-import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
  * Displays a switch for enabling or disabling unlock with biometrics functionality.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -232,7 +232,7 @@ fun AccountSecurityScreen(
                     .padding(horizontal = 16.dp),
             )
             BitwardenUnlockWithBiometricsSwitch(
-                isBiometricsSupported = biometricsManager.isBiometricsSupported,
+                biometricSupportStatus = biometricsManager.biometricSupportStatus,
                 isChecked = state.isUnlockWithBiometricsEnabled || showBiometricsPrompt,
                 onDisableBiometrics = remember(viewModel) {
                     {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManager.kt
@@ -9,7 +9,8 @@ import javax.crypto.Cipher
 @Immutable
 interface BiometricsManager {
     /**
-     * Returns `true` if the device supports string biometric authentication, `false` otherwise.
+     * Returns `true` if the device supports Class 3 (STRONG) biometric authentication, `false`
+     * otherwise.
      */
     val isBiometricsSupported: Boolean
 
@@ -18,6 +19,11 @@ interface BiometricsManager {
      * credentials, `false` otherwise.
      */
     val isUserVerificationSupported: Boolean
+
+    /**
+     * Returns the status of biometric support available on the device.
+     */
+    val biometricSupportStatus: BiometricSupportStatus
 
     /**
      * Display a prompt for setting up or verifying biometrics.
@@ -48,4 +54,13 @@ interface BiometricsManager {
         onError: () -> Unit,
         onNotSupported: () -> Unit,
     )
+}
+
+/**
+ * Status of biometric support available on the device.
+ */
+enum class BiometricSupportStatus {
+    CLASS_3_SUPPORTED,
+    CLASS_2_SUPPORTED,
+    NOT_SUPPORTED,
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
@@ -22,12 +22,25 @@ class BiometricsManagerImpl(
     private val fragmentActivity: FragmentActivity get() = activity as FragmentActivity
 
     override val isBiometricsSupported: Boolean
-        get() = canAuthenticate(Authenticators.BIOMETRIC_STRONG)
+        get() = biometricSupportStatus == BiometricSupportStatus.CLASS_3_SUPPORTED
 
     override val isUserVerificationSupported: Boolean
         get() = canAuthenticate(
             authenticators = Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL,
         )
+
+    override val biometricSupportStatus: BiometricSupportStatus
+        get() = when {
+            canAuthenticate(Authenticators.BIOMETRIC_STRONG) -> {
+                BiometricSupportStatus.CLASS_3_SUPPORTED
+            }
+
+            canAuthenticate(Authenticators.BIOMETRIC_WEAK) -> {
+                BiometricSupportStatus.CLASS_2_SUPPORTED
+            }
+
+            else -> BiometricSupportStatus.NOT_SUPPORTED
+        }
 
     override fun promptBiometrics(
         onSuccess: (cipher: Cipher?) -> Unit,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1028,4 +1028,6 @@ Do you want to switch to this account?</string>
   <string name="import_logins">Import Logins</string>
   <string name="from_your_computer_follow_these_instructions_to_export_saved_passwords">From your computer, follow these instructions to export saved passwords from your browser or other password manager. Then, safely import them to Bitwarden.</string>
   <string name="give_your_vault_a_head_start">Give your vault a head start</string>
+  <string name="class_3_biometrics_description">Unlock with biometrics requires strong biometric authentication and may not be compatible with all biometric options on this device.</string>
+  <string name="class_2_biometrics_description">Unlock with biometrics requires strong biometric authentication and is not compatible with the biometrics options available on this device.</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFl
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.components.toggle.UnlockWithPinState
+import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricSupportStatus
 import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricsManager
 import com.x8bit.bitwarden.ui.util.assertNoDialogExists
 import io.mockk.every
@@ -40,7 +41,7 @@ class SetupUnlockScreenTest : BaseComposeTest() {
     private val captureBiometricsLockOut = slot<() -> Unit>()
     private val captureBiometricsError = slot<() -> Unit>()
     private val biometricsManager: BiometricsManager = mockk {
-        every { isBiometricsSupported } returns true
+        every { biometricSupportStatus } returns BiometricSupportStatus.CLASS_3_SUPPORTED
         every {
             promptBiometrics(
                 onSuccess = capture(captureBiometricsSuccess),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -26,6 +26,7 @@ import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFl
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.components.toggle.UnlockWithPinState
+import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricSupportStatus
 import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricsManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.util.assertNoDialogExists
@@ -60,7 +61,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
     private val captureBiometricsLockOut = slot<() -> Unit>()
     private val captureBiometricsError = slot<() -> Unit>()
     private val biometricsManager: BiometricsManager = mockk {
-        every { isBiometricsSupported } returns true
+        every { biometricSupportStatus } returns BiometricSupportStatus.CLASS_3_SUPPORTED
         every {
             promptBiometrics(
                 onSuccess = capture(captureBiometricsSuccess),


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13382
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Show a message under the biometric toggle with context to the biometrics available on the users device.
- A separate message for all devices with Class 3 (strong) and class 2 (weak) authentication.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
![after1](https://github.com/user-attachments/assets/b96bcaf6-47d7-4e8e-bc19-1b168840d625)
![after2](https://github.com/user-attachments/assets/c1ea00e2-8f02-430a-bb1d-8087abddefed)
![after3](https://github.com/user-attachments/assets/60037f1c-8603-4492-8a81-437ee967bd4b)
![after4](https://github.com/user-attachments/assets/40a12bab-7de9-4bcb-8674-8ab8345d070f)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
