### PR TITLE
PM-10600: Re-register device with push token every 7 days.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
@@ -312,6 +312,7 @@ class PushManagerImpl @Inject constructor(
                     userId = userId,
                     token = it,
                 )
+                registerStoredPushTokenIfNecessaryInternal(userId)
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10600

## 📔 Objective

The Azure Notification Hub tags can change frequently, like here for Notification Center work we need to add new tags to existing devices registrations. Instead of painful migration plan, this PR adds a frequent 7 day interval re-registration of push notification for the device against Bitwarden Server.

Technical change:
- A new coroutine is added that runs every 1 minute (scheduled job) and detects if the last time the currently stored push was sent to Bitwarden Server is older than 7 days.
  - If true, the current device is re-registered against Bitwarden Server. In normal circumstances this would have no effect whatsoever from server point of view, but in case a new tag needs to be added for Azure Notification Hub, that is being now done with this functionality.
  - If false, nothing happens.
- On user id change (login, switch user, first app open with locked vault):
  - we run the coroutine immediately, for an edge case, that app was opened, vault unlocked and app killed immediately after (does not reach 1 minute delay).
  - the above coroutine is started with initial delay of 1 minute, for an edge case, that app is never killed and runs constantly.
- Change the meaning of the `LastPushTokenRegistrationDate`, to only serve the above coroutine case.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
