### PR TITLE
PM-14379: Stop storing 'null' in as the word separator

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -351,7 +351,7 @@ class GeneratorViewModel @Inject constructor(
                     GeneratorState.MainType.Passphrase(
                         numWords = max(options.numWords, minNumWords),
                         minNumWords = minNumWords,
-                        wordSeparator = options.wordSeparator.toCharArray().first(),
+                        wordSeparator = options.wordSeparator.toCharArray().firstOrNull(),
                         capitalize = options.allowCapitalize || policy.capitalize == true,
                         capitalizeEnabled = policy.capitalize != true,
                         includeNumber = options.allowIncludeNumber || policy.includeNumber == true,
@@ -462,7 +462,7 @@ class GeneratorViewModel @Inject constructor(
         val newOptions = options.copy(
             type = PasscodeGenerationOptions.PasscodeType.PASSPHRASE,
             numWords = passphrase.numWords,
-            wordSeparator = passphrase.wordSeparator.toString(),
+            wordSeparator = passphrase.wordSeparator?.toString().orEmpty(),
             allowCapitalize = passphrase.capitalize,
             allowIncludeNumber = passphrase.includeNumber,
         )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14379](https://bitwarden.atlassian.net/browse/PM-14379)

## 📔 Objective

This PR fixes a bug where we were storing the word `null` as the word separator which caused the value to default to the first char, `n`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14379]: https://bitwarden.atlassian.net/browse/PM-14379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ