### PR TITLE
Simplify usages of turbineScope

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -4309,18 +4309,11 @@ class VaultRepositoryTest {
                 )
             } returns Throwable().asFailure()
 
-            turbineScope {
-                val expected = DecryptFido2CredentialAutofillViewResult.Error
-                val result = vaultRepository
-                    .getDecryptedFido2CredentialAutofillViews(
-                        cipherViewList = cipherViewList,
-                    )
+            val result = vaultRepository.getDecryptedFido2CredentialAutofillViews(
+                cipherViewList = cipherViewList,
+            )
 
-                assertEquals(
-                    expected,
-                    result,
-                )
-            }
+            assertEquals(DecryptFido2CredentialAutofillViewResult.Error, result)
             coVerify {
                 vaultSdkSource.decryptFido2CredentialAutofillViews(
                     userId = MOCK_USER_STATE.activeUserId,
@@ -4346,17 +4339,11 @@ class VaultRepositoryTest {
                 )
             } returns autofillViewList.asSuccess()
 
-            turbineScope {
-                val result = vaultRepository
-                    .getDecryptedFido2CredentialAutofillViews(
-                        cipherViewList = cipherViewList,
-                    )
+            val result = vaultRepository.getDecryptedFido2CredentialAutofillViews(
+                cipherViewList = cipherViewList,
+            )
 
-                assertEquals(
-                    expected,
-                    result,
-                )
-            }
+            assertEquals(expected, result)
             coVerify {
                 vaultSdkSource.decryptFido2CredentialAutofillViews(
                     userId = MOCK_USER_STATE.activeUserId,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.ui.auth.feature.completeregistration
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_0
 import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_1
@@ -154,9 +153,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
                 )
             } returns RegisterResult.Success(captchaToken = CAPTCHA_BYPASS_TOKEN)
             val viewModel = createCompleteRegistrationViewModel(VALID_INPUT_STATE)
-            turbineScope {
-                val stateFlow = viewModel.stateFlow.testIn(backgroundScope)
-                val eventFlow = viewModel.eventFlow.testIn(backgroundScope)
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 assertEquals(VALID_INPUT_STATE, stateFlow.awaitItem())
                 viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
                 assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModelTest.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.auth.feature.createaccount
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_0
 import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength.LEVEL_1
@@ -243,9 +242,7 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
             savedStateHandle = validInputHandle,
             authRepository = repo,
         )
-        turbineScope {
-            val stateFlow = viewModel.stateFlow.testIn(backgroundScope)
-            val eventFlow = viewModel.eventFlow.testIn(backgroundScope)
+        viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
             assertEquals(VALID_INPUT_STATE, stateFlow.awaitItem())
             viewModel.trySendAction(CreateAccountAction.SubmitClick)
             assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.auth.feature.enterprisesignon
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
@@ -511,10 +510,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
             )
             val ssoCallbackResult = SsoCallbackResult.Success(state = "abc", code = "lmn")
 
-            turbineScope {
-                val stateFlow = viewModel.stateFlow.testIn(backgroundScope)
-                val eventFlow = viewModel.eventFlow.testIn(backgroundScope)
-
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 assertEquals(initialState, stateFlow.awaitItem())
 
                 mutableSsoCallbackResultFlow.tryEmit(ssoCallbackResult)
@@ -566,10 +562,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
             )
             val ssoCallbackResult = SsoCallbackResult.Success(state = "abc", code = "lmn")
 
-            turbineScope {
-                val stateFlow = viewModel.stateFlow.testIn(backgroundScope)
-                val eventFlow = viewModel.eventFlow.testIn(backgroundScope)
-
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 assertEquals(initialState, stateFlow.awaitItem())
 
                 mutableSsoCallbackResultFlow.tryEmit(ssoCallbackResult)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.auth.feature.startregistration
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.SendVerificationEmailResult
@@ -177,9 +176,7 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
             environmentRepository = fakeEnvironmentRepository,
             featureFlagManager = featureFlagManager,
         )
-        turbineScope {
-            val stateFlow = viewModel.stateFlow.testIn(backgroundScope)
-            val eventFlow = viewModel.eventFlow.testIn(backgroundScope)
+        viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
             assertEquals(VALID_INPUT_STATE, stateFlow.awaitItem())
             viewModel.trySendAction(ContinueClick)
             assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.vault.feature.addedit
 import android.content.pm.SigningInfo
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.bitwarden.send.SendView
 import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.CollectionView
@@ -611,25 +610,22 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 vaultRepository.createCipherInOrganization(any(), any())
             } returns CreateCipherResult.Success
 
-            turbineScope {
-                val stateTurbine = viewModel.stateFlow.testIn(backgroundScope)
-                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
-
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
-                assertEquals(stateWithName, stateTurbine.awaitItem())
-                assertEquals(stateWithDialog, stateTurbine.awaitItem())
-                assertEquals(stateWithName, stateTurbine.awaitItem())
+                assertEquals(stateWithName, stateFlow.awaitItem())
+                assertEquals(stateWithDialog, stateFlow.awaitItem())
+                assertEquals(stateWithName, stateFlow.awaitItem())
 
                 assertEquals(
                     VaultAddEditEvent.ShowToast(
                         R.string.new_item_created.asText(),
                     ),
-                    eventTurbine.awaitItem(),
+                    eventFlow.awaitItem(),
                 )
                 assertEquals(
                     VaultAddEditEvent.NavigateBack,
-                    eventTurbine.awaitItem(),
+                    eventFlow.awaitItem(),
                 )
             }
             coVerify(exactly = 1) {
@@ -680,19 +676,16 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 vaultRepository.createCipherInOrganization(any(), any())
             } returns CreateCipherResult.Success
 
-            turbineScope {
-                val stateTurbine = viewModel.stateFlow.testIn(backgroundScope)
-                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
-
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
-                assertEquals(stateWithName, stateTurbine.awaitItem())
-                assertEquals(stateWithDialog, stateTurbine.awaitItem())
-                assertEquals(stateWithName, stateTurbine.awaitItem())
+                assertEquals(stateWithName, stateFlow.awaitItem())
+                assertEquals(stateWithDialog, stateFlow.awaitItem())
+                assertEquals(stateWithName, stateFlow.awaitItem())
 
                 assertEquals(
                     VaultAddEditEvent.ExitApp,
-                    eventTurbine.awaitItem(),
+                    eventFlow.awaitItem(),
                 )
             }
             assertNull(specialCircumstanceManager.specialCircumstance)
@@ -821,17 +814,14 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             } returns mockAttestationOptions
             every { authRepository.activeUserId } returns "mockUserId"
 
-            turbineScope {
-                val stateTurbine = viewModel.stateFlow.testIn(backgroundScope)
-                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
-
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
-                assertEquals(stateWithNewLogin, stateTurbine.awaitItem())
-                assertEquals(stateWithSavingDialog, stateTurbine.awaitItem())
+                assertEquals(stateWithNewLogin, stateFlow.awaitItem())
+                assertEquals(stateWithSavingDialog, stateFlow.awaitItem())
                 assertEquals(
                     VaultAddEditEvent.Fido2UserVerification(isRequired = true),
-                    eventTurbine.awaitItem(),
+                    eventFlow.awaitItem(),
                 )
             }
         }
@@ -899,22 +889,19 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             } returns mockAttestationOptions
             every { authRepository.activeUserId } returns mockUserId
 
-            turbineScope {
-                val stateTurbine = viewModel.stateFlow.testIn(backgroundScope)
-                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
-
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
-                assertEquals(stateWithName, stateTurbine.awaitItem())
-                assertEquals(stateWithSavingDialog, stateTurbine.awaitItem())
+                assertEquals(stateWithName, stateFlow.awaitItem())
+                assertEquals(stateWithSavingDialog, stateFlow.awaitItem())
                 assertEquals(
                     VaultAddEditEvent.ShowToast(R.string.item_updated.asText()),
-                    eventTurbine.awaitItem(),
+                    eventFlow.awaitItem(),
                 )
-                assertEquals(stateWithName, stateTurbine.awaitItem())
+                assertEquals(stateWithName, stateFlow.awaitItem())
                 assertEquals(
                     VaultAddEditEvent.CompleteFido2Registration(mockCreateResult),
-                    eventTurbine.awaitItem(),
+                    eventFlow.awaitItem(),
                 )
                 coVerify(exactly = 1) {
                     fido2CredentialManager.registerFido2Credential(
@@ -1059,11 +1046,10 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
             viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
-            turbineScope {
-                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
+            viewModel.eventFlow.test {
                 assertEquals(
                     VaultAddEditEvent.Fido2UserVerification(isRequired = false),
-                    eventTurbine.awaitItem(),
+                    awaitItem(),
                 )
             }
         }
@@ -1105,11 +1091,10 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
             viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
-            turbineScope {
-                val eventTurbine = viewModel.eventFlow.testIn(backgroundScope)
+            viewModel.eventFlow.test {
                 assertEquals(
                     VaultAddEditEvent.Fido2UserVerification(isRequired = true),
-                    eventTurbine.awaitItem(),
+                    awaitItem(),
                 )
             }
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.ui.vault.feature.importlogins
 
 import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
@@ -95,9 +94,7 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
     @Test
     fun `ConfirmImportLater sets dialog state to null and sends NavigateBack event`() = runTest {
         val viewModel = createViewModel()
-        turbineScope {
-            val stateFlow = viewModel.stateFlow.testIn(backgroundScope)
-            val eventFlow = viewModel.eventFlow.testIn(backgroundScope)
+        viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
             // Initial state
             assertEquals(DEFAULT_STATE, stateFlow.awaitItem())
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.vault.feature.item
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
@@ -653,9 +652,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                 val loginState = DEFAULT_STATE.copy(viewState = loginViewState)
                 val viewModel = createViewModel(state = loginState)
 
-                turbineScope {
-                    val stateFlow = viewModel.stateFlow.testIn(backgroundScope)
-                    val eventFlow = viewModel.eventFlow.testIn(backgroundScope)
+                viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                     assertEquals(loginState, stateFlow.awaitItem())
                     viewModel.trySendAction(
                         VaultItemAction.Common.MasterPasswordSubmit(


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates usages of `turbinScope` in test to make them a bit cleaner.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
