### PR TITLE
Use array to define knownCerts for authenticator bridge permission

### DIFF
--- a/app/src/beta/res/values/manifest.xml
+++ b/app/src/beta/res/values/manifest.xml
@@ -5,5 +5,5 @@
     AuthenticatorBridgeService in the beta variant. If later another variant of the
     Bitwarden Authenticator app is added, a SHA-256 digest of that variant's APK can be added here.
     -->
-    <string name="known_authenticator_app_cert">@null</string>
+    <string-array name="known_authenticator_app_certs" />
 </resources>

--- a/app/src/debug/res/values/manifest.xml
+++ b/app/src/debug/res/values/manifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- This is the SHA-256 digest for the Authenticator App debug variant:-->
-    <string name="known_authenticator_app_cert">13144ab52af797a88c2fe292674461ef1715e0e1e4f5f538f63f1c174696f476</string>
+    <string-array name="known_authenticator_app_certs">
+        <!-- This is the SHA-256 digest for the Authenticator App debug variant:-->
+        <item>13144ab52af797a88c2fe292674461ef1715e0e1e4f5f538f63f1c174696f476</item>
+    </string-array>
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
     app. -->
     <permission
         android:name="${applicationId}.permission.AUTHENTICATOR_BRIDGE_SERVICE"
-        android:knownCerts="@string/known_authenticator_app_cert"
+        android:knownCerts="@array/known_authenticator_app_certs"
         android:label="Bitwarden Bridge"
         android:protectionLevel="signature|knownSigner"
         tools:targetApi="s" />

--- a/app/src/release/res/values/manifest.xml
+++ b/app/src/release/res/values/manifest.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- This is the SHA-256 digest for Google Play signing key of the Authenticator App Release
-    variant: -->
-    <string name="known_authenticator_app_cert">45bd689eb1493eaef19c346dc1385197ddbb53ddc5d09476db4895df75b9b53b</string>
+    <string-array name="known_authenticator_app_certs">
+        <!-- This is the SHA-256 digest for Google Play signing key of the Authenticator App release
+        variant: -->
+        <item>45bd689eb1493eaef19c346dc1385197ddbb53ddc5d09476db4895df75b9b53b</item>
+
+        <!-- This is the SHA-256 digest for Firebase App Distribution signing key of the
+         Authenticator App release variant: -->
+        <item>B06B54566AF2FBCC762700C8844B84EC410C230EACC3878FCF0248C0D9772A95</item>
+
+        <!-- These are the SHA-256 digest for one-off builds created from branches by the Github
+        Action of the Authenticator App release variant. Uncomment this to one off builds generated
+        from the Authenticator App repo. -->
+<!--        <item>52f393fb529fbf2ab5bb018bf17bf0f829d2fbebce099915aba42deab5a2fbb8</item>-->
+    </string-array>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

The goal here is to make it so that the authenticator app can sync with the main password manager both when release via firebase app distribution and also the play store. 

## 📸 Screenshots

N/A 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
