### PR TITLE
BITAU-182 BITAU-107 Don't show authetnicator sync toggle below API 31

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity
 
+import android.os.Build
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -18,6 +19,7 @@ import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.data.platform.repository.util.baseWebVaultUrlOrDefault
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
@@ -69,9 +71,9 @@ class AccountSecurityViewModel @Inject constructor(
                 ?.activeAccount
                 ?.hasMasterPassword != false,
             isUnlockWithPinEnabled = settingsRepository.isUnlockWithPinEnabled,
-            shouldShowEnableAuthenticatorSync = featureFlagManager.getFeatureFlag(
-                key = FlagKey.AuthenticatorSync,
-            ),
+            shouldShowEnableAuthenticatorSync =
+            featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) &&
+                !isBuildVersionBelow(Build.VERSION_CODES.S),
             userId = userId,
             vaultTimeout = settingsRepository.vaultTimeout,
             vaultTimeoutAction = settingsRepository.vaultTimeoutAction,
@@ -371,9 +373,11 @@ class AccountSecurityViewModel @Inject constructor(
     private fun handleAuthenticatorSyncFeatureFlagUpdate(
         action: AccountSecurityAction.Internal.AuthenticatorSyncFeatureFlagUpdate,
     ) {
+        val shouldShowAuthenticatorSync =
+            action.isEnabled && !isBuildVersionBelow(Build.VERSION_CODES.S)
         mutableStateFlow.update {
             it.copy(
-                shouldShowEnableAuthenticatorSync = action.isEnabled,
+                shouldShowEnableAuthenticatorSync = shouldShowAuthenticatorSync,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1001,7 +1001,7 @@ Do you want to switch to this account?</string>
   <string name="please_restart_registration_or_try_logging_in">Please restart registration or try logging in. You may already have an account.</string>
   <string name="restart_registration">Restart registration</string>
   <string name="authenticator_sync">Authenticator Sync</string>
-  <string name="allow_bitwarden_authenticator_syncing">Allow Bitwarden Authenticator Syncing</string>
+  <string name="allow_bitwarden_authenticator_syncing">Allow authenticator syncing</string>
   <string name="there_was_an_issue_validating_the_registration_token">There was an issue validating the registration token.</string>
   <string name="turn_on_autofill">Turn on autofill</string>
   <string name="use_autofill_to_log_into_your_accounts">Use autofill to log into your accounts with a single tap.</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -1465,7 +1465,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
 
     @Test
     fun `sync with Bitwarden authenticator UI should be displayed according to state`() {
-        val toggleText = "Allow Bitwarden Authenticator Syncing"
+        val toggleText = "Allow authenticator syncing"
         composeTestRule.onNodeWithText(toggleText).assertDoesNotExist()
 
         mutableStateFlow.update { DEFAULT_STATE.copy(shouldShowEnableAuthenticatorSync = true) }
@@ -1486,7 +1486,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
     fun `sync with Bitwarden authenticator click should send AuthenticatorSyncToggle action`() {
         mutableStateFlow.update { DEFAULT_STATE.copy(shouldShowEnableAuthenticatorSync = true) }
         composeTestRule
-            .onNodeWithText("Allow Bitwarden Authenticator Syncing")
+            .onNodeWithText("Allow authenticator syncing")
             .performScrollTo()
             .performClick()
         verify { viewModel.trySendAction(AccountSecurityAction.AuthenticatorSyncToggle(true)) }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -710,13 +710,9 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
     @Test
     fun `when featureFlagManger returns true for AuthenticatorSync, and version is under 31 should not show authenticator sync UI`() {
         every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
-        val vm = createViewModel(
-            initialState = null,
-            featureFlagManager = mockk {
-                every { getFeatureFlag(FlagKey.AuthenticatorSync) } returns true
-                every { getFeatureFlagFlow(FlagKey.AuthenticatorSync) } returns emptyFlow()
-            },
-        )
+        every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns true
+        every { featureFlagManager.getFeatureFlagFlow(FlagKey.AuthenticatorSync) } returns emptyFlow()
+        val vm = createViewModel(initialState = null)
         assertEquals(
             DEFAULT_STATE,
             vm.stateFlow.value,
@@ -745,23 +741,22 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `when featureFlagManger updates value AuthenticatorSync, authenticator sync row should never show if below API 31`() = runTest {
-        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
-        val featureFlagFlow = MutableStateFlow(false)
-        val vm = createViewModel(
-            initialState = null,
-            featureFlagManager = mockk {
-                every { getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
-                every { getFeatureFlagFlow(FlagKey.AuthenticatorSync) } returns featureFlagFlow
-            },
-        )
-        vm.stateFlow.test {
-            assertEquals(DEFAULT_STATE, awaitItem())
-            featureFlagFlow.value = true
-            featureFlagFlow.value = false
-            expectNoEvents()
+    fun `when featureFlagManger updates value AuthenticatorSync, authenticator sync row should never show if below API 31`() =
+        runTest {
+            every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
+            val featureFlagFlow = MutableStateFlow(false)
+            every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
+            every {
+                featureFlagManager.getFeatureFlagFlow(FlagKey.AuthenticatorSync)
+            } returns featureFlagFlow
+            val vm = createViewModel(initialState = null)
+            vm.stateFlow.test {
+                assertEquals(DEFAULT_STATE, awaitItem())
+                featureFlagFlow.value = true
+                featureFlagFlow.value = false
+                expectNoEvents()
+            }
         }
-    }
 
     @Test
     fun `when showUnlockBadgeFlow updates value, should update state`() = runTest {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity
 
+import android.os.Build
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.x8bit.bitwarden.R
@@ -21,6 +22,7 @@ import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockPolicy
@@ -34,7 +36,9 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -43,7 +47,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.crypto.Cipher
 
@@ -85,6 +91,16 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
     }
     private val featureFlagManager: FeatureFlagManager = mockk(relaxed = true) {
         every { getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(::isBuildVersionBelow)
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkStatic(::isBuildVersionBelow)
     }
 
     @Test
@@ -675,7 +691,8 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `when featureFlagManger returns true for AuthenticatorSync, should show authenticator sync UI`() {
+    fun `when featureFlagManger returns true for AuthenticatorSync, and version is at least 31 should show authenticator sync UI`() {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns false
         val vm = createViewModel(
             initialState = null,
             featureFlagManager = mockk {
@@ -689,8 +706,26 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         )
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when featureFlagManger returns true for AuthenticatorSync, and version is under 31 should not show authenticator sync UI`() {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
+        val vm = createViewModel(
+            initialState = null,
+            featureFlagManager = mockk {
+                every { getFeatureFlag(FlagKey.AuthenticatorSync) } returns true
+                every { getFeatureFlagFlow(FlagKey.AuthenticatorSync) } returns emptyFlow()
+            },
+        )
+        assertEquals(
+            DEFAULT_STATE,
+            vm.stateFlow.value,
+        )
+    }
+
     @Test
     fun `when featureFlagManger updates value AuthenticatorSync, should update UI`() = runTest {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns false
         val featureFlagFlow = MutableStateFlow(false)
         val vm = createViewModel(
             initialState = null,
@@ -705,6 +740,26 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
             assertEquals(DEFAULT_STATE.copy(shouldShowEnableAuthenticatorSync = true), awaitItem())
             featureFlagFlow.value = false
             assertEquals(DEFAULT_STATE, awaitItem())
+        }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `when featureFlagManger updates value AuthenticatorSync, authenticator sync row should never show if below API 31`() = runTest {
+        every { isBuildVersionBelow(Build.VERSION_CODES.S) } returns true
+        val featureFlagFlow = MutableStateFlow(false)
+        val vm = createViewModel(
+            initialState = null,
+            featureFlagManager = mockk {
+                every { getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
+                every { getFeatureFlagFlow(FlagKey.AuthenticatorSync) } returns featureFlagFlow
+            },
+        )
+        vm.stateFlow.test {
+            assertEquals(DEFAULT_STATE, awaitItem())
+            featureFlagFlow.value = true
+            featureFlagFlow.value = false
+            expectNoEvents()
         }
     }
 

--- a/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/util/AndroidBuildUtils.kt
+++ b/authenticatorbridge/src/main/java/com/bitwarden/authenticatorbridge/util/AndroidBuildUtils.kt
@@ -7,4 +7,4 @@ import android.os.Build
  *
  * @see Build.VERSION_CODES
  */
-fun isBuildVersionBelow(version: Int): Boolean = version > Build.VERSION.SDK_INT
+internal fun isBuildVersionBelow(version: Int): Boolean = version > Build.VERSION.SDK_INT


### PR DESCRIPTION
## 🎟️ Tracking

https://livefront.atlassian.net/browse/BITAU-182
https://livefront.atlassian.net/browse/BITAU-107

## 📔 Objective

The goal of this PR is to not show authenticator sync UI when API level is below 31. Also, I made a small copy update that Lukus found while I was in there.

## 📸 Screenshots

Note: the design file is still using v2 design, so we can ignore that difference.

| Design | Implementation |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5ae01fe0-7abc-4cf0-a3c8-6c22359394e5" width="300" /> | <img src="https://github.com/user-attachments/assets/b4f0e5a3-8706-46a7-a6a4-0da0d6ad2ccb" width="300" /> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
