### PR TITLE
Allow CrashLogsManager to handle generic Throwables

### DIFF
--- a/app/src/fdroid/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManagerImpl.kt
+++ b/app/src/fdroid/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManagerImpl.kt
@@ -12,5 +12,5 @@ class CrashLogsManagerImpl(
 ) : CrashLogsManager {
     override var isEnabled: Boolean = true
 
-    override fun trackNonFatalException(e: Exception) = Unit
+    override fun trackNonFatalException(throwable: Throwable) = Unit
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManager.kt
@@ -11,7 +11,7 @@ interface CrashLogsManager {
     var isEnabled: Boolean
 
     /**
-     * Tracks an exception if logs are enabled.
+     * Tracks a [Throwable] if logs are enabled.
      */
-    fun trackNonFatalException(e: Exception)
+    fun trackNonFatalException(throwable: Throwable)
 }

--- a/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManagerImpl.kt
+++ b/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/CrashLogsManagerImpl.kt
@@ -22,9 +22,9 @@ class CrashLogsManagerImpl(
             Firebase.crashlytics.isCrashlyticsCollectionEnabled = value
         }
 
-    override fun trackNonFatalException(e: Exception) {
+    override fun trackNonFatalException(throwable: Throwable) {
         if (settingsRepository.isCrashLoggingEnabled) {
-            Firebase.crashlytics.recordException(e)
+            Firebase.crashlytics.recordException(throwable)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR allows the `CrashLogsManager` to handle generic `Throwable`s when logging non-fatal-errors.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
