### PR TITLE
PM-13627 show action card on vault settings if applicable

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.vault
 
 import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,12 +19,17 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
+import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
+import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
+import com.x8bit.bitwarden.ui.platform.components.card.BitwardenActionCard
+import com.x8bit.bitwarden.ui.platform.components.card.actionCardExitAnimation
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenTextRow
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
@@ -90,6 +96,35 @@ fun VaultSettingsScreen(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState()),
         ) {
+            AnimatedVisibility(
+                visible = state.shouldShowImportCard,
+                label = "ImportLoginsActionCard",
+                exit = actionCardExitAnimation(),
+            ) {
+                BitwardenActionCard(
+                    cardTitle = stringResource(id = R.string.import_saved_logins),
+                    actionText = stringResource(R.string.get_started),
+                    cardSubtitle = stringResource(R.string.use_a_computer_to_import_logins),
+                    onActionClick = remember(viewModel) {
+                        {
+                            viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
+                        }
+                    },
+                    onDismissClick = remember(viewModel) {
+                        {
+                            viewModel.trySendAction(
+                                VaultSettingsAction.ImportLoginsCardDismissClick,
+                            )
+                        }
+                    },
+                    leadingContent = {
+                        NotificationBadge(notificationCount = 1)
+                    },
+                    modifier = Modifier
+                        .standardHorizontalMargin()
+                        .padding(top = 12.dp, bottom = 16.dp),
+                )
+            }
             BitwardenTextRow(
                 text = stringResource(R.string.folders),
                 onClick = remember(viewModel) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
@@ -1,12 +1,14 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.vault
 
 import androidx.lifecycle.viewModelScope
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.util.toBaseWebVaultImportUrl
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -16,12 +18,16 @@ import javax.inject.Inject
 /**
  * View model for the vault screen.
  */
+@Suppress("TooManyFunctions")
 @HiltViewModel
 class VaultSettingsViewModel @Inject constructor(
     environmentRepository: EnvironmentRepository,
-    val featureFlagManager: FeatureFlagManager,
+    featureFlagManager: FeatureFlagManager,
+    private val authRepository: AuthRepository,
 ) : BaseViewModel<VaultSettingsState, VaultSettingsEvent, VaultSettingsAction>(
     initialState = run {
+        val userFirstTimeState =
+            requireNotNull(authRepository.userStateFlow.value).activeUserFirstTimeState
         VaultSettingsState(
             importUrl = environmentRepository
                 .environment
@@ -29,6 +35,7 @@ class VaultSettingsViewModel @Inject constructor(
                 .toBaseWebVaultImportUrl,
             isNewImportLoginsFlowEnabled = featureFlagManager
                 .getFeatureFlag(FlagKey.ImportLoginsFlow),
+            showImportActionCard = userFirstTimeState.showImportLoginsCard,
         )
     },
 ) {
@@ -38,6 +45,17 @@ class VaultSettingsViewModel @Inject constructor(
             .map { VaultSettingsAction.Internal.ImportLoginsFeatureFlagChanged(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
+
+        authRepository
+            .userStateFlow
+            .filterNotNull()
+            .map {
+                VaultSettingsAction.Internal.UserFirstTimeStateChanged(
+                    showImportLoginsCard = it.activeUserFirstTimeState.showImportLoginsCard,
+                )
+            }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
     }
 
     override fun handleAction(action: VaultSettingsAction): Unit = when (action) {
@@ -45,8 +63,37 @@ class VaultSettingsViewModel @Inject constructor(
         VaultSettingsAction.ExportVaultClick -> handleExportVaultClicked()
         VaultSettingsAction.FoldersButtonClick -> handleFoldersButtonClicked()
         VaultSettingsAction.ImportItemsClick -> handleImportItemsClicked()
-        is VaultSettingsAction.Internal.ImportLoginsFeatureFlagChanged -> {
-            handleImportLoginsFeatureFlagChanged(action)
+        VaultSettingsAction.ImportLoginsCardCtaClick -> handleImportLoginsCardClicked()
+        VaultSettingsAction.ImportLoginsCardDismissClick -> handleImportLoginsCardDismissClicked()
+        is VaultSettingsAction.Internal -> handleInternalAction(action)
+    }
+
+    private fun handleInternalAction(action: VaultSettingsAction.Internal) {
+        when (action) {
+            is VaultSettingsAction.Internal.ImportLoginsFeatureFlagChanged -> {
+                handleImportLoginsFeatureFlagChanged(action)
+            }
+
+            is VaultSettingsAction.Internal.UserFirstTimeStateChanged -> {
+                handleUserFirstTimeStateChanged(action)
+            }
+        }
+    }
+
+    private fun handleImportLoginsCardDismissClicked() {
+        dismissImportLoginsCard()
+    }
+
+    private fun handleImportLoginsCardClicked() {
+        dismissImportLoginsCard()
+        sendEvent(VaultSettingsEvent.NavigateToImportVault(state.importUrl))
+    }
+
+    private fun handleUserFirstTimeStateChanged(
+        action: VaultSettingsAction.Internal.UserFirstTimeStateChanged,
+    ) {
+        mutableStateFlow.update {
+            it.copy(showImportActionCard = action.showImportLoginsCard)
         }
     }
 
@@ -75,6 +122,11 @@ class VaultSettingsViewModel @Inject constructor(
             VaultSettingsEvent.NavigateToImportVault(state.importUrl),
         )
     }
+
+    private fun dismissImportLoginsCard() {
+        if (!state.shouldShowImportCard) return
+        authRepository.setShowImportLogins(showImportLogins = false)
+    }
 }
 
 /**
@@ -83,7 +135,13 @@ class VaultSettingsViewModel @Inject constructor(
 data class VaultSettingsState(
     val importUrl: String,
     val isNewImportLoginsFlowEnabled: Boolean,
-)
+    private val showImportActionCard: Boolean,
+) {
+    /**
+     * Should only show the import action card if the import logins feature flag is enabled.
+     */
+    val shouldShowImportCard: Boolean = showImportActionCard && isNewImportLoginsFlowEnabled
+}
 
 /**
  * Models events for the vault screen.
@@ -142,6 +200,16 @@ sealed class VaultSettingsAction {
     data object ImportItemsClick : VaultSettingsAction()
 
     /**
+     * Indicates that the user clicked the CTA on the action card.
+     */
+    data object ImportLoginsCardCtaClick : VaultSettingsAction()
+
+    /**
+     * Indicates that the user dismissed the action card.
+     */
+    data object ImportLoginsCardDismissClick : VaultSettingsAction()
+
+    /**
      * Internal actions not performed by user interation
      */
     sealed class Internal : VaultSettingsAction() {
@@ -151,6 +219,13 @@ sealed class VaultSettingsAction {
          */
         data class ImportLoginsFeatureFlagChanged(
             val isEnabled: Boolean,
+        ) : Internal()
+
+        /**
+         * Indicates user first time state has changed.
+         */
+        data class UserFirstTimeStateChanged(
+            val showImportLoginsCard: Boolean,
         ) : Internal()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
@@ -139,7 +139,8 @@ data class VaultSettingsState(
     /**
      * Should only show the import action card if the import logins feature flag is enabled.
      */
-    val shouldShowImportCard: Boolean = showImportActionCard && isNewImportLoginsFlowEnabled
+    val shouldShowImportCard: Boolean
+        get() = showImportActionCard && isNewImportLoginsFlowEnabled
 }
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
@@ -6,7 +6,10 @@ import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.printToLog
 import androidx.core.net.toUri
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
@@ -34,6 +37,7 @@ class VaultSettingsScreenTest : BaseComposeTest() {
         VaultSettingsState(
             importUrl = "testUrl/#/tools/import",
             isNewImportLoginsFlowEnabled = false,
+            showImportActionCard = false,
         ),
     )
     private val intentManager: IntentManager = mockk(relaxed = true) {
@@ -156,5 +160,60 @@ class VaultSettingsScreenTest : BaseComposeTest() {
         mutableEventFlow.tryEmit(VaultSettingsEvent.NavigateToImportVault(testUrl))
         assertTrue(onNavigateToImportLoginsCalled)
         verify(exactly = 0) { intentManager.launchUri(testUrl.toUri()) }
+    }
+
+    @Test
+    fun `when new show action card is true the import logins card should show`() {
+        mutableStateFlow.update {
+            it.copy(
+                showImportActionCard = true,
+                isNewImportLoginsFlowEnabled = true,
+            )
+        }
+        composeTestRule.onRoot().printToLog("Help")
+        composeTestRule
+            .onNodeWithText("Import saved logins")
+            .performScrollTo()
+            .assertIsDisplayed()
+        mutableStateFlow.update {
+            it.copy(showImportActionCard = false)
+        }
+        composeTestRule
+            .onNodeWithText("Import saved logins")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `when action card is visible clicking the close icon should send correct action`() {
+        mutableStateFlow.update {
+            it.copy(
+                showImportActionCard = true,
+                isNewImportLoginsFlowEnabled = true,
+            )
+        }
+        composeTestRule
+            .onNodeWithContentDescription("Close")
+            .performScrollTo()
+            .performClick()
+        verify {
+            viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardDismissClick)
+        }
+    }
+
+    @Test
+    fun `when action card is visible get started button should send correct action`() {
+        mutableStateFlow.update {
+            it.copy(
+                showImportActionCard = true,
+                isNewImportLoginsFlowEnabled = true,
+            )
+        }
+        composeTestRule
+            .onNodeWithText("Get started")
+            .performScrollTo()
+            .performClick()
+        verify {
+            viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
+        }
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
@@ -6,10 +6,8 @@ import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.printToLog
 import androidx.core.net.toUri
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
@@ -170,7 +170,6 @@ class VaultSettingsScreenTest : BaseComposeTest() {
                 isNewImportLoginsFlowEnabled = true,
             )
         }
-        composeTestRule.onRoot().printToLog("Help")
         composeTestRule
             .onNodeWithText("Import saved logins")
             .performScrollTo()

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModelTest.kt
@@ -122,7 +122,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
     fun `ImportLoginsCardDismissClick action should set repository value to false `() = runTest {
         val viewModel = createViewModel()
         mutableImportLoginsFlagFlow.update { true }
-        viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
+        viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardDismissClick)
         verify(exactly = 1) { authRepository.setShowImportLogins(false) }
     }
 
@@ -131,7 +131,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
     fun `ImportLoginsCardDismissClick action should not set repository value to false if already false`() =
         runTest {
             val viewModel = createViewModel()
-            viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
+            viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardDismissClick)
             verify(exactly = 0) { authRepository.setShowImportLogins(false) }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModelTest.kt
@@ -1,12 +1,17 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.vault
 
 import app.cash.turbine.test
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
@@ -21,6 +26,14 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
     private val featureFlagManager = mockk<FeatureFlagManager> {
         every { getFeatureFlagFlow(FlagKey.ImportLoginsFlow) } returns mutableImportLoginsFlagFlow
         every { getFeatureFlag(FlagKey.ImportLoginsFlow) } returns false
+    }
+    private val mockUserState = mockk<UserState> {
+        every { activeUserFirstTimeState } returns DEFAULT_FIRST_TIME_STATE
+    }
+    private val mockUserStateFlow = MutableStateFlow(mockUserState)
+    private val authRepository = mockk<AuthRepository> {
+        every { userStateFlow } returns mockUserStateFlow
+        every { setShowImportLogins(any()) } just runs
     }
 
     @Test
@@ -67,8 +80,66 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
         assertTrue(viewModel.stateFlow.value.isNewImportLoginsFlowEnabled)
     }
 
+    @Test
+    fun `shouldShowImportCard should update when user state changes`() = runTest {
+        mutableImportLoginsFlagFlow.update { true }
+        val viewModel = createViewModel()
+        assertTrue(viewModel.stateFlow.value.shouldShowImportCard)
+        val newUserState = mockk<UserState>(relaxed = true) {
+            every { activeUserFirstTimeState } returns DEFAULT_FIRST_TIME_STATE.copy(
+                showImportLoginsCard = false,
+            )
+        }
+        mockUserStateFlow.update { newUserState }
+        assertFalse(viewModel.stateFlow.value.shouldShowImportCard)
+    }
+
+    @Test
+    fun `shouldShowImportCard should be false when feature flag not enabled`() = runTest {
+        val viewModel = createViewModel()
+        mutableImportLoginsFlagFlow.update { false }
+        assertFalse(viewModel.stateFlow.value.shouldShowImportCard)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ImportLoginsCardCtaClick action should set repository value to false and send navigation event`() =
+        runTest {
+            val viewModel = createViewModel()
+            val expected = "https://vault.bitwarden.com/#/tools/import"
+            mutableImportLoginsFlagFlow.update { true }
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
+                assertEquals(
+                    VaultSettingsEvent.NavigateToImportVault(url = expected),
+                    awaitItem(),
+                )
+            }
+            verify(exactly = 1) { authRepository.setShowImportLogins(false) }
+        }
+
+    @Test
+    fun `ImportLoginsCardDismissClick action should set repository value to false `() = runTest {
+        val viewModel = createViewModel()
+        mutableImportLoginsFlagFlow.update { true }
+        viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
+        verify(exactly = 1) { authRepository.setShowImportLogins(false) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ImportLoginsCardDismissClick action should not set repository value to false if already false`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
+            verify(exactly = 0) { authRepository.setShowImportLogins(false) }
+        }
+
     private fun createViewModel(): VaultSettingsViewModel = VaultSettingsViewModel(
         environmentRepository = environmentRepository,
         featureFlagManager = featureFlagManager,
+        authRepository = authRepository,
     )
 }
+
+private val DEFAULT_FIRST_TIME_STATE = UserState.FirstTimeState(showImportLoginsCard = true)


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13627
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- show the action card for the import logins on the VaultSettings screen as well, same logic applies to showing, feature flag must be enabled and vault must be empty.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/6096d2b6-90a2-4440-8baf-86f0d10b224b


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
