### PR TITLE
PM-14200: Add count to sends type header

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
@@ -21,6 +21,8 @@ import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.tools.feature.send.handlers.SendHandlers
 import kotlinx.collections.immutable.toImmutableList
 
+private const val SEND_TYPES_COUNT: Int = 2
+
 /**
  * Content view for the [SendScreen].
  */
@@ -48,6 +50,7 @@ fun SendContent(
         item {
             BitwardenListHeaderText(
                 label = stringResource(id = R.string.types),
+                supportingLabel = SEND_TYPES_COUNT.toString(),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -22,6 +22,9 @@ import com.x8bit.bitwarden.ui.vault.feature.vault.handlers.VaultHandlers
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 
+private const val TOTP_TYPES_COUNT: Int = 1
+private const val TRASH_TYPES_COUNT: Int = 1
+
 /**
  * Content view for the [VaultScreen].
  */
@@ -41,7 +44,7 @@ fun VaultContent(
             item {
                 BitwardenListHeaderText(
                     label = stringResource(id = R.string.totp),
-                    supportingLabel = "1",
+                    supportingLabel = TOTP_TYPES_COUNT.toString(),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
@@ -341,7 +344,7 @@ fun VaultContent(
         item {
             BitwardenListHeaderText(
                 label = stringResource(id = R.string.trash),
-                supportingLabel = "1",
+                supportingLabel = TRASH_TYPES_COUNT.toString(),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14200](https://bitwarden.atlassian.net/browse/PM-14200)

## 📔 Objective

This PR updates the Send Screen's types header to contain a count.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/7c321db9-9825-4a8f-bea8-26c4322c1c0c" width="300" /> | <img src="https://github.com/user-attachments/assets/5a4af936-935d-4652-9ac7-ad88b52b0223" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14200]: https://bitwarden.atlassian.net/browse/PM-14200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ