### PR TITLE
PM-13024: After saving cipher in totp flow, app should not close

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -124,8 +124,7 @@ class VaultAddEditViewModel @Inject constructor(
 
             // Exit on save if handling an autofill, Fido2 Attestation, or TOTP link
             val shouldExitOnSave = autofillSaveItem != null ||
-                fido2AttestationOptions != null ||
-                totpData != null
+                fido2AttestationOptions != null
 
             val dialogState = if (!settingsRepository.initialAutofillDialogShown &&
                 vaultAddEditType is VaultAddEditType.AddItem &&


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13024](https://bitwarden.atlassian.net/browse/PM-13024)

## 📔 Objective

This PR updates the `VaultAddEditViewModel` to no close the app when you are done updating or creating a cipher via the totp flow.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/2a095a25-360d-4d10-b08c-3a117d93917c" width="300" /> | <video src="https://github.com/user-attachments/assets/1a0d6731-7b17-42dc-b24c-8f0c8a7c25f8" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13024]: https://bitwarden.atlassian.net/browse/PM-13024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ