### PR TITLE
QA-952: Adding test tags for Toggle items

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenWideSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenWideSwitch.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.toggleableState
@@ -82,6 +83,8 @@ fun BitwardenWideSwitch(
                 } else {
                     BitwardenTheme.colorScheme.filledButton.foregroundDisabled
                 },
+                modifier = modifier
+                    .testTag("SwitchTitle"),
             )
             description?.let {
                 Text(
@@ -100,7 +103,8 @@ fun BitwardenWideSwitch(
 
         Switch(
             modifier = Modifier
-                .height(56.dp),
+                .height(56.dp)
+                .testTag("SwitchToggle"),
             enabled = enabled,
             checked = isChecked,
             onCheckedChange = null,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenWideSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenWideSwitch.kt
@@ -83,8 +83,7 @@ fun BitwardenWideSwitch(
                 } else {
                     BitwardenTheme.colorScheme.filledButton.foregroundDisabled
                 },
-                modifier = modifier
-                    .testTag("SwitchTitle"),
+                modifier = Modifier.testTag("SwitchText"),
             )
             description?.let {
                 Text(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[QA-947]: https://bitwarden.atlassian.net/browse/QA-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ