### PR TITLE
PM-13464 centralize check for empty vault list

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/di/AuthDiskModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/di/AuthDiskModule.kt
@@ -6,6 +6,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSourceImpl
 import com.x8bit.bitwarden.data.platform.datasource.di.EncryptedPreferences
 import com.x8bit.bitwarden.data.platform.datasource.di.UnencryptedPreferences
 import com.x8bit.bitwarden.data.platform.datasource.disk.legacy.LegacySecureStorageMigrator
+import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -27,11 +28,13 @@ object AuthDiskModule {
         @UnencryptedPreferences sharedPreferences: SharedPreferences,
         legacySecureStorageMigrator: LegacySecureStorageMigrator,
         json: Json,
+        vaultDiskSource: VaultDiskSource,
     ): AuthDiskSource =
         AuthDiskSourceImpl(
             encryptedSharedPreferences = encryptedSharedPreferences,
             sharedPreferences = sharedPreferences,
             legacySecureStorageMigrator = legacySecureStorageMigrator,
             json = json,
+            vaultDiskSource = vaultDiskSource,
         )
 }


### PR DESCRIPTION
## 🎟️ Tracking
This is in support for the PRs #4101  and #4096 to centralize the check for the empty vault lise
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Only return true for the showImportLoginsValue if the ciphers list is also empty.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
