### PR TITLE
[PM-14656] Add default value to BaseEnumeratedIntSerializer

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/serializer/BaseEnumeratedIntSerializer.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/serializer/BaseEnumeratedIntSerializer.kt
@@ -10,11 +10,13 @@ import kotlinx.serialization.encoding.Encoder
 
 /**
  * Base [KSerializer] for mapping an [Enum] with possible values given by [values] to/from integer
- * values, which should be specified using [SerialName].
+ * values, which should be specified using [SerialName]. If a [default] value is provided, it will
+ * be used when an unknown value is provided.
  */
 @Suppress("UnnecessaryAbstractClass")
 abstract class BaseEnumeratedIntSerializer<T : Enum<T>>(
     private val values: Array<T>,
+    private val default: T? = null,
 ) : KSerializer<T> {
 
     override val descriptor: SerialDescriptor
@@ -25,7 +27,9 @@ abstract class BaseEnumeratedIntSerializer<T : Enum<T>>(
 
     override fun deserialize(decoder: Decoder): T {
         val decodedValue = decoder.decodeInt().toString()
-        return values.first { it.serialNameAnnotation?.value == decodedValue }
+        return values.firstOrNull { it.serialNameAnnotation?.value == decodedValue }
+            ?: default
+            ?: throw IllegalArgumentException("Unknown value $decodedValue")
     }
 
     override fun serialize(encoder: Encoder, value: T) {

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/PolicyTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/PolicyTypeJson.kt
@@ -81,8 +81,19 @@ enum class PolicyTypeJson {
      */
     @SerialName("11")
     ACTIVATE_AUTOFILL,
+
+    /**
+     * Represents an unknown policy type.
+     *
+     * This is used for forward compatibility to handle new policy types that the client doesn't yet
+     * understand.
+     */
+    @SerialName("-1")
+    UNKNOWN,
 }
 
 @Keep
-private class PolicyTypeSerializer :
-    BaseEnumeratedIntSerializer<PolicyTypeJson>(PolicyTypeJson.entries.toTypedArray())
+private class PolicyTypeSerializer : BaseEnumeratedIntSerializer<PolicyTypeJson>(
+    values = PolicyTypeJson.entries.toTypedArray(),
+    default = PolicyTypeJson.UNKNOWN,
+)

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/serializer/BaseEnumeratedIntSerializerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/serializer/BaseEnumeratedIntSerializerTest.kt
@@ -35,6 +35,18 @@ class BaseEnumeratedIntSerializerTest {
             ),
         )
     }
+
+    @Test
+    fun `properly returns default value when unknown value is provided`() {
+        assertEquals(
+            TestEnum.UNKNOWN,
+            json.decodeFromString<TestEnum>(
+                """
+                -1
+                """,
+            ),
+        )
+    }
 }
 
 @Serializable(TestEnumSerializer::class)
@@ -44,7 +56,12 @@ private enum class TestEnum {
 
     @SerialName("2")
     CASE_2,
+
+    @SerialName("-1")
+    UNKNOWN,
 }
 
-private class TestEnumSerializer :
-    BaseEnumeratedIntSerializer<TestEnum>(values = TestEnum.entries.toTypedArray())
+private class TestEnumSerializer : BaseEnumeratedIntSerializer<TestEnum>(
+    values = TestEnum.entries.toTypedArray(),
+    default = TestEnum.UNKNOWN,
+)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14656

## 📔 Objective

Adds a default value to the BaseEnumeratedIntSerializer to handle unknown values during deserialization. This ensures that unknown values will be deserialized to the specified default value instead of throwing an exception.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
