### PR TITLE
Improve accessibility autofill performance

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/BitwardenAccessibilityService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/BitwardenAccessibilityService.kt
@@ -22,8 +22,7 @@ class BitwardenAccessibilityService : AccessibilityService() {
     lateinit var processor: BitwardenAccessibilityProcessor
 
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
-        if (rootInActiveWindow?.packageName != event.packageName) return
-        processor.processAccessibilityEvent(rootAccessibilityNodeInfo = event.source)
+        processor.processAccessibilityEvent(event = event) { rootInActiveWindow }
     }
 
     override fun onInterrupt() = Unit

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/processor/BitwardenAccessibilityProcessor.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/processor/BitwardenAccessibilityProcessor.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.autofill.accessibility.processor
 
+import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 
 /**
@@ -7,7 +8,12 @@ import android.view.accessibility.AccessibilityNodeInfo
  */
 interface BitwardenAccessibilityProcessor {
     /**
-     * Processes the [AccessibilityNodeInfo] for autofill options.
+     * Processes the [AccessibilityEvent] for autofill options and grant access to the current
+     * [AccessibilityNodeInfo] via the [rootAccessibilityNodeInfoProvider] (note that calling the
+     * `rootAccessibilityNodeInfoProvider` is expensive).
      */
-    fun processAccessibilityEvent(rootAccessibilityNodeInfo: AccessibilityNodeInfo?)
+    fun processAccessibilityEvent(
+        event: AccessibilityEvent,
+        rootAccessibilityNodeInfoProvider: () -> AccessibilityNodeInfo?,
+    )
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds some additional performance improvements to the accessibility autofill by deferring the call to the `rootAccessibilityNodeInfo` until after all other checks have passed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
