### PR TITLE
PM-14805: Ensure results cannot be double wrapped from 'asSuccess'

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/ResultExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/ResultExtensions.kt
@@ -14,9 +14,16 @@ inline fun <T, R> Result<T>.flatMap(transform: (T) -> Result<R>): Result<R> =
 
 /**
  * Returns the given receiver of type [T] as a "success" [Result].
+ *
+ * Note that this will never double wrap the `Result` and we return the original value if [T] is
+ * already an instance of `Result`
  */
-fun <T> T.asSuccess(): Result<T> =
+fun <T> T.asSuccess(): Result<T> = if (this is Result<*>) {
+    @Suppress("UNCHECKED_CAST")
+    this as Result<T>
+} else {
     Result.success(this)
+}
 
 /**
  * Returns the given [Throwable] as a "failure" [Result].

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/util/ResultTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/util/ResultTest.kt
@@ -60,6 +60,14 @@ class ResultTest {
     }
 
     @Test
+    fun `asSuccess returns a success Result with the correct content that is not double-wrapped`() {
+        assertEquals(
+            Result.success("Test"),
+            "Test".asSuccess().asSuccess(),
+        )
+    }
+
+    @Test
     fun `asFailure returns a failure Result with the correct content`() {
         val throwable = IllegalStateException("Test")
         assertEquals(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14805](https://bitwarden.atlassian.net/browse/PM-14805)

## 📔 Objective

This PR ensures that you cannot double wrap a `Result` in a `Result` when using the `asSuccess` helper method.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14805]: https://bitwarden.atlassian.net/browse/PM-14805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ