### PR TITLE
PM-15062 Checking if the user has a no longer supported biometric as their only way of unlocking their account.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/model/AccountJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/model/AccountJson.kt
@@ -2,8 +2,10 @@ package com.x8bit.bitwarden.data.auth.datasource.disk.model
 
 import com.x8bit.bitwarden.data.auth.datasource.network.model.KdfTypeJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.UserDecryptionOptionsJson
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
 /**
  * Represents the current account information for a given user.
@@ -45,6 +47,7 @@ data class AccountJson(
      * @property kdfParallelism The number of threads to use when calculating a password hash.
      * @property userDecryptionOptions The options available to a user for decryption.
      */
+    @OptIn(ExperimentalSerializationApi::class)
     @Serializable
     data class Profile(
         @SerialName("userId")
@@ -86,7 +89,8 @@ data class AccountJson(
         @SerialName("kdfParallelism")
         val kdfParallelism: Int?,
 
-        @SerialName("accountDecryptionOptions")
+        @SerialName("userDecryptionOptions")
+        @JsonNames("accountDecryptionOptions")
         val userDecryptionOptions: UserDecryptionOptionsJson?,
     )
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KeyConnectorUserDecryptionOptionsJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KeyConnectorUserDecryptionOptionsJson.kt
@@ -1,15 +1,19 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
 /**
  * Decryption options related to a user's key connector.
  *
  * @property keyConnectorUrl URL to the user's key connector.
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class KeyConnectorUserDecryptionOptionsJson(
-    @SerialName("KeyConnectorUrl")
+    @SerialName("keyConnectorUrl")
+    @JsonNames("KeyConnectorUrl")
     val keyConnectorUrl: String,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/TrustedDeviceUserDecryptionOptionsJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/TrustedDeviceUserDecryptionOptionsJson.kt
@@ -1,7 +1,9 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
 /**
  * Decryption options related to a user's trusted device.
@@ -13,20 +15,26 @@ import kotlinx.serialization.Serializable
  * @property hasManageResetPasswordPermission Whether or not the user has manage reset password
  * permission.
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class TrustedDeviceUserDecryptionOptionsJson(
-    @SerialName("EncryptedPrivateKey")
+    @SerialName("encryptedPrivateKey")
+    @JsonNames("EncryptedPrivateKey")
     val encryptedPrivateKey: String?,
 
-    @SerialName("EncryptedUserKey")
+    @SerialName("encryptedUserKey")
+    @JsonNames("EncryptedUserKey")
     val encryptedUserKey: String?,
 
-    @SerialName("HasAdminApproval")
+    @SerialName("hasAdminApproval")
+    @JsonNames("HasAdminApproval")
     val hasAdminApproval: Boolean,
 
-    @SerialName("HasLoginApprovingDevice")
+    @SerialName("hasLoginApprovingDevice")
+    @JsonNames("HasLoginApprovingDevice")
     val hasLoginApprovingDevice: Boolean,
 
-    @SerialName("HasManageResetPasswordPermission")
+    @SerialName("hasManageResetPasswordPermission")
+    @JsonNames("HasManageResetPasswordPermission")
     val hasManageResetPasswordPermission: Boolean,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/UserDecryptionOptionsJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/UserDecryptionOptionsJson.kt
@@ -1,7 +1,9 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
 /**
  * The options available to a user for decryption.
@@ -12,14 +14,18 @@ import kotlinx.serialization.Serializable
  * device.
  * @property keyConnectorUserDecryptionOptions Decryption options related to a user's key connector.
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class UserDecryptionOptionsJson(
-    @SerialName("HasMasterPassword")
+    @SerialName("hasMasterPassword")
+    @JsonNames("HasMasterPassword")
     val hasMasterPassword: Boolean,
 
-    @SerialName("TrustedDeviceOption")
+    @SerialName("trustedDeviceOption")
+    @JsonNames("TrustedDeviceOption")
     val trustedDeviceUserDecryptionOptions: TrustedDeviceUserDecryptionOptionsJson?,
 
-    @SerialName("KeyConnectorOption")
+    @SerialName("keyConnectorOption")
+    @JsonNames("KeyConnectorOption")
     val keyConnectorUserDecryptionOptions: KeyConnectorUserDecryptionOptionsJson?,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -85,6 +86,12 @@ fun VaultUnlockScreen(
     val context = LocalContext.current
     val resources = context.resources
 
+    LaunchedEffect(state.requiresBiometricsLogin) {
+        if (state.requiresBiometricsLogin && !biometricsManager.isBiometricsSupported) {
+            viewModel.trySendAction(VaultUnlockAction.BiometricsNoLongerSupported)
+        }
+    }
+
     val onBiometricsUnlockSuccess: (cipher: Cipher?) -> Unit = remember(viewModel) {
         { viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(it)) }
     }
@@ -147,6 +154,22 @@ fun VaultUnlockScreen(
         VaultUnlockState.VaultUnlockDialog.Loading -> BitwardenLoadingDialog(
             visibilityState = LoadingDialogState.Shown(R.string.loading.asText()),
         )
+
+        VaultUnlockState.VaultUnlockDialog.BiometricsNoLongerSupported -> {
+            BitwardenBasicDialog(
+                visibilityState = BasicDialogState.Shown(
+                    title = R.string.biometrics_no_longer_supported_title.asText(),
+                    message = R.string.biometrics_no_longer_supported.asText(),
+                ),
+                onDismissRequest = remember {
+                    {
+                        viewModel.trySendAction(
+                            VaultUnlockAction.DismissBiometricsNoLongerSupportedDialog,
+                        )
+                    }
+                },
+            )
+        }
 
         null -> Unit
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1095,4 +1095,6 @@ Do you want to switch to this account?</string>
   <string name="copy_email">Copy email</string>
   <string name="copy_phone">Copy phone number</string>
   <string name="copy_address">Copy address</string>
+  <string name="biometrics_no_longer_supported_title">Biometrics are no longer supported on this device</string>
+  <string name="biometrics_no_longer_supported">You’ve been logged out because your device’s biometrics don’t meet the latest security requirements. To update settings, log in once again or contact your administrator for access.</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -1266,17 +1266,17 @@ private const val USER_STATE_JSON = """
             "kdfIterations": 600000,
             "kdfMemory": 16,
             "kdfParallelism": 4,
-            "accountDecryptionOptions": {
-              "HasMasterPassword": true,
-              "TrustedDeviceOption": {
-                "EncryptedPrivateKey": "encryptedPrivateKey",
-                "EncryptedUserKey": "encryptedUserKey",
-                "HasAdminApproval": true,
-                "HasLoginApprovingDevice": true,
-                "HasManageResetPasswordPermission": true
+            "userDecryptionOptions": { 
+              "hasMasterPassword": true,
+              "trustedDeviceOption": {
+                "encryptedPrivateKey": "encryptedPrivateKey",
+                "encryptedUserKey": "encryptedUserKey",
+                "hasAdminApproval": true,
+                "hasLoginApprovingDevice": true,
+                "hasManageResetPasswordPermission": true
               },
-              "KeyConnectorOption": {
-                "KeyConnectorUrl": "keyConnectorUrl"
+              "keyConnectorOption": {
+                "keyConnectorUrl": "keyConnectorUrl"
               }
             }
           },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -1227,6 +1227,35 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         verify { fido2CredentialManager.isUserVerified = false }
     }
 
+    @Test
+    fun `on BiometricsNoLongerSupported should show correct dialog state`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(VaultUnlockAction.BiometricsNoLongerSupported)
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialog = VaultUnlockState.VaultUnlockDialog.BiometricsNoLongerSupported,
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on DismissBiometricsNoLongerSupportedDialog should dismiss dialog state and log the user out`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(VaultUnlockAction.DismissBiometricsNoLongerSupportedDialog)
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialog = null,
+            ),
+            viewModel.stateFlow.value,
+        )
+        verify(exactly = 1) {
+            authRepository.logout()
+            authRepository.hasPendingAccountAddition = true
+        }
+    }
+
     private fun createViewModel(
         state: VaultUnlockState? = null,
         unlockType: UnlockType = UnlockType.STANDARD,
@@ -1275,6 +1304,7 @@ private val DEFAULT_STATE: VaultUnlockState = VaultUnlockState(
     showBiometricInvalidatedMessage = false,
     userId = USER_ID,
     vaultUnlockType = VaultUnlockType.MASTER_PASSWORD,
+    hasMasterPassword = true,
 )
 
 private val TRUSTED_DEVICE: UserState.TrustedDevice = UserState.TrustedDevice(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15062
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- If a user has a no longer supported biometric set up as their only way to unlock their account (particularly after migration from MAUI -> native) we want to inform them of that and then log them out.
- Should support single and multi-account.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/2e4258ed-a499-4b06-815f-9ad04695dfa6


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
