### PR TITLE
Log JWT parsing errors

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/JwtTokenUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/JwtTokenUtils.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.auth.repository.util
 import com.x8bit.bitwarden.data.auth.repository.model.JwtTokenDataJson
 import com.x8bit.bitwarden.data.platform.datasource.network.util.base64UrlDecodeOrNull
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 
 /**
  * Internal, generally basic [Json] instance for JWT parsing purposes.
@@ -17,17 +18,24 @@ private val json: Json by lazy {
 /**
  * Parses a [JwtTokenDataJson] from the given [jwtToken], or `null` if this parsing is not possible.
  */
-@Suppress("MagicNumber")
+@Suppress("MagicNumber", "TooGenericExceptionCaught")
 fun parseJwtTokenDataOrNull(jwtToken: String): JwtTokenDataJson? {
     val parts = jwtToken.split(".")
-    if (parts.size != 3) return null
+    if (parts.size != 3) {
+        Timber.e(IllegalArgumentException("Incorrect number of parts"), "Invalid JWT Token")
+        return null
+    }
 
     val dataJson = parts[1]
-    val decodedDataJson = dataJson.base64UrlDecodeOrNull() ?: return null
+    val decodedDataJson = dataJson.base64UrlDecodeOrNull() ?: run {
+        Timber.e(IllegalArgumentException("Unable to decode"), "Invalid JWT Token")
+        return null
+    }
 
     return try {
         json.decodeFromString<JwtTokenDataJson>(decodedDataJson)
-    } catch (_: Throwable) {
+    } catch (throwable: Throwable) {
+        Timber.e(throwable, "Failed to decode JwtTokenDataJson")
         null
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds logging to track when a JWT Token fails to be parsed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
