### PR TITLE
PM-14202 make bottom sheet full width in landscape

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/bottomsheet/BitwardenModalBottomSheet.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/bottomsheet/BitwardenModalBottomSheet.kt
@@ -2,7 +2,9 @@ package com.x8bit.bitwarden.ui.platform.components.bottomsheet
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.union
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
@@ -10,6 +12,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -52,8 +56,9 @@ fun BitwardenModalBottomSheet(
         sheetState = sheetState,
         contentWindowInsets = {
             WindowInsets(left = 0, top = 0, right = 0, bottom = 0)
+                .union(WindowInsets.displayCutout)
         },
-        shape = BitwardenTheme.shapes.bottomSheet,
+        containerColor = Color.Transparent,
     ) {
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
         BitwardenScaffold(
@@ -70,6 +75,9 @@ fun BitwardenModalBottomSheet(
                 )
             },
             modifier = Modifier
+                // We apply the shape here due to implementation of the ModalBottomSheet applying
+                // the insets to the content but the shape to an outer container.
+                .clip(shape = BitwardenTheme.shapes.bottomSheet)
                 .nestedScroll(scrollBehavior.nestedScrollConnection)
                 .fillMaxSize(),
         ) { paddingValues ->

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreen.kt
@@ -116,7 +116,9 @@ fun ImportLoginsScreen(
         sheetTitle = stringResource(R.string.bitwarden_tools),
         onDismiss = hideSheetAndExecuteCompleteImportLogins,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-        modifier = Modifier.statusBarsPadding(),
+        modifier = Modifier
+            .statusBarsPadding()
+            .fillMaxSize(),
     ) { paddingValues ->
         ImportLoginsSuccessBottomSheetContent(
             onCompleteImportLogins = hideSheetAndExecuteCompleteImportLogins,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-14202
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Have the bottom sheet for import logins success match full width of underlying content in landscape
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
Before: 

https://github.com/user-attachments/assets/e5973952-681d-444a-b78a-79958bb269fd

After:

https://github.com/user-attachments/assets/904cb4cf-4202-48da-a8ac-b00937f61822



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
