### PR TITLE
[PM-14596] Sync on database scheme change

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -75,6 +75,11 @@ interface SettingsDiskSource {
     var lastDatabaseSchemeChangeInstant: Instant?
 
     /**
+     * Emits updates that track [lastDatabaseSchemeChangeInstant].
+     */
+    val lastDatabaseSchemeChangeInstantFlow: Flow<Instant?>
+
+    /**
      * Clears all the settings data for the given user.
      */
     fun clearData(userId: String)

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManager.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.platform.manager
 
+import kotlinx.coroutines.flow.Flow
 import java.time.Instant
 
 /**
@@ -14,4 +15,9 @@ interface DatabaseSchemeManager {
      * that a scheme change to any database will update this value and trigger a sync.
      */
     var lastDatabaseSchemeChangeInstant: Instant?
+
+    /**
+     * A flow of the last database schema change instant.
+     */
+    val lastDatabaseSchemeChangeInstantFlow: Flow<Instant?>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManagerImpl.kt
@@ -1,6 +1,10 @@
 package com.x8bit.bitwarden.data.platform.manager
 
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import java.time.Instant
 
 /**
@@ -8,10 +12,23 @@ import java.time.Instant
  */
 class DatabaseSchemeManagerImpl(
     val settingsDiskSource: SettingsDiskSource,
+    val dispatcherManager: DispatcherManager,
 ) : DatabaseSchemeManager {
+
+    private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
+
     override var lastDatabaseSchemeChangeInstant: Instant?
         get() = settingsDiskSource.lastDatabaseSchemeChangeInstant
         set(value) {
             settingsDiskSource.lastDatabaseSchemeChangeInstant = value
         }
+
+    override val lastDatabaseSchemeChangeInstantFlow =
+        settingsDiskSource
+            .lastDatabaseSchemeChangeInstantFlow
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = settingsDiskSource.lastDatabaseSchemeChangeInstant,
+            )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -308,7 +308,9 @@ object PlatformManagerModule {
     @Singleton
     fun provideDatabaseSchemeManager(
         settingsDiskSource: SettingsDiskSource,
+        dispatcherManager: DispatcherManager,
     ): DatabaseSchemeManager = DatabaseSchemeManagerImpl(
         settingsDiskSource = settingsDiskSource,
+        dispatcherManager = dispatcherManager,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -99,6 +99,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -322,6 +323,12 @@ class VaultRepositoryImpl(
         pushManager
             .syncFolderUpsertFlow
             .onEach(::syncFolderIfNecessary)
+            .launchIn(ioScope)
+
+        databaseSchemeManager
+            .lastDatabaseSchemeChangeInstantFlow
+            .filterNotNull()
+            .onEach { sync() }
             .launchIn(ioScope)
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -42,6 +42,9 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val mutableScreenCaptureAllowedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
+    private val mutableLastDatabaseSchemeChangeInstant =
+        bufferedMutableSharedFlow<Instant?>()
+
     private var storedAppTheme: AppTheme = AppTheme.DEFAULT
     private val storedLastSyncTime = mutableMapOf<String, Instant?>()
     private val storedVaultTimeoutActions = mutableMapOf<String, VaultTimeoutAction?>()
@@ -140,6 +143,11 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     override var lastDatabaseSchemeChangeInstant: Instant?
         get() = storedLastDatabaseSchemeChangeInstant
         set(value) { storedLastDatabaseSchemeChangeInstant = value }
+
+    override val lastDatabaseSchemeChangeInstantFlow: Flow<Instant?>
+        get() = mutableLastDatabaseSchemeChangeInstant.onSubscription {
+            emit(lastDatabaseSchemeChangeInstant)
+        }
 
     override fun getAccountBiometricIntegrityValidity(
         userId: String,

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManagerTest.kt
@@ -1,24 +1,37 @@
 package com.x8bit.bitwarden.data.platform.manager
 
+import app.cash.turbine.test
+import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 
 class DatabaseSchemeManagerTest {
 
+    private val mutableLastDatabaseSchemeChangeInstantFlow = MutableStateFlow<Instant?>(null)
     private val mockSettingsDiskSource: SettingsDiskSource = mockk {
-        every { lastDatabaseSchemeChangeInstant } returns null
-        every { lastDatabaseSchemeChangeInstant = any() } just runs
+        every {
+            lastDatabaseSchemeChangeInstant
+        } returns mutableLastDatabaseSchemeChangeInstantFlow.value
+        every { lastDatabaseSchemeChangeInstant = any() } answers {
+            mutableLastDatabaseSchemeChangeInstantFlow.value = firstArg()
+        }
+        every {
+            lastDatabaseSchemeChangeInstantFlow
+        } returns mutableLastDatabaseSchemeChangeInstantFlow
     }
+    private val dispatcherManager = FakeDispatcherManager()
     private val databaseSchemeManager = DatabaseSchemeManagerImpl(
         settingsDiskSource = mockSettingsDiskSource,
+        dispatcherManager = dispatcherManager,
     )
 
     @Suppress("MaxLineLength")
@@ -27,6 +40,23 @@ class DatabaseSchemeManagerTest {
         databaseSchemeManager.lastDatabaseSchemeChangeInstant = FIXED_CLOCK.instant()
         verify {
             mockSettingsDiskSource.lastDatabaseSchemeChangeInstant = FIXED_CLOCK.instant()
+        }
+    }
+
+    @Test
+    fun `setLastDatabaseSchemeChangeInstant does emit value`() = runTest {
+        databaseSchemeManager.lastDatabaseSchemeChangeInstantFlow.test {
+            // Assert the value is initialized to null
+            assertEquals(
+                null,
+                awaitItem(),
+            )
+            // Assert the new value is emitted
+            databaseSchemeManager.lastDatabaseSchemeChangeInstant = FIXED_CLOCK.instant()
+            assertEquals(
+                FIXED_CLOCK.instant(),
+                awaitItem(),
+            )
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-14596

cherry picked from #4257 (3c77933b) on `release/hotfix-v2024.11.3`

## 📔 Objective

Trigger a sync when the database schema changes. This ensures that the client and server are in sync after a schema update.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
