### PR TITLE
PM-15025: Update sendVerificationEmail to handle error responses

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityService.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterFinishRequ
 import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEmailRequestJson
+import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEmailResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TwoFactorDataModel
 import com.x8bit.bitwarden.data.auth.datasource.network.model.VerifyEmailTokenRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.VerifyEmailTokenResponseJson
@@ -68,7 +69,7 @@ interface IdentityService {
      */
     suspend fun sendVerificationEmail(
         body: SendVerificationEmailRequestJson,
-    ): Result<String?>
+    ): Result<SendVerificationEmailResponseJson>
 
     /**
      * Register a new account to Bitwarden using email verification flow.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -22,6 +22,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterResponseJs
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResendEmailRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResetPasswordRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEmailRequestJson
+import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEmailResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.SetPasswordRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TwoFactorAuthMethod
@@ -1282,7 +1283,15 @@ class AuthRepositoryImpl(
             )
             .fold(
                 onSuccess = {
-                    SendVerificationEmailResult.Success(it)
+                    when (it) {
+                        is SendVerificationEmailResponseJson.Invalid -> {
+                            SendVerificationEmailResult.Error(it.message)
+                        }
+
+                        is SendVerificationEmailResponseJson.Success -> {
+                            SendVerificationEmailResult.Success(it.emailVerificationToken)
+                        }
+                    }
                 },
                 onFailure = {
                     SendVerificationEmailResult.Error(null)

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
@@ -13,6 +13,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterFinishRequ
 import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEmailRequestJson
+import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEmailResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TwoFactorAuthMethod
 import com.x8bit.bitwarden.data.auth.datasource.network.model.UserDecryptionOptionsJson
@@ -370,14 +371,19 @@ class IdentityServiceTest : BaseServiceTest() {
         runTest {
             server.enqueue(MockResponse().setResponseCode(200).setBody(EMAIL_TOKEN))
             val result = identityService.sendVerificationEmail(SEND_VERIFICATION_EMAIL_REQUEST)
-            assertEquals(JsonPrimitive(EMAIL_TOKEN).content.asSuccess(), result)
+            assertEquals(
+                SendVerificationEmailResponseJson
+                    .Success(JsonPrimitive(EMAIL_TOKEN).content)
+                    .asSuccess(),
+                result,
+            )
         }
 
     @Test
     fun `sendVerificationEmail should return null when response is empty success`() = runTest {
         server.enqueue(MockResponse().setResponseCode(204))
         val result = identityService.sendVerificationEmail(SEND_VERIFICATION_EMAIL_REQUEST)
-        assertEquals(null.asSuccess(), result)
+        assertEquals(SendVerificationEmailResponseJson.Success(null).asSuccess(), result)
     }
 
     @Test
@@ -422,7 +428,6 @@ class IdentityServiceTest : BaseServiceTest() {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `verifyEmailToken should return Invalid when response message is non expired error`() =
         runTest {

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -38,6 +38,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.RegisterResponseJs
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResendEmailRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResetPasswordRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEmailRequestJson
+import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEmailResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.SetPasswordRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TwoFactorAuthMethod
@@ -6043,7 +6044,7 @@ class AuthRepositoryTest {
                     receiveMarketingEmails = true,
                 ),
             )
-        } returns EMAIL_VERIFICATION_TOKEN.asSuccess()
+        } returns SendVerificationEmailResponseJson.Success(EMAIL_VERIFICATION_TOKEN).asSuccess()
 
         val result = repository.sendVerificationEmail(
             email = EMAIL,
@@ -6052,6 +6053,32 @@ class AuthRepositoryTest {
         )
         assertEquals(
             SendVerificationEmailResult.Success(EMAIL_VERIFICATION_TOKEN),
+            result,
+        )
+    }
+
+    @Test
+    fun `sendVerificationEmail success with invalid email should return error`() = runTest {
+        val errorMessage = "Failure"
+        coEvery {
+            identityService.sendVerificationEmail(
+                SendVerificationEmailRequestJson(
+                    email = EMAIL,
+                    name = NAME,
+                    receiveMarketingEmails = true,
+                ),
+            )
+        } returns SendVerificationEmailResponseJson
+            .Invalid(invalidMessage = errorMessage, validationErrors = null)
+            .asSuccess()
+
+        val result = repository.sendVerificationEmail(
+            email = EMAIL,
+            name = NAME,
+            receiveMarketingEmails = true,
+        )
+        assertEquals(
+            SendVerificationEmailResult.Error(errorMessage = errorMessage),
             result,
         )
     }
@@ -6066,7 +6093,7 @@ class AuthRepositoryTest {
                     receiveMarketingEmails = true,
                 ),
             )
-        } returns null.asSuccess()
+        } returns SendVerificationEmailResponseJson.Success(null).asSuccess()
 
         val result = repository.sendVerificationEmail(
             email = EMAIL,
@@ -6089,7 +6116,7 @@ class AuthRepositoryTest {
                     receiveMarketingEmails = true,
                 ),
             )
-        } returns EMAIL_VERIFICATION_TOKEN.asSuccess()
+        } returns SendVerificationEmailResponseJson.Success(EMAIL_VERIFICATION_TOKEN).asSuccess()
 
         val result = repository.sendVerificationEmail(
             email = EMAIL,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15025](https://bitwarden.atlassian.net/browse/PM-15025)

## 📔 Objective

This PR updates the `sendVerificationEmail` API to properly parse error messages from the server so they can be displayed to the user.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/19293c07-9918-4587-8262-a54de42a6184" width="300" /> | <img src="https://github.com/user-attachments/assets/90c71081-64ac-4ab0-b65b-77c5f7063c11" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15025]: https://bitwarden.atlassian.net/browse/PM-15025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ