### PR TITLE
PM-14433 update flow type to nullable so we can handle when an empty …

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -124,6 +125,7 @@ class VaultDiskSourceImpl(
     override fun getDomains(userId: String): Flow<SyncResponseJson.Domains> =
         domainsDao
             .getDomains(userId)
+            .filterNotNull()
             .map { entity ->
                 withContext(dispatcherManager.default) {
                     json.decodeFromString<SyncResponseJson.Domains>(entity.domainsJson)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/dao/DomainsDao.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/dao/DomainsDao.kt
@@ -25,7 +25,7 @@ interface DomainsDao {
     @Query("SELECT * FROM domains WHERE user_id = :userId")
     fun getDomains(
         userId: String,
-    ): Flow<DomainsEntity>
+    ): Flow<DomainsEntity?>
 
     /**
      * Inserts domains into the database.


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-14433
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Avoid call on a null object when a query is made against an empty table returning a Flow. 
- According to the [documentation](https://developer.android.com/reference/androidx/room/Query), this should have thrown a NPE, but it seems that there is an open [issue](https://issuetracker.google.com/issues/213175894) where it actually is returning Flow<T?> and emitting `null`. Updating the contract to return a `Flow<DomainEntity>` so it matches the result we get from Room, then we filter out the null emissions where we are mapping back to the JSON.
- FWIW: I checked other areas in the codebase where we are returning `Flow`s from Room and they are all `Flow<List<T>>` so they will return an empty list when the table is empty.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
