### PR TITLE
PM-14036: Add extra slider padding

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -460,7 +460,7 @@ private fun ColumnScope.PasswordTypeContent(
         valueTag = "PasswordLengthLabel",
         modifier = Modifier
             .fillMaxWidth()
-            .padding(end = 16.dp),
+            .padding(end = 28.dp),
     )
 
     Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14036](https://bitwarden.atlassian.net/browse/PM-14036)

## 📔 Objective

This PR adds addition end padding to the slider on the Generator Screen. This is an attempt to lower the odds that grabbing the slider thumb when it is at the end of the screen will trigger a navigate-back gesture.

Design approved of this extra padding.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/97fce7fb-d84b-4bd4-9f61-ff48433f3737" width="300" /> | <img src="https://github.com/user-attachments/assets/d836e862-ba60-4b54-b5d3-49484e0584fd" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14036]: https://bitwarden.atlassian.net/browse/PM-14036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ