### PR TITLE
PM-14644: Segmented control should be conditionally displayed for modal generator screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
@@ -29,6 +29,7 @@ fun BitwardenSegmentedButton(
     options: ImmutableList<SegmentedButtonState>,
     modifier: Modifier = Modifier,
 ) {
+    if (options.isEmpty()) return
     Box(
         modifier = modifier
             .background(color = BitwardenTheme.colorScheme.background.secondary)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -202,16 +202,14 @@ fun GeneratorScreen(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
-            if (state.generatorMode == GeneratorMode.Default) {
-                MainStateOptionsItem(
-                    selectedType = state.selectedType,
-                    passcodePolicyOverride = state.passcodePolicyOverride,
-                    possibleMainStates = state.typeOptions.toImmutableList(),
-                    onMainStateOptionClicked = onMainStateOptionClicked,
-                    modifier = Modifier
-                        .scrolledContainerBottomDivider(topAppBarScrollBehavior = scrollBehavior),
-                )
-            }
+            MainStateOptionsItem(
+                selectedType = state.selectedType,
+                passcodePolicyOverride = state.passcodePolicyOverride,
+                possibleMainStates = state.typeOptions.toImmutableList(),
+                onMainStateOptionClicked = onMainStateOptionClicked,
+                modifier = Modifier
+                    .scrolledContainerBottomDivider(topAppBarScrollBehavior = scrollBehavior),
+            )
             ScrollContent(
                 state = state,
                 onRegenerateClick = onRegenerateClick,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import kotlin.collections.filter
 import kotlin.math.max
 
 private const val KEY_STATE = "state"
@@ -1726,10 +1727,17 @@ data class GeneratorState(
 ) : Parcelable {
 
     /**
-     * Provides a list of available main types for the generator.
+     * Provides a list of available main types for the generator based on the [GeneratorMode].
      */
     val typeOptions: List<MainTypeOption>
-        get() = MainTypeOption.entries.toList()
+        get() = when (generatorMode) {
+            GeneratorMode.Default -> MainTypeOption.entries.toList()
+            GeneratorMode.Modal.Password -> MainTypeOption
+                .entries
+                .filter { it != MainTypeOption.USERNAME }
+
+            is GeneratorMode.Modal.Username -> emptyList()
+        }
 
     /**
      * Enum representing the main type options for the generator, such as PASSWORD PASSPHRASE, and


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14644](https://bitwarden.atlassian.net/browse/PM-14644)

## 📔 Objective

This PR updates the logic for displaying the segmented control and its options on the generator screen based on the `GeneratorMode`.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/72b9ee5b-3380-463d-a996-0c47c43a52a2" width="300" /> | <img src="https://github.com/user-attachments/assets/767e679d-2a9e-4321-b1b7-ee5a3b2ca4da" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14644]: https://bitwarden.atlassian.net/browse/PM-14644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ