### PR TITLE
PM-14934: Allow accessibility autofill to fill just a username or just a password

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/model/FillableFields.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/model/FillableFields.kt
@@ -9,5 +9,5 @@ data class FillableFields(
     val usernameField: AccessibilityNodeInfo?,
     val passwordFields: List<AccessibilityNodeInfo>,
 ) {
-    val hasFields: Boolean = usernameField != null && passwordFields.isNotEmpty()
+    val hasFields: Boolean = usernameField != null || passwordFields.isNotEmpty()
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14934](https://bitwarden.atlassian.net/browse/PM-14934)

## 📔 Objective

This PR adjusts the `hasFields` property to allow the accessibility autofill to fill usernames or passwords in a stand-alone manner. Meaning that it could be a site with just a password or just a username.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14934]: https://bitwarden.atlassian.net/browse/PM-14934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ