### PR TITLE
[PM-13900] Update Bitwarden SDK to add `canManage` to Collection objects

### DIFF
--- a/app/schemas/com.x8bit.bitwarden.data.vault.datasource.disk.database.VaultDatabase/4.json
+++ b/app/schemas/com.x8bit.bitwarden.data.vault.datasource.disk.database.VaultDatabase/4.json
@@ -1,0 +1,256 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "f7906c69e0a2c065d4d3be140fc721b6",
+    "entities": [
+      {
+        "tableName": "ciphers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `cipher_type` TEXT NOT NULL, `cipher_json` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cipherType",
+            "columnName": "cipher_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cipherJson",
+            "columnName": "cipher_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ciphers_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ciphers_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `organization_id` TEXT NOT NULL, `should_hide_passwords` INTEGER NOT NULL, `name` TEXT NOT NULL, `external_id` TEXT, `read_only` INTEGER NOT NULL, `manage` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "organizationId",
+            "columnName": "organization_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldHidePasswords",
+            "columnName": "should_hide_passwords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalId",
+            "columnName": "external_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isReadOnly",
+            "columnName": "read_only",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManage",
+            "columnName": "manage",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collections_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "domains",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` TEXT NOT NULL, `domains_json` TEXT NOT NULL, PRIMARY KEY(`user_id`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainsJson",
+            "columnName": "domains_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "user_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `name` TEXT, `revision_date` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "revisionDate",
+            "columnName": "revision_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_folders_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_folders_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sends",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `send_type` TEXT NOT NULL, `send_json` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sendType",
+            "columnName": "send_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sendJson",
+            "columnName": "send_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sends_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sends_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f7906c69e0a2c065d4d3be140fc721b6')"
+    ]
+  }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -94,6 +94,7 @@ class VaultDiskSourceImpl(
                 shouldHidePasswords = collection.shouldHidePasswords,
                 externalId = collection.externalId,
                 isReadOnly = collection.isReadOnly,
+                canManage = collection.canManage,
             ),
         )
     }
@@ -114,6 +115,7 @@ class VaultDiskSourceImpl(
                             shouldHidePasswords = entity.shouldHidePasswords,
                             externalId = entity.externalId,
                             isReadOnly = entity.isReadOnly,
+                            canManage = entity.canManage,
                         )
                     }
                 },
@@ -229,6 +231,7 @@ class VaultDiskSourceImpl(
                             shouldHidePasswords = collection.shouldHidePasswords,
                             externalId = collection.externalId,
                             isReadOnly = collection.isReadOnly,
+                            canManage = collection.canManage,
                         )
                     },
                 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/database/VaultDatabase.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/database/VaultDatabase.kt
@@ -26,7 +26,7 @@ import com.x8bit.bitwarden.data.vault.datasource.disk.entity.SendEntity
         FolderEntity::class,
         SendEntity::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 @TypeConverters(ZonedDateTimeTypeConverter::class)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/entity/CollectionEntity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/entity/CollectionEntity.kt
@@ -30,4 +30,7 @@ data class CollectionEntity(
 
     @ColumnInfo(name = "read_only")
     val isReadOnly: Boolean,
+
+    @ColumnInfo(name = "manage")
+    val canManage: Boolean,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
@@ -969,5 +969,8 @@ data class SyncResponseJson(
 
         @SerialName("id")
         val id: String,
+
+        @SerialName("manage")
+        val canManage: Boolean,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCollectionExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCollectionExtensions.kt
@@ -17,6 +17,7 @@ fun SyncResponseJson.Collection.toEncryptedSdkCollection(): Collection =
         externalId = this.externalId,
         hidePasswords = this.shouldHidePasswords,
         readOnly = this.isReadOnly,
+        manage = this.canManage,
     )
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -431,6 +431,7 @@ private val COLLECTION_ENTITY = CollectionEntity(
     name = "mockName-3",
     externalId = "mockExternalId-3",
     isReadOnly = false,
+    canManage = true,
 )
 
 private const val DOMAINS_JSON = """

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseCollectionUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseCollectionUtil.kt
@@ -11,4 +11,5 @@ fun createMockCollection(number: Int): SyncResponseJson.Collection =
         externalId = "mockExternalId-$number",
         isReadOnly = false,
         id = "mockId-$number",
+        canManage = true,
     )

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceTest.kt
@@ -193,7 +193,8 @@ private const val SYNC_SUCCESS_JSON = """
       "name": "mockName-1",
       "externalId": "mockExternalId-1",
       "readOnly": false,
-      "id": "mockId-1"
+      "id": "mockId-1",
+      "manage": true
     }
   ],
   "ciphers": [

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CollectionViewUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CollectionViewUtil.kt
@@ -13,4 +13,5 @@ fun createMockCollectionView(number: Int, name: String? = null): CollectionView 
         name = name ?: "mockName-$number",
         externalId = "mockExternalId-$number",
         readOnly = false,
+        manage = true,
     )

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/VaultSdkCollectionUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/VaultSdkCollectionUtil.kt
@@ -13,4 +13,5 @@ fun createMockSdkCollection(number: Int): Collection =
         name = "mockName-$number",
         externalId = "mockExternalId-$number",
         readOnly = false,
+        manage = true,
     )

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCollectionExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCollectionExtensionsTest.kt
@@ -17,6 +17,7 @@ class VaultSdkCollectionExtensionsTest {
                 externalId = "externalId",
                 readOnly = true,
                 id = "id",
+                manage = true,
             ),
             SyncResponseJson.Collection(
                 organizationId = "organizationId",
@@ -25,6 +26,7 @@ class VaultSdkCollectionExtensionsTest {
                 externalId = "externalId",
                 isReadOnly = true,
                 id = "id",
+                canManage = true,
             )
                 .toEncryptedSdkCollection(),
         )
@@ -42,6 +44,7 @@ class VaultSdkCollectionExtensionsTest {
                     externalId = "externalId",
                     readOnly = true,
                     id = "id",
+                    manage = true,
                 ),
             ),
             listOf(
@@ -52,6 +55,7 @@ class VaultSdkCollectionExtensionsTest {
                     externalId = "externalId",
                     isReadOnly = true,
                     id = "id",
+                    canManage = true,
                 )
                     .toEncryptedSdkCollection(),
             ),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ androidxSplash = "1.1.0-rc01"
 androidXAppCompat = "1.7.0"
 androdixAutofill = "1.1.0"
 androidxWork = "2.9.1"
-bitwardenSdk = "1.0.0-20241021.160919-71"
+bitwardenSdk = "1.0.0-20241024.173753-4"
 crashlytics = "3.0.2"
 detekt = "1.23.7"
 firebaseBom = "33.5.1"
@@ -84,7 +84,7 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidXSecurityCrypto" }
 androidx-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidxSplash" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidxWork" }
-bitwarden-sdk = { module = "com.bitwarden:sdk-android", version.ref = "bitwardenSdk" }
+bitwarden-sdk = { module = "com.bitwarden:sdk-android-temp", version.ref = "bitwardenSdk" }
 bumptech-glide = { module = "com.github.bumptech.glide:compose", version.ref = "glide" }
 detekt-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detekt-detekt-rules = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }


### PR DESCRIPTION
## 🎟️ Tracking

### JIRA

https://bitwarden.atlassian.net/browse/PM-13900
https://bitwarden.atlassian.net/browse/PM-13933
https://bitwarden.atlassian.net/browse/PM-14062

### GitHub
Closes #4171

## 📔 Objective
This commit updates the Bitwarden SDK to the latest version and references the temporary internal group name. The group name will be reverted back when internal SDK infrastructure changes are completed.

This commit also adds the `canManage` property to the `CollectionEntity` and `SyncResponseJson` classes to support the management of collections. It also includes necessary test updates and updates to the database schema to reflect these changes.

Depends on #4158

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
