### PR TITLE
PM-13842: Hide ownership when the user has no organizations

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
@@ -300,7 +300,7 @@ fun LazyListScope.vaultAddEditCardItems(
         )
     }
 
-    if (isAddItemMode) {
+    if (isAddItemMode && commonState.hasOrganizations) {
         item {
             Spacer(modifier = Modifier.height(24.dp))
             BitwardenListHeaderText(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
@@ -414,7 +414,7 @@ fun LazyListScope.vaultAddEditIdentityItems(
         )
     }
 
-    if (isAddItemMode) {
+    if (isAddItemMode && commonState.hasOrganizations) {
         item {
             Spacer(modifier = Modifier.height(24.dp))
             BitwardenListHeaderText(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
@@ -317,7 +317,7 @@ fun LazyListScope.vaultAddEditLoginItems(
         )
     }
 
-    if (isAddItemMode) {
+    if (isAddItemMode && commonState.hasOrganizations) {
         item {
             Spacer(modifier = Modifier.height(24.dp))
             BitwardenListHeaderText(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSecureNotesItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSecureNotesItems.kt
@@ -176,7 +176,7 @@ fun LazyListScope.vaultAddEditSecureNotesItems(
         )
     }
 
-    if (isAddItemMode) {
+    if (isAddItemMode && commonState.hasOrganizations) {
         item {
             Spacer(modifier = Modifier.height(24.dp))
             BitwardenListHeaderText(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -2114,6 +2114,7 @@ data class VaultAddEditState(
              * @property availableFolders The list of folders that this item could be added too.
              * @property selectedOwnerId The ID of the owner associated with the item.
              * @property availableOwners A list of available owners.
+             * @property hasOrganizations Indicates if the user is part of any organizations.
              */
             @Parcelize
             data class Common(
@@ -2129,6 +2130,7 @@ data class VaultAddEditState(
                 val availableFolders: List<Folder> = emptyList(),
                 val selectedOwnerId: String? = null,
                 val availableOwners: List<Owner> = emptyList(),
+                val hasOrganizations: Boolean = false,
             ) : Parcelable {
 
                 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
@@ -106,6 +106,7 @@ fun CipherView.toViewState(
             masterPasswordReprompt = this.reprompt == CipherRepromptType.PASSWORD,
             notes = this.notes.orEmpty(),
             availableOwners = emptyList(),
+            hasOrganizations = false,
             customFieldData = this.fields.orEmpty().map { it.toCustomField() },
         ),
         isIndividualVaultDisabled = isIndividualVaultDisabled,
@@ -139,6 +140,7 @@ fun VaultAddEditState.ViewState.appendFolderAndOwnerData(
                     isIndividualVaultDisabled = isIndividualVaultDisabled,
                 ),
                 isUnlockWithPasswordEnabled = activeAccount.hasMasterPassword,
+                hasOrganizations = activeAccount.organizations.isNotEmpty(),
             ),
         )
     } ?: this

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -2362,6 +2362,31 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     }
 
     @Test
+    fun `ownership section should not be displayed when no organizations present`() {
+        updateStateWithOwners(selectedOwnerId = "mockOwnerId-2")
+
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "mockCollectionName-2")
+            .assertIsDisplayed()
+
+        updateStateWithOwners(
+            selectedOwnerId = null,
+            availableOwners = listOf(
+                VaultAddEditState.Owner(
+                    id = null,
+                    name = "placeholder@email.com",
+                    collections = DEFAULT_COLLECTIONS,
+                ),
+            ),
+            hasOrganizations = false,
+        )
+
+        composeTestRule
+            .onNodeWithText(text = "mockCollectionName-2")
+            .assertDoesNotExist()
+    }
+
+    @Test
     fun `Collection list should display according to state`() {
         updateStateWithOwners(selectedOwnerId = "mockOwnerId-2")
 
@@ -3482,12 +3507,14 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     private fun updateStateWithOwners(
         selectedOwnerId: String? = null,
         availableOwners: List<VaultAddEditState.Owner> = DEFAULT_OWNERS,
+        hasOrganizations: Boolean = true,
     ) {
         mutableStateFlow.update { currentState ->
             updateCommonContent(currentState) {
                 copy(
                     selectedOwnerId = selectedOwnerId,
                     availableOwners = availableOwners,
+                    hasOrganizations = hasOrganizations,
                 )
             }
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -4026,6 +4026,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         ),
         availableOwners: List<VaultAddEditState.Owner> = createOwnerList(),
         selectedOwnerId: String? = null,
+        hasOrganizations: Boolean = true,
     ): VaultAddEditState.ViewState.Content.Common =
         VaultAddEditState.ViewState.Content.Common(
             name = name,
@@ -4038,6 +4039,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             originalCipher = originalCipher,
             availableFolders = availableFolders,
             availableOwners = availableOwners,
+            hasOrganizations = hasOrganizations,
         )
 
     @Suppress("LongParameterList")

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -505,6 +505,7 @@ class CipherViewExtensionsTest {
                                     name = "mockName-1",
                                 ),
                             ),
+                            hasOrganizations = true,
                             availableOwners = listOf(
                                 VaultAddEditState.Owner(
                                     id = null,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13842](https://bitwarden.atlassian.net/browse/PM-13842)

## 📔 Objective

This PR removes the ownership section for the create cipher UI when there are no organizations to select from.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13842]: https://bitwarden.atlassian.net/browse/PM-13842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ