### PR TITLE
[PM-13425] Login request display on push

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
@@ -25,6 +25,7 @@ import com.x8bit.bitwarden.ui.platform.composition.LocalManagerProvider
 import com.x8bit.bitwarden.ui.platform.feature.debugmenu.manager.DebugMenuLaunchManager
 import com.x8bit.bitwarden.ui.platform.feature.debugmenu.navigateToDebugMenuScreen
 import com.x8bit.bitwarden.ui.platform.feature.rootnav.RootNavScreen
+import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.loginapproval.navigateToLoginApproval
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -93,6 +94,13 @@ class MainActivity : AppCompatActivity() {
                                 Toast.LENGTH_SHORT,
                             )
                             .show()
+                    }
+
+                    is MainEvent.NavigateToLoginApproval -> {
+                        navController.navigateToLoginApproval(
+                            fingerprint = "",
+                            requestId = event.requestId,
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -273,13 +273,16 @@ class MainViewModel @Inject constructor(
                         authRepository.switchAccount(passwordlessRequestData.userId)
                     }
                 }
-                specialCircumstanceManager.specialCircumstance =
-                    SpecialCircumstance.PasswordlessRequest(
-                        passwordlessRequestData = passwordlessRequestData,
-                        // Allow users back into the already-running app when completing the
-                        // autofill task when this is not the first intent.
-                        shouldFinishWhenComplete = isFirstIntent,
-                    )
+
+                sendEvent(MainEvent.NavigateToLoginApproval(passwordlessRequestData.loginRequestId))
+
+//                specialCircumstanceManager.specialCircumstance =
+//                    SpecialCircumstance.PasswordlessRequest(
+//                        passwordlessRequestData = passwordlessRequestData,
+//                        // Allow users back into the already-running app when completing the
+//                        // autofill task when this is not the first intent.
+//                        shouldFinishWhenComplete = isFirstIntent,
+//                    )
             }
 
             completeRegistrationData != null -> {
@@ -518,4 +521,11 @@ sealed class MainEvent {
      * Show a toast with the given [message].
      */
     data class ShowToast(val message: Text) : MainEvent()
+
+    /**
+     * Navigates to the Login Approval screen with the given fingerprint.
+     */
+    data class NavigateToLoginApproval(
+        val requestId: String,
+    ) : MainEvent()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
@@ -21,6 +21,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManagerImpl
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.AppStateManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.GeneratorDiskSource
@@ -49,12 +50,14 @@ object AuthManagerModule {
         authDiskSource: AuthDiskSource,
         pushManager: PushManager,
         dispatcherManager: DispatcherManager,
+        appStateManager: AppStateManager,
     ): AuthRequestNotificationManager =
         AuthRequestNotificationManagerImpl(
             context = context,
             authDiskSource = authDiskSource,
             pushManager = pushManager,
             dispatcherManager = dispatcherManager,
+            appStateManager = appStateManager,
         )
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalNavigation.kt
@@ -10,16 +10,19 @@ import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 
 private const val FINGERPRINT: String = "fingerprint"
+private const val REQUEST_ID: String = "requestId"
 private const val LOGIN_APPROVAL_PREFIX = "login_approval"
-private const val LOGIN_APPROVAL_ROUTE = "$LOGIN_APPROVAL_PREFIX?$FINGERPRINT={$FINGERPRINT}"
+private const val LOGIN_APPROVAL_ROUTE =
+    "$LOGIN_APPROVAL_PREFIX?$FINGERPRINT={$FINGERPRINT}&$REQUEST_ID={$REQUEST_ID}"
 
 /**
  * Class to retrieve login approval arguments from the [SavedStateHandle].
  */
 @OmitFromCoverage
-data class LoginApprovalArgs(val fingerprint: String?) {
+data class LoginApprovalArgs(val fingerprint: String?, val requestId: String?) {
     constructor(savedStateHandle: SavedStateHandle) : this(
         fingerprint = savedStateHandle.get<String>(FINGERPRINT),
+        requestId = savedStateHandle.get<String>(REQUEST_ID),
     )
 }
 
@@ -37,6 +40,11 @@ fun NavGraphBuilder.loginApprovalDestination(
                 nullable = true
                 defaultValue = null
             },
+            navArgument(REQUEST_ID) {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            },
         ),
     ) {
         LoginApprovalScreen(
@@ -50,7 +58,8 @@ fun NavGraphBuilder.loginApprovalDestination(
  */
 fun NavController.navigateToLoginApproval(
     fingerprint: String?,
+    requestId: String? = null,
     navOptions: NavOptions? = null,
 ) {
-    navigate("$LOGIN_APPROVAL_PREFIX?$FINGERPRINT=$fingerprint", navOptions)
+    navigate("$LOGIN_APPROVAL_PREFIX?$FINGERPRINT=$fingerprint&$REQUEST_ID=$requestId", navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
@@ -48,7 +48,7 @@ class LoginApprovalViewModel @Inject constructor(
                     ?: requireNotNull(LoginApprovalArgs(savedStateHandle).fingerprint),
                 masterPasswordHash = null,
                 publicKey = "",
-                requestId = "",
+                requestId = LoginApprovalArgs(savedStateHandle).requestId.orEmpty(),
                 viewState = LoginApprovalState.ViewState.Loading,
                 dialogState = null,
             )
@@ -86,11 +86,19 @@ class LoginApprovalViewModel @Inject constructor(
                 }
             }
             ?: run {
-                authRepository
-                    .getAuthRequestByFingerprintFlow(state.fingerprint)
-                    .map { LoginApprovalAction.Internal.AuthRequestResultReceive(it) }
-                    .onEach(::sendAction)
-                    .launchIn(viewModelScope)
+                if (state.requestId.isNotEmpty()) {
+                    authRepository
+                        .getAuthRequestByIdFlow(state.requestId)
+                        .map { LoginApprovalAction.Internal.AuthRequestResultReceive(it) }
+                        .onEach(::sendAction)
+                        .launchIn(viewModelScope)
+                } else {
+                    authRepository
+                        .getAuthRequestByIdFlow(state.fingerprint)
+                        .map { LoginApprovalAction.Internal.AuthRequestResultReceive(it) }
+                        .onEach(::sendAction)
+                        .launchIn(viewModelScope)
+                }
             }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13425

## 📔 Objective

On passwordless login push, when the app is open should automatically navigate to the login request

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
