### PR TITLE
QA-954: Add testtags to Send screen elements

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.components.stepper
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.input.KeyboardType
@@ -64,9 +65,7 @@ fun BitwardenStepper(
                     }
                 },
                 isEnabled = isDecrementEnabled && !isAtRangeMinimum,
-                modifier = Modifier.semantics {
-                    decreaseButtonTestTag?.let { testTag = it }
-                },
+                modifier = Modifier.testTag("DecrementValue"),
             )
             BitwardenTonalIconButton(
                 vectorIconRes = R.drawable.ic_plus,
@@ -78,9 +77,7 @@ fun BitwardenStepper(
                     }
                 },
                 isEnabled = isIncrementEnabled && !isAtRangeMaximum,
-                modifier = Modifier.semantics {
-                    increaseButtonTestTag?.let { testTag = it }
-                },
+                modifier = Modifier.testTag("IncrementValue"),
             )
         },
         readOnly = textFieldReadOnly,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -3,8 +3,6 @@ package com.x8bit.bitwarden.ui.platform.components.stepper
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.ZERO_WIDTH_CHARACTER

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -39,8 +39,6 @@ fun BitwardenStepper(
     isDecrementEnabled: Boolean = true,
     textFieldReadOnly: Boolean = true,
     stepperActionsTestTag: String? = null,
-    increaseButtonTestTag: String? = null,
-    decreaseButtonTestTag: String? = null,
 ) {
     val clampedValue = value?.coerceIn(range)
     if (clampedValue != value && clampedValue != null) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -610,8 +610,6 @@ private fun PasswordMinNumbersCounterItem(
         value = minNumbers.coerceIn(minValue, maxValue),
         range = minValue..maxValue,
         onValueChange = onPasswordMinNumbersCounterChange,
-        increaseButtonTestTag = "MinNumberIncreaseButton",
-        decreaseButtonTestTag = "MinNumberDecreaseButton",
         modifier = Modifier
             .testTag("MinNumberValueLabel")
             .padding(horizontal = 16.dp),
@@ -630,8 +628,6 @@ private fun PasswordMinSpecialCharactersCounterItem(
         value = minSpecial.coerceIn(minValue, maxValue),
         range = minValue..maxValue,
         onValueChange = onPasswordMinSpecialCharactersChange,
-        increaseButtonTestTag = "MinSpecialIncreaseButton",
-        decreaseButtonTestTag = "MinSpecialDecreaseButton",
         modifier = Modifier
             .testTag("MinSpecialValueLabel")
             .padding(horizontal = 16.dp),
@@ -717,8 +713,6 @@ private fun PassphraseNumWordsCounterItem(
         range = minValue..maxValue,
         onValueChange = onPassphraseNumWordsCounterChange,
         stepperActionsTestTag = "NumberOfWordsStepper",
-        increaseButtonTestTag = "NumberOfWordsIncreaseButton",
-        decreaseButtonTestTag = "NumberOfWordsDecreaseButton",
         modifier = Modifier
             .testTag("NumberOfWordsLabel")
             .padding(horizontal = 16.dp),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendContent.kt
@@ -104,7 +104,8 @@ fun AddSendContent(
                     text = stringResource(id = R.string.send_disabled_warning),
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .testTag("SendPolicyInEffectLabel"),
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }
@@ -113,7 +114,7 @@ fun AddSendContent(
                 BitwardenInfoCalloutCard(
                     text = stringResource(id = R.string.send_options_policy_in_effect),
                     modifier = Modifier
-                        .testTag(tag = "SendOptionsPolicyInEffectLabel")
+                        .testTag(tag = "SendPolicyInEffectLabel")
                         .padding(horizontal = 16.dp)
                         .fillMaxWidth(),
                 )


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[QA-947]: https://bitwarden.atlassian.net/browse/QA-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ