### PR TITLE
PM-15109 only accept numeric values for account pin lock value

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithPinSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithPinSwitch.kt
@@ -79,6 +79,7 @@ fun BitwardenUnlockWithPinSwitch(
                     onUnlockWithPinToggleAction(UnlockWithPinState.Disabled)
                     pin = ""
                 },
+                isPinCreation = true,
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
@@ -107,7 +107,11 @@ fun PinInputDialog(
                     label = stringResource(id = R.string.pin),
                     value = pin,
                     autoFocus = true,
-                    onValueChange = { pin = it },
+                    onValueChange = { newValue ->
+                        if (newValue.all { it.isDigit() }) {
+                            pin = newValue
+                        }
+                    },
                     keyboardType = KeyboardType.Number,
                     modifier = Modifier
                         .testTag(tag = "AlertInputField")

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
@@ -43,6 +43,9 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * @param onCancelClick A callback for when the "Cancel" button is clicked.
  * @param onSubmitClick A callback for when the "Submit" button is clicked.
  * @param onDismissRequest A callback for when the dialog is requesting to be dismissed.
+ * @param isPinCreation A flag for determining if the dialog is being used for PIN creation. We
+ * want to restrict PINs to numeric values but also support any existing PINs with non-numeric
+ * characters.
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Suppress("LongMethod")
@@ -51,6 +54,7 @@ fun PinInputDialog(
     onCancelClick: () -> Unit,
     onSubmitClick: (String) -> Unit,
     onDismissRequest: () -> Unit,
+    isPinCreation: Boolean = false,
 ) {
     var pin by remember { mutableStateOf(value = "") }
     Dialog(
@@ -108,9 +112,7 @@ fun PinInputDialog(
                     value = pin,
                     autoFocus = true,
                     onValueChange = { newValue ->
-                        if (newValue.all { it.isDigit() }) {
-                            pin = newValue
-                        }
+                        pin = newValue.filter { it.isDigit() || !isPinCreation }
                     },
                     keyboardType = KeyboardType.Number,
                     modifier = Modifier

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -388,7 +388,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
         composeTestRule
             .onAllNodesWithText(text = "PIN")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .performTextInput("PIN")
+            .performTextInput("1234")
         composeTestRule
             .onAllNodesWithText(text = "Submit")
             .filterToOne(hasAnyAncestor(isDialog()))
@@ -397,7 +397,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
         verify {
             viewModel.trySendAction(
                 VaultAddEditAction.Common.PinFido2SetUpSubmit(
-                    pin = "PIN",
+                    pin = "1234",
                 ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -1788,7 +1788,7 @@ class VaultItemListingScreenTest : BaseComposeTest() {
         composeTestRule
             .onAllNodesWithText(text = "PIN")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .performTextInput("PIN")
+            .performTextInput("1234")
         composeTestRule
             .onAllNodesWithText(text = "Submit")
             .filterToOne(hasAnyAncestor(isDialog()))
@@ -1797,7 +1797,7 @@ class VaultItemListingScreenTest : BaseComposeTest() {
         verify {
             viewModel.trySendAction(
                 VaultItemListingsAction.PinFido2SetUpSubmit(
-                    pin = "PIN",
+                    pin = "1234",
                     selectedCipherId = selectedCipherId,
                 ),
             )


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15109
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- prevent users from entering or pasting non numeric values in for the text field.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/2c168289-c382-407c-a668-e159f6b134bc


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
