### PR TITLE
[PM-11753] Listening to vaultUnlock state on mutableCiphers, folders, collections and send state flow

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/util/StateFlowExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/util/StateFlowExtensions.kt
@@ -1,12 +1,15 @@
 package com.x8bit.bitwarden.data.platform.repository.util
 
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -27,6 +30,38 @@ fun <T, R> MutableStateFlow<T>.observeWhenSubscribedAndLoggedIn(
         userStateFlow.map { it?.activeUserId }.distinctUntilChanged(),
     ) { isSubscribed, activeUserId ->
         activeUserId.takeIf { isSubscribed }
+    }
+        .flatMapLatest { activeUserId ->
+            activeUserId?.let(observer) ?: flow { awaitCancellation() }
+        }
+
+/**
+ * Invokes the [observer] callback whenever the user is logged in, the active changes,
+ * the vault for the user changes and there are subscribers to the [MutableStateFlow].
+ * The flow from all previous calls to the `observer`
+ * is canceled whenever the `observer` is re-invoked, there is no active user (logged-out),
+ * there are no subscribers to the [MutableStateFlow] or the vault is not unlocked.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun <T, R> MutableStateFlow<T>.observeWhenSubscribedAndUnlocked(
+    userStateFlow: Flow<UserStateJson?>,
+    vaultUnlockFlow: StateFlow<List<VaultUnlockData>>,
+    observer: (activeUserId: String) -> Flow<R>,
+): Flow<R> =
+    combine(
+        this.subscriptionCount.map { it > 0 }.distinctUntilChanged(),
+        userStateFlow.map {
+            it?.activeUserId
+        }.distinctUntilChanged(),
+        userStateFlow.map { it?.activeUserId }
+            .filterNotNull()
+            .flatMapLatest { activeUserId ->
+                vaultUnlockFlow.map { vaultUnlockDataList ->
+                    vaultUnlockDataList.any { it.userId == activeUserId }
+                }.distinctUntilChanged()
+            },
+    ) { isSubscribed, activeUserId, isUnlocked ->
+        activeUserId.takeIf { isSubscribed && isUnlocked }
     }
         .flatMapLatest { activeUserId ->
             activeUserId?.let(observer) ?: flow { awaitCancellation() }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -35,7 +35,7 @@ import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFl
 import com.x8bit.bitwarden.data.platform.repository.util.combineDataStates
 import com.x8bit.bitwarden.data.platform.repository.util.map
 import com.x8bit.bitwarden.data.platform.repository.util.mapNullable
-import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAndLoggedIn
+import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAndUnlocked
 import com.x8bit.bitwarden.data.platform.repository.util.updateToPendingOrLoading
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
@@ -238,31 +238,47 @@ class VaultRepositoryImpl(
 
         // Setup ciphers MutableStateFlow
         mutableCiphersStateFlow
-            .observeWhenSubscribedAndLoggedIn(authDiskSource.userStateFlow) { activeUserId ->
+            .observeWhenSubscribedAndUnlocked(
+                authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultUnlockDataStateFlow,
+            ) { activeUserId ->
                 observeVaultDiskCiphers(activeUserId)
             }
             .launchIn(unconfinedScope)
+
         // Setup domains MutableStateFlow
         mutableDomainsStateFlow
-            .observeWhenSubscribedAndLoggedIn(authDiskSource.userStateFlow) { activeUserId ->
+            .observeWhenSubscribedAndUnlocked(
+                authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultUnlockDataStateFlow,
+            ) { activeUserId ->
                 observeVaultDiskDomains(activeUserId)
             }
             .launchIn(unconfinedScope)
         // Setup folders MutableStateFlow
         mutableFoldersStateFlow
-            .observeWhenSubscribedAndLoggedIn(authDiskSource.userStateFlow) { activeUserId ->
+            .observeWhenSubscribedAndUnlocked(
+                authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultUnlockDataStateFlow,
+            ) { activeUserId ->
                 observeVaultDiskFolders(activeUserId)
             }
             .launchIn(unconfinedScope)
         // Setup collections MutableStateFlow
         mutableCollectionsStateFlow
-            .observeWhenSubscribedAndLoggedIn(authDiskSource.userStateFlow) { activeUserId ->
+            .observeWhenSubscribedAndUnlocked(
+                authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultUnlockDataStateFlow,
+            ) { activeUserId ->
                 observeVaultDiskCollections(activeUserId)
             }
             .launchIn(unconfinedScope)
         // Setup sends MutableStateFlow
         mutableSendDataStateFlow
-            .observeWhenSubscribedAndLoggedIn(authDiskSource.userStateFlow) { activeUserId ->
+            .observeWhenSubscribedAndUnlocked(
+                authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultUnlockDataStateFlow,
+            ) { activeUserId ->
                 observeVaultDiskSends(activeUserId)
             }
             .launchIn(unconfinedScope)

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/util/StateFlowExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/util/StateFlowExtensionsTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.repository.util
 
 import app.cash.turbine.test
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,6 +48,74 @@ class StateFlowExtensionsTest {
                 }
                 // The user changed, so we clear the previous observer but then resubscribe
                 // with the new user ID
+                assertEquals(0, awaitItem())
+                assertEquals(1, awaitItem())
+
+                job.cancel()
+                // Job is canceled, we should have no more subscribers
+                assertEquals(0, awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `observeWhenSubscribedAndUnlocked should observe the given flow depending on the state of the source user and vault unlock flow`() =
+        runTest {
+            val userStateFlow = MutableStateFlow<UserStateJson?>(null)
+            val vaultUnlockFlow = MutableStateFlow<List<VaultUnlockData>>(emptyList())
+            val observerStateFlow = MutableStateFlow("")
+            val sourceMutableStateFlow = MutableStateFlow(Unit)
+
+            assertEquals(0, observerStateFlow.subscriptionCount.value)
+            sourceMutableStateFlow
+                .observeWhenSubscribedAndUnlocked(
+                    userStateFlow = userStateFlow,
+                    vaultUnlockFlow = vaultUnlockFlow,
+                    observer = { observerStateFlow },
+                )
+                .launchIn(backgroundScope)
+
+            observerStateFlow.subscriptionCount.test {
+                // No subscriber to start
+                assertEquals(0, awaitItem())
+
+                userStateFlow.value = mockk<UserStateJson> {
+                    every { activeUserId } returns "user_id_1234"
+                }
+                // Still none, since no one has subscribed to the testMutableStateFlow
+                expectNoEvents()
+
+                vaultUnlockFlow.value = listOf(
+                    VaultUnlockData(
+                        userId = "user_id_1234",
+                        status = VaultUnlockData.Status.UNLOCKED,
+                    ),
+                )
+
+                // Still none, since no one has subscribed to the testMutableStateFlow
+                expectNoEvents()
+
+                val job = sourceMutableStateFlow.launchIn(backgroundScope)
+                // Now we subscribe to the observer flow since have a active user and a listener
+                assertEquals(1, awaitItem())
+
+                userStateFlow.value = mockk<UserStateJson> {
+                    every { activeUserId } returns "user_id_4321"
+                }
+                // The user changed, so we clear the previous observer but then resubscribe
+                // with the new user ID
+                assertEquals(0, awaitItem())
+                assertEquals(1, awaitItem())
+
+                vaultUnlockFlow.value = listOf(
+                    VaultUnlockData(
+                        userId = "user_id_4321",
+                        status = VaultUnlockData.Status.UNLOCKED,
+                    ),
+                )
+
+                // The VaultUnlockData changed, so we clear the previous observer but then resubscribe
+                // with the new data
                 assertEquals(0, awaitItem())
                 assertEquals(1, awaitItem())
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -339,7 +339,11 @@ class VaultRepositoryTest {
             collectionsStateFlow.expectNoEvents()
             foldersStateFlow.expectNoEvents()
             sendsStateFlow.expectNoEvents()
-            domainsStateFlow.expectNoEvents()
+            // Domains does not care about being unlocked
+            assertEquals(
+                DataState.Loaded(createMockDomainsData(number = 1)),
+                domainsStateFlow.awaitItem(),
+            )
 
             setVaultToUnlocked(userId = userId)
 
@@ -365,10 +369,8 @@ class VaultRepositoryTest {
                 DataState.Loaded(SendData(listOf(createMockSendView(number = 1)))),
                 sendsStateFlow.awaitItem(),
             )
-            assertEquals(
-                DataState.Loaded(createMockDomainsData(number = 1)),
-                domainsStateFlow.awaitItem(),
-            )
+            // Domain data has not changed
+            domainsStateFlow.expectNoEvents()
 
             fakeAuthDiskSource.userState = null
 
@@ -492,7 +494,7 @@ class VaultRepositoryTest {
                 assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
                 assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
                 assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
-                assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
+                domainsStateFlow.expectNoEvents()
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11753

## 📔 Objective

In some instances the vault gets stuck on an infinite loading. 
This is caused by some scenarios when the app is on background and the vault gets locked the requirements to emit on `observeWhenSubscribedAndLoggedIn` are not met causing the observer to not be called anymore.

This tries to fix it by creating a new flow that also listens to the `vaultUnlockFlow`.
mutableStateFlow on the VaultRepository will listen to the `observeWhenSubscribedAndUnlocked` and call the observer on unlock

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
