### PR TITLE
[PM-14526] Add JsonNames annotation to SyncResponseJson

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -125,7 +124,6 @@ class VaultDiskSourceImpl(
     override fun getDomains(userId: String): Flow<SyncResponseJson.Domains?> =
         domainsDao
             .getDomains(userId)
-            .filterNotNull()
             .map { entity ->
                 withContext(dispatcherManager.default) {
                     entity?.domainsJson?.let { json.decodeFromString<SyncResponseJson.Domains>(it) }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
@@ -1,8 +1,10 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import kotlinx.serialization.json.JsonObject
 import java.time.ZonedDateTime
 
@@ -21,6 +23,7 @@ private const val DEFAULT_FIDO_2_KEY_CURVE = "P-256"
  * @property domains A domains object associated with the vault data.
  * @property sends A list of send objects associated with the vault data (nullable).
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SyncResponseJson(
     @SerialName("folders")
@@ -30,6 +33,7 @@ data class SyncResponseJson(
     val collections: List<Collection>?,
 
     @SerialName("profile")
+    @JsonNames("Profile")
     val profile: Profile,
 
     @SerialName("ciphers")
@@ -39,6 +43,7 @@ data class SyncResponseJson(
     val policies: List<Policy>?,
 
     @SerialName("domains")
+    @JsonNames("Domains")
     val domains: Domains?,
 
     @SerialName("sends")


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14526
Cherry-picked from #4247 (816b9769) from branch `release/hotfix-v2024.11.1`.

## 📔 Objective

Adds the `@JsonNames` annotation to the `profile` and `domains` properties in the `SyncResponseJson` data class.

This ensures that the properties are correctly deserialized even if the server response uses different casing for the property names.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
