### PR TITLE
PM-13988 Hide the action card if the user makes a selection but does not click continue on setup unlock

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
@@ -76,6 +76,11 @@ class SetupUnlockViewModel @Inject constructor(
     }
 
     private fun handleCloseClick() {
+        // If the user has enabled biometric or PIN lock, but then closes the screen we
+        // want to dismiss the action card.
+        if (state.isContinueButtonEnabled) {
+            firstTimeActionManager.storeShowUnlockSettingBadge(showBadge = false)
+        }
         sendEvent(SetupUnlockEvent.NavigateBack)
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
@@ -352,7 +352,22 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
                 awaitItem(),
             )
         }
+        verify(exactly = 0) {
+            firstTimeActionManager.storeShowUnlockSettingBadge(showBadge = false)
+        }
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `CloseClick action should update the first time state to false if continue button is enabled`() =
+        runTest {
+            val viewModel =
+                createViewModel(state = DEFAULT_STATE.copy(isUnlockWithPinEnabled = true))
+            viewModel.trySendAction(SetupUnlockAction.CloseClick)
+            verify {
+                firstTimeActionManager.storeShowUnlockSettingBadge(showBadge = false)
+            }
+        }
 
     private fun createViewModel(
         state: SetupUnlockState? = null,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13988
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Expected behavior is that if a selection is made for unlock method that the action card and badge should no longer appear in the settings menu.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/bb1bfb5c-f246-4ee2-baf5-de6077f42405


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
