### PR TITLE
Remove query params from network logging

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/core/ResultCall.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/core/ResultCall.kt
@@ -66,7 +66,11 @@ class ResultCall<T>(
 
     private fun Throwable.toFailure(): Result<T> =
         this
-            .also { Timber.w(it, "Network Error: ${backingCall.request().url}") }
+            .also {
+                // We rebuild the URL without query params, we do not want to log those
+                val url = backingCall.request().url.toUrl().run { "$protocol://$authority$path" }
+                Timber.w(it, "Network Error: $url")
+            }
             .asFailure()
 
     private fun Response<T>.toResult(): Result<T> =

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/util/CallExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/util/CallExtensionsTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.platform.datasource.network.util
 import com.x8bit.bitwarden.data.platform.util.asSuccess
 import io.mockk.every
 import io.mockk.mockk
+import okhttp3.HttpUrl
 import okhttp3.Request
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -11,14 +12,13 @@ import org.junit.jupiter.api.Test
 import retrofit2.Call
 import retrofit2.Response
 import java.io.IOException
+import java.net.URL
 
 class CallExtensionsTest {
 
     @Test
     fun `executeForResult returns failure when execute throws IOException`() {
-        val request = mockk<Request> {
-            every { url } returns mockk()
-        }
+        val request = createMockkRequest()
         val call = mockk<Call<Unit>> {
             every { request() } returns request
             every { execute() } throws IOException("Fail")
@@ -31,9 +31,7 @@ class CallExtensionsTest {
 
     @Test
     fun `executeForResult returns failure when execute throws RuntimeException`() {
-        val request = mockk<Request> {
-            every { url } returns mockk()
-        }
+        val request = createMockkRequest()
         val call = mockk<Call<Unit>> {
             every { request() } returns request
             every { execute() } throws RuntimeException("Fail")
@@ -46,9 +44,7 @@ class CallExtensionsTest {
 
     @Test
     fun `executeForResult returns failure when response is failure`() {
-        val request = mockk<Request> {
-            every { url } returns mockk()
-        }
+        val request = createMockkRequest()
         val call = mockk<Call<Unit>> {
             every { request() } returns request
             every { execute() } returns Response.error(400, "".toResponseBody())
@@ -68,5 +64,19 @@ class CallExtensionsTest {
         val result = call.executeForResult()
 
         assertEquals(Unit.asSuccess(), result)
+    }
+
+    private fun createMockkRequest(): Request {
+        val mockkUrl = mockk<URL> {
+            every { protocol } returns "http"
+            every { authority } returns "bitwarden.com"
+            every { path } returns "/example/path"
+        }
+        val mockkHttpUrl = mockk<HttpUrl> {
+            every { toUrl() } returns mockkUrl
+        }
+        return mockk<Request> {
+            every { url } returns mockkHttpUrl
+        }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the query params from the network logs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
