### PR TITLE
PM-14429 Set the min and max range of the slider to match the restrictions not update the min with the computed min.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -455,8 +455,12 @@ private fun ColumnScope.PasswordTypeContent(
 
     BitwardenSlider(
         value = passwordTypeState.length,
-        onValueChange = passwordHandlers.onPasswordSliderLengthChange,
-        range = passwordTypeState.computedMinimumLength..passwordTypeState.maxLength,
+        onValueChange = { newValue, isUserInteracting ->
+            if (newValue >= passwordTypeState.computedMinimumLength) {
+                passwordHandlers.onPasswordSliderLengthChange(newValue, isUserInteracting)
+            }
+        },
+        range = passwordTypeState.minLength..passwordTypeState.maxLength,
         sliderTag = "PasswordLengthSlider",
         valueTag = "PasswordLengthLabel",
         modifier = Modifier


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-14429
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- When decreasing the  min numbers or special characters the value continues to change because the length of the pw does not change and the minimum range is changing.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
Before: See story
After: 

https://github.com/user-attachments/assets/56807212-d0f7-4ae4-a9dc-a5d8afc1cb1d


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
