### PR TITLE
[PM-10483] Fix collection manage check for delete permission

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
@@ -94,16 +94,17 @@ fun String.toCollectionDisplayName(list: List<CollectionView>): String {
  *
  * Deletion is allowed when the item is in any collection that the user has "manage" permission for.
  */
-fun List<CollectionView>?.hasDeletePermissionInAtLeastOneCollection(collectionIds: List<String>?) =
-    this
-        ?.takeUnless { it.isEmpty() }
-        ?.any {
+fun List<CollectionView>?.hasDeletePermissionInAtLeastOneCollection(
+    collectionIds: List<String>?,
+): Boolean {
+    if (this.isNullOrEmpty() || collectionIds.isNullOrEmpty()) return true
+    return this
+        .any { collectionView ->
             collectionIds
-                ?.contains(it.id)
-                ?.let { isInCollection -> !isInCollection || it.manage }
-                ?: true
+                .contains(collectionView.id)
+                .let { isInCollection -> isInCollection && collectionView.manage }
         }
-        ?: true
+}
 
 /**
  * Checks if the user has permission to assign an item to a collection.


### PR DESCRIPTION
## 🎟️ Tracking

PM-14843

## 📔 Objective

Adjusts the item deletion logic to allow deletion when an item is not in any collections, or if it's in any collection where the user has "manage" permissions.

## 📸 Screenshots

Coming soon! 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
