### PR TITLE
PM-14411: Allow accessibility autofill to run when app is already in …

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
@@ -38,7 +38,7 @@ fun createAutofillSelectionIntent(
         .apply {
             // This helps prevent a crash when using the accessibility framework
             if (framework == AutofillSelectionData.Framework.ACCESSIBILITY) {
-                setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
             putExtra(
                 AUTOFILL_BUNDLE_KEY,

--- a/app/src/main/java/com/x8bit/bitwarden/data/tiles/BitwardenAutofillTileService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tiles/BitwardenAutofillTileService.kt
@@ -44,7 +44,7 @@ class BitwardenAutofillTileService : TileService() {
         }
         accessibilityAutofillManager.accessibilityAction = AccessibilityAction.AttemptParseUri
         val intent = Intent(applicationContext, AccessibilityActivity::class.java)
-            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .setFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
         if (isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
             @Suppress("DEPRECATION")
             startActivityAndCollapse(intent)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14411](https://bitwarden.atlassian.net/browse/PM-14411)

## 📔 Objective

This PR allows the accessibility autofill functionality to work when the app is already open.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/fbda7ad5-fd10-43e2-acdc-f21cf9eb8574" width="300" /> | <video src="https://github.com/user-attachments/assets/238813ab-7186-4914-9be3-5583501e3de0" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14411]: https://bitwarden.atlassian.net/browse/PM-14411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ