### PR TITLE
PM-14009 complete fix importlogins card show logic

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -298,4 +298,20 @@ interface SettingsDiskSource {
      * Emits updates that track [getShowUnlockSettingBadge] for the given [userId].
      */
     fun getShowUnlockSettingBadgeFlow(userId: String): Flow<Boolean?>
+
+    /**
+     * Gets whether or not the given [userId] has signalled they want to import logins later.
+     */
+    fun getShowImportLoginsSettingBadge(userId: String): Boolean?
+
+    /**
+     * Stores the given value for whether or not the given [userId] has signalled they want to
+     * set import logins later, during first time usage.
+     */
+    fun storeShowImportLoginsSettingBadge(userId: String, showBadge: Boolean?)
+
+    /**
+     * Emits updates that track [getShowImportLoginsSettingBadge] for the given [userId].
+     */
+    fun getShowImportLoginsSettingBadgeFlow(userId: String): Flow<Boolean?>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -35,6 +35,7 @@ private const val INITIAL_AUTOFILL_DIALOG_SHOWN = "addSitePromptShown"
 private const val HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY = "hasUserLoggedInOrCreatedAccount"
 private const val SHOW_AUTOFILL_SETTING_BADGE = "showAutofillSettingBadge"
 private const val SHOW_UNLOCK_SETTING_BADGE = "showUnlockSettingBadge"
+private const val SHOW_IMPORT_LOGINS_SETTING_BADGE = "showImportLoginsSettingBadge"
 private const val LAST_SCHEME_CHANGE_INSTANT = "lastDatabaseSchemeChangeInstant"
 
 /**
@@ -63,6 +64,9 @@ class SettingsDiskSourceImpl(
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     private val mutableShowUnlockSettingBadgeFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutableShowImportLoginsSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     private val mutableIsIconLoadingDisabledFlow = bufferedMutableSharedFlow<Boolean?>()
@@ -412,6 +416,24 @@ class SettingsDiskSourceImpl(
         getMutableShowUnlockSettingBadgeFlow(userId = userId)
             .onSubscription { emit(getShowUnlockSettingBadge(userId)) }
 
+    override fun getShowImportLoginsSettingBadge(userId: String): Boolean? {
+        return getBoolean(
+            key = SHOW_IMPORT_LOGINS_SETTING_BADGE.appendIdentifier(userId),
+        )
+    }
+
+    override fun storeShowImportLoginsSettingBadge(userId: String, showBadge: Boolean?) {
+        putBoolean(
+            key = SHOW_IMPORT_LOGINS_SETTING_BADGE.appendIdentifier(userId),
+            showBadge,
+        )
+        getMutableShowImportLoginsSettingBadgeFlow(userId).tryEmit(showBadge)
+    }
+
+    override fun getShowImportLoginsSettingBadgeFlow(userId: String): Flow<Boolean?> =
+        getMutableShowImportLoginsSettingBadgeFlow(userId)
+            .onSubscription { emit(getShowImportLoginsSettingBadge(userId)) }
+
     private fun getMutableLastSyncFlow(
         userId: String,
     ): MutableSharedFlow<Instant?> =
@@ -453,6 +475,13 @@ class SettingsDiskSourceImpl(
 
     private fun getMutableShowUnlockSettingBadgeFlow(userId: String): MutableSharedFlow<Boolean?> =
         mutableShowUnlockSettingBadgeFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutableShowImportLoginsSettingBadgeFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> =
+        mutableShowImportLoginsSettingBadgeFlowMap.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManager.kt
@@ -61,4 +61,9 @@ interface FirstTimeActionManager {
      * Update the value of the showImportLogins status for the active user.
      */
     fun storeShowImportLogins(showImportLogins: Boolean)
+
+    /**
+     * Update the value of the showImportLoginsSettingsBadge status for the active user.
+     */
+    fun storeShowImportLoginsSettingsBadge(showBadge: Boolean)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FirstTimeState.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FirstTimeState.kt
@@ -5,6 +5,7 @@ package com.x8bit.bitwarden.data.platform.manager.model
  */
 data class FirstTimeState(
     val showImportLoginsCard: Boolean,
+    val showImportLoginsCardInSettings: Boolean,
     val showSetupUnlockCard: Boolean,
     val showSetupAutofillCard: Boolean,
 ) {
@@ -16,9 +17,11 @@ data class FirstTimeState(
         showImportLoginsCard: Boolean? = null,
         showSetupUnlockCard: Boolean? = null,
         showSetupAutofillCard: Boolean? = null,
+        showImportLoginsCardInSettings: Boolean? = null,
     ) : this(
         showImportLoginsCard = showImportLoginsCard ?: true,
         showSetupUnlockCard = showSetupUnlockCard ?: false,
         showSetupAutofillCard = showSetupAutofillCard ?: false,
+        showImportLoginsCardInSettings = showImportLoginsCardInSettings ?: false,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
@@ -33,7 +33,7 @@ class VaultSettingsViewModel @Inject constructor(
                 .toBaseWebVaultImportUrl,
             isNewImportLoginsFlowEnabled = featureFlagManager
                 .getFeatureFlag(FlagKey.ImportLoginsFlow),
-            showImportActionCard = firstTimeState.showImportLoginsCard,
+            showImportActionCard = firstTimeState.showImportLoginsCardInSettings,
         )
     },
 ) {
@@ -48,7 +48,7 @@ class VaultSettingsViewModel @Inject constructor(
             .firstTimeStateFlow
             .map {
                 VaultSettingsAction.Internal.UserFirstTimeStateChanged(
-                    showImportLoginsCard = it.showImportLoginsCard,
+                    showImportLoginsCard = it.showImportLoginsCardInSettings,
                 )
             }
             .onEach(::sendAction)
@@ -79,7 +79,7 @@ class VaultSettingsViewModel @Inject constructor(
 
     private fun handleImportLoginsCardDismissClicked() {
         if (!state.shouldShowImportCard) return
-        firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
+        firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = false)
     }
 
     private fun handleImportLoginsCardClicked() {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
@@ -97,6 +97,7 @@ class ImportLoginsViewModel @Inject constructor(
             is SyncVaultDataResult.Success -> {
                 if (result.itemsAvailable) {
                     firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
+                    firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = false)
                     mutableStateFlow.update {
                         it.copy(
                             showBottomSheet = true,
@@ -160,6 +161,8 @@ class ImportLoginsViewModel @Inject constructor(
 
     private fun handleConfirmImportLater() {
         dismissDialog()
+        firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
+        firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = true)
         sendEvent(ImportLoginsEvent.NavigateBack)
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -186,6 +186,7 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleDismissImportActionCard() {
+        firstTimeActionManager.storeShowImportLoginsSettingsBadge(true)
         if (!state.showImportActionCard) return
         firstTimeActionManager.storeShowImportLogins(false)
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1062,10 +1062,10 @@ class SettingsDiskSourceTest {
     @Test
     fun `storeShowAutoFillSettingBadge should update the flow value`() = runTest {
         val mockUserId = "mockUserId"
-        settingsDiskSource.storeShowAutoFillSettingBadge(mockUserId, true)
         settingsDiskSource.getShowAutoFillSettingBadgeFlow(userId = mockUserId).test {
             // The initial values of the Flow are in sync
-            assertTrue(awaitItem() ?: false)
+            assertFalse(awaitItem() ?: false)
+            settingsDiskSource.storeShowAutoFillSettingBadge(mockUserId, true)
             assertTrue(awaitItem() ?: false)
 
             // update the value to false
@@ -1103,10 +1103,10 @@ class SettingsDiskSourceTest {
     @Test
     fun `storeShowUnlockSettingsBadge should update the flow value`() = runTest {
         val mockUserId = "mockUserId"
-        settingsDiskSource.storeShowUnlockSettingBadge(mockUserId, true)
         settingsDiskSource.getShowUnlockSettingBadgeFlow(userId = mockUserId).test {
             // The initial values of the Flow are in sync
-            assertTrue(awaitItem() ?: false)
+            assertFalse(awaitItem() ?: false)
+            settingsDiskSource.storeShowUnlockSettingBadge(mockUserId, true)
             assertTrue(awaitItem() ?: false)
 
             // update the value to false
@@ -1164,5 +1164,48 @@ class SettingsDiskSourceTest {
             schemeChangeInstant.toEpochMilli(),
             actual,
         )
+    }
+
+    @Test
+    fun `getShowImportLoginsSettingBadge should pull from shared preferences`() {
+        val mockUserId = "mockUserId"
+        val showImportLoginsSettingBadgeKey =
+            "bwPreferencesStorage:showImportLoginsSettingBadge_$mockUserId"
+        fakeSharedPreferences.edit {
+            putBoolean(showImportLoginsSettingBadgeKey, true)
+        }
+        assertTrue(
+            settingsDiskSource.getShowImportLoginsSettingBadge(userId = mockUserId)!!,
+        )
+    }
+
+    @Test
+    fun `storeShowImportLoginsSettingBadge should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val showImportLoginsSettingBadgeKey =
+            "bwPreferencesStorage:showImportLoginsSettingBadge_$mockUserId"
+        settingsDiskSource.storeShowImportLoginsSettingBadge(mockUserId, true)
+        assertTrue(
+            fakeSharedPreferences.getBoolean(showImportLoginsSettingBadgeKey, false),
+        )
+    }
+
+    @Test
+    fun `storeShowImportLoginsSettingBadge should update the flow value`() = runTest {
+        val mockUserId = "mockUserId"
+        settingsDiskSource.getShowImportLoginsSettingBadgeFlow(mockUserId).test {
+            // The initial values of the Flow are in sync
+            assertFalse(awaitItem() ?: false)
+            settingsDiskSource.storeShowImportLoginsSettingBadge(
+                userId = mockUserId,
+                showBadge = true,
+            )
+            assertTrue(awaitItem() ?: false)
+            // update the value to false
+            settingsDiskSource.storeShowImportLoginsSettingBadge(
+                userId = mockUserId, false,
+            )
+            assertFalse(awaitItem() ?: true)
+        }
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -63,12 +63,16 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val userSignIns = mutableMapOf<String, Boolean>()
     private val userShowAutoFillBadge = mutableMapOf<String, Boolean?>()
     private val userShowUnlockBadge = mutableMapOf<String, Boolean?>()
+    private val userShowImportLoginsBadge = mutableMapOf<String, Boolean?>()
     private var storedLastDatabaseSchemeChangeInstant: Instant? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     private val mutableShowUnlockSettingBadgeFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutableShowImportLoginsSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     override var appLanguage: AppLanguage? = null
@@ -323,6 +327,19 @@ class FakeSettingsDiskSource : SettingsDiskSource {
             emit(getShowUnlockSettingBadge(userId = userId))
         }
 
+    override fun getShowImportLoginsSettingBadge(userId: String): Boolean? =
+        userShowImportLoginsBadge[userId]
+
+    override fun storeShowImportLoginsSettingBadge(userId: String, showBadge: Boolean?) {
+        userShowImportLoginsBadge[userId] = showBadge
+        getMutableShowImportLoginsSettingBadgeFlow(userId).tryEmit(showBadge)
+    }
+
+    override fun getShowImportLoginsSettingBadgeFlow(userId: String): Flow<Boolean?> =
+        getMutableShowImportLoginsSettingBadgeFlow(userId = userId).onSubscription {
+            emit(getShowImportLoginsSettingBadge(userId = userId))
+        }
+
     //region Private helper functions
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {
         return mutableScreenCaptureAllowedFlowMap.getOrPut(userId) {
@@ -368,6 +385,12 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         mutableShowUnlockSettingBadgeFlowMap.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
+
+    private fun getMutableShowImportLoginsSettingBadgeFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> = mutableShowImportLoginsSettingBadgeFlowMap.getOrPut(userId) {
+        bufferedMutableSharedFlow(replay = 1)
+    }
 
     //endregion Private helper functions
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -110,7 +110,7 @@ class FirstTimeActionManagerTest {
                 // for the import logins count it is dependent on the feature flag state and
                 // cipher list being empty
                 mutableImportLoginsFlow.update { true }
-                fakeAuthDiskSource.storeShowImportLogins(USER_ID, true)
+                fakeSettingsDiskSource.storeShowImportLoginsSettingBadge(USER_ID, true)
                 assertEquals(2, awaitItem())
             }
         }
@@ -127,15 +127,15 @@ class FirstTimeActionManagerTest {
             firstTimeActionManager.allVaultSettingsBadgeCountFlow.test {
                 assertEquals(0, awaitItem())
                 mutableImportLoginsFlow.update { true }
-                fakeAuthDiskSource.storeShowImportLogins(USER_ID, true)
+                fakeSettingsDiskSource.storeShowImportLoginsSettingBadge(USER_ID, true)
                 assertEquals(1, awaitItem())
                 mutableImportLoginsFlow.update { false }
                 assertEquals(0, awaitItem())
                 mutableImportLoginsFlow.update { true }
                 assertEquals(1, awaitItem())
-                fakeAuthDiskSource.storeShowImportLogins(USER_ID, false)
+                fakeSettingsDiskSource.storeShowImportLoginsSettingBadge(USER_ID, false)
                 assertEquals(0, awaitItem())
-                fakeAuthDiskSource.storeShowImportLogins(USER_ID, true)
+                fakeSettingsDiskSource.storeShowImportLoginsSettingBadge(USER_ID, true)
                 assertEquals(1, awaitItem())
                 mutableCiphersListFlow.update {
                     listOf(mockCipher)
@@ -156,7 +156,7 @@ class FirstTimeActionManagerTest {
                     ),
                     awaitItem(),
                 )
-                fakeAuthDiskSource.storeShowImportLogins(USER_ID, false)
+                firstTimeActionManager.storeShowImportLogins(false)
                 assertEquals(
                     FirstTimeState(
                         showImportLoginsCard = false,
@@ -232,6 +232,13 @@ class FirstTimeActionManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         firstTimeActionManager.storeShowImportLogins(showImportLogins = true)
         assertTrue(fakeAuthDiskSource.getShowImportLogins(userId = USER_ID)!!)
+    }
+
+    @Test
+    fun `storeShowImportLoginsSettingsBadge should store value of true to disk`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = false)
+        assertFalse(fakeSettingsDiskSource.getShowImportLoginsSettingBadge(userId = USER_ID)!!)
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModelTest.kt
@@ -31,7 +31,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
     private val firstTimeActionManager = mockk<FirstTimeActionManager> {
         every { currentOrDefaultUserFirstTimeState } returns DEFAULT_FIRST_TIME_STATE
         every { firstTimeStateFlow } returns mutableFirstTimeStateFlow
-        every { storeShowImportLogins(any()) } just runs
+        every { storeShowImportLoginsSettingsBadge(any()) } just runs
     }
 
     @Test
@@ -84,7 +84,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         assertTrue(viewModel.stateFlow.value.shouldShowImportCard)
         mutableFirstTimeStateFlow.update {
-            it.copy(showImportLoginsCard = false)
+            it.copy(showImportLoginsCardInSettings = false)
         }
         assertFalse(viewModel.stateFlow.value.shouldShowImportCard)
     }
@@ -111,7 +111,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
                 )
             }
             verify(exactly = 0) {
-                firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
+                firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = false)
             }
         }
 
@@ -121,7 +121,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardDismissClick)
         verify(exactly = 1) {
-            firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
+            firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = false)
         }
     }
 
@@ -132,7 +132,7 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardDismissClick)
             verify(exactly = 0) {
-                firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
+                firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = false)
             }
         }
 
@@ -143,4 +143,4 @@ class VaultSettingsViewModelTest : BaseViewModelTest() {
     )
 }
 
-private val DEFAULT_FIRST_TIME_STATE = FirstTimeState(showImportLoginsCard = true)
+private val DEFAULT_FIRST_TIME_STATE = FirstTimeState(showImportLoginsCardInSettings = true)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
@@ -28,6 +28,7 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
 
     private val firstTimeActionManager: FirstTimeActionManager = mockk {
         every { storeShowImportLogins(any()) } just runs
+        every { storeShowImportLoginsSettingsBadge(any()) } just runs
     }
 
     @Test
@@ -100,8 +101,9 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `ConfirmImportLater sets dialog state to null and sends NavigateBack event`() = runTest {
+    fun `ConfirmImportLater sets dialog state to null, sends NavigateBack event, and stores first time values`() = runTest {
         val viewModel = createViewModel()
         viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
             // Initial state
@@ -132,6 +134,10 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
                 ImportLoginsEvent.NavigateBack,
                 eventFlow.awaitItem(),
             )
+        }
+        verify(exactly = 1) {
+            firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
+            firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = true)
         }
     }
 
@@ -320,6 +326,7 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
         )
         verify {
             firstTimeActionManager.storeShowImportLogins(showImportLogins = false)
+            firstTimeActionManager.storeShowImportLoginsSettingsBadge(showBadge = false)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -86,6 +86,7 @@ class VaultViewModelTest : BaseViewModelTest() {
     private val firstTimeActionManager: FirstTimeActionManager = mockk {
         every { firstTimeStateFlow } returns mutableFirstTimeStateFlow
         every { storeShowImportLogins(any()) } just runs
+        every { storeShowImportLoginsSettingsBadge(any()) } just runs
     }
 
     private val authRepository: AuthRepository =
@@ -1555,12 +1556,14 @@ class VaultViewModelTest : BaseViewModelTest() {
             }
         }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `when DismissImportActionCard is sent, repository called to set value to false`() {
+    fun `when DismissImportActionCard is sent, repository called to showImportLogins to false and storeShowImportLoginsBadge to true`() {
         val viewModel = createViewModel()
         viewModel.trySendAction(VaultAction.DismissImportActionCard)
         verify(exactly = 1) {
             firstTimeActionManager.storeShowImportLogins(false)
+            firstTimeActionManager.storeShowImportLoginsSettingsBadge(true)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-14009
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Only show "Vault settings/Import logins" badge and action card if the user dismisses the card in their vault/chooses the "import later" option.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/496d6f1a-8211-4d46-9d0d-90a253165e82



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
