### PR TITLE
PM-14036: Update the slider UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/slider/BitwardenSlider.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/slider/BitwardenSlider.kt
@@ -2,17 +2,16 @@ package com.x8bit.bitwarden.ui.platform.components.slider
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,7 +20,9 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -68,12 +69,9 @@ fun BitwardenSlider(
     val density = LocalDensity.current
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp)
-            .semantics(mergeDescendants = true) {},
+        modifier = modifier.semantics(mergeDescendants = true) {},
     ) {
-        OutlinedTextField(
+        TextField(
             value = sliderValue.toString(),
             textStyle = BitwardenTheme.typography.bodyLarge,
             readOnly = true,
@@ -90,7 +88,11 @@ fun BitwardenSlider(
             },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            colors = bitwardenTextFieldColors(),
+            colors = bitwardenTextFieldColors(
+                disabledBorderColor = Color.Transparent,
+                focusedBorderColor = Color.Transparent,
+                unfocusedBorderColor = Color.Transparent,
+            ),
             modifier = Modifier
                 .onPreviewKeyEvent { keyEvent ->
                     when (keyEvent.key) {
@@ -125,6 +127,7 @@ fun BitwardenSlider(
                     interactionSource = remember { MutableInteractionSource() },
                     colors = bitwardenSliderColors(),
                     thumbSize = DpSize(width = 20.dp, height = 20.dp),
+                    modifier = Modifier.shadow(elevation = 2.dp, shape = CircleShape),
                 )
             },
             track = { sliderState ->

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -458,6 +458,9 @@ private fun ColumnScope.PasswordTypeContent(
         range = passwordTypeState.computedMinimumLength..passwordTypeState.maxLength,
         sliderTag = "PasswordLengthSlider",
         valueTag = "PasswordLengthLabel",
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(end = 16.dp),
     )
 
     Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14036](https://bitwarden.atlassian.net/browse/PM-14036)

## 📔 Objective

This PR updates the `BitwardenSlider` to match the v3 designs.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ab49dbf7-4c2d-4f24-9650-6f714dec5fb4" width="300" /> | <img src="https://github.com/user-attachments/assets/06b094ab-288d-480b-a505-5c849b4925f2" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14036]: https://bitwarden.atlassian.net/browse/PM-14036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ