### PR TITLE
User TImber instead of LogsManager directly

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
@@ -21,7 +21,6 @@ import com.x8bit.bitwarden.data.autofill.processor.AutofillProcessor
 import com.x8bit.bitwarden.data.autofill.processor.AutofillProcessorImpl
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProvider
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProviderImpl
-import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
@@ -121,7 +120,6 @@ object AutofillModule {
         policyManager: PolicyManager,
         saveInfoBuilder: SaveInfoBuilder,
         settingsRepository: SettingsRepository,
-        logsManager: LogsManager,
     ): AutofillProcessor =
         AutofillProcessorImpl(
             dispatcherManager = dispatcherManager,
@@ -131,7 +129,6 @@ object AutofillModule {
             policyManager = policyManager,
             saveInfoBuilder = saveInfoBuilder,
             settingsRepository = settingsRepository,
-            logsManager = logsManager,
         )
 
     @Singleton

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
@@ -13,7 +13,6 @@ import com.x8bit.bitwarden.data.autofill.model.AutofillRequest
 import com.x8bit.bitwarden.data.autofill.parser.AutofillParser
 import com.x8bit.bitwarden.data.autofill.util.createAutofillSavedItemIntentSender
 import com.x8bit.bitwarden.data.autofill.util.toAutofillSaveItem
-import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -21,6 +20,7 @@ import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /**
  * The default implementation of [AutofillProcessor]. Its purpose is to handle autofill related
@@ -35,7 +35,6 @@ class AutofillProcessorImpl(
     private val parser: AutofillParser,
     private val saveInfoBuilder: SaveInfoBuilder,
     private val settingsRepository: SettingsRepository,
-    private val logsManager: LogsManager,
 ) : AutofillProcessor {
 
     /**
@@ -146,7 +145,7 @@ class AutofillProcessorImpl(
                 } catch (e: RuntimeException) {
                     // This is to catch any TransactionTooLargeExceptions that could occur here.
                     // These exceptions get wrapped as a RuntimeException.
-                    logsManager.trackNonFatalException(e)
+                    Timber.e(e, "Autofill Error")
                 }
             }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
@@ -22,7 +22,6 @@ import com.x8bit.bitwarden.data.autofill.parser.AutofillParser
 import com.x8bit.bitwarden.data.autofill.util.createAutofillSavedItemIntentSender
 import com.x8bit.bitwarden.data.autofill.util.toAutofillSaveItem
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
-import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
@@ -57,7 +56,6 @@ class AutofillProcessorTest {
     private val policyManager: PolicyManager = mockk()
     private val saveInfoBuilder: SaveInfoBuilder = mockk()
     private val settingsRepository: SettingsRepository = mockk()
-    private val logsManager: LogsManager = mockk()
 
     private val appInfo: AutofillAppInfo = AutofillAppInfo(
         context = mockk(),
@@ -79,7 +77,6 @@ class AutofillProcessorTest {
             policyManager = policyManager,
             saveInfoBuilder = saveInfoBuilder,
             settingsRepository = settingsRepository,
-            logsManager = logsManager,
         )
     }
 
@@ -246,7 +243,6 @@ class AutofillProcessorTest {
             } returns fillResponse
             val runtimeException = RuntimeException("TransactionToLarge")
             every { fillCallback.onSuccess(fillResponse) } throws runtimeException
-            every { logsManager.trackNonFatalException(runtimeException) } just runs
 
             // Test
             autofillProcessor.processFillRequest(
@@ -271,7 +267,6 @@ class AutofillProcessorTest {
                     saveInfo = saveInfo,
                 )
                 fillCallback.onSuccess(fillResponse)
-                logsManager.trackNonFatalException(runtimeException)
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the error handling in the `AutofillProcessorImpl` to use `Timber` instead of the `LogsManager` directly.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
