### PR TITLE
PM-13698 only dismiss the card if the user dismisses or completes the…

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
@@ -104,6 +104,7 @@ class SetupAutoFillViewModel @Inject constructor(
     }
 
     private fun handleContinueClick() {
+        firstTimeActionManager.storeShowAutoFillSettingBadge(showBadge = false)
         if (state.isInitialSetup) {
             updateOnboardingStatusToNextStep()
         } else {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
@@ -80,6 +80,7 @@ class SetupUnlockViewModel @Inject constructor(
     }
 
     private fun handleContinueClick() {
+        firstTimeActionManager.storeShowUnlockSettingBadge(showBadge = false)
         if (state.isInitialSetup) {
             updateOnboardingStatusToNextStep()
         } else {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.vault.feature.importlogins
 
 import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
@@ -19,6 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ImportLoginsViewModel @Inject constructor(
     private val vaultRepository: VaultRepository,
+    private val firstTimeActionManager: FirstTimeActionManager,
 ) :
     BaseViewModel<ImportLoginsState, ImportLoginsEvent, ImportLoginsAction>(
         initialState = ImportLoginsState(
@@ -94,6 +96,7 @@ class ImportLoginsViewModel @Inject constructor(
 
             is SyncVaultDataResult.Success -> {
                 if (result.itemsAvailable) {
+                    firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
                     mutableStateFlow.update {
                         it.copy(
                             showBottomSheet = true,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
@@ -143,24 +143,25 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
     @Test
     fun `handleContinueClick send NavigateBack event when not initial setup and sets first time flag to false`() =
         runTest {
-        val viewModel = createViewModel(initialState = DEFAULT_STATE.copy(isInitialSetup = false))
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(SetupAutoFillAction.ContinueClick)
-            assertEquals(
-                SetupAutoFillEvent.NavigateBack,
-                awaitItem(),
-            )
-        }
+            val viewModel =
+                createViewModel(initialState = DEFAULT_STATE.copy(isInitialSetup = false))
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(SetupAutoFillAction.ContinueClick)
+                assertEquals(
+                    SetupAutoFillEvent.NavigateBack,
+                    awaitItem(),
+                )
+            }
             verify(exactly = 1) {
                 firstTimeActionManager.storeShowAutoFillSettingBadge(showBadge = false)
             }
-        verify(exactly = 0) {
-            authRepository.setOnboardingStatus(
-                DEFAULT_USER_ID,
-                OnboardingStatus.FINAL_STEP,
-            )
+            verify(exactly = 0) {
+                authRepository.setOnboardingStatus(
+                    DEFAULT_USER_ID,
+                    OnboardingStatus.FINAL_STEP,
+                )
+            }
         }
-    }
 
     @Test
     fun `handleTurnOnLaterConfirmClick sets showAutoFillSettingBadge to true`() {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
@@ -125,20 +125,24 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `handleContinueClick sets onboarding status to FINAL_STEP`() {
+    fun `handleContinueClick sets onboarding status to FINAL_STEP and sets first time flag to false`() {
         val viewModel = createViewModel()
         viewModel.trySendAction(SetupAutoFillAction.ContinueClick)
-        verify {
+        verify(exactly = 1) {
             authRepository.setOnboardingStatus(
                 DEFAULT_USER_ID,
                 OnboardingStatus.FINAL_STEP,
             )
+            firstTimeActionManager.storeShowAutoFillSettingBadge(showBadge = false)
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `handleContinueClick send NavigateBack event when not initial setup`() = runTest {
+    fun `handleContinueClick send NavigateBack event when not initial setup and sets first time flag to false`() =
+        runTest {
         val viewModel = createViewModel(initialState = DEFAULT_STATE.copy(isInitialSetup = false))
         viewModel.eventFlow.test {
             viewModel.trySendAction(SetupAutoFillAction.ContinueClick)
@@ -147,6 +151,9 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
                 awaitItem(),
             )
         }
+            verify(exactly = 1) {
+                firstTimeActionManager.storeShowAutoFillSettingBadge(showBadge = false)
+            }
         verify(exactly = 0) {
             authRepository.setOnboardingStatus(
                 DEFAULT_USER_ID,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
@@ -86,14 +86,16 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `ContinueClick should send NavigateBack event if this is not the initial setup`() =
+    fun `ContinueClick should send NavigateBack event if this is not the initial setup and set first time value to false`() =
         runTest {
             val viewModel = createViewModel(DEFAULT_STATE.copy(isInitialSetup = false))
             viewModel.eventFlow.test {
                 viewModel.trySendAction(SetupUnlockAction.ContinueClick)
                 assertEquals(SetupUnlockEvent.NavigateBack, awaitItem())
             }
-
+            verify(exactly = 1) {
+                firstTimeActionManager.storeShowUnlockSettingBadge(showBadge = false)
+            }
             verify(exactly = 0) {
                 authRepository.setOnboardingStatus(
                     userId = DEFAULT_USER_ID,
@@ -118,15 +120,16 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `ContinueClick should call setOnboardingStatus and set to FINAL_STEP if AutoFill is already enabled`() {
+    fun `ContinueClick should call setOnboardingStatus and set to FINAL_STEP if AutoFill is already enabled and set first time value to false`() {
         mutableAutofillEnabledStateFlow.update { true }
         val viewModel = createViewModel()
         viewModel.trySendAction(SetupUnlockAction.ContinueClick)
-        verify {
+        verify(exactly = 1) {
             authRepository.setOnboardingStatus(
                 userId = DEFAULT_USER_ID,
                 status = OnboardingStatus.FINAL_STEP,
             )
+            firstTimeActionManager.storeShowUnlockSettingBadge(showBadge = false)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13986
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Action card/settings badges should be removed when the action's flow is complete (or if they are dismissed, which is already implemented).
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/72727cf7-04aa-40df-9675-344045e00d63


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
