### PR TITLE
[PM-13980] Add SSH Key Cipher Item Types feature flag

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -31,6 +31,7 @@ sealed class FlagKey<out T : Any> {
                 OnboardingFlow,
                 OnboardingCarousel,
                 ImportLoginsFlow,
+                SshKeyCipherItems,
             )
         }
     }
@@ -76,6 +77,15 @@ sealed class FlagKey<out T : Any> {
      */
     data object ImportLoginsFlow : FlagKey<Boolean>() {
         override val keyName: String = "import-logins-flow"
+        override val defaultValue: Boolean = false
+        override val isRemotelyConfigured: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for the SSH key cipher items feature.
+     */
+    data object SshKeyCipherItems : FlagKey<Boolean>() {
+        override val keyName: String = "ssh-key-cipher-items"
         override val defaultValue: Boolean = false
         override val isRemotelyConfigured: Boolean = false
     }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -85,9 +85,9 @@ sealed class FlagKey<out T : Any> {
      * Data object holding the feature flag key for the SSH key cipher items feature.
      */
     data object SshKeyCipherItems : FlagKey<Boolean>() {
-        override val keyName: String = "ssh-key-cipher-items"
+        override val keyName: String = "ssh-key-vault-item"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
+        override val isRemotelyConfigured: Boolean = true
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -27,6 +27,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.OnboardingCarousel,
     FlagKey.OnboardingFlow,
     FlagKey.ImportLoginsFlow,
+    FlagKey.SshKeyCipherItems,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
         key = flagKey as FlagKey<Boolean>,
@@ -69,4 +70,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.OnboardingCarousel -> stringResource(R.string.onboarding_carousel)
     FlagKey.OnboardingFlow -> stringResource(R.string.onboarding_flow)
     FlagKey.ImportLoginsFlow -> stringResource(R.string.import_logins_flow)
+    FlagKey.SshKeyCipherItems -> stringResource(R.string.ssh_key_cipher_item_types)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1061,4 +1061,5 @@ Do you want to switch to this account?</string>
   <string name="save_the_exported_file_highlight">Save the exported file</string>
   <string name="this_is_not_a_recognized_bitwarden_server_you_may_need_to_check_with_your_provider_or_update_your_server">This is not a recognized Bitwarden server. You may need to check with your provider or update your server.</string>
   <string name="syncing_logins_loading_message">Syncing logins...</string>
+  <string name="ssh_key_cipher_item_types">SSH Key Cipher Item Types</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -30,4 +30,9 @@ class FlagKeyTest {
     fun `ImportLoginsFlow default value should be false`() {
         assertFalse(FlagKey.ImportLoginsFlow.defaultValue)
     }
+
+    @Test
+    fun `SshKeyCipherItems default value should be false`() {
+        assertFalse(FlagKey.SshKeyCipherItems.defaultValue)
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -112,6 +112,7 @@ private val DEFAULT_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.OnboardingCarousel to true,
     FlagKey.OnboardingFlow to true,
     FlagKey.ImportLoginsFlow to true,
+    FlagKey.SshKeyCipherItems to true,
 )
 
 private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
@@ -120,6 +121,7 @@ private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.OnboardingCarousel to true,
     FlagKey.OnboardingFlow to false,
     FlagKey.ImportLoginsFlow to false,
+    FlagKey.SshKeyCipherItems to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13980

## 📔 Objective

This commit introduces a new feature flag which can be used to enable or disable the SSH Key Cipher Item Types feature.

## 📸 Screenshots

<img width="379" alt="image" src="https://github.com/user-attachments/assets/ee405386-2b43-4b9a-939a-b6755665ff3f">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
