### PR TITLE
PM-14353 : Clean up consumed snackbar on quick resubmission due to state based nav.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelayManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelayManager.kt
@@ -19,4 +19,9 @@ interface SnackbarRelayManager {
      * the [relay] to receive the data from.
      */
     fun getSnackbarDataFlow(relay: SnackbarRelay): Flow<BitwardenSnackbarData>
+
+    /**
+     * Clears the buffer for the given [relay].
+     */
+    fun clearRelayBuffer(relay: SnackbarRelay)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelayManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelayManagerImpl.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.manager.snackbar
 
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -25,6 +26,11 @@ class SnackbarRelayManagerImpl : SnackbarRelayManager {
                 mutableSnackbarRelayMap.remove(relay)
             }
             .filterNotNull()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun clearRelayBuffer(relay: SnackbarRelay) {
+        getSnackbarDataFlowInternal(relay).resetReplayCache()
+    }
 
     private fun getSnackbarDataFlowInternal(
         relay: SnackbarRelay,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -76,8 +76,8 @@ class VaultViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val vaultRepository: VaultRepository,
     private val firstTimeActionManager: FirstTimeActionManager,
+    private val snackbarRelayManager: SnackbarRelayManager,
     featureFlagManager: FeatureFlagManager,
-    snackbarRelayManager: SnackbarRelayManager,
 ) : BaseViewModel<VaultState, VaultEvent, VaultAction>(
     initialState = run {
         val userState = requireNotNull(authRepository.userStateFlow.value)
@@ -287,6 +287,9 @@ class VaultViewModel @Inject constructor(
                 SwitchAccountResult.AccountSwitched -> true
                 SwitchAccountResult.NoChange -> false
             }
+        if (isSwitchingAccounts) {
+            snackbarRelayManager.clearRelayBuffer(SnackbarRelay.MY_VAULT_RELAY)
+        }
         mutableStateFlow.update {
             it.copy(isSwitchingAccounts = isSwitchingAccounts)
         }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-14353
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Snackbar was briefly showing while the account was switched, due to the navigation being user state based the next instance of the VaultViewModel was collecting from the shared flow before it was removed from the internal map on completion of the previous instance. 
- Added a function to explicitly clear the replay cache.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
| before | after |
|--------|--------|
| [example](https://github.com/user-attachments/assets/532028a8-4d41-4ab9-9cd1-43167ba4f94e) | [pm14353after.webm](https://github.com/user-attachments/assets/4fecf845-a430-416b-84ac-8ee1b1144abe) | 
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
