### PR TITLE
PM-12733: Trim totp codes before saving them

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryViewModel.kt
@@ -46,7 +46,7 @@ class ManualCodeEntryViewModel @Inject constructor(
     }
 
     private fun handleCodeSubmit() {
-        vaultRepository.emitTotpCodeResult(TotpCodeResult.Success(state.code))
+        vaultRepository.emitTotpCodeResult(TotpCodeResult.Success(state.code.trim()))
         sendEvent(ManualCodeEntryEvent.NavigateBack)
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryViewModelTests.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryViewModelTests.kt
@@ -36,8 +36,7 @@ class ManualCodeEntryViewModelTests : BaseViewModelTest() {
 
     @Test
     fun `CodeSubmit should emit new code and NavigateBack`() = runTest {
-        val viewModel =
-            createViewModel(initialState = ManualCodeEntryState("TestCode"))
+        val viewModel = createViewModel(initialState = ManualCodeEntryState("   TestCode   "))
 
         viewModel.eventFlow.test {
             viewModel.trySendAction(ManualCodeEntryAction.CodeSubmit)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12733](https://bitwarden.atlassian.net/browse/PM-12733)

## 📔 Objective

This PR trims the totp before saving it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12733]: https://bitwarden.atlassian.net/browse/PM-12733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ