### PR TITLE
[PM-15054] Add API for importing ciphers

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/api/CiphersApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/api/CiphersApi.kt
@@ -6,7 +6,6 @@ import com.x8bit.bitwarden.data.vault.datasource.network.model.AttachmentJsonRes
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CipherJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateCipherInOrganizationJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersJsonRequest
-import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.ShareCipherJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateCipherCollectionsJsonRequest
@@ -155,5 +154,5 @@ interface CiphersApi {
     @POST("ciphers/import")
     suspend fun importCiphers(
         @Body body: ImportCiphersJsonRequest,
-    ): NetworkResult<ImportCiphersResponseJson>
+    ): NetworkResult<Unit>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/api/CiphersApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/api/CiphersApi.kt
@@ -5,6 +5,8 @@ import com.x8bit.bitwarden.data.vault.datasource.network.model.AttachmentJsonReq
 import com.x8bit.bitwarden.data.vault.datasource.network.model.AttachmentJsonResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CipherJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateCipherInOrganizationJsonRequest
+import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersJsonRequest
+import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.ShareCipherJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateCipherCollectionsJsonRequest
@@ -149,4 +151,9 @@ interface CiphersApi {
      */
     @GET("ciphers/has-unassigned-ciphers")
     suspend fun hasUnassignedCiphers(): NetworkResult<Boolean>
+
+    @POST("ciphers/import")
+    suspend fun importCiphers(
+        @Body body: ImportCiphersJsonRequest,
+    ): NetworkResult<ImportCiphersResponseJson>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/ImportCiphersJsonRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/ImportCiphersJsonRequest.kt
@@ -1,0 +1,37 @@
+package com.x8bit.bitwarden.data.vault.datasource.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an import ciphers request.
+ *
+ * @property folders A list of folders to import.
+ * @property ciphers A list of ciphers to import.
+ * @property folderRelationships A map of cipher folder relationships to import. Key correlates to
+ * the index of the cipher in the ciphers list. Value correlates to the index of the folder in the
+ * folders list.
+ */
+@Serializable
+data class ImportCiphersJsonRequest(
+    @SerialName("folders")
+    val folders: List<FolderWithIdJsonRequest>,
+    @SerialName("ciphers")
+    val ciphers: List<CipherJsonRequest>,
+    @SerialName("folderRelationships")
+    val folderRelationships: Map<Int, Int>,
+) {
+    /**
+     * Represents a folder request with an optional [id] if the folder already exists.
+     *
+     * @property name The name of the folder.
+     * @property id The ID of the folder, if it already exists. Null otherwise.
+     **/
+    @Serializable
+    data class FolderWithIdJsonRequest(
+        @SerialName("name")
+        val name: String?,
+        @SerialName("id")
+        val id: String?,
+    )
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/ImportCiphersResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/ImportCiphersResponseJson.kt
@@ -1,0 +1,41 @@
+package com.x8bit.bitwarden.data.vault.datasource.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The response body for importing ciphers.
+ */
+@Serializable
+sealed class ImportCiphersResponseJson {
+
+    /**
+     * Models a successful json response.
+     */
+    @Serializable
+    object Success : ImportCiphersResponseJson()
+
+    /**
+     * Represents the json body of an invalid request.
+     *
+     * @param validationErrors a map where each value is a list of error messages for each key.
+     * The values in the array should be used for display to the user, since the keys tend to come
+     * back as nonsense. (eg: empty string key)
+     */
+    @Serializable
+    data class Invalid(
+        @SerialName("message")
+        private val invalidMessage: String? = null,
+
+        @SerialName("Message")
+        private val errorMessage: String? = null,
+
+        @SerialName("validationErrors")
+        val validationErrors: Map<String, List<String>>?,
+    ) : ImportCiphersResponseJson() {
+        /**
+         * A generic error message.
+         */
+        val message: String? get() = invalidMessage ?: errorMessage
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersService.kt
@@ -5,6 +5,8 @@ import com.x8bit.bitwarden.data.vault.datasource.network.model.AttachmentJsonReq
 import com.x8bit.bitwarden.data.vault.datasource.network.model.AttachmentJsonResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CipherJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateCipherInOrganizationJsonRequest
+import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersJsonRequest
+import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.ShareCipherJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateCipherCollectionsJsonRequest
@@ -118,4 +120,9 @@ interface CiphersService {
      * Returns a boolean indicating if the active user has unassigned ciphers.
      */
     suspend fun hasUnassignedCiphers(): Result<Boolean>
+
+    /**
+     * Attempt to import ciphers.
+     */
+    suspend fun importCiphers(request: ImportCiphersJsonRequest): Result<ImportCiphersResponseJson>
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceTest.kt
@@ -6,6 +6,7 @@ import com.x8bit.bitwarden.data.vault.datasource.network.api.AzureApi
 import com.x8bit.bitwarden.data.vault.datasource.network.api.CiphersApi
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateCipherInOrganizationJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.FileUploadType
+import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.ShareCipherJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateCipherCollectionsJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateCipherResponseJson
@@ -320,6 +321,32 @@ class CiphersServiceTest : BaseServiceTest() {
         server.enqueue(MockResponse().setBody("true"))
         val result = ciphersService.hasUnassignedCiphers()
         assertTrue(result.getOrThrow())
+    }
+
+    @Test
+    fun `importCiphers should return the correct response`() = runTest {
+        server.enqueue(MockResponse().setBody(""))
+        val result = ciphersService.importCiphers(
+            request = ImportCiphersJsonRequest(
+                ciphers = listOf(createMockCipherJsonRequest(number = 1)),
+                folders = emptyList(),
+                folderRelationships = emptyMap(),
+            ),
+        )
+        assertEquals(Unit, result.getOrThrow())
+    }
+
+    @Test
+    fun `importCiphers should return an error when the response is an error`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(400))
+        val result = ciphersService.importCiphers(
+            request = ImportCiphersJsonRequest(
+                ciphers = listOf(createMockCipherJsonRequest(number = 1)),
+                folders = emptyList(),
+                folderRelationships = emptyMap(),
+            ),
+        )
+        assertTrue(result.isFailure)
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceTest.kt
@@ -7,6 +7,7 @@ import com.x8bit.bitwarden.data.vault.datasource.network.api.CiphersApi
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateCipherInOrganizationJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.FileUploadType
 import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersJsonRequest
+import com.x8bit.bitwarden.data.vault.datasource.network.model.ImportCiphersResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.ShareCipherJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateCipherCollectionsJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateCipherResponseJson
@@ -325,7 +326,7 @@ class CiphersServiceTest : BaseServiceTest() {
 
     @Test
     fun `importCiphers should return the correct response`() = runTest {
-        server.enqueue(MockResponse().setBody(""))
+        server.enqueue(MockResponse().setResponseCode(200))
         val result = ciphersService.importCiphers(
             request = ImportCiphersJsonRequest(
                 ciphers = listOf(createMockCipherJsonRequest(number = 1)),
@@ -333,7 +334,7 @@ class CiphersServiceTest : BaseServiceTest() {
                 folderRelationships = emptyMap(),
             ),
         )
-        assertEquals(Unit, result.getOrThrow())
+        assertEquals(ImportCiphersResponseJson.Success, result.getOrThrow())
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

PM-15054

## 📔 Objective

Add an API for importing ciphers, including folders and folder relationships.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
