### PR TITLE
PM-14255: Remove accessibility logic to improve overall performance

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/BitwardenAccessibilityService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/BitwardenAccessibilityService.kt
@@ -23,7 +23,7 @@ class BitwardenAccessibilityService : AccessibilityService() {
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
         if (rootInActiveWindow?.packageName != event.packageName) return
-        processor.processAccessibilityEvent(rootAccessibilityNodeInfo = rootInActiveWindow)
+        processor.processAccessibilityEvent(rootAccessibilityNodeInfo = event.source)
     }
 
     override fun onInterrupt() = Unit

--- a/app/src/main/res/xml/accessibility_service.xml
+++ b/app/src/main/res/xml/accessibility_service.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:accessibilityEventTypes="typeWindowStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:accessibilityFlags="flagReportViewIds|flagRetrieveInteractiveWindows"
     android:canRetrieveWindowContent="true"


### PR DESCRIPTION
## 🎟️ Tracking

PM-14255

## 📔 Objective

This PR makes two major performance improvements for the accessibility service.
* Remove the `typeWindowContentChanged` event type which occurs much more frequently than needed.
* Remove the usage of the `RootInActiveWindow` which can take a long time to access.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/67a2f221-e2aa-46c1-a9aa-7b8e74e9d5ed" width="300" /> | <video src="https://github.com/user-attachments/assets/0fa0afa5-b633-47ed-b164-0dcfaad66fe4" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
