### PR TITLE
PM-14433: Handle a null domains object in the sync response and database

### DIFF
--- a/app/schemas/com.x8bit.bitwarden.data.vault.datasource.disk.database.VaultDatabase/5.json
+++ b/app/schemas/com.x8bit.bitwarden.data.vault.datasource.disk.database.VaultDatabase/5.json
@@ -1,0 +1,256 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "ee697e71290c92fe5b607d0b7665481b",
+    "entities": [
+      {
+        "tableName": "ciphers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `cipher_type` TEXT NOT NULL, `cipher_json` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cipherType",
+            "columnName": "cipher_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cipherJson",
+            "columnName": "cipher_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ciphers_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ciphers_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `organization_id` TEXT NOT NULL, `should_hide_passwords` INTEGER NOT NULL, `name` TEXT NOT NULL, `external_id` TEXT, `read_only` INTEGER NOT NULL, `manage` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "organizationId",
+            "columnName": "organization_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldHidePasswords",
+            "columnName": "should_hide_passwords",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalId",
+            "columnName": "external_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isReadOnly",
+            "columnName": "read_only",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canManage",
+            "columnName": "manage",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collections_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_collections_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "domains",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` TEXT NOT NULL, `domains_json` TEXT, PRIMARY KEY(`user_id`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainsJson",
+            "columnName": "domains_json",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "user_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `name` TEXT, `revision_date` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "revisionDate",
+            "columnName": "revision_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_folders_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_folders_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sends",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `send_type` TEXT NOT NULL, `send_json` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sendType",
+            "columnName": "send_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sendJson",
+            "columnName": "send_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sends_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sends_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ee697e71290c92fe5b607d0b7665481b')"
+    ]
+  }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
@@ -37,7 +37,7 @@ interface VaultDiskSource {
     /**
      * Retrieves all domains from the data source for a given [userId].
      */
-    fun getDomains(userId: String): Flow<SyncResponseJson.Domains>
+    fun getDomains(userId: String): Flow<SyncResponseJson.Domains?>
 
     /**
      * Deletes a folder from the data source for the given [userId] and [folderId].

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -121,12 +121,12 @@ class VaultDiskSourceImpl(
                 },
         )
 
-    override fun getDomains(userId: String): Flow<SyncResponseJson.Domains> =
+    override fun getDomains(userId: String): Flow<SyncResponseJson.Domains?> =
         domainsDao
             .getDomains(userId)
             .map { entity ->
                 withContext(dispatcherManager.default) {
-                    json.decodeFromString<SyncResponseJson.Domains>(entity.domainsJson)
+                    entity?.domainsJson?.let { json.decodeFromString<SyncResponseJson.Domains>(it) }
                 }
             }
 
@@ -240,7 +240,7 @@ class VaultDiskSourceImpl(
                 domainsDao.insertDomains(
                     domains = DomainsEntity(
                         userId = userId,
-                        domainsJson = json.encodeToString(vault.domains),
+                        domainsJson = vault.domains?.let { json.encodeToString(it) },
                     ),
                 )
             }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/dao/DomainsDao.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/dao/DomainsDao.kt
@@ -25,7 +25,7 @@ interface DomainsDao {
     @Query("SELECT * FROM domains WHERE user_id = :userId")
     fun getDomains(
         userId: String,
-    ): Flow<DomainsEntity>
+    ): Flow<DomainsEntity?>
 
     /**
      * Inserts domains into the database.

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/database/VaultDatabase.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/database/VaultDatabase.kt
@@ -26,7 +26,7 @@ import com.x8bit.bitwarden.data.vault.datasource.disk.entity.SendEntity
         FolderEntity::class,
         SendEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 @TypeConverters(ZonedDateTimeTypeConverter::class)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/entity/DomainsEntity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/entity/DomainsEntity.kt
@@ -14,5 +14,5 @@ data class DomainsEntity(
     val userId: String,
 
     @ColumnInfo(name = "domains_json")
-    val domainsJson: String,
+    val domainsJson: String?,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
@@ -39,7 +39,7 @@ data class SyncResponseJson(
     val policies: List<Policy>?,
 
     @SerialName("domains")
-    val domains: Domains,
+    val domains: Domains?,
 
     @SerialName("sends")
     val sends: List<Send>?,

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/util/DomainsExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/util/DomainsExtensions.kt
@@ -6,14 +6,14 @@ import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 /**
  * Map the API [Domains] model to the internal [DomainsData] model.
  */
-fun Domains.toDomainsData(): DomainsData {
+fun Domains?.toDomainsData(): DomainsData {
     val globalEquivalentDomains = this
-        .globalEquivalentDomains
+        ?.globalEquivalentDomains
         ?.map { it.toInternalModel() }
         .orEmpty()
 
     return DomainsData(
-        equivalentDomains = this.equivalentDomains.orEmpty(),
+        equivalentDomains = this?.equivalentDomains.orEmpty(),
         globalEquivalentDomains = globalEquivalentDomains,
     )
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -248,10 +248,13 @@ class VaultDiskSourceTest {
         // We cannot compare the JSON strings directly because of formatting differences
         // So we split that off into its own assertion.
         assertEquals(
-            DOMAINS_ENTITY.copy(domainsJson = ""),
-            storedDomainsEntity.copy(domainsJson = ""),
+            DOMAINS_ENTITY.copy(domainsJson = null),
+            storedDomainsEntity.copy(domainsJson = null),
         )
-        assertJsonEquals(DOMAINS_ENTITY.domainsJson, storedDomainsEntity.domainsJson)
+        assertJsonEquals(
+            requireNotNull(DOMAINS_ENTITY.domainsJson),
+            requireNotNull(storedDomainsEntity.domainsJson),
+        )
 
         // Verify the folders dao is updated
         assertEquals(listOf(FOLDER_ENTITY), foldersDao.storedFolders)

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeDomainsDao.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeDomainsDao.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.data.vault.datasource.disk.dao
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.data.vault.datasource.disk.entity.DomainsEntity
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filterNotNull
 
 class FakeDomainsDao : DomainsDao {
     var storedDomains: DomainsEntity? = null
@@ -18,9 +17,9 @@ class FakeDomainsDao : DomainsDao {
         deleteDomainsCalled = true
     }
 
-    override fun getDomains(userId: String): Flow<DomainsEntity> {
+    override fun getDomains(userId: String): Flow<DomainsEntity?> {
         getDomainsCalled = true
-        return mutableDomainsFlow.filterNotNull()
+        return mutableDomainsFlow
     }
 
     override suspend fun insertDomains(domains: DomainsEntity) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14433](https://bitwarden.atlassian.net/browse/PM-14433)

## 📔 Objective

This PR allows for the domains data to be nullable in the sync response JSON and handles all the downstream affects that change has.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
