### PR TITLE
PM-13425: Auto-navigate to Login Approval screen when app is foregrounded

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
@@ -21,6 +21,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManagerImpl
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.AppStateManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.GeneratorDiskSource
@@ -47,12 +48,14 @@ object AuthManagerModule {
     fun provideAuthRequestNotificationManager(
         @ApplicationContext context: Context,
         authDiskSource: AuthDiskSource,
+        appStateManager: AppStateManager,
         pushManager: PushManager,
         dispatcherManager: DispatcherManager,
     ): AuthRequestNotificationManager =
         AuthRequestNotificationManagerImpl(
             context = context,
             authDiskSource = authDiskSource,
+            appStateManager = appStateManager,
             pushManager = pushManager,
             dispatcherManager = dispatcherManager,
         )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13425](https://bitwarden.atlassian.net/browse/PM-13425)

## 📔 Objective

This PR adds logic to auto-navigate the user to the `LoginApprovalScreen` when the active user is the target of the request and the app is foregrounded.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
