### PR TITLE
PM-13726: Process cipher notifications without organizationIds or collectionIds

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
@@ -162,19 +162,14 @@ class PushManagerImpl @Inject constructor(
                         string = notification.payload,
                     )
                     .takeIf { isLoggedIn(userId) && it.userMatchesNotification(userId) }
-                    ?.takeIf {
-                        it.cipherId != null &&
-                            it.revisionDate != null &&
-                            it.organizationId != null &&
-                            it.collectionIds != null
-                    }
+                    ?.takeIf { it.cipherId != null && it.revisionDate != null }
                     ?.let {
                         mutableSyncCipherUpsertSharedFlow.tryEmit(
                             SyncCipherUpsertData(
                                 cipherId = requireNotNull(it.cipherId),
                                 revisionDate = requireNotNull(it.revisionDate),
-                                organizationId = requireNotNull(it.organizationId),
-                                collectionIds = requireNotNull(it.collectionIds),
+                                organizationId = it.organizationId,
+                                collectionIds = it.collectionIds,
                                 isUpdate = type == NotificationType.SYNC_CIPHER_UPDATE,
                             ),
                         )
@@ -339,6 +334,6 @@ class PushManagerImpl @Inject constructor(
     ): Boolean = authDiskSource.getAccountTokens(userId)?.isLoggedIn == true
 }
 
-private fun NotificationPayload.userMatchesNotification(userId: String?): Boolean {
+private fun NotificationPayload.userMatchesNotification(userId: String): Boolean {
     return this.userId != null && this.userId == userId
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13726](https://bitwarden.atlassian.net/browse/PM-13726)

## 📔 Objective

This PR removes the restriction on cipher update notification that require it to have an organization ID and collection IDs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
