### PR TITLE
[PM-14346] Run alias generation on the IO dispatcher

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryImpl.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.Clock
 import javax.inject.Singleton
 
@@ -190,7 +191,7 @@ class GeneratorRepositoryImpl(
 
     override suspend fun generateForwardedServiceUsername(
         forwardedServiceGeneratorRequest: UsernameGeneratorRequest.Forwarded,
-    ): GeneratedForwardedServiceUsernameResult =
+    ): GeneratedForwardedServiceUsernameResult = withContext(scope.coroutineContext) {
         generatorSdkSource.generateForwardedServiceEmail(forwardedServiceGeneratorRequest)
             .fold(
                 onSuccess = { generatedEmail ->
@@ -200,6 +201,7 @@ class GeneratorRepositoryImpl(
                     GeneratedForwardedServiceUsernameResult.InvalidRequest(it.message)
                 },
             )
+    }
 
     override fun getPasscodeGenerationOptions(): PasscodeGenerationOptions? {
         val userId = authDiskSource.userState?.activeUserId


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14346

## 📔 Objective

This commit modifies `generateForwardedServiceUsername` to run on the IO dispatcher by using `withContext`. This change ensures that any network calls made by the SDK are not executed on the main thread.

## 📸 Screenshots

https://github.com/user-attachments/assets/c21c060b-596c-47ba-9a35-bcd8dda87dc3

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
