### PR TITLE
PM-13690: Add dialog before switching account during passwordless login

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -1106,10 +1106,12 @@ class MainViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `on ReceiveNewIntent with a passwordless auth request data userId that doesn't match activeUserId should switchAccount`() {
+    fun `on ReceiveNewIntent with a passwordless auth request data userId that doesn't match activeUserId and the vault is not locked should switchAccount`() {
+        val userId = "userId"
         val viewModel = createViewModel()
         val mockIntent = mockk<Intent>()
         val passwordlessRequestData = mockk<PasswordlessRequestData>()
+        every { vaultRepository.isVaultUnlocked(ACTIVE_USER_ID) } returns false
         every {
             mockIntent.getPasswordlessRequestDataIntentOrNull()
         } returns passwordlessRequestData
@@ -1121,7 +1123,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { mockIntent.isMyVaultShortcut } returns false
         every { mockIntent.isPasswordGeneratorShortcut } returns false
         every { mockIntent.isAccountSecurityShortcut } returns false
-        every { passwordlessRequestData.userId } returns "userId"
+        every { passwordlessRequestData.userId } returns userId
 
         viewModel.trySendAction(
             MainAction.ReceiveNewIntent(
@@ -1129,7 +1131,7 @@ class MainViewModelTest : BaseViewModelTest() {
             ),
         )
 
-        verify { authRepository.switchAccount("userId") }
+        verify { authRepository.switchAccount(userId) }
     }
 
     private fun createViewModel(
@@ -1162,8 +1164,9 @@ private val DEFAULT_FIRST_TIME_STATE = FirstTimeState(
 )
 
 private const val SPECIAL_CIRCUMSTANCE_KEY: String = "special-circumstance"
+private const val ACTIVE_USER_ID: String = "activeUserId"
 private val DEFAULT_ACCOUNT = UserState.Account(
-    userId = "activeUserId",
+    userId = ACTIVE_USER_ID,
     name = "Active User",
     email = "active@bitwarden.com",
     environment = Environment.Us,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13690](https://bitwarden.atlassian.net/browse/PM-13690)

## 📔 Objective

This PR adds a dialog that appears for users who are logged in when switching to a different account for passwordless login.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/2efb9f48-bf4f-42bc-b3d9-008724c151f5" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13690]: https://bitwarden.atlassian.net/browse/PM-13690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ