### PR TITLE
PM-12259: Use validatePin SDK to validate the users pin

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
@@ -95,6 +95,15 @@ interface VaultSdkSource {
     ): Result<String>
 
     /**
+     * Validate the user pin using the [pinProtectedUserKey].
+     */
+    suspend fun validatePin(
+        userId: String,
+        pin: String,
+        pinProtectedUserKey: String,
+    ): Result<Boolean>
+
+    /**
      * Gets the key for an auth request that is required to approve or decline it.
      */
     suspend fun getAuthRequestKey(

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -109,6 +109,17 @@ class VaultSdkSourceImpl(
                 .derivePinUserKey(encryptedPin = encryptedPin)
         }
 
+    override suspend fun validatePin(
+        userId: String,
+        pin: String,
+        pinProtectedUserKey: String,
+    ): Result<Boolean> =
+        runCatchingWithLogs {
+            getClient(userId = userId)
+                .auth()
+                .validatePin(pin = pin, pinProtectedUserKey = pinProtectedUserKey)
+        }
+
     override suspend fun getAuthRequestKey(
         publicKey: String,
         userId: String,

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
@@ -235,6 +235,30 @@ class VaultSdkSourceTest {
         }
 
     @Test
+    fun `validatePin should call SDK and return a Result with the correct data`() =
+        runBlocking {
+            val userId = "userId"
+            val pin = "pin"
+            val pinProtectedUserKey = "pinProtectedUserKey"
+            val expectedResult = true
+            coEvery {
+                clientAuth.validatePin(pin = pin, pinProtectedUserKey = pinProtectedUserKey)
+            } returns expectedResult
+
+            val result = vaultSdkSource.validatePin(
+                userId = userId,
+                pin = pin,
+                pinProtectedUserKey = pinProtectedUserKey,
+            )
+
+            assertEquals(expectedResult.asSuccess(), result)
+            coVerify(exactly = 1) {
+                clientAuth.validatePin(pin = pin, pinProtectedUserKey = pinProtectedUserKey)
+                sdkClientManager.getOrCreateClient(userId = userId)
+            }
+        }
+
+    @Test
     fun `getAuthRequestKey should call SDK and return a Result with correct data`() =
         runBlocking {
             val publicKey = "key"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12259](https://bitwarden.atlassian.net/browse/PM-12259)

## 📔 Objective

This PR update the `validatePin` function in the `AuthRepository` to use the purpose-made SDK function to validate the pin. This fixes some bugs that can occur from calling the `initializeCrypto` function in unexpected places, which is how the previous logic worked.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12259]: https://bitwarden.atlassian.net/browse/PM-12259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ