### PR TITLE
PM-15041: Update stepper buttons

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenFilledIconButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenFilledIconButton.kt
@@ -1,0 +1,55 @@
+package com.x8bit.bitwarden.ui.platform.components.button
+
+import androidx.annotation.DrawableRes
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.color.bitwardenFilledIconButtonColors
+import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+
+/**
+ * A filled icon button that displays an icon.
+ *
+ * @param vectorIconRes Icon to display on the button.
+ * @param contentDescription The content description for this icon button.
+ * @param onClick Callback for when the icon button is clicked.
+ * @param modifier A [Modifier] for the composable.
+ * @param isEnabled Whether or not the button should be enabled.
+ */
+@Composable
+fun BitwardenFilledIconButton(
+    @DrawableRes vectorIconRes: Int,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
+) {
+    FilledIconButton(
+        modifier = modifier.semantics(mergeDescendants = true) {},
+        onClick = onClick,
+        colors = bitwardenFilledIconButtonColors(),
+        enabled = isEnabled,
+    ) {
+        Icon(
+            painter = rememberVectorPainter(id = vectorIconRes),
+            contentDescription = contentDescription,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BitwardenFilledIconButton_preview() {
+    BitwardenTheme {
+        BitwardenFilledIconButton(
+            vectorIconRes = R.drawable.ic_question_circle,
+            contentDescription = "Sample Icon",
+            onClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/color/BitwardenIconButtonColors.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/color/BitwardenIconButtonColors.kt
@@ -6,6 +6,17 @@ import androidx.compose.ui.graphics.Color
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
+ * Provides a default set of Bitwarden-styled colors for a filled icon button.
+ */
+@Composable
+fun bitwardenFilledIconButtonColors(): IconButtonColors = IconButtonColors(
+    containerColor = BitwardenTheme.colorScheme.filledButton.background,
+    contentColor = BitwardenTheme.colorScheme.filledButton.foreground,
+    disabledContainerColor = BitwardenTheme.colorScheme.filledButton.backgroundDisabled,
+    disabledContentColor = BitwardenTheme.colorScheme.filledButton.foregroundDisabled,
+)
+
+/**
  * Provides a default set of Bitwarden-styled colors for a standard icon button.
  */
 @Composable

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.ZERO_WIDTH_CHARACTER
 import com.x8bit.bitwarden.ui.platform.base.util.orNullIfBlank
-import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTonalIconButton
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledIconButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextFieldWithActions
 
 /**
@@ -51,7 +51,7 @@ fun BitwardenStepper(
         value = clampedValue?.toString() ?: ZERO_WIDTH_CHARACTER,
         actionsTestTag = stepperActionsTestTag,
         actions = {
-            BitwardenTonalIconButton(
+            BitwardenFilledIconButton(
                 vectorIconRes = R.drawable.ic_minus,
                 contentDescription = "\u2212",
                 onClick = {
@@ -63,7 +63,7 @@ fun BitwardenStepper(
                 isEnabled = isDecrementEnabled && !isAtRangeMinimum,
                 modifier = Modifier.testTag("DecrementValue"),
             )
-            BitwardenTonalIconButton(
+            BitwardenFilledIconButton(
                 vectorIconRes = R.drawable.ic_plus,
                 contentDescription = "+",
                 onClick = {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15041](https://bitwarden.atlassian.net/browse/PM-15041)

## 📔 Objective

This PR adds the `BitwardenFilledIconButton` to the app and applies it to all steppers.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5d12eb51-1b68-4b1b-b6d0-f6400b0bd2bc" width="300" /> | <img src="https://github.com/user-attachments/assets/e75dcafa-e86c-4d83-a736-b919b833f989" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15041]: https://bitwarden.atlassian.net/browse/PM-15041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ