### PR TITLE
PM-13848 Handle URIs with ports and host matching

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
@@ -15,16 +15,7 @@ private const val ANDROID_APP_PROTOCOL: String = "androidapp://"
  */
 fun String.toUriOrNull(): URI? =
     try {
-        val uri = URI(this)
-        if (
-            uri.host == null &&
-            this.contains(".") &&
-            !this.hasHttpProtocol()
-        ) {
-            URI("https://$this")
-        } else {
-            uri
-        }
+        URI(this)
     } catch (e: URISyntaxException) {
         null
     }
@@ -80,7 +71,18 @@ fun String.hasPort(): Boolean {
  * Extract the host from this [String] if possible, otherwise return null.
  */
 @OmitFromCoverage
-fun String.getHostOrNull(): String? = this.toUriOrNull()?.host
+fun String.getHostOrNull(): String? = this.toUriOrNull()
+    ?.let { uri ->
+        if (
+            uri.host == null &&
+            this.contains(".") &&
+            !this.hasHttpProtocol()
+        ) {
+            URI("https://$this")
+        } else {
+            uri
+        }
+    }?.host
 
 /**
  * Extract the host with optional port from this [String] if possible, otherwise return null.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
@@ -15,7 +15,16 @@ private const val ANDROID_APP_PROTOCOL: String = "androidapp://"
  */
 fun String.toUriOrNull(): URI? =
     try {
-        URI(this)
+        val uri = URI(this)
+        if (
+            uri.host == null &&
+            this.contains(".") &&
+            !this.hasHttpProtocol()
+        ) {
+            URI("https://$this")
+        } else {
+            uri
+        }
     } catch (e: URISyntaxException) {
         null
     }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
@@ -65,7 +65,7 @@ fun String.getDomainOrNull(resourceCacheManager: ResourceCacheManager): String? 
 fun String.hasPort(): Boolean {
     val uri = this
         .toUriOrNull()
-        ?.let { addSchemeToUriIfNecessary(this, uri = it) }
+        ?.addSchemeToUriIfNecessary()
         ?: return false
     return uri.port != -1
 }
@@ -75,9 +75,8 @@ fun String.hasPort(): Boolean {
  */
 @OmitFromCoverage
 fun String.getHostOrNull(): String? = this.toUriOrNull()
-    ?.let { uri ->
-        addSchemeToUriIfNecessary(uriString = this, uri = uri)
-    }?.host
+    ?.addSchemeToUriIfNecessary()
+    ?.host
 
 /**
  * Extract the host with optional port from this [String] if possible, otherwise return null.
@@ -86,7 +85,7 @@ fun String.getHostOrNull(): String? = this.toUriOrNull()
 fun String.getHostWithPortOrNull(): String? {
     val uri = this
         .toUriOrNull()
-        ?.let { addSchemeToUriIfNecessary(uriString = this, uri = it) }
+        ?.addSchemeToUriIfNecessary()
         ?: return null
     return uri.host?.let { host ->
         val port = uri.port
@@ -110,27 +109,5 @@ fun String.findLastSubstringIndicesOrNull(substring: String): IntRange? {
         IntRange(lastIndex, endIndex)
     } else {
         null
-    }
-}
-
-/**
- * Private helper method which takes a string and a [URI] derived from that string and adds
- * an HTTPS scheme to the URI if it is necessary. (i.e. foo.com:9090 -> https://foo.com:9090)
- * This would be necessary if you have a source string like "foo.com:9090" and you want to want
- * to extract the [URI.getHost] or [URI.getPort] from it which would fail.
- */
-private fun addSchemeToUriIfNecessary(uriString: String, uri: URI): URI? {
-    if (uriString.toUriOrNull()?.equals(uri) != true) return null
-    return if (
-    // see if the string contains a host pattern
-        uriString.contains(".") &&
-        // if it does but the URI's host is null, add an https scheme
-        uri.host == null &&
-        // provided that scheme does not exist already.
-        !uriString.hasHttpProtocol()
-    ) {
-        URI("https://$uriString")
-    } else {
-        uri
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/StringExtensions.kt
@@ -56,6 +56,7 @@ fun String.getWebHostFromAndroidUriOrNull(): String? =
 fun String.getDomainOrNull(resourceCacheManager: ResourceCacheManager): String? =
     this
         .toUriOrNull()
+        ?.addSchemeToUriIfNecessary()
         ?.parseDomainOrNull(resourceCacheManager = resourceCacheManager)
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/URIExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/URIExtensions.kt
@@ -45,6 +45,22 @@ fun URI.parseDomainNameOrNull(resourceCacheManager: ResourceCacheManager): Domai
             )
         }
 
+fun URI.addSchemeToUriIfNecessary(): URI {
+    val uriString = this.toString()
+    return if (
+    // see if the string contains a host pattern
+        uriString.contains(".") &&
+        // if it does but the URI's host is null, add an https scheme
+        this.host == null &&
+        // provided that scheme does not exist already.
+        !uriString.hasHttpProtocol()
+    ) {
+        URI("https://$uriString")
+    } else {
+        this
+    }
+}
+
 /**
  * The internal implementation of [parseDomainNameOrNull]. This doesn't extend URI and has a
  * non-null [host] parameter. Technically, URI.host could be null and we want to avoid issues with

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/URIExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/URIExtensions.kt
@@ -45,6 +45,11 @@ fun URI.parseDomainNameOrNull(resourceCacheManager: ResourceCacheManager): Domai
             )
         }
 
+/**
+ * Adds and HTTPS scheme to a valid URI if that URI has a valid host in the raw string but
+ * the standard parsing of `URI("foo.com")` is not able to determine a valid host.
+ * (i.e. val uri = URI("foo.bar:1090") -> uri.host == null)
+ */
 fun URI.addSchemeToUriIfNecessary(): URI {
     val uriString = this.toString()
     return if (

--- a/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
@@ -181,15 +181,12 @@ class StringExtensionsTest {
     fun `getHostOrNull should return host from URI string when present and has port but no scheme`() {
         val expectedHost = "www.google.com"
         val hostWithPort = "$expectedHost:8080"
-        // control
-        assertNull(hostWithPort.toUriOrNull()?.host)
         assertEquals(expectedHost, hostWithPort.getHostOrNull())
     }
 
     @Test
     fun `hasPort returns true when port is present`() {
         val uriString = "www.google.com:8080"
-        assertEquals(-1, uriString.toUriOrNull()?.port)
         assertTrue("www.google.com:8080".hasPort())
     }
 
@@ -201,14 +198,12 @@ class StringExtensionsTest {
     @Test
     fun `hasPort return true when port is present and custom scheme is present`() {
         val uriString = "androidapp://www.google.com:8080"
-        assertEquals(8080, uriString.toUriOrNull()?.port)
         assertTrue(uriString.hasPort())
     }
 
     @Test
     fun `getHostWithPortOrNull should return host with port when present`() {
         val uriString = "www.google.com:8080"
-        assertEquals(-1, uriString.toUriOrNull()?.port)
         assertEquals("www.google.com:8080", uriString.getHostWithPortOrNull())
     }
 
@@ -227,7 +222,6 @@ class StringExtensionsTest {
     @Test
     fun `getHostWithPortOrNull should return host with port when present and custom scheme is present`() {
         val uriString = "androidapp://www.google.com:8080"
-        assertEquals(8080, uriString.toUriOrNull()?.port)
         assertEquals("www.google.com:8080", uriString.getHostWithPortOrNull())
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
@@ -39,6 +39,17 @@ class StringExtensionsTest {
         assertNotNull("www.google.com".toUriOrNull())
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toUriOrNull should return URI with accurate host name when a scheme is not present but a port is`() {
+        val expectedHost = "www.google.com"
+        val hostWithPort = "$expectedHost:8080"
+        // control
+        assertNull(URI(hostWithPort).host)
+        val uri = hostWithPort.toUriOrNull()
+        assertEquals(expectedHost, uri?.host)
+    }
+
     @Test
     fun `isAndroidApp should return true when string starts with android app protocol`() {
         assertTrue("androidapp://com.x8bit.bitwarden".isAndroidApp())

--- a/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
@@ -4,8 +4,10 @@ import com.x8bit.bitwarden.data.platform.manager.ResourceCacheManager
 import com.x8bit.bitwarden.data.platform.util.findLastSubstringIndicesOrNull
 import com.x8bit.bitwarden.data.platform.util.getDomainOrNull
 import com.x8bit.bitwarden.data.platform.util.getHostOrNull
+import com.x8bit.bitwarden.data.platform.util.getHostWithPortOrNull
 import com.x8bit.bitwarden.data.platform.util.getWebHostFromAndroidUriOrNull
 import com.x8bit.bitwarden.data.platform.util.hasHttpProtocol
+import com.x8bit.bitwarden.data.platform.util.hasPort
 import com.x8bit.bitwarden.data.platform.util.isAndroidApp
 import com.x8bit.bitwarden.data.platform.util.parseDomainOrNull
 import com.x8bit.bitwarden.data.platform.util.toUriOrNull
@@ -180,7 +182,52 @@ class StringExtensionsTest {
         val expectedHost = "www.google.com"
         val hostWithPort = "$expectedHost:8080"
         // control
-        assertNull(URI(hostWithPort).host)
-        assertEquals(expectedHost, hostWithPort.toUriOrNull())
+        assertNull(hostWithPort.toUriOrNull()?.host)
+        assertEquals(expectedHost, hostWithPort.getHostOrNull())
+    }
+
+    @Test
+    fun `hasPort returns true when port is present`() {
+        val uriString = "www.google.com:8080"
+        assertEquals(-1, uriString.toUriOrNull()?.port)
+        assertTrue("www.google.com:8080".hasPort())
+    }
+
+    @Test
+    fun `hasPort returns false when port is not present`() {
+        assertFalse("www.google.com".hasPort())
+    }
+
+    @Test
+    fun `hasPort return true when port is present and custom scheme is present`() {
+        val uriString = "androidapp://www.google.com:8080"
+        assertEquals(8080, uriString.toUriOrNull()?.port)
+        assertTrue(uriString.hasPort())
+    }
+
+    @Test
+    fun `getHostWithPortOrNull should return host with port when present`() {
+        val uriString = "www.google.com:8080"
+        assertEquals(8080, uriString.toUriOrNull()?.port)
+        assertEquals("www.google.com:8080", uriString.getHostWithPortOrNull())
+    }
+
+    @Test
+    fun `getHostWithPortOrNull should return host when no port is present`() {
+        val uriString = "www.google.com"
+        assertEquals("www.google.com", uriString.getHostWithPortOrNull())
+    }
+
+    @Test
+    fun `getHostWithPortOrNull should return null when no host is present`() {
+        assertNull("boo".getHostWithPortOrNull())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getHostWithPortOrNull should return host with port when present and custom scheme is present`() {
+        val uriString = "androidapp://www.google.com:8080"
+        assertEquals(8080, uriString.toUriOrNull()?.port)
+        assertEquals("www.google.com:8080", uriString.getHostWithPortOrNull())
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.util
 import com.x8bit.bitwarden.data.platform.manager.ResourceCacheManager
 import com.x8bit.bitwarden.data.platform.util.findLastSubstringIndicesOrNull
 import com.x8bit.bitwarden.data.platform.util.getDomainOrNull
+import com.x8bit.bitwarden.data.platform.util.getHostOrNull
 import com.x8bit.bitwarden.data.platform.util.getWebHostFromAndroidUriOrNull
 import com.x8bit.bitwarden.data.platform.util.hasHttpProtocol
 import com.x8bit.bitwarden.data.platform.util.isAndroidApp
@@ -37,17 +38,6 @@ class StringExtensionsTest {
     @Test
     fun `toUriOrNull should return URI when uri is valid`() {
         assertNotNull("www.google.com".toUriOrNull())
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `toUriOrNull should return URI with accurate host name when a scheme is not present but a port is`() {
-        val expectedHost = "www.google.com"
-        val hostWithPort = "$expectedHost:8080"
-        // control
-        assertNull(URI(hostWithPort).host)
-        val uri = hostWithPort.toUriOrNull()
-        assertEquals(expectedHost, uri?.host)
     }
 
     @Test
@@ -164,5 +154,33 @@ class StringExtensionsTest {
 
         // Verify
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `getHostOrNull should return host when one is present`() {
+        val expectedHost = "www.google.com"
+        assertEquals(expectedHost, expectedHost.getHostOrNull())
+    }
+
+    @Test
+    fun `getHostOrNull should return null when no host is present`() {
+        assertNull("boo".getHostOrNull())
+    }
+
+    @Test
+    fun `getHostOrNull should return host from URI string when present and custom URI scheme`() {
+        val expectedHost = "www.google.com"
+        val hostWithScheme = "androidapp://$expectedHost"
+        assertEquals(expectedHost, hostWithScheme.getHostOrNull())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getHostOrNull should return host from URI string when present and has port but no scheme`() {
+        val expectedHost = "www.google.com"
+        val hostWithPort = "$expectedHost:8080"
+        // control
+        assertNull(URI(hostWithPort).host)
+        assertEquals(expectedHost, hostWithPort.toUriOrNull())
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
@@ -208,7 +208,7 @@ class StringExtensionsTest {
     @Test
     fun `getHostWithPortOrNull should return host with port when present`() {
         val uriString = "www.google.com:8080"
-        assertEquals(8080, uriString.toUriOrNull()?.port)
+        assertEquals(-1, uriString.toUriOrNull()?.port)
         assertEquals("www.google.com:8080", uriString.getHostWithPortOrNull())
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/util/UriExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/util/UriExtensionsTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.util
 
 import com.x8bit.bitwarden.data.platform.manager.ResourceCacheManager
 import com.x8bit.bitwarden.data.platform.manager.model.DomainName
+import com.x8bit.bitwarden.data.platform.util.addSchemeToUriIfNecessary
 import com.x8bit.bitwarden.data.platform.util.parseDomainNameOrNull
 import com.x8bit.bitwarden.data.platform.util.parseDomainOrNull
 import io.mockk.every
@@ -320,5 +321,39 @@ class UriExtensionsTest {
                 // Verify
                 assertEquals(expected[index], actual)
             }
+    }
+
+    @Test
+    fun `addSchemeToUriIfNecessary should add https when missing`() {
+        val uriWithNoScheme = URI("example.com")
+        assertEquals(URI("https://example.com"), uriWithNoScheme.addSchemeToUriIfNecessary())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `addSchemeToUriIfNecessary should add https when https scheme is missing and a port is present`() {
+        val uriWithPort = URI("example.com:8080")
+        assertEquals(URI("https://example.com:8080"), uriWithPort.addSchemeToUriIfNecessary())
+    }
+
+    @Test
+    fun `addSchemeToUriIfNecessary should not add https when http scheme is present`() {
+        val uriWithHttpScheme = URI("http://example.com")
+        assertEquals(URI("http://example.com"), uriWithHttpScheme.addSchemeToUriIfNecessary())
+    }
+
+    @Test
+    fun `addSchemeToUriIfNecessary should not add https when https scheme is present`() {
+        val uriWithHttpsScheme = URI("https://example.com")
+        assertEquals(URI("https://example.com"), uriWithHttpsScheme.addSchemeToUriIfNecessary())
+    }
+
+    @Test
+    fun `addSchemeToUriIfNecessary should not add https when custom scheme is already present`() {
+        val uriWithCustomScheme = URI("bitwarden://example.com")
+        assertEquals(
+            URI("bitwarden://example.com"),
+            uriWithCustomScheme.addSchemeToUriIfNecessary(),
+        )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13948
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- If a port was specified with no scheme, the `URI` was not parsing the string correctly and was using the `host` as the `scheme`
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
before: 

https://github.com/user-attachments/assets/a0248aeb-e46f-49ac-8ae1-54b5306a7828

After: 

https://github.com/user-attachments/assets/927c4711-0a73-4d4f-beee-35331533a65a


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
