### PR TITLE
PM-14044: Fix line-breaking logic

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensions.kt
@@ -21,7 +21,7 @@ import kotlin.math.floor
  * This character takes up no space but can be used to ensure a string is not empty. It can also
  * be used to insert "safe" line-break positions in a string.
  *
- * Note: Is a string only contains this charactor, it is _not_ considered blank.
+ * Note: Is a string only contains this character, it is _not_ considered blank.
  */
 const val ZERO_WIDTH_CHARACTER: String = "\u200B"
 
@@ -126,14 +126,15 @@ fun String.withLineBreaksAtWidth(
 ): String {
     val measurer = rememberTextMeasurer()
     return remember(this, widthPx, monospacedTextStyle) {
-        val characterSizePx = measurer
-            .measure("*", monospacedTextStyle)
-            .size
-            .width
-        val perLineCharacterLimit = floor(widthPx / characterSizePx).toInt()
-        if (widthPx > 0) {
+        if (widthPx > 0 && this.isNotEmpty()) {
+            val stringLengthPx = measurer
+                .measure(text = this, softWrap = false, style = monospacedTextStyle)
+                .size
+                .width
+            val linesRequired = stringLengthPx / widthPx
+            val charsPerLine = floor(this.length / linesRequired).toInt()
             this
-                .chunked(perLineCharacterLimit)
+                .chunked(size = charsPerLine)
                 .joinToString(separator = "\n")
         } else {
             this


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14044](https://bitwarden.atlassian.net/browse/PM-14044)

## 📔 Objective

This PR adjusts the line break logic to measure the entire string instead of an individual character.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/30cd4915-6a8a-4479-b643-7fda0ce3df97" width="300" /> | <video src="https://github.com/user-attachments/assets/9be271eb-b9d8-4af4-8f5c-2644fe566ec7" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14044]: https://bitwarden.atlassian.net/browse/PM-14044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ