### PR TITLE
PM-14044: Update generator line breaks to account for padding on both sides

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -72,7 +72,7 @@ fun BitwardenTextField(
     val formattedText = if (shouldAddCustomLineBreaks) {
         value.withLineBreaksAtWidth(
             // Adjust for built in padding
-            widthPx = widthPx - 16.dp.toPx(),
+            widthPx = widthPx - 32.dp.toPx(),
             monospacedTextStyle = textStyle,
         )
     } else {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14044](https://bitwarden.atlassian.net/browse/PM-14044)

## 📔 Objective

This PR updates the line-break logic to account for padding on both sides of the text field.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/56cacb7a-41ab-4791-b54a-c5ba55482dea" width="300" /> | <video src="https://github.com/user-attachments/assets/73d5a951-c06e-47b4-9f0f-c8b9f1165775" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14044]: https://bitwarden.atlassian.net/browse/PM-14044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ