### PR TITLE
QA-951: Adding missing IDs for Attachment rows

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsContent.kt
@@ -65,7 +65,8 @@ fun AttachmentsContent(
                     onDeleteClick = attachmentsHandlers.onDeleteClick,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                        .padding(horizontal = 16.dp)
+                        .testTag("AttachmentList"),
                 )
             }
         }
@@ -92,7 +93,8 @@ fun AttachmentsContent(
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 16.dp)
+                    .testTag("SelectedFileNameLabel"),
             )
         }
 
@@ -103,7 +105,8 @@ fun AttachmentsContent(
                 onClick = attachmentsHandlers.onChooseFileClick,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 16.dp)
+                    .testTag("AttachmentSelectFileButton"),
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
@@ -159,7 +162,9 @@ private fun AttachmentListEntry(
             style = BitwardenTheme.typography.bodyMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .testTag("AttachmentNameLabel"),
         )
 
         Spacer(modifier = Modifier.width(16.dp))
@@ -168,7 +173,8 @@ private fun AttachmentListEntry(
             text = attachmentItem.displaySize,
             color = BitwardenTheme.colorScheme.text.primary,
             style = BitwardenTheme.typography.labelSmall,
-            modifier = Modifier,
+            modifier = Modifier
+                .testTag("AttachmentSizeLabel"),
         )
 
         Spacer(modifier = Modifier.width(8.dp))
@@ -177,6 +183,8 @@ private fun AttachmentListEntry(
             vectorIconRes = R.drawable.ic_trash,
             contentDescription = stringResource(id = R.string.delete),
             onClick = { shouldShowDeleteDialog = true },
+            modifier = Modifier
+                .testTag("AttachmentDeleteButton"),
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemAttachmentContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemAttachmentContent.kt
@@ -84,7 +84,7 @@ fun AttachmentItemContent(
                 onAttachmentDownloadClick(attachmentItem)
             },
             modifier = Modifier
-                .testTag("AttachmentDownloadButton")
+                .testTag("AttachmentDownloadButton"),
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemAttachmentContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemAttachmentContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -40,7 +41,8 @@ fun AttachmentItemContent(
         modifier = modifier
             .bottomDivider()
             .defaultMinSize(minHeight = 56.dp)
-            .padding(vertical = 8.dp),
+            .padding(vertical = 8.dp)
+            .testTag("CipherAttachment"),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -49,7 +51,8 @@ fun AttachmentItemContent(
             style = BitwardenTheme.typography.bodyMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f)
+                .testTag("AttachmentNameLabel"),
         )
 
         Spacer(modifier = Modifier.width(16.dp))
@@ -58,7 +61,8 @@ fun AttachmentItemContent(
             text = attachmentItem.displaySize,
             color = BitwardenTheme.colorScheme.text.primary,
             style = BitwardenTheme.typography.labelSmall,
-            modifier = Modifier,
+            modifier = Modifier
+                .testTag("AttachmentSizeLabel"),
         )
 
         Spacer(modifier = Modifier.width(8.dp))
@@ -79,6 +83,8 @@ fun AttachmentItemContent(
 
                 onAttachmentDownloadClick(attachmentItem)
             },
+            modifier = Modifier
+                .testTag("AttachmentDownloadButton")
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
@@ -203,7 +203,6 @@ fun VaultItemLoginContent(
             items(attachments) { attachmentItem ->
                 AttachmentItemContent(
                     modifier = Modifier
-                        .testTag("CipherAttachment")
                         .fillMaxWidth()
                         .padding(start = 16.dp),
                     attachmentItem = attachmentItem,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[QA-947]: https://bitwarden.atlassian.net/browse/QA-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ