### PR TITLE
[PM-14254] Keep Android verifier for JNI usage

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -6,6 +6,10 @@
 # we keep it here.
 -keep class com.bitwarden.** { *; }
 
+# The Android Verifier component must be kept because it looks like dead code. Proguard is unable to
+# see any JNI usage, so our rules must manually opt into keeping it.
+-keep, includedescriptorclasses class org.rustls.platformverifier.** { *; }
+
 ################################################################################
 # Bitwarden Models
 ################################################################################


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14254

## 📔 Objective

The Android Verifier component is incorrectly flagged as dead code by Proguard, as it's unable to detect JNI usage.
This change manually keeps the `org.rustls.platformverifier` classes to resolve the issue.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
