### PR TITLE
PM-14963: Add toast when login via device succeeds

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreen.kt
@@ -62,6 +62,7 @@ fun LoginWithDeviceScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val resources = context.resources
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             LoginWithDeviceEvent.NavigateBack -> onNavigateBack()
@@ -74,7 +75,7 @@ fun LoginWithDeviceScreen(
             }
 
             is LoginWithDeviceEvent.ShowToast -> {
-                Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, event.message(resources), Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
@@ -13,6 +13,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.generateUriForCaptcha
 import com.x8bit.bitwarden.ui.auth.feature.loginwithdevice.model.LoginWithDeviceType
 import com.x8bit.bitwarden.ui.auth.feature.loginwithdevice.util.toAuthRequestType
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
+import com.x8bit.bitwarden.ui.platform.base.util.BackgroundEvent
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -252,6 +253,7 @@ class LoginWithDeviceViewModel @Inject constructor(
             }
 
             is LoginResult.Success -> {
+                sendEvent(LoginWithDeviceEvent.ShowToast(R.string.login_approved.asText()))
                 mutableStateFlow.update { it.copy(dialogState = null) }
             }
         }
@@ -494,8 +496,8 @@ sealed class LoginWithDeviceEvent {
      * Shows a toast with the given [message].
      */
     data class ShowToast(
-        val message: String,
-    ) : LoginWithDeviceEvent()
+        val message: Text,
+    ) : LoginWithDeviceEvent(), BackgroundEvent
 }
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
@@ -162,8 +162,8 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                 )
             } returns LoginResult.Success
             val viewModel = createViewModel()
-            viewModel.stateFlow.test {
-                assertEquals(DEFAULT_STATE, awaitItem())
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
+                assertEquals(DEFAULT_STATE, stateFlow.awaitItem())
                 mutableCreateAuthRequestWithUpdatesFlow.tryEmit(
                     CreateAuthRequestResult.Success(
                         authRequest = AUTH_REQUEST,
@@ -181,7 +181,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                             message = R.string.logging_in.asText(),
                         ),
                     ),
-                    awaitItem(),
+                    stateFlow.awaitItem(),
                 )
                 assertEquals(
                     DEFAULT_STATE.copy(
@@ -191,7 +191,11 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                         dialogState = null,
                         loginData = DEFAULT_LOGIN_DATA,
                     ),
-                    awaitItem(),
+                    stateFlow.awaitItem(),
+                )
+                assertEquals(
+                    LoginWithDeviceEvent.ShowToast(R.string.login_approved.asText()),
+                    eventFlow.awaitItem(),
                 )
             }
 
@@ -227,8 +231,8 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
             )
             val viewModel = createViewModel(initialState)
 
-            viewModel.stateFlow.test {
-                assertEquals(initialState, awaitItem())
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
+                assertEquals(initialState, stateFlow.awaitItem())
                 mutableCreateAuthRequestWithUpdatesFlow.tryEmit(
                     CreateAuthRequestResult.Success(
                         authRequest = AUTH_REQUEST,
@@ -246,7 +250,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                         ),
                         loginData = DEFAULT_LOGIN_DATA,
                     ),
-                    awaitItem(),
+                    stateFlow.awaitItem(),
                 )
                 assertEquals(
                     initialState.copy(
@@ -256,7 +260,11 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                         dialogState = null,
                         loginData = DEFAULT_LOGIN_DATA,
                     ),
-                    awaitItem(),
+                    stateFlow.awaitItem(),
+                )
+                assertEquals(
+                    LoginWithDeviceEvent.ShowToast(R.string.login_approved.asText()),
+                    eventFlow.awaitItem(),
                 )
             }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-14963

## 📔 Objective

This PR adds a toast when you successfully login with device.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
