### PR TITLE
QA-955: Adding testTag to About screen rows

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreen.kt
@@ -181,6 +181,7 @@ private fun ContentColumn(
             text = stringResource(id = R.string.bitwarden_help_center),
             onConfirmClick = onHelpCenterClick,
             dialogTitle = stringResource(id = R.string.continue_to_help_center),
+            modifier = Modifier.testTag("BitwardenHelpCenterRow"),
             dialogMessage = stringResource(
                 id = R.string.learn_more_about_how_to_use_bitwarden_on_the_help_center,
             ),
@@ -189,6 +190,7 @@ private fun ContentColumn(
             text = stringResource(id = R.string.privacy_policy),
             onConfirmClick = onPrivacyPolicyClick,
             dialogTitle = stringResource(id = R.string.continue_to_privacy_policy),
+            modifier = Modifier.testTag("PrivacyPolicyRow"),
             dialogMessage = stringResource(
                 id = R.string.privacy_policy_description_long,
             ),
@@ -196,6 +198,7 @@ private fun ContentColumn(
         BitwardenExternalLinkRow(
             text = stringResource(id = R.string.web_vault),
             onConfirmClick = onWebVaultClick,
+            modifier = Modifier.testTag("BitwardenWebVaultRow"),
             dialogTitle = stringResource(id = R.string.continue_to_web_app),
             dialogMessage = stringResource(
                 id = R.string.explore_more_features_of_your_bitwarden_account_on_the_web_app,
@@ -205,6 +208,7 @@ private fun ContentColumn(
             text = stringResource(id = R.string.learn_org),
             onConfirmClick = onLearnAboutOrgsClick,
             dialogTitle = stringResource(id = R.string.continue_to_x, "bitwarden.com"),
+            modifier = Modifier.testTag("LearnAboutOrganizationsRow"),
             dialogMessage = stringResource(
                 id = R.string.learn_about_organizations_description_long,
             ),
@@ -212,12 +216,14 @@ private fun ContentColumn(
         BitwardenExternalLinkRow(
             text = stringResource(R.string.give_feedback),
             onConfirmClick = onGiveFeedbackClick,
+            modifier = Modifier.testTag("GiveFeedbackRow"),
             dialogTitle = stringResource(R.string.continue_to_give_feedback),
             dialogMessage = stringResource(R.string.continue_to_provide_feedback),
         )
         CopyRow(
             text = state.version,
             onClick = onVersionClick,
+            modifier = Modifier.testTag("CopyAboutInfoRow"),
         )
         Box(
             modifier = Modifier


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[QA-947]: https://bitwarden.atlassian.net/browse/QA-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ