### PR TITLE
PM-13988 observe changes to unlock status on settings screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
@@ -182,6 +182,11 @@ interface AuthDiskSource {
     fun storeUserBiometricUnlockKey(userId: String, biometricsKey: String?)
 
     /**
+     * Gets the flow for the biometrics key for the given [userId].
+     */
+    fun getUserBiometicUnlockKeyFlow(userId: String): Flow<String?>
+
+    /**
      * Retrieves a pin-protected user key for the given [userId].
      */
     fun getPinProtectedUserKey(userId: String): String?
@@ -197,6 +202,11 @@ interface AuthDiskSource {
         pinProtectedUserKey: String?,
         inMemoryOnly: Boolean = false,
     )
+
+    /**
+     * Retrieves a flow for the pin-protected user key for the given [userId].
+     */
+    fun getPinProtectedUserKeyFlow(userId: String): Flow<String?>
 
     /**
      * Gets a two-factor auth token using a user's [email].

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -109,9 +109,19 @@ interface SettingsRepository {
     val isUnlockWithBiometricsEnabled: Boolean
 
     /**
+     * Emits updates whenever there is a change in the user status for biometric unlocking.
+     */
+    val isUnlockWithBiometricsEnabledFlow: Flow<Boolean>
+
+    /**
      * Whether or not PIN unlocking is enabled for the current user.
      */
     val isUnlockWithPinEnabled: Boolean
+
+    /**
+     * Emits updates whenever there is a change in the user status for PIN unlocking.
+     */
+    val isUnlockWithPinEnabledFlow: Flow<Boolean>
 
     /**
      * Whether or not inline autofill is enabled for the current user.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -265,7 +265,8 @@ class SettingsRepositoryImpl(
                 authDiskSource
                     .getPinProtectedUserKeyFlow(userId)
                     .map { it != null }
-            } ?: flowOf(false)
+            }
+            ?: flowOf(false)
 
     override var isInlineAutofillEnabled: Boolean
         get() = activeUserId

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -245,10 +245,27 @@ class SettingsRepositoryImpl(
             ?.let { authDiskSource.getUserBiometricUnlockKey(userId = it) != null }
             ?: false
 
+    override val isUnlockWithBiometricsEnabledFlow: Flow<Boolean>
+        get() = activeUserId
+            ?.let { userId ->
+                authDiskSource
+                    .getUserBiometicUnlockKeyFlow(userId)
+                    .map { it != null }
+            }
+            ?: flowOf(false)
+
     override val isUnlockWithPinEnabled: Boolean
         get() = activeUserId
             ?.let { authDiskSource.getEncryptedPin(userId = it) != null }
             ?: false
+
+    override val isUnlockWithPinEnabledFlow: Flow<Boolean>
+        get() = activeUserId
+            ?.let { userId ->
+                authDiskSource
+                    .getPinProtectedUserKeyFlow(userId)
+                    .map { it != null }
+            } ?: flowOf(false)
 
     override var isInlineAutofillEnabled: Boolean
         get() = activeUserId

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -126,6 +126,26 @@ class AccountSecurityViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
+        settingsRepository
+            .isUnlockWithBiometricsEnabledFlow
+            .map {
+                AccountSecurityAction.Internal.BiometricLockUpdate(
+                    isBiometricEnabled = it,
+                )
+            }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        settingsRepository
+            .isUnlockWithPinEnabledFlow
+            .map {
+                AccountSecurityAction.Internal.PinProtectedLockUpdate(
+                    isPinProtected = it,
+                )
+            }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
         viewModelScope.launch {
             trySendAction(
                 AccountSecurityAction.Internal.FingerprintResultReceive(
@@ -358,6 +378,34 @@ class AccountSecurityViewModel @Inject constructor(
             is AccountSecurityAction.Internal.ShowUnlockBadgeUpdated -> {
                 handleShowUnlockBadgeUpdated(action)
             }
+
+            is AccountSecurityAction.Internal.BiometricLockUpdate -> {
+                hanleBiometricUnlockUpdate(action)
+            }
+
+            is AccountSecurityAction.Internal.PinProtectedLockUpdate -> {
+                handlePinProtectedLockUpdate(action)
+            }
+        }
+    }
+
+    private fun handlePinProtectedLockUpdate(
+        action: AccountSecurityAction.Internal.PinProtectedLockUpdate,
+    ) {
+        mutableStateFlow.update {
+            it.copy(
+                isUnlockWithPinEnabled = action.isPinProtected,
+            )
+        }
+    }
+
+    private fun hanleBiometricUnlockUpdate(
+        action: AccountSecurityAction.Internal.BiometricLockUpdate,
+    ) {
+        mutableStateFlow.update {
+            it.copy(
+                isUnlockWithBiometricsEnabled = action.isBiometricEnabled,
+            )
         }
     }
 
@@ -734,5 +782,19 @@ sealed class AccountSecurityAction {
          * The show unlock badge update has been received.
          */
         data class ShowUnlockBadgeUpdated(val showUnlockBadge: Boolean) : Internal()
+
+        /**
+         * The user's biometric unlock status has been updated.
+         */
+        data class BiometricLockUpdate(
+            val isBiometricEnabled: Boolean,
+        ) : Internal()
+
+        /**
+         * The user's pin unlock status has been updated.
+         */
+        data class PinProtectedLockUpdate(
+            val isPinProtected: Boolean,
+        ) : Internal()
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -684,6 +684,22 @@ class AuthDiskSourceTest {
         assertFalse(fakeEncryptedSharedPreferences.contains(biometricsKeyKey))
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `storeUserBiometricUnlockKey should update the resulting flow from getUserBiometicUnlockKeyFlow`() =
+        runTest {
+            val topSecretKey = "topsecret"
+            val mockUserId = "mockUserId"
+            authDiskSource.getUserBiometicUnlockKeyFlow(mockUserId).test {
+                assertNull(awaitItem())
+                authDiskSource.storeUserBiometricUnlockKey(
+                    userId = mockUserId,
+                    biometricsKey = topSecretKey,
+                )
+                assertEquals(topSecretKey, awaitItem())
+            }
+        }
+
     @Test
     fun `getPinProtectedUserKey should pull from SharedPreferences`() {
         val pinProtectedUserKeyBaseKey = "bwPreferencesStorage:pinKeyEncryptedUserKey"
@@ -722,6 +738,21 @@ class AuthDiskSourceTest {
             actual,
         )
     }
+
+    @Test
+    fun `storePinProtectedUserKey should update result flow from getPinProtectedUserKeyFlow`() =
+        runTest {
+            val topSecretKey = "topsecret"
+            val mockUserId = "mockUserId"
+            authDiskSource.getPinProtectedUserKeyFlow(mockUserId).test {
+                assertNull(awaitItem())
+                authDiskSource.storePinProtectedUserKey(
+                    userId = mockUserId,
+                    pinProtectedUserKey = topSecretKey,
+                )
+                assertEquals(topSecretKey, awaitItem())
+            }
+        }
 
     @Test
     fun `getEncryptedPin should pull from SharedPreferences`() {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1150,6 +1150,42 @@ class SettingsRepositoryTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             assertFalse(settingsRepository.isAuthenticatorSyncEnabled)
         }
+
+    @Test
+    fun `isUnlockWithBiometricsEnabledFlow should react to changes in AuthDiskSource`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        settingsRepository.isUnlockWithBiometricsEnabledFlow.test {
+            assertFalse(awaitItem())
+            fakeAuthDiskSource.storeUserBiometricUnlockKey(
+                userId = USER_ID,
+                biometricsKey = "biometricsKey",
+            )
+            assertTrue(awaitItem())
+            fakeAuthDiskSource.storeUserBiometricUnlockKey(
+                userId = USER_ID,
+                biometricsKey = null,
+            )
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `isUnlockWithPinEnabledFlow should react to changes in AuthDiskSource`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        settingsRepository.isUnlockWithPinEnabledFlow.test {
+            assertFalse(awaitItem())
+            fakeAuthDiskSource.storePinProtectedUserKey(
+                userId = USER_ID,
+                pinProtectedUserKey = "pinProtectedUserKey",
+            )
+            assertTrue(awaitItem())
+            fakeAuthDiskSource.storePinProtectedUserKey(
+                userId = USER_ID,
+                pinProtectedUserKey = null,
+            )
+            assertFalse(awaitItem())
+        }
+    }
 }
 
 private const val USER_ID: String = "userId"

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -63,6 +63,8 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         every { userStateFlow } returns mutableUserStateFlow
     }
     private val vaultRepository: VaultRepository = mockk(relaxed = true)
+    private val mutableBiometricsUnlockEnabledFlow = bufferedMutableSharedFlow<Boolean>()
+    private val mutablePinUnlockEnabledFlow = bufferedMutableSharedFlow<Boolean>()
     private val settingsRepository: SettingsRepository = mockk {
         every { isAuthenticatorSyncEnabled } returns false
         every { isUnlockWithBiometricsEnabled } returns false
@@ -70,6 +72,8 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         every { vaultTimeout } returns VaultTimeout.ThirtyMinutes
         every { vaultTimeoutAction } returns VaultTimeoutAction.LOCK
         coEvery { getUserFingerprint() } returns UserFingerprintResult.Success(FINGERPRINT)
+        every { isUnlockWithBiometricsEnabledFlow } returns mutableBiometricsUnlockEnabledFlow
+        every { isUnlockWithPinEnabledFlow } returns mutablePinUnlockEnabledFlow
     }
 
     private val mutableFirstTimeStateFlow = MutableStateFlow(FirstTimeState())
@@ -799,6 +803,28 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                 firstTimeActionManager.storeShowUnlockSettingBadge(showBadge = false)
             }
         }
+
+    @Test
+    fun `when BiometricLockUpdate action is handled, should update the state`() = runTest {
+        val viewModel = createViewModel()
+        mutableBiometricsUnlockEnabledFlow.emit(true)
+        val expectedState = DEFAULT_STATE.copy(isUnlockWithBiometricsEnabled = true)
+        assertEquals(
+            viewModel.stateFlow.value,
+            expectedState,
+        )
+    }
+
+    @Test
+    fun `when PinProtectedLockUpdate action is handled, should update the state`() = runTest {
+        val viewModel = createViewModel()
+        mutablePinUnlockEnabledFlow.emit(true)
+        val expectedState = DEFAULT_STATE.copy(isUnlockWithPinEnabled = true)
+        assertEquals(
+            viewModel.stateFlow.value,
+            expectedState,
+        )
+    }
 
     @Suppress("LongParameterList")
     private fun createViewModel(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13988
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Fix issue where the account lock values were not updating when changed through the "Setup unlock" screen after clicking the action card.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
Before: 

https://github.com/user-attachments/assets/0c500fb7-f305-4ab1-97b6-40db505e1078

After: 

https://github.com/user-attachments/assets/5e5cfb4b-39e2-4e4d-bfb5-f311046b5600


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
