### PR TITLE
PM-15049 PW strength indicator design audit

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/PasswordStrengthIndicator.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/PasswordStrengthIndicator.kt
@@ -42,14 +42,20 @@ fun PasswordStrengthIndicator(
     currentCharacterCount: Int,
     minimumCharacterCount: Int? = null,
 ) {
+    val minimumRequirementMet = (minimumCharacterCount == null) ||
+        (currentCharacterCount >= minimumCharacterCount)
     val widthPercent by animateFloatAsState(
-        targetValue = when (state) {
-            PasswordStrengthState.NONE -> 0f
-            PasswordStrengthState.WEAK_1 -> .25f
-            PasswordStrengthState.WEAK_2 -> .5f
-            PasswordStrengthState.WEAK_3 -> .66f
-            PasswordStrengthState.GOOD -> .82f
-            PasswordStrengthState.STRONG -> 1f
+        targetValue = if (minimumRequirementMet) {
+            when (state) {
+                PasswordStrengthState.NONE -> 0f
+                PasswordStrengthState.WEAK_1 -> .25f
+                PasswordStrengthState.WEAK_2 -> .5f
+                PasswordStrengthState.WEAK_3 -> .66f
+                PasswordStrengthState.GOOD -> .82f
+                PasswordStrengthState.STRONG -> 1f
+            }
+        } else {
+            0f
         },
         label = "Width Percent State",
     )
@@ -107,11 +113,13 @@ fun PasswordStrengthIndicator(
                     minimumCharacterCount = minCount,
                 )
             }
-            Text(
-                text = label(),
-                style = BitwardenTheme.typography.labelSmall,
-                color = indicatorColor,
-            )
+            if (minimumRequirementMet) {
+                Text(
+                    text = label(),
+                    style = BitwardenTheme.typography.labelSmall,
+                    color = indicatorColor,
+                )
+            }
         }
     }
 }
@@ -122,14 +130,6 @@ private fun MinimumCharacterCount(
     minimumRequirementMet: Boolean,
     minimumCharacterCount: Int,
 ) {
-    val characterCountColor by animateColorAsState(
-        targetValue = if (minimumRequirementMet) {
-            BitwardenTheme.colorScheme.status.strong
-        } else {
-            BitwardenTheme.colorScheme.text.secondary
-        },
-        label = "minmumCharacterCountColor",
-    )
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -145,14 +145,14 @@ private fun MinimumCharacterCount(
             Icon(
                 painter = rememberVectorPainter(id = it),
                 contentDescription = null,
-                tint = characterCountColor,
+                tint = BitwardenTheme.colorScheme.text.secondary,
                 modifier = Modifier.size(12.dp),
             )
         }
         Spacer(modifier = Modifier.width(2.dp))
         Text(
             text = stringResource(R.string.minimum_characters, minimumCharacterCount),
-            color = characterCountColor,
+            color = BitwardenTheme.colorScheme.text.secondary,
             style = BitwardenTheme.typography.labelSmall,
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15049
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Strength indicator shouldn't show till min chars is met.
- Min chars info color should no longer change once met.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
| Before | After |
|--------|--------|
| <img width="325" alt="image" src="https://github.com/user-attachments/assets/44e2ab96-5469-4531-94c2-9505a5ef87f1"> | ![image](https://github.com/user-attachments/assets/0c847d1b-fadb-4b09-8a5d-99cc12a4bcde) |
| <img width="339" alt="image" src="https://github.com/user-attachments/assets/455a0efc-728f-4c28-a41b-bdbf37687f09"> | ![image](https://github.com/user-attachments/assets/43d9a86f-4427-410b-aaef-56e4aa84eef7) | 
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
