### PR TITLE
PM-14854: Keep NetworkResult to avoid obfuscation crash in release

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/model/NetworkResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/model/NetworkResult.kt
@@ -1,10 +1,13 @@
 package com.x8bit.bitwarden.data.platform.datasource.network.model
 
+import androidx.annotation.Keep
+
 /**
  * A wrapper class for a network result for type [T]. If the network request is successful, the
  * response will be a [Success] containing the data. If the network request is a failure, the
  * response will be a [Failure] containing the [Throwable].
  */
+@Keep
 sealed class NetworkResult<out T> {
     /**
      * A successful network result with the relevant [T] data.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14854](https://bitwarden.atlassian.net/browse/PM-14854)

## 📔 Objective

This PR fixes a crash on app startup in release caused by the `NetworkResult` being obfuscated.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14854]: https://bitwarden.atlassian.net/browse/PM-14854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ