### PR TITLE
[PM-14879] Release Branch creation workflow

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,57 @@
+name: Cut Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release Type'
+        required: true
+        type: choice
+        options:
+          - RC
+          - Hotfix
+      rc_prefix_date:
+        description: 'RC - Prefix with date. E.g. 2024.11-rc1'
+        type: boolean
+        default: true
+
+jobs:
+  create-release-branch:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Create RC Branch
+        if: inputs.release_type == 'RC'
+        env:
+          RC_PREFIX_DATE: ${{ inputs.rc_prefix_date }}
+        run: |
+          if [ "$RC_PREFIX_DATE" = "true" ]; then
+            current_date=$(date +'%Y.%m')
+            branch_name="release/${current_date}-rc${{ github.run_number }}"
+          else
+            branch_name="release/rc${{ github.run_number }}"
+          fi
+          git checkout main
+          git checkout -b $branch_name
+          git push origin $branch_name
+          echo "# :cherry_blossom: RC branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create Hotfix Branch
+        if: inputs.release_type == 'Hotfix'
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0)
+          if [ -z "$latest_tag" ]; then
+            echo "::error::No tags found in the repository"
+            exit 1
+          fi
+          branch_name="release/hotfix-${latest_tag}"
+          git checkout $latest_tag
+          git checkout -b $branch_name
+          git push origin $branch_name
+          echo "# :fire: Hotfix branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -37,8 +37,8 @@ jobs:
           else
             branch_name="release/rc${{ github.run_number }}"
           fi
-          git checkout main
-          git checkout -b $branch_name
+          git switch main
+          git switch -c $branch_name
           git push origin $branch_name
           echo "# :cherry_blossom: RC branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY
 
@@ -51,7 +51,6 @@ jobs:
             exit 1
           fi
           branch_name="release/hotfix-${latest_tag}"
-          git checkout $latest_tag
-          git checkout -b $branch_name
+          git switch -c $branch_name $latest_tag
           git push origin $branch_name
           echo "# :fire: Hotfix branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14879

## 📔 Objective

Adds workflow to create release branches, supports RC and Hotfix:

1. RC branches are created with the following naming pattern: `release/{YYY.MM}-rc{build_number}`, e.g. `release/2024.11-rc5`. Date prefix can be removed by a workflow input, in that case it would create a `release/rc5`.
2. Hotfix branches are created using the last release tag, e.g. `hotfix-v2024.11.4`

Running this workflow with `Hotfix` multiple times won't fail, although logs are slightly different - we don't receive remote logs  

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
