### PR TITLE
[PM-14271] Disable editing SSH key fields in edit mode

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSshKeyItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSshKeyItems.kt
@@ -46,7 +46,8 @@ fun LazyListScope.vaultAddEditSshKeyItems(
         BitwardenTextField(
             label = stringResource(id = R.string.public_key),
             value = sshKeyState.publicKey,
-            onValueChange = sshKeyTypeHandlers.onPublicKeyTextChange,
+            readOnly = true,
+            onValueChange = { },
             modifier = Modifier
                 .testTag("PublicKeyEntry")
                 .fillMaxWidth()
@@ -59,7 +60,8 @@ fun LazyListScope.vaultAddEditSshKeyItems(
         BitwardenPasswordField(
             label = stringResource(id = R.string.private_key),
             value = sshKeyState.privateKey,
-            onValueChange = sshKeyTypeHandlers.onPrivateKeyTextChange,
+            readOnly = true,
+            onValueChange = { /* no-op */ },
             showPassword = sshKeyState.showPrivateKey,
             showPasswordChange = { sshKeyTypeHandlers.onPrivateKeyVisibilityChange(it) },
             showPasswordTestTag = "ViewPrivateKeyButton",
@@ -75,7 +77,8 @@ fun LazyListScope.vaultAddEditSshKeyItems(
         BitwardenTextField(
             label = stringResource(id = R.string.fingerprint),
             value = sshKeyState.fingerprint,
-            onValueChange = sshKeyTypeHandlers.onFingerprintTextChange,
+            readOnly = true,
+            onValueChange = { /* no-op */ },
             modifier = Modifier
                 .testTag("FingerprintEntry")
                 .fillMaxWidth()
@@ -116,10 +119,7 @@ private fun VaultAddEditSshKeyItems_preview() {
                     onHiddenFieldVisibilityChange = { },
                 ),
                 sshKeyTypeHandlers = VaultAddEditSshKeyTypeHandlers(
-                    onPublicKeyTextChange = { },
-                    onPrivateKeyTextChange = { },
                     onPrivateKeyVisibilityChange = { },
-                    onFingerprintTextChange = { },
                 ),
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1394,46 +1394,16 @@ class VaultAddEditViewModel @Inject constructor(
 
     private fun handleSshKeyTypeActions(action: VaultAddEditAction.ItemType.SshKeyType) {
         when (action) {
-            is VaultAddEditAction.ItemType.SshKeyType.PublicKeyTextChange -> {
-                handlePublicKeyTextChange(action)
-            }
-
-            is VaultAddEditAction.ItemType.SshKeyType.PrivateKeyTextChange -> {
-                handlePrivateKeyTextChange(action)
-            }
-
             is VaultAddEditAction.ItemType.SshKeyType.PrivateKeyVisibilityChange -> {
                 handlePrivateKeyVisibilityChange(action)
             }
-
-            is VaultAddEditAction.ItemType.SshKeyType.FingerprintTextChange -> {
-                handleSshKeyFingerprintTextChange(action)
-            }
         }
-    }
-
-    private fun handlePublicKeyTextChange(
-        action: VaultAddEditAction.ItemType.SshKeyType.PublicKeyTextChange,
-    ) {
-        updateSshKeyContent { it.copy(publicKey = action.publicKey) }
-    }
-
-    private fun handlePrivateKeyTextChange(
-        action: VaultAddEditAction.ItemType.SshKeyType.PrivateKeyTextChange,
-    ) {
-        updateSshKeyContent { it.copy(privateKey = action.privateKey) }
     }
 
     private fun handlePrivateKeyVisibilityChange(
         action: VaultAddEditAction.ItemType.SshKeyType.PrivateKeyVisibilityChange,
     ) {
         updateSshKeyContent { it.copy(showPrivateKey = action.isVisible) }
-    }
-
-    private fun handleSshKeyFingerprintTextChange(
-        action: VaultAddEditAction.ItemType.SshKeyType.FingerprintTextChange,
-    ) {
-        updateSshKeyContent { it.copy(fingerprint = action.fingerprint) }
     }
 
     //endregion SSH Key Type Handlers
@@ -3062,25 +3032,11 @@ sealed class VaultAddEditAction {
          * Represents actions specific to the SSH Key type.
          */
         sealed class SshKeyType : ItemType() {
-            /**
-             * Fired when the public key text input is changed.
-             */
-            data class PublicKeyTextChange(val publicKey: String) : SshKeyType()
-
-            /**
-             * Fired when the private key text input is changed.
-             */
-            data class PrivateKeyTextChange(val privateKey: String) : SshKeyType()
 
             /**
              * Fired when the private key's visibility has changed.
              */
             data class PrivateKeyVisibilityChange(val isVisible: Boolean) : SshKeyType()
-
-            /**
-             * Fired when the fingerprint text input is changed.
-             */
-            data class FingerprintTextChange(val fingerprint: String) : SshKeyType()
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditSshKeyTypeHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditSshKeyTypeHandlers.kt
@@ -10,16 +10,10 @@ import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditViewModel
  * These handlers are used to update the ViewModel with user actions such as text changes and
  * visibility changes for different SSH key fields (public key, private key, fingerprint).
  *
- * @property onPublicKeyTextChange Handler for changes in the public key text field.
- * @property onPrivateKeyTextChange Handler for changes in the private key text field.
  * @property onPrivateKeyVisibilityChange Handler for toggling the visibility of the private key.
- * @property onFingerprintTextChange Handler for changes in the fingerprint text field.
  */
 data class VaultAddEditSshKeyTypeHandlers(
-    val onPublicKeyTextChange: (String) -> Unit,
-    val onPrivateKeyTextChange: (String) -> Unit,
     val onPrivateKeyVisibilityChange: (Boolean) -> Unit,
-    val onFingerprintTextChange: (String) -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -31,31 +25,11 @@ data class VaultAddEditSshKeyTypeHandlers(
          */
         fun create(viewModel: VaultAddEditViewModel): VaultAddEditSshKeyTypeHandlers =
             VaultAddEditSshKeyTypeHandlers(
-                onPublicKeyTextChange = { newPublicKey ->
-                    viewModel.trySendAction(
-                        VaultAddEditAction.ItemType.SshKeyType.PublicKeyTextChange(
-                            publicKey = newPublicKey,
-                        ),
-                    )
-                },
-                onPrivateKeyTextChange = { newPrivateKey ->
-                    viewModel.trySendAction(
-                        VaultAddEditAction.ItemType.SshKeyType.PrivateKeyTextChange(
-                            privateKey = newPrivateKey,
-                        ),
-                    )
-                },
+
                 onPrivateKeyVisibilityChange = {
                     viewModel.trySendAction(
                         VaultAddEditAction.ItemType.SshKeyType.PrivateKeyVisibilityChange(
                             isVisible = it,
-                        ),
-                    )
-                },
-                onFingerprintTextChange = { newFingerprint ->
-                    viewModel.trySendAction(
-                        VaultAddEditAction.ItemType.SshKeyType.FingerprintTextChange(
-                            fingerprint = newFingerprint,
                         ),
                     )
                 },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
+import androidx.compose.ui.test.isEditable
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -3323,54 +3324,33 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `in ItemType_SshKeys changing the public key should trigger PublicKeyTextChange`() {
+    fun `in ItemType_SshKeys the public key field should be read only`() {
         mutableStateFlow.value = DEFAULT_STATE_SSH_KEYS
 
         composeTestRule
-            .onNodeWithTextAfterScroll("Public key")
-            .performTextInput("TestPublicKey")
-
-        verify {
-            viewModel.trySendAction(
-                VaultAddEditAction.ItemType.SshKeyType.PublicKeyTextChange(
-                    publicKey = "TestPublicKey",
-                ),
-            )
-        }
+            .onNodeWithTextAfterScroll(text = "Public key")
+            .assertExists()
+            .assert(!isEditable())
     }
 
     @Test
-    fun `in ItemType_SshKeys changing the private key should trigger PrivateKeyTextChange`() {
+    fun `in ItemType_SshKeys the private key field should be read only`() {
         mutableStateFlow.value = DEFAULT_STATE_SSH_KEYS
 
         composeTestRule
-            .onNodeWithTextAfterScroll("Private key")
-            .performTextInput("TestPrivateKey")
-
-        verify {
-            viewModel.trySendAction(
-                VaultAddEditAction.ItemType.SshKeyType.PrivateKeyTextChange(
-                    privateKey = "TestPrivateKey",
-                ),
-            )
-        }
+            .onNodeWithTextAfterScroll(text = "Private key")
+            .assertExists()
+            .assert(!isEditable())
     }
 
     @Test
-    fun `in ItemType_SshKeys changing the fingerprint should trigger FingerprintTextChange`() {
+    fun `in ItemType_SshKeys the fingerprint field should be read only`() {
         mutableStateFlow.value = DEFAULT_STATE_SSH_KEYS
 
         composeTestRule
-            .onNodeWithTextAfterScroll("Fingerprint")
-            .performTextInput("TestFingerprint")
-
-        verify {
-            viewModel.trySendAction(
-                VaultAddEditAction.ItemType.SshKeyType.FingerprintTextChange(
-                    fingerprint = "TestFingerprint",
-                ),
-            )
-        }
+            .onNodeWithTextAfterScroll(text = "Fingerprint")
+            .assertExists()
+            .assert(!isEditable())
     }
 
     @Suppress("MaxLineLength")

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -2726,36 +2726,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         }
 
         @Test
-        fun `PublicKeyTextChange should update public key`() = runTest {
-            val action = VaultAddEditAction.ItemType.SshKeyType.PublicKeyTextChange(
-                publicKey = "newPublicKey",
-            )
-            val expectedState = createVaultAddItemState(
-                typeContentViewState = VaultAddEditState.ViewState.Content.ItemType.SshKey(
-                    publicKey = "newPublicKey",
-                ),
-            )
-            viewModel.trySendAction(action)
-
-            assertEquals(expectedState, viewModel.stateFlow.value)
-        }
-
-        @Test
-        fun `PrivateKeyTextChange should update private key`() = runTest {
-            val action = VaultAddEditAction.ItemType.SshKeyType.PrivateKeyTextChange(
-                privateKey = "newPrivateKey",
-            )
-            val expectedState = createVaultAddItemState(
-                typeContentViewState = VaultAddEditState.ViewState.Content.ItemType.SshKey(
-                    privateKey = "newPrivateKey",
-                ),
-            )
-            viewModel.trySendAction(action)
-
-            assertEquals(expectedState, viewModel.stateFlow.value)
-        }
-
-        @Test
         fun `PrivateKeyVisibilityChange should update private key visibility`() = runTest {
             val action = VaultAddEditAction.ItemType.SshKeyType.PrivateKeyVisibilityChange(
                 isVisible = true,
@@ -2763,21 +2733,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val expectedState = createVaultAddItemState(
                 typeContentViewState = VaultAddEditState.ViewState.Content.ItemType.SshKey(
                     showPrivateKey = true,
-                ),
-            )
-            viewModel.trySendAction(action)
-
-            assertEquals(expectedState, viewModel.stateFlow.value)
-        }
-
-        @Test
-        fun `FingerprintTextChange should update fingerprint`() = runTest {
-            val action = VaultAddEditAction.ItemType.SshKeyType.FingerprintTextChange(
-                fingerprint = "newFingerprint",
-            )
-            val expectedState = createVaultAddItemState(
-                typeContentViewState = VaultAddEditState.ViewState.Content.ItemType.SshKey(
-                    fingerprint = "newFingerprint",
                 ),
             )
             viewModel.trySendAction(action)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14271

## 📔 Objective

The commit disables editing of public key, private key, and fingerprint fields for SSH keys in edit mode. This is achieved by:

- Making the corresponding text fields read-only.
- Removing the handlers that were previously updating the ViewModel with text changes for these fields.

## 📸 Screenshots

https://github.com/user-attachments/assets/0acf00bc-a0fe-453a-b510-804c927efbd4


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
