### PR TITLE
PM-14411: Autofill logic to work better with QuickTile

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/model/FillableFields.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/model/FillableFields.kt
@@ -8,4 +8,6 @@ import android.view.accessibility.AccessibilityNodeInfo
 data class FillableFields(
     val usernameField: AccessibilityNodeInfo?,
     val passwordFields: List<AccessibilityNodeInfo>,
-)
+) {
+    val hasFields: Boolean = usernameField != null && passwordFields.isNotEmpty()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/exit/ExitManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/exit/ExitManagerImpl.kt
@@ -8,9 +8,9 @@ import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
  */
 @OmitFromCoverage
 class ExitManagerImpl(
-    val activity: Activity,
+    private val activity: Activity,
 ) : ExitManager {
     override fun exitApplication() {
-        activity.finish()
+        activity.finishAndRemoveTask()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -850,7 +850,7 @@ class VaultItemListingViewModel @Inject constructor(
 
     private fun handleBackClick() {
         sendEvent(
-            event = if (state.isTotp) {
+            event = if (state.isTotp || state.isAutofill) {
                 VaultItemListingEvent.ExitApp
             } else {
                 VaultItemListingEvent.NavigateBack

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -282,6 +282,23 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `BackClick with AutofillSelectionData should emit ExitApp`() = runTest {
+        specialCircumstanceManager.specialCircumstance = SpecialCircumstance.AutofillSelection(
+            autofillSelectionData = AutofillSelectionData(
+                framework = AutofillSelectionData.Framework.ACCESSIBILITY,
+                type = AutofillSelectionData.Type.LOGIN,
+                uri = null,
+            ),
+            shouldFinishWhenComplete = false,
+        )
+        val viewModel = createVaultItemListingViewModel()
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(VaultItemListingsAction.BackClick)
+            assertEquals(VaultItemListingEvent.ExitApp, awaitItem())
+        }
+    }
+
+    @Test
     fun `BackClick should emit NavigateBack`() = runTest {
         val viewModel = createVaultItemListingViewModel()
         viewModel.eventFlow.test {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14411](https://bitwarden.atlassian.net/browse/PM-14411)

## 📔 Objective

This PR addresses multiple issues concerning the QuickTile and Accessibility Autofill.

* After parsing a Url, if there are no fields available to fill, we should toast and return.
* Do not clear the `AccessibilityAction` just because the event is for a launcher or skipped package, the missing fields logic will handle it.
* The `VaultItemListingScreen` should dismiss the activity when navigating back from attempting autofill.
* Closing the app via the `ExitManager` should kill the task as well, this is needed specifically because the `AccessibilityService` runs in the background and we want to clear the state.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14411]: https://bitwarden.atlassian.net/browse/PM-14411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ