### PR TITLE
PM-14352 Dismiss Snackbar when user clicks it as a default unless the specific dismiss action is present.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/snackbar/BitwardenSnackbar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/snackbar/BitwardenSnackbar.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.platform.components.snackbar
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * Custom snackbar for Bitwarden.
  * Shows a message with an optional actions and title.
  */
+@Suppress("LongMethod")
 @Composable
 fun BitwardenSnackbar(
     bitwardenSnackbarData: BitwardenSnackbarData,
@@ -44,6 +46,12 @@ fun BitwardenSnackbar(
                 .background(
                     color = BitwardenTheme.colorScheme.background.alert,
                     shape = BitwardenTheme.shapes.snackbar,
+                )
+                // I there is no explicit dismiss action, the Snackbar can be dismissed by clicking
+                // anywhere on the Snackbar.
+                .clickable(
+                    enabled = !bitwardenSnackbarData.withDismissAction,
+                    onClick = onDismiss,
                 )
                 .padding(16.dp),
         ) {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.vault
 
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -226,5 +227,18 @@ class VaultSettingsScreenTest : BaseComposeTest() {
         val data = BitwardenSnackbarData("message".asText())
         mutableEventFlow.tryEmit(VaultSettingsEvent.ShowSnackbar(data))
         composeTestRule.onNodeWithText("message").assertIsDisplayed()
+    }
+
+    @Test
+    fun `when snackbar is displayed clicking on it should dismiss`() {
+        val data = BitwardenSnackbarData("message".asText())
+        mutableEventFlow.tryEmit(VaultSettingsEvent.ShowSnackbar(data))
+        composeTestRule
+            .onNodeWithText("message")
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule
+            .onNodeWithText("message")
+            .assertIsNotDisplayed()
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -1207,6 +1207,19 @@ class VaultScreenTest : BaseComposeTest() {
     }
 
     @Test
+    fun `when snackbar is displayed clicking on it should dismiss`() {
+        val data = BitwardenSnackbarData("message".asText())
+        mutableEventFlow.tryEmit(VaultEvent.ShowSnackbar(data))
+        composeTestRule
+            .onNodeWithText("message")
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule
+            .onNodeWithText("message")
+            .assertIsNotDisplayed()
+    }
+
+    @Test
     fun `SSH key group header should display correctly based on state`() {
         val count = 1
         // Verify SSH key group is displayed when showSshKeys is true


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-14352
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- dismiss on click of snackbar 
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/66e6ecb5-8173-4946-9c72-9eba3ff105b0


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
