### PR TITLE
PM-12733: Add error dialog to be displayed if TOTP code is blank

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenBasicDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenBasicDialog.kt
@@ -20,13 +20,64 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import kotlinx.parcelize.Parcelize
 
 /**
+ * Represents a Bitwarden-styled dialog.
+ *
+ * @param title The optional title to be displayed by the dialog.
+ * @param message The message to be displayed under the [title] by the dialog.
+ * @param onDismissRequest A lambda that is invoked when the user has requested to dismiss the
+ * dialog, whether by tapping "OK", tapping outside the dialog, or pressing the back button.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun BitwardenBasicDialog(
+    title: String?,
+    message: String,
+    onDismissRequest: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            BitwardenTextButton(
+                label = stringResource(id = R.string.ok),
+                onClick = onDismissRequest,
+                modifier = Modifier.testTag(tag = "AcceptAlertButton"),
+            )
+        },
+        title = title?.let {
+            {
+                Text(
+                    text = it,
+                    style = BitwardenTheme.typography.headlineSmall,
+                    modifier = Modifier.testTag(tag = "AlertTitleText"),
+                )
+            }
+        },
+        text = {
+            Text(
+                text = message,
+                style = BitwardenTheme.typography.bodyMedium,
+                modifier = Modifier.testTag(tag = "AlertContentText"),
+            )
+        },
+        shape = BitwardenTheme.shapes.dialog,
+        containerColor = BitwardenTheme.colorScheme.background.primary,
+        iconContentColor = BitwardenTheme.colorScheme.icon.secondary,
+        titleContentColor = BitwardenTheme.colorScheme.text.primary,
+        textContentColor = BitwardenTheme.colorScheme.text.primary,
+        modifier = Modifier.semantics {
+            testTagsAsResourceId = true
+            testTag = "AlertPopup"
+        },
+    )
+}
+
+/**
  * Represents a Bitwarden-styled dialog that is hidden or shown based on [visibilityState].
  *
  * @param visibilityState the [BasicDialogState] used to populate the dialog.
  * @param onDismissRequest called when the user has requested to dismiss the dialog, whether by
  * tapping "OK", tapping outside the dialog, or pressing the back button.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun BitwardenBasicDialog(
     visibilityState: BasicDialogState,
@@ -34,40 +85,10 @@ fun BitwardenBasicDialog(
 ): Unit = when (visibilityState) {
     BasicDialogState.Hidden -> Unit
     is BasicDialogState.Shown -> {
-        AlertDialog(
+        BitwardenBasicDialog(
+            title = visibilityState.title?.invoke(),
+            message = visibilityState.message(),
             onDismissRequest = onDismissRequest,
-            confirmButton = {
-                BitwardenTextButton(
-                    label = stringResource(id = R.string.ok),
-                    onClick = onDismissRequest,
-                    modifier = Modifier.testTag("AcceptAlertButton"),
-                )
-            },
-            title = visibilityState.title?.let {
-                {
-                    Text(
-                        text = it(),
-                        style = BitwardenTheme.typography.headlineSmall,
-                        modifier = Modifier.testTag("AlertTitleText"),
-                    )
-                }
-            },
-            text = {
-                Text(
-                    text = visibilityState.message(),
-                    style = BitwardenTheme.typography.bodyMedium,
-                    modifier = Modifier.testTag("AlertContentText"),
-                )
-            },
-            shape = BitwardenTheme.shapes.dialog,
-            containerColor = BitwardenTheme.colorScheme.background.primary,
-            iconContentColor = BitwardenTheme.colorScheme.icon.secondary,
-            titleContentColor = BitwardenTheme.colorScheme.text.primary,
-            textContentColor = BitwardenTheme.colorScheme.text.primary,
-            modifier = Modifier.semantics {
-                testTagsAsResourceId = true
-                testTag = "AlertPopup"
-            },
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -32,6 +32,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
+import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
@@ -107,6 +108,13 @@ fun ManualCodeEntryScreen(
             title = null,
         )
     }
+
+    ManualCodeEntryDialogs(
+        state = state.dialog,
+        onDismissRequest = remember(viewModel) {
+            { viewModel.trySendAction(ManualCodeEntryAction.DialogDismiss) }
+        },
+    )
 
     BitwardenScaffold(
         modifier = Modifier.fillMaxSize(),
@@ -198,5 +206,23 @@ fun ManualCodeEntryScreen(
                 modifier = Modifier.testTag("ScanQRCodeButton"),
             )
         }
+    }
+}
+
+@Composable
+private fun ManualCodeEntryDialogs(
+    state: ManualCodeEntryState.DialogState?,
+    onDismissRequest: () -> Unit,
+) {
+    when (state) {
+        is ManualCodeEntryState.DialogState.Error -> {
+            BitwardenBasicDialog(
+                title = state.title?.invoke(),
+                message = state.message(),
+                onDismissRequest = onDismissRequest,
+            )
+        }
+
+        null -> Unit
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12733](https://bitwarden.atlassian.net/browse/PM-12733)

## 📔 Objective

This PR adds an error dialog to be displayed if the user attempts to enter a blank totp code.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12733]: https://bitwarden.atlassian.net/browse/PM-12733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ