### PR TITLE
PM-13886 show dialog when no logins were imported

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -1336,7 +1336,11 @@ class VaultRepositoryImpl(
                             userId = userId,
                             lastSyncTime = clock.instant(),
                         )
-                        return SyncVaultDataResult.Success
+                        val itemsAvailable = vaultDiskSource
+                            .getCiphers(userId)
+                            .firstOrNull()
+                            ?.isNotEmpty() ?: false
+                        return SyncVaultDataResult.Success(itemsAvailable = itemsAvailable)
                     }
                 },
                 onFailure = {
@@ -1381,7 +1385,8 @@ class VaultRepositoryImpl(
                         lastSyncTime = clock.instant(),
                     )
                     vaultDiskSource.replaceVaultData(userId = userId, vault = syncResponse)
-                    return SyncVaultDataResult.Success
+                    val itemsAvailable = syncResponse.ciphers?.isNotEmpty() ?: false
+                    return SyncVaultDataResult.Success(itemsAvailable = itemsAvailable)
                 },
                 onFailure = { throwable ->
                     updateVaultStateFlowsToError(throwable)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -1339,7 +1339,8 @@ class VaultRepositoryImpl(
                         val itemsAvailable = vaultDiskSource
                             .getCiphers(userId)
                             .firstOrNull()
-                            ?.isNotEmpty() ?: false
+                            ?.isNotEmpty()
+                            ?: false
                         return SyncVaultDataResult.Success(itemsAvailable = itemsAvailable)
                     }
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/SyncVaultDataResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/SyncVaultDataResult.kt
@@ -6,8 +6,10 @@ package com.x8bit.bitwarden.data.vault.repository.model
 sealed class SyncVaultDataResult {
     /**
      * Indicates a successful sync operation.
+     *
+     * @property itemsAvailable indicated whether the sync returned any vault items or not.
      */
-    data object Success : SyncVaultDataResult()
+    data class Success(val itemsAvailable: Boolean) : SyncVaultDataResult()
 
     /**
      * Indicates a failed sync operation.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreen.kt
@@ -222,7 +222,7 @@ private fun ImportLoginsDialogContent(
             )
         }
 
-        ImportLoginsState.DialogState.Error -> {
+        is ImportLoginsState.DialogState.Error -> {
             BitwardenTwoButtonDialog(
                 title = dialogState.title?.invoke(),
                 message = dialogState.message(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1073,4 +1073,5 @@ Do you want to switch to this account?</string>
   <string name="bitwarden_tools">Bitwarden Tools</string>
   <string name="got_it">Got it</string>
     <string name="no_logins_were_imported">No logins were imported</string>
+  <string name="no_logins_were_imported">No logins were imported</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1072,4 +1072,5 @@ Do you want to switch to this account?</string>
   <string name="manage_your_logins_from_anywhere_with_bitwarden_tools">Manage your logins from anywhere with Bitwarden tools for web and desktop.</string>
   <string name="bitwarden_tools">Bitwarden Tools</string>
   <string name="got_it">Got it</string>
+    <string name="no_logins_were_imported">No logins were imported</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1072,6 +1072,5 @@ Do you want to switch to this account?</string>
   <string name="manage_your_logins_from_anywhere_with_bitwarden_tools">Manage your logins from anywhere with Bitwarden tools for web and desktop.</string>
   <string name="bitwarden_tools">Bitwarden Tools</string>
   <string name="got_it">Got it</string>
-    <string name="no_logins_were_imported">No logins were imported</string>
   <string name="no_logins_were_imported">No logins were imported</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -4398,73 +4398,75 @@ class VaultRepositoryTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `syncForResult should return success result with itemsAvailable = true when sync succeeds and ciphers list is not empty`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        val userId = "mockId-1"
-        val mockSyncResponse = createMockSyncResponse(number = 1)
-        coEvery {
-            syncService.sync()
-        } returns mockSyncResponse.asSuccess()
-        coEvery {
-            vaultSdkSource.initializeOrganizationCrypto(
-                userId = userId,
-                request = InitOrgCryptoRequest(
-                    organizationKeys = createMockOrganizationKeys(1),
-                ),
-            )
-        } returns InitializeCryptoResult.Success.asSuccess()
-        coEvery {
-            vaultDiskSource.replaceVaultData(
-                userId = MOCK_USER_STATE.activeUserId,
-                vault = mockSyncResponse,
-            )
-        } just runs
+    fun `syncForResult should return success result with itemsAvailable = true when sync succeeds and ciphers list is not empty`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val userId = "mockId-1"
+            val mockSyncResponse = createMockSyncResponse(number = 1)
+            coEvery {
+                syncService.sync()
+            } returns mockSyncResponse.asSuccess()
+            coEvery {
+                vaultSdkSource.initializeOrganizationCrypto(
+                    userId = userId,
+                    request = InitOrgCryptoRequest(
+                        organizationKeys = createMockOrganizationKeys(1),
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                vaultDiskSource.replaceVaultData(
+                    userId = MOCK_USER_STATE.activeUserId,
+                    vault = mockSyncResponse,
+                )
+            } just runs
 
-        every {
-            settingsDiskSource.storeLastSyncTime(
-                MOCK_USER_STATE.activeUserId,
-                clock.instant(),
-            )
-        } just runs
+            every {
+                settingsDiskSource.storeLastSyncTime(
+                    MOCK_USER_STATE.activeUserId,
+                    clock.instant(),
+                )
+            } just runs
 
-        val syncResult = vaultRepository.syncForResult()
-        assertEquals(SyncVaultDataResult.Success(itemsAvailable = true), syncResult)
-    }
+            val syncResult = vaultRepository.syncForResult()
+            assertEquals(SyncVaultDataResult.Success(itemsAvailable = true), syncResult)
+        }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `syncForResult should return success result with itemsAvailable = false when sync succeeds and ciphers list is empty`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        val userId = "mockId-1"
-        val mockSyncResponse = createMockSyncResponse(number = 1).copy(ciphers = emptyList())
-        coEvery {
-            syncService.sync()
-        } returns mockSyncResponse.asSuccess()
-        coEvery {
-            vaultSdkSource.initializeOrganizationCrypto(
-                userId = userId,
-                request = InitOrgCryptoRequest(
-                    organizationKeys = createMockOrganizationKeys(1),
-                ),
-            )
-        } returns InitializeCryptoResult.Success.asSuccess()
-        coEvery {
-            vaultDiskSource.replaceVaultData(
-                userId = MOCK_USER_STATE.activeUserId,
-                vault = mockSyncResponse,
-            )
-        } just runs
+    fun `syncForResult should return success result with itemsAvailable = false when sync succeeds and ciphers list is empty`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val userId = "mockId-1"
+            val mockSyncResponse = createMockSyncResponse(number = 1).copy(ciphers = emptyList())
+            coEvery {
+                syncService.sync()
+            } returns mockSyncResponse.asSuccess()
+            coEvery {
+                vaultSdkSource.initializeOrganizationCrypto(
+                    userId = userId,
+                    request = InitOrgCryptoRequest(
+                        organizationKeys = createMockOrganizationKeys(1),
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                vaultDiskSource.replaceVaultData(
+                    userId = MOCK_USER_STATE.activeUserId,
+                    vault = mockSyncResponse,
+                )
+            } just runs
 
-        every {
-            settingsDiskSource.storeLastSyncTime(
-                MOCK_USER_STATE.activeUserId,
-                clock.instant(),
-            )
-        } just runs
+            every {
+                settingsDiskSource.storeLastSyncTime(
+                    MOCK_USER_STATE.activeUserId,
+                    clock.instant(),
+                )
+            } just runs
 
-        val syncResult = vaultRepository.syncForResult()
-        assertEquals(SyncVaultDataResult.Success(itemsAvailable = false), syncResult)
-    }
+            val syncResult = vaultRepository.syncForResult()
+            assertEquals(SyncVaultDataResult.Success(itemsAvailable = false), syncResult)
+        }
 
     @Test
     fun `syncForResult should return error when getAccountRevisionDateMillis fails`() =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreenTest.kt
@@ -370,7 +370,7 @@ class ImportLoginsScreenTest : BaseComposeTest() {
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
             .performClick()
-        verifyActionSent(ImportLoginsAction.FailSyncAcknowledged)
+        verifyActionSent(ImportLoginsAction.FailedSyncAcknowledged)
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
@@ -332,6 +332,7 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
                         dialogState = null,
                         viewState = ImportLoginsState.ViewState.InitialContent,
                         isVaultSyncing = true,
+                        showBottomSheet = false,
                     ),
                     awaitItem(),
                 )
@@ -340,6 +341,7 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
                         dialogState = ImportLoginsState.DialogState.Error(R.string.no_logins_were_imported.asText()),
                         viewState = ImportLoginsState.ViewState.InitialContent,
                         isVaultSyncing = false,
+                        showBottomSheet = false,
                     ),
                     awaitItem(),
                 )


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13886
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- when the import logins flow attempts to sync, and it's successful but no items are returned we want to display this to the user in the form of the error dialog as if the sync failed. Allowing them to try again or exit.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
https://github.com/user-attachments/assets/beffd0b9-06a5-4b23-bcdf-d0a095db7e41
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
