### PR TITLE
[PM-14241] Checking if Timber tree has been added before trying to remove it

### DIFF
--- a/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/LogsManagerImpl.kt
+++ b/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/LogsManagerImpl.kt
@@ -30,7 +30,7 @@ class LogsManagerImpl(
             }
             if (value) {
                 Timber.plant(nonfatalErrorTree)
-            } else {
+            } else if (Timber.forest().contains(nonfatalErrorTree)) {
                 Timber.uproot(nonfatalErrorTree)
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14241

## 📔 Objective

Trying to uproot the `nonfatalErrorTree` when it has not been planted is causing the application to crash. This will add a check to verify it exists on the Timber array before trying to remove it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
