### PR TITLE
PM-14411: Allow accessibility autofill to run when app is already in …

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -190,12 +190,14 @@ class MainViewModel @Inject constructor(
     private fun handleAccessibilitySelectionReceive(
         action: MainAction.Internal.AccessibilitySelectionReceive,
     ) {
+        specialCircumstanceManager.specialCircumstance = null
         sendEvent(MainEvent.CompleteAccessibilityAutofill(cipherView = action.cipherView))
     }
 
     private fun handleAutofillSelectionReceive(
         action: MainAction.Internal.AutofillSelectionReceive,
     ) {
+        specialCircumstanceManager.specialCircumstance = null
         sendEvent(MainEvent.CompleteAutofill(cipherView = action.cipherView))
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityCompletionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityCompletionManagerImpl.kt
@@ -26,18 +26,18 @@ class AccessibilityCompletionManagerImpl(
             .intent
             ?.getAutofillSelectionDataOrNull()
             ?: run {
-                activity.finish()
+                activity.finishAndRemoveTask()
                 return
             }
         if (autofillSelectionData.framework != AutofillSelectionData.Framework.ACCESSIBILITY) {
-            activity.finish()
+            activity.finishAndRemoveTask()
             return
         }
         val uri = autofillSelectionData
             .uri
             ?.toUriOrNull()
             ?: run {
-                activity.finish()
+                activity.finishAndRemoveTask()
                 return
             }
 
@@ -47,7 +47,7 @@ class AccessibilityCompletionManagerImpl(
         )
         mainScope.launch {
             totpManager.tryCopyTotpToClipboard(cipherView = cipherView)
-            activity.finish()
         }
+        activity.finishAndRemoveTask()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
@@ -38,7 +38,7 @@ fun createAutofillSelectionIntent(
         .apply {
             // This helps prevent a crash when using the accessibility framework
             if (framework == AutofillSelectionData.Framework.ACCESSIBILITY) {
-                setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
             }
             putExtra(
                 AUTOFILL_BUNDLE_KEY,

--- a/app/src/main/java/com/x8bit/bitwarden/data/tiles/BitwardenAutofillTileService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tiles/BitwardenAutofillTileService.kt
@@ -44,7 +44,7 @@ class BitwardenAutofillTileService : TileService() {
         }
         accessibilityAutofillManager.accessibilityAction = AccessibilityAction.AttemptParseUri
         val intent = Intent(applicationContext, AccessibilityActivity::class.java)
-            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
         if (isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
             @Suppress("DEPRECATION")
             startActivityAndCollapse(intent)

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityCompletionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityCompletionManagerTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
 class AccessibilityCompletionManagerTest {
 
     private val activity: Activity = mockk {
-        every { finish() } just runs
+        every { finishAndRemoveTask() } just runs
     }
     private val accessibilityAutofillManager: AccessibilityAutofillManager = mockk()
     private val totpManager: AutofillTotpManager = mockk()
@@ -68,7 +68,7 @@ class AccessibilityCompletionManagerTest {
 
         verify(exactly = 1) {
             activity.intent
-            activity.finish()
+            activity.finishAndRemoveTask()
         }
     }
 
@@ -87,7 +87,7 @@ class AccessibilityCompletionManagerTest {
         verify(exactly = 1) {
             activity.intent
             mockIntent.getAutofillSelectionDataOrNull()
-            activity.finish()
+            activity.finishAndRemoveTask()
         }
     }
 
@@ -111,7 +111,7 @@ class AccessibilityCompletionManagerTest {
         verify(exactly = 1) {
             activity.intent
             mockIntent.getAutofillSelectionDataOrNull()
-            activity.finish()
+            activity.finishAndRemoveTask()
         }
     }
 
@@ -135,7 +135,7 @@ class AccessibilityCompletionManagerTest {
         verify(exactly = 1) {
             activity.intent
             mockIntent.getAutofillSelectionDataOrNull()
-            activity.finish()
+            activity.finishAndRemoveTask()
         }
     }
 
@@ -162,7 +162,7 @@ class AccessibilityCompletionManagerTest {
         verify(exactly = 1) {
             activity.intent
             mockIntent.getAutofillSelectionDataOrNull()
-            activity.finish()
+            activity.finishAndRemoveTask()
         }
     }
 
@@ -201,7 +201,7 @@ class AccessibilityCompletionManagerTest {
                 cipherView = cipherView,
                 uri = uri,
             )
-            activity.finish()
+            activity.finishAndRemoveTask()
         }
         coVerify(exactly = 1) {
             totpManager.tryCopyTotpToClipboard(cipherView = cipherView)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14411](https://bitwarden.atlassian.net/browse/PM-14411)

## 📔 Objective

This PR allows the accessibility autofill functionality to work when the app is already open.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/fbda7ad5-fd10-43e2-acdc-f21cf9eb8574" width="300" /> | <video src="https://github.com/user-attachments/assets/238813ab-7186-4914-9be3-5583501e3de0" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14411]: https://bitwarden.atlassian.net/browse/PM-14411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ