### PR TITLE
PM-13688: Remove race condition from AuthTokenInterceptor

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/di/PlatformNetworkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/di/PlatformNetworkModule.kt
@@ -58,7 +58,9 @@ object PlatformNetworkModule {
 
     @Provides
     @Singleton
-    fun providesAuthTokenInterceptor(): AuthTokenInterceptor = AuthTokenInterceptor()
+    fun providesAuthTokenInterceptor(
+        authDiskSource: AuthDiskSource,
+    ): AuthTokenInterceptor = AuthTokenInterceptor(authDiskSource = authDiskSource)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/NetworkConfigManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/NetworkConfigManagerImpl.kt
@@ -1,9 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager
 
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
-import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.platform.datasource.network.authenticator.RefreshAuthenticator
-import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.AuthTokenInterceptor
 import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.BaseUrlInterceptors
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
@@ -18,10 +16,8 @@ private const val ENVIRONMENT_DEBOUNCE_TIMEOUT_MS: Long = 500L
 /**
  * Primary implementation of [NetworkConfigManager].
  */
-@Suppress("LongParameterList")
 class NetworkConfigManagerImpl(
     authRepository: AuthRepository,
-    private val authTokenInterceptor: AuthTokenInterceptor,
     environmentRepository: EnvironmentRepository,
     serverConfigRepository: ServerConfigRepository,
     private val baseUrlInterceptors: BaseUrlInterceptors,
@@ -32,17 +28,6 @@ class NetworkConfigManagerImpl(
     private val collectionScope = CoroutineScope(dispatcherManager.unconfined)
 
     init {
-        authRepository
-            .authStateFlow
-            .onEach { authState ->
-                authTokenInterceptor.authToken = when (authState) {
-                    is AuthState.Authenticated -> authState.accessToken
-                    is AuthState.Unauthenticated -> null
-                    is AuthState.Uninitialized -> null
-                }
-            }
-            .launchIn(collectionScope)
-
         @Suppress("OPT_IN_USAGE")
         environmentRepository
             .environmentStateFlow

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager
 
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.network.model.PushTokenRequest
 import com.x8bit.bitwarden.data.platform.datasource.network.service.PushService
@@ -21,7 +22,6 @@ import com.x8bit.bitwarden.data.platform.util.decodeFromStringOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
@@ -100,9 +100,8 @@ class PushManagerImpl @Inject constructor(
 
     init {
         authDiskSource
-            .userStateFlow
-            .mapNotNull { it?.activeUserId }
-            .distinctUntilChanged()
+            .activeUserIdChangesFlow
+            .mapNotNull { it }
             .onEach { registerStoredPushTokenIfNecessary() }
             .launchIn(unconfinedScope)
     }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -10,7 +10,6 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.legacy.LegacyAppCenterMigrator
 import com.x8bit.bitwarden.data.platform.datasource.network.authenticator.RefreshAuthenticator
-import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.AuthTokenInterceptor
 import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.BaseUrlInterceptors
 import com.x8bit.bitwarden.data.platform.datasource.network.service.EventService
 import com.x8bit.bitwarden.data.platform.datasource.network.service.PushService
@@ -185,7 +184,6 @@ object PlatformManagerModule {
     @Singleton
     fun provideNetworkConfigManager(
         authRepository: AuthRepository,
-        authTokenInterceptor: AuthTokenInterceptor,
         environmentRepository: EnvironmentRepository,
         serverConfigRepository: ServerConfigRepository,
         baseUrlInterceptors: BaseUrlInterceptors,
@@ -194,7 +192,6 @@ object PlatformManagerModule {
     ): NetworkConfigManager =
         NetworkConfigManagerImpl(
             authRepository = authRepository,
-            authTokenInterceptor = authTokenInterceptor,
             environmentRepository = environmentRepository,
             serverConfigRepository = serverConfigRepository,
             baseUrlInterceptors = baseUrlInterceptors,

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/NetworkConfigManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/NetworkConfigManagerTest.kt
@@ -4,7 +4,6 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.network.authenticator.RefreshAuthenticator
-import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.AuthTokenInterceptor
 import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.BaseUrlInterceptors
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
@@ -19,7 +18,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -44,7 +42,6 @@ class NetworkConfigManagerTest {
     }
 
     private val refreshAuthenticator = RefreshAuthenticator()
-    private val authTokenInterceptor = AuthTokenInterceptor()
     private val baseUrlInterceptors = BaseUrlInterceptors()
 
     private lateinit var networkConfigManager: NetworkConfigManager
@@ -53,36 +50,12 @@ class NetworkConfigManagerTest {
     fun setUp() {
         networkConfigManager = NetworkConfigManagerImpl(
             authRepository = authRepository,
-            authTokenInterceptor = authTokenInterceptor,
             environmentRepository = environmentRepository,
             serverConfigRepository = serverConfigRepository,
             baseUrlInterceptors = baseUrlInterceptors,
             refreshAuthenticator = refreshAuthenticator,
             dispatcherManager = dispatcherManager,
         )
-    }
-
-    @Test
-    fun `authenticatorProvider should be set on initialization`() {
-        assertEquals(
-            authRepository,
-            refreshAuthenticator.authenticatorProvider,
-        )
-    }
-
-    @Test
-    fun `changes in the AuthState should update the AuthTokenInterceptor`() {
-        mutableAuthStateFlow.value = AuthState.Uninitialized
-        assertNull(authTokenInterceptor.authToken)
-
-        mutableAuthStateFlow.value = AuthState.Authenticated(accessToken = "accessToken")
-        assertEquals(
-            "accessToken",
-            authTokenInterceptor.authToken,
-        )
-
-        mutableAuthStateFlow.value = AuthState.Unauthenticated
-        assertNull(authTokenInterceptor.authToken)
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13688](https://bitwarden.atlassian.net/browse/PM-13688)

## 📔 Objective

This PR addresses a race condition that can occur when different parts of the app are directly checking disk source to determine the login state but the `AuthTokenInterceptor` is not being updated as quickly. To avoid race conditions like this, the interceptor will now query the disk source directly.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13688]: https://bitwarden.atlassian.net/browse/PM-13688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ