### PR TITLE
PM-14333 Gather more information around our custom password fields to see if that is related to the Index OoB crash.

### DIFF
--- a/app/src/fdroid/java/com/x8bit/bitwarden/data/platform/manager/LogsManagerImpl.kt
+++ b/app/src/fdroid/java/com/x8bit/bitwarden/data/platform/manager/LogsManagerImpl.kt
@@ -24,4 +24,6 @@ class LogsManagerImpl(
     override fun setUserData(userId: String?, environmentType: Environment.Type) = Unit
 
     override fun trackNonFatalException(throwable: Throwable) = Unit
+
+    override fun trackBreadCrumb(breadCrumbMessage: String) = Unit
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/LogsManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/LogsManager.kt
@@ -18,6 +18,11 @@ interface LogsManager {
     fun trackNonFatalException(throwable: Throwable)
 
     /**
+     * Logs a breadcrumb to be used for debugging errors if logs are enabled.
+     */
+    fun trackBreadCrumb(breadCrumbMessage: String)
+
+    /**
      * Tracks the current user data.
      */
     fun setUserData(userId: String?, environmentType: Environment.Type)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -83,16 +83,15 @@ fun BitwardenPasswordField(
     }
     val currentLocale = LocalConfiguration.current.locales[0]
     LaunchedEffect(
-        key1 = showPassword,
-        key2 = readOnly,
+        key1 = transformationLogKey,
     ) {
         val anyUndefinedChars = value.any { !it.isDefined() }
         Timber.i(
-            message = "Recording this value for debugging issue related to issue PM-14333\n" +
-                "Transformation applied: $transformationLogKey " +
-                "the length of the text is ${value.length}. \n" +
+            message = "Recording this value for debugging issue related to issue PM-14333.\n" +
+                "Transformation applied: $transformationLogKey.\n " +
+                "the length of the text is ${value.length}.\n" +
                 "Current system language is ${currentLocale.language}.\n" +
-                "Determined that there are undefined characters: $anyUndefinedChars",
+                "Determined that there are undefined characters: $anyUndefinedChars.",
         )
     }
 

--- a/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/LogsManagerImpl.kt
+++ b/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/LogsManagerImpl.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.platform.manager
 
+import android.util.Log
 import com.google.firebase.crashlytics.ktx.crashlytics
 import com.google.firebase.ktx.Firebase
 import com.x8bit.bitwarden.BuildConfig
@@ -49,6 +50,12 @@ class LogsManagerImpl(
         }
     }
 
+    override fun trackBreadCrumb(breadCrumbMessage: String) {
+        if (isEnabled) {
+            Firebase.crashlytics.log(breadCrumbMessage)
+        }
+    }
+
     init {
         legacyAppCenterMigrator.migrateIfNecessary()
         isEnabled = settingsRepository.isCrashLoggingEnabled
@@ -56,6 +63,9 @@ class LogsManagerImpl(
 
     private inner class NonfatalErrorTree : Timber.Tree() {
         override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            if (priority == Log.INFO) {
+                trackBreadCrumb(message)
+            }
             t?.let { trackNonFatalException(BitwardenNonfatalException(message, it)) }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-14333
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Gather information breadcrumbs around the `BitwardenPasswordField`s to see if there is any correlation with the index out of bounds crash.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
![image](https://github.com/user-attachments/assets/0242f1e7-97e6-48d6-a6ea-5b738e152616)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
