### PR TITLE
Remove the BasicDialogState

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
@@ -103,7 +103,8 @@ fun CompleteRegistrationScreen(
     when (val dialog = state.dialog) {
         is CompleteRegistrationDialog.Error -> {
             BitwardenBasicDialog(
-                visibilityState = dialog.state,
+                title = dialog.title?.invoke(),
+                message = dialog.message(),
                 onDismissRequest = handler.onDismissErrorDialog,
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
@@ -28,7 +28,6 @@ import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.isValidEmail
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filterIsInstance
@@ -207,11 +206,9 @@ class CompleteRegistrationViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialog = CompleteRegistrationDialog.Error(
-                            BasicDialogState.Shown(
-                                title = R.string.an_error_has_occurred.asText(),
-                                message = registerAccountResult.errorMessage?.asText()
-                                    ?: R.string.generic_error_message.asText(),
-                            ),
+                            title = R.string.an_error_has_occurred.asText(),
+                            message = registerAccountResult.errorMessage?.asText()
+                                ?: R.string.generic_error_message.asText(),
                         ),
                     )
                 }
@@ -319,36 +316,49 @@ class CompleteRegistrationViewModel @Inject constructor(
 
     private fun handleCallToActionClick() = when {
         state.userEmail.isBlank() -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.validation_field_required
-                    .asText(R.string.email_address.asText()),
-            )
-            mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CompleteRegistrationDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.validation_field_required
+                            .asText(R.string.email_address.asText()),
+                    ),
+                )
+            }
         }
 
         !state.userEmail.isValidEmail() -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.invalid_email.asText(),
-            )
-            mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CompleteRegistrationDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.invalid_email.asText(),
+                    ),
+                )
+            }
         }
 
         state.passwordInput.length < MIN_PASSWORD_LENGTH -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.master_password_length_val_message_x.asText(MIN_PASSWORD_LENGTH),
-            )
-            mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CompleteRegistrationDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.master_password_length_val_message_x
+                            .asText(MIN_PASSWORD_LENGTH),
+                    ),
+                )
+            }
         }
 
         state.passwordInput != state.confirmPasswordInput -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.master_password_confirmation_val_message.asText(),
-            )
-            mutableStateFlow.update { it.copy(dialog = CompleteRegistrationDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CompleteRegistrationDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.master_password_confirmation_val_message.asText(),
+                    ),
+                )
+            }
         }
 
         else -> {
@@ -506,7 +516,10 @@ sealed class CompleteRegistrationDialog : Parcelable {
      * General error dialog with an OK button.
      */
     @Parcelize
-    data class Error(val state: BasicDialogState.Shown) : CompleteRegistrationDialog()
+    data class Error(
+        val title: Text?,
+        val message: Text,
+    ) : CompleteRegistrationDialog()
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
@@ -114,7 +114,8 @@ fun CreateAccountScreen(
     when (val dialog = state.dialog) {
         is CreateAccountDialog.Error -> {
             BitwardenBasicDialog(
-                visibilityState = dialog.state,
+                title = dialog.title?.invoke(),
+                message = dialog.message(),
                 onDismissRequest = remember(viewModel) {
                     { viewModel.trySendAction(ErrorDialogDismiss) }
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModel.kt
@@ -28,7 +28,6 @@ import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.concat
 import com.x8bit.bitwarden.ui.platform.base.util.isValidEmail
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
@@ -143,10 +142,8 @@ class CreateAccountViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialog = CreateAccountDialog.Error(
-                            BasicDialogState.Shown(
-                                title = R.string.an_error_has_occurred.asText(),
-                                message = R.string.captcha_failed.asText(),
-                            ),
+                            title = R.string.an_error_has_occurred.asText(),
+                            message = R.string.captcha_failed.asText(),
                         ),
                     )
                 }
@@ -180,11 +177,9 @@ class CreateAccountViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialog = CreateAccountDialog.Error(
-                            BasicDialogState.Shown(
-                                title = R.string.an_error_has_occurred.asText(),
-                                message = registerAccountResult.errorMessage?.asText()
-                                    ?: R.string.generic_error_message.asText(),
-                            ),
+                            title = R.string.an_error_has_occurred.asText(),
+                            message = registerAccountResult.errorMessage?.asText()
+                                ?: R.string.generic_error_message.asText(),
                         ),
                     )
                 }
@@ -293,46 +288,63 @@ class CreateAccountViewModel @Inject constructor(
         mutableStateFlow.update { it.copy(confirmPasswordInput = action.input) }
     }
 
+    @Suppress("LongMethod")
     private fun handleSubmitClick() = when {
         state.emailInput.isBlank() -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.validation_field_required
-                    .asText(R.string.email_address.asText()),
-            )
-            mutableStateFlow.update { it.copy(dialog = CreateAccountDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CreateAccountDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.validation_field_required
+                            .asText(R.string.email_address.asText()),
+                    ),
+                )
+            }
         }
 
         !state.emailInput.isValidEmail() -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.invalid_email.asText(),
-            )
-            mutableStateFlow.update { it.copy(dialog = CreateAccountDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CreateAccountDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.invalid_email.asText(),
+                    ),
+                )
+            }
         }
 
         state.passwordInput.length < MIN_PASSWORD_LENGTH -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.master_password_length_val_message_x.asText(MIN_PASSWORD_LENGTH),
-            )
-            mutableStateFlow.update { it.copy(dialog = CreateAccountDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CreateAccountDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.master_password_length_val_message_x
+                            .asText(MIN_PASSWORD_LENGTH),
+                    ),
+                )
+            }
         }
 
         state.passwordInput != state.confirmPasswordInput -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.master_password_confirmation_val_message.asText(),
-            )
-            mutableStateFlow.update { it.copy(dialog = CreateAccountDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CreateAccountDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.master_password_confirmation_val_message.asText(),
+                    ),
+                )
+            }
         }
 
         !state.isAcceptPoliciesToggled -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.accept_policies_error.asText(),
-            )
-            mutableStateFlow.update { it.copy(dialog = CreateAccountDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = CreateAccountDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.accept_policies_error.asText(),
+                    ),
+                )
+            }
         }
 
         else -> {
@@ -449,7 +461,10 @@ sealed class CreateAccountDialog : Parcelable {
      * General error dialog with an OK button.
      */
     @Parcelize
-    data class Error(val state: BasicDialogState.Shown) : CreateAccountDialog()
+    data class Error(
+        val title: Text?,
+        val message: Text,
+    ) : CreateAccountDialog()
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -138,7 +138,8 @@ fun StartRegistrationScreen(
     when (val dialog = state.dialog) {
         is StartRegistrationDialog.Error -> {
             BitwardenBasicDialog(
-                visibilityState = dialog.state,
+                title = dialog.title?.invoke(),
+                message = dialog.message(),
                 onDismissRequest = remember(viewModel) {
                     { viewModel.trySendAction(ErrorDialogDismiss) }
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
@@ -27,9 +27,9 @@ import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAc
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.TermsClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.UnsubscribeMarketingEmailsClick
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
+import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.isValidEmail
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -197,20 +197,26 @@ class StartRegistrationViewModel @Inject constructor(
 
     private fun handleContinueClick() = when {
         state.emailInput.isBlank() -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.validation_field_required
-                    .asText(R.string.email_address.asText()),
-            )
-            mutableStateFlow.update { it.copy(dialog = StartRegistrationDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = StartRegistrationDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.validation_field_required
+                            .asText(R.string.email_address.asText()),
+                    ),
+                )
+            }
         }
 
         !state.emailInput.isValidEmail() -> {
-            val dialog = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
-                message = R.string.invalid_email.asText(),
-            )
-            mutableStateFlow.update { it.copy(dialog = StartRegistrationDialog.Error(dialog)) }
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = StartRegistrationDialog.Error(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.invalid_email.asText(),
+                    ),
+                )
+            }
         }
 
         else -> {
@@ -245,13 +251,11 @@ class StartRegistrationViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialog = StartRegistrationDialog.Error(
-                            BasicDialogState.Shown(
-                                title = R.string.an_error_has_occurred.asText(),
-                                message = sendVerificationEmailResult
-                                    .errorMessage
-                                    ?.asText()
-                                    ?: R.string.generic_error_message.asText(),
-                            ),
+                            title = R.string.an_error_has_occurred.asText(),
+                            message = sendVerificationEmailResult
+                                .errorMessage
+                                ?.asText()
+                                ?: R.string.generic_error_message.asText(),
                         ),
                     )
                 }
@@ -307,7 +311,10 @@ sealed class StartRegistrationDialog : Parcelable {
      * General error dialog with an OK button.
      */
     @Parcelize
-    data class Error(val state: BasicDialogState.Shown) : StartRegistrationDialog()
+    data class Error(
+        val title: Text?,
+        val message: Text,
+    ) : StartRegistrationDialog()
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenBasicDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenBasicDialog.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.components.dialog
 
-import android.os.Parcelable
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,11 +12,8 @@ import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.base.util.Text
-import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
-import kotlinx.parcelize.Parcelize
 
 /**
  * Represents a Bitwarden-styled dialog.
@@ -71,59 +67,14 @@ fun BitwardenBasicDialog(
     )
 }
 
-/**
- * Represents a Bitwarden-styled dialog that is hidden or shown based on [visibilityState].
- *
- * @param visibilityState the [BasicDialogState] used to populate the dialog.
- * @param onDismissRequest called when the user has requested to dismiss the dialog, whether by
- * tapping "OK", tapping outside the dialog, or pressing the back button.
- */
-@Composable
-fun BitwardenBasicDialog(
-    visibilityState: BasicDialogState,
-    onDismissRequest: () -> Unit,
-): Unit = when (visibilityState) {
-    BasicDialogState.Hidden -> Unit
-    is BasicDialogState.Shown -> {
-        BitwardenBasicDialog(
-            title = visibilityState.title?.invoke(),
-            message = visibilityState.message(),
-            onDismissRequest = onDismissRequest,
-        )
-    }
-}
-
 @Preview
 @Composable
 private fun BitwardenBasicDialog_preview() {
     BitwardenTheme {
         BitwardenBasicDialog(
-            visibilityState = BasicDialogState.Shown(
-                title = "An error has occurred.".asText(),
-                message = "Username or password is incorrect. Try again.".asText(),
-            ),
+            title = "An error has occurred.",
+            message = "Username or password is incorrect. Try again.",
             onDismissRequest = {},
         )
     }
-}
-
-/**
- * Models display of a [BitwardenBasicDialog].
- */
-sealed class BasicDialogState : Parcelable {
-
-    /**
-     * Hide the dialog.
-     */
-    @Parcelize
-    data object Hidden : BasicDialogState()
-
-    /**
-     * Show the dialog with the given values.
-     */
-    @Parcelize
-    data class Shown(
-        val title: Text?,
-        val message: Text,
-    ) : BasicDialogState()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -25,9 +25,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
-import com.x8bit.bitwarden.ui.platform.base.util.asText
+import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenSelectionRow
@@ -121,16 +120,16 @@ private fun LanguageSelectionRow(
     onLanguageSelection: (AppLanguage) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var languageChangedDialogState: BasicDialogState by rememberSaveable {
-        mutableStateOf(BasicDialogState.Hidden)
+    var languageChangedDialogOption: Text? by rememberSaveable { mutableStateOf(value = null) }
+    var shouldShowLanguageSelectionDialog by rememberSaveable { mutableStateOf(value = false) }
+
+    languageChangedDialogOption?.let {
+        BitwardenBasicDialog(
+            title = stringResource(id = R.string.language),
+            message = stringResource(id = R.string.language_change_x_description, it),
+            onDismissRequest = { languageChangedDialogOption = null },
+        )
     }
-    var shouldShowLanguageSelectionDialog by rememberSaveable { mutableStateOf(false) }
-
-    BitwardenBasicDialog(
-        visibilityState = languageChangedDialogState,
-        onDismissRequest = { languageChangedDialogState = BasicDialogState.Hidden },
-    )
-
     BitwardenTextRow(
         text = stringResource(id = R.string.language),
         onClick = { shouldShowLanguageSelectionDialog = true },
@@ -155,10 +154,7 @@ private fun LanguageSelectionRow(
                     onClick = {
                         shouldShowLanguageSelectionDialog = false
                         onLanguageSelection(option)
-                        languageChangedDialogState = BasicDialogState.Shown(
-                            title = R.string.language.asText(),
-                            message = R.string.language_change_x_description.asText(option.text),
-                        )
+                        languageChangedDialogOption = option.text
                     },
                 )
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -32,7 +32,6 @@ import com.x8bit.bitwarden.ui.platform.components.appbar.action.BitwardenSearchA
 import com.x8bit.bitwarden.ui.platform.components.appbar.action.OverflowMenuItemData
 import com.x8bit.bitwarden.ui.platform.components.content.BitwardenErrorContent
 import com.x8bit.bitwarden.ui.platform.components.content.BitwardenLoadingContent
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenMasterPasswordDialog
@@ -293,10 +292,8 @@ private fun VaultItemListingDialogs(
 ) {
     when (dialogState) {
         is VaultItemListingState.DialogState.Error -> BitwardenBasicDialog(
-            visibilityState = BasicDialogState.Shown(
-                title = dialogState.title,
-                message = dialogState.message,
-            ),
+            title = dialogState.title?.invoke(),
+            message = dialogState.message(),
             onDismissRequest = onDismissRequest,
         )
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreenTest.kt
@@ -26,7 +26,6 @@ import com.x8bit.bitwarden.ui.auth.feature.completeregistration.CompleteRegistra
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.CompleteRegistrationAction.PasswordInputChange
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -151,10 +150,8 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 dialog = CompleteRegistrationDialog.Error(
-                    BasicDialogState.Shown(
-                        title = "title".asText(),
-                        message = "message".asText(),
-                    ),
+                    title = "title".asText(),
+                    message = "message".asText(),
                 ),
             )
         }
@@ -194,10 +191,8 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 dialog = CompleteRegistrationDialog.Error(
-                    BasicDialogState.Shown(
-                        title = "title".asText(),
-                        message = "message".asText(),
-                    ),
+                    title = "title".asText(),
+                    message = "message".asText(),
                 ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
@@ -31,7 +31,6 @@ import com.x8bit.bitwarden.ui.auth.feature.completeregistration.CompleteRegistra
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.CompleteRegistrationAction.PasswordInputChange
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -193,10 +192,8 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
             assertEquals(
                 VALID_INPUT_STATE.copy(
                     dialog = CompleteRegistrationDialog.Error(
-                        BasicDialogState.Shown(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = "mock_error".asText(),
-                        ),
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = "mock_error".asText(),
                     ),
                 ),
                 awaitItem(),
@@ -595,10 +592,8 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
             val expectedState = DEFAULT_STATE.copy(
                 passwordInput = input,
                 dialog = CompleteRegistrationDialog.Error(
-                    BasicDialogState.Shown(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.master_password_length_val_message_x.asText(12),
-                    ),
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.master_password_length_val_message_x.asText(12),
                 ),
             )
             viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
@@ -619,10 +614,8 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
                 userEmail = EMAIL,
                 passwordInput = PASSWORD,
                 dialog = CompleteRegistrationDialog.Error(
-                    BasicDialogState.Shown(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.master_password_confirmation_val_message.asText(),
-                    ),
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.master_password_confirmation_val_message.asText(),
                 ),
             )
             viewModel.trySendAction(CompleteRegistrationAction.CallToActionClick)
@@ -644,11 +637,9 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
             userEmail = "",
             passwordInput = PASSWORD,
             dialog = CompleteRegistrationDialog.Error(
-                BasicDialogState.Shown(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.validation_field_required.asText(
-                        R.string.email_address.asText(),
-                    ),
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.validation_field_required.asText(
+                    R.string.email_address.asText(),
                 ),
             ),
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreenTest.kt
@@ -28,7 +28,6 @@ import com.x8bit.bitwarden.ui.auth.feature.createaccount.CreateAccountAction.Pas
 import com.x8bit.bitwarden.ui.auth.feature.createaccount.CreateAccountAction.SubmitClick
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import io.mockk.every
 import io.mockk.just
@@ -182,10 +181,8 @@ class CreateAccountScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 dialog = CreateAccountDialog.Error(
-                    BasicDialogState.Shown(
-                        title = "title".asText(),
-                        message = "message".asText(),
-                    ),
+                    title = "title".asText(),
+                    message = "message".asText(),
                 ),
             )
         }
@@ -225,10 +222,8 @@ class CreateAccountScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 dialog = CreateAccountDialog.Error(
-                    BasicDialogState.Shown(
-                        title = "title".asText(),
-                        message = "message".asText(),
-                    ),
+                    title = "title".asText(),
+                    message = "message".asText(),
                 ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModelTest.kt
@@ -23,7 +23,6 @@ import com.x8bit.bitwarden.ui.auth.feature.createaccount.CreateAccountAction.Pas
 import com.x8bit.bitwarden.ui.auth.feature.createaccount.CreateAccountAction.PasswordInputChange
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -101,10 +100,8 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
         val expectedState = DEFAULT_STATE.copy(
             emailInput = input,
             dialog = CreateAccountDialog.Error(
-                BasicDialogState.Shown(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.invalid_email.asText(),
-                ),
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.invalid_email.asText(),
             ),
         )
         viewModel.trySendAction(CreateAccountAction.SubmitClick)
@@ -124,11 +121,9 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
         val expectedState = DEFAULT_STATE.copy(
             emailInput = input,
             dialog = CreateAccountDialog.Error(
-                BasicDialogState.Shown(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.validation_field_required
-                        .asText(R.string.email_address.asText()),
-                ),
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.validation_field_required
+                    .asText(R.string.email_address.asText()),
             ),
         )
         viewModel.trySendAction(CreateAccountAction.SubmitClick)
@@ -153,10 +148,8 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
             emailInput = EMAIL,
             passwordInput = input,
             dialog = CreateAccountDialog.Error(
-                BasicDialogState.Shown(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.master_password_length_val_message_x.asText(12),
-                ),
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.master_password_length_val_message_x.asText(12),
             ),
         )
         viewModel.trySendAction(CreateAccountAction.SubmitClick)
@@ -181,10 +174,8 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
             emailInput = "test@test.com",
             passwordInput = input,
             dialog = CreateAccountDialog.Error(
-                BasicDialogState.Shown(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.master_password_confirmation_val_message.asText(),
-                ),
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.master_password_confirmation_val_message.asText(),
             ),
         )
         viewModel.trySendAction(CreateAccountAction.SubmitClick)
@@ -211,10 +202,8 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
             passwordInput = password,
             confirmPasswordInput = password,
             dialog = CreateAccountDialog.Error(
-                BasicDialogState.Shown(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.accept_policies_error.asText(),
-                ),
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.accept_policies_error.asText(),
             ),
         )
         viewModel.trySendAction(CreateAccountAction.SubmitClick)
@@ -290,10 +279,8 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
             assertEquals(
                 VALID_INPUT_STATE.copy(
                     dialog = CreateAccountDialog.Error(
-                        BasicDialogState.Shown(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = "mock_error".asText(),
-                        ),
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = "mock_error".asText(),
                     ),
                 ),
                 awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
@@ -18,7 +18,6 @@ import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAc
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EmailInputChange
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.util.performCustomAccessibilityAction
 import io.mockk.every
@@ -149,10 +148,8 @@ class StartRegistrationScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 dialog = StartRegistrationDialog.Error(
-                    BasicDialogState.Shown(
-                        title = "title".asText(),
-                        message = "message".asText(),
-                    ),
+                    title = "title".asText(),
+                    message = "message".asText(),
                 ),
             )
         }
@@ -168,10 +165,8 @@ class StartRegistrationScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 dialog = StartRegistrationDialog.Error(
-                    BasicDialogState.Shown(
-                        title = "title".asText(),
-                        message = "message".asText(),
-                    ),
+                    title = "title".asText(),
+                    message = "message".asText(),
                 ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
@@ -28,7 +28,6 @@ import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationEv
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationEvent.NavigateToUnsubscribe
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
-import com.x8bit.bitwarden.ui.platform.components.dialog.BasicDialogState
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -118,10 +117,8 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
             emailInput = input,
             isContinueButtonEnabled = true,
             dialog = StartRegistrationDialog.Error(
-                BasicDialogState.Shown(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.invalid_email.asText(),
-                ),
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.invalid_email.asText(),
             ),
         )
         viewModel.trySendAction(ContinueClick)
@@ -143,11 +140,9 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
         val expectedState = DEFAULT_STATE.copy(
             emailInput = input,
             dialog = StartRegistrationDialog.Error(
-                BasicDialogState.Shown(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.validation_field_required
-                        .asText(R.string.email_address.asText()),
-                ),
+                title = R.string.an_error_has_occurred.asText(),
+                message = R.string.validation_field_required
+                    .asText(R.string.email_address.asText()),
             ),
         )
         viewModel.trySendAction(ContinueClick)
@@ -220,10 +215,8 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
             assertEquals(
                 VALID_INPUT_STATE.copy(
                     dialog = StartRegistrationDialog.Error(
-                        BasicDialogState.Shown(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = "mock_error".asText(),
-                        ),
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = "mock_error".asText(),
                     ),
                 ),
                 awaitItem(),


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR simplifies the `BitwardenBasicDialog` by removing the `BasicDialogState` class.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
