### PR TITLE
[PM-13396] Add support for legacy error response model in getToken

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/GetTokenResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/GetTokenResponseJson.kt
@@ -96,8 +96,16 @@ sealed class GetTokenResponseJson {
     @Serializable
     data class Invalid(
         @SerialName("ErrorModel")
-        val errorModel: ErrorModel,
+        val errorModel: ErrorModel?,
+        @SerialName("errorModel")
+        val legacyErrorModel: LegacyErrorModel?,
     ) : GetTokenResponseJson() {
+
+        /**
+         * The error message returned from the server, or null.
+         */
+        val errorMessage: String?
+            get() = errorModel?.errorMessage ?: legacyErrorModel?.errorMessage
 
         /**
          * The error body of an invalid request containing a message.
@@ -105,6 +113,18 @@ sealed class GetTokenResponseJson {
         @Serializable
         data class ErrorModel(
             @SerialName("Message")
+            val errorMessage: String,
+        )
+
+        /**
+         * The legacy error body of an invalid request containing a message.
+         *
+         * This model is used to support older versions of the error response model that used
+         * lower-case keys.
+         */
+        @Serializable
+        data class LegacyErrorModel(
+            @SerialName("message")
             val errorMessage: String,
         )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -45,7 +45,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.DeleteAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.EmailTokenResult
-import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
@@ -99,6 +98,7 @@ import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
+import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.util.getActivePolicies
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
@@ -1503,7 +1503,7 @@ class AuthRepositoryImpl(
                     )
 
                     is GetTokenResponseJson.Invalid -> LoginResult.Error(
-                        errorMessage = loginResponse.errorModel.errorMessage,
+                        errorMessage = loginResponse.errorMessage,
                     )
                 }
             },

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
@@ -274,6 +274,22 @@ class IdentityServiceTest : BaseServiceTest() {
     }
 
     @Test
+    fun `getToken when response is a 400 with a legacy error body should return Invalid`() =
+        runTest {
+            server.enqueue(MockResponse().setResponseCode(400).setBody(LEGACY_INVALID_LOGIN_JSON))
+            val result = identityService.getToken(
+                email = EMAIL,
+                authModel = IdentityTokenAuthModel.MasterPassword(
+                    username = EMAIL,
+                    password = PASSWORD_HASH,
+                ),
+                captchaToken = null,
+                uniqueAppId = UNIQUE_APP_ID,
+            )
+            assertEquals(LEGACY_INVALID_LOGIN.asSuccess(), result)
+        }
+
+    @Test
     fun `prevalidateSso when response is success should return PrevalidateSsoResponseJson`() =
         runTest {
             val organizationId = "organizationId"
@@ -613,6 +629,14 @@ private const val INVALID_LOGIN_JSON = """
 }
 """
 
+private const val LEGACY_INVALID_LOGIN_JSON = """
+{
+  "errorModel": {
+    "message": "Legacy-123"
+  }
+}
+"""
+
 private const val TOO_MANY_REQUEST_ERROR_JSON = """
 {
   "Object": "error",
@@ -644,6 +668,14 @@ private const val CAPTCHA_BYPASS_TOKEN_RESPONSE_JSON = """
 private val INVALID_LOGIN = GetTokenResponseJson.Invalid(
     errorModel = GetTokenResponseJson.Invalid.ErrorModel(
         errorMessage = "123",
+    ),
+    legacyErrorModel = null,
+)
+
+private val LEGACY_INVALID_LOGIN = GetTokenResponseJson.Invalid(
+    errorModel = null,
+    legacyErrorModel = GetTokenResponseJson.Invalid.LegacyErrorModel(
+        errorMessage = "Legacy-123",
     ),
 )
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -65,7 +65,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.DeleteAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.EmailTokenResult
-import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
@@ -106,6 +105,7 @@ import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
+import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.model.NotificationLogoutData
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -1522,6 +1522,7 @@ class AuthRepositoryTest {
                 errorModel = GetTokenResponseJson.Invalid.ErrorModel(
                     errorMessage = "mock_error_message",
                 ),
+                legacyErrorModel = null,
             )
             .asSuccess()
 
@@ -2314,6 +2315,7 @@ class AuthRepositoryTest {
                     errorModel = GetTokenResponseJson.Invalid.ErrorModel(
                         errorMessage = "mock_error_message",
                     ),
+                    legacyErrorModel = null,
                 )
                 .asSuccess()
 
@@ -2782,6 +2784,7 @@ class AuthRepositoryTest {
                 errorModel = GetTokenResponseJson.Invalid.ErrorModel(
                     errorMessage = "mock_error_message",
                 ),
+                legacyErrorModel = null,
             )
             .asSuccess()
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13396

## 📔 Objective

This commit adds support for the legacy error response model returned by the `getToken` endpoint.

The legacy model uses lowercase keys for error messages, while the current model uses uppercase keys. This change ensures that the app can handle both models correctly.

Additionally, the unit tests were updated to cover the scenario where the server returns a legacy error response.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
