### PR TITLE
[PM-15057] Rename Fido2CredentialRequest to Fido2CreateCredentialRequest

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -325,7 +325,7 @@ class MainViewModel @Inject constructor(
                 fido2CredentialManager.isUserVerified = false
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.Fido2Save(
-                        fido2CredentialRequest = fido2CredentialRequestData,
+                        fido2CreateCredentialRequest = fido2CredentialRequestData,
                     )
 
                 // Switch accounts if the selected user is not the active user.

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
@@ -4,7 +4,7 @@ import androidx.credentials.provider.CallingAppInfo
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAssertionOptions
@@ -53,7 +53,7 @@ interface Fido2CredentialManager {
      */
     suspend fun registerFido2Credential(
         userId: String,
-        fido2CredentialRequest: Fido2CredentialRequest,
+        fido2CreateCredentialRequest: Fido2CreateCredentialRequest,
         selectedCipherView: CipherView,
     ): Fido2RegisterCredentialResult
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CreateCredentialRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CreateCredentialRequest.kt
@@ -14,7 +14,7 @@ import kotlinx.parcelize.Parcelize
  * @property callingAppInfo Information about the application that initiated the request.
  */
 @Parcelize
-data class Fido2CredentialRequest(
+data class Fido2CreateCredentialRequest(
     val userId: String,
     val requestJson: String,
     val packageName: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
@@ -7,7 +7,7 @@ import androidx.credentials.GetPublicKeyCredentialOption
 import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
 import androidx.credentials.provider.PendingIntentHandler
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_CIPHER_ID
@@ -15,10 +15,10 @@ import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_CREDENTIAL_ID
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_USER_ID
 
 /**
- * Checks if this [Intent] contains a [Fido2CredentialRequest] related to an ongoing FIDO 2
+ * Checks if this [Intent] contains a [Fido2CreateCredentialRequest] related to an ongoing FIDO 2
  * credential creation process.
  */
-fun Intent.getFido2CredentialRequestOrNull(): Fido2CredentialRequest? {
+fun Intent.getFido2CredentialRequestOrNull(): Fido2CreateCredentialRequest? {
     if (isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) return null
 
     val systemRequest = PendingIntentHandler
@@ -33,7 +33,7 @@ fun Intent.getFido2CredentialRequestOrNull(): Fido2CredentialRequest? {
     val userId = getStringExtra(EXTRA_KEY_USER_ID)
         ?: return null
 
-    return Fido2CredentialRequest(
+    return Fido2CreateCredentialRequest(
         userId = userId,
         requestJson = createPublicKeyRequest.requestJson,
         packageName = systemRequest.callingAppInfo.packageName,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
@@ -2,7 +2,7 @@ package com.x8bit.bitwarden.data.platform.manager.model
 
 import android.os.Parcelable
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
@@ -65,7 +65,7 @@ sealed class SpecialCircumstance : Parcelable {
      */
     @Parcelize
     data class Fido2Save(
-        val fido2CredentialRequest: Fido2CredentialRequest,
+        val fido2CreateCredentialRequest: Fido2CreateCredentialRequest,
     ) : SpecialCircumstance()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensions.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager.util
 
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
@@ -27,11 +27,11 @@ fun SpecialCircumstance.toAutofillSelectionDataOrNull(): AutofillSelectionData? 
     }
 
 /**
- * Returns [Fido2CredentialRequest] when contained in the given [SpecialCircumstance].
+ * Returns [Fido2CreateCredentialRequest] when contained in the given [SpecialCircumstance].
  */
-fun SpecialCircumstance.toFido2RequestOrNull(): Fido2CredentialRequest? =
+fun SpecialCircumstance.toFido2RequestOrNull(): Fido2CreateCredentialRequest? =
     when (this) {
-        is SpecialCircumstance.Fido2Save -> this.fido2CredentialRequest
+        is SpecialCircumstance.Fido2Save -> this.fido2CreateCredentialRequest
         else -> null
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -8,7 +8,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.util.parseJwtTokenDataOrNull
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
@@ -133,7 +133,7 @@ class RootNavViewModel @Inject constructor(
                     is SpecialCircumstance.Fido2Save -> {
                         RootNavState.VaultUnlockedForFido2Save(
                             activeUserId = userState.activeUserId,
-                            fido2CredentialRequest = specialCircumstance.fido2CredentialRequest,
+                            fido2CreateCredentialRequest = specialCircumstance.fido2CreateCredentialRequest,
                         )
                     }
 
@@ -286,12 +286,12 @@ sealed class RootNavState : Parcelable {
      *
      * @param activeUserId ID of the active user. Indirectly used to notify [RootNavViewModel] the
      * active user has changed.
-     * @param fido2CredentialRequest System request containing FIDO credential data.
+     * @param fido2CreateCredentialRequest System request containing FIDO credential data.
      */
     @Parcelize
     data class VaultUnlockedForFido2Save(
         val activeUserId: String,
-        val fido2CredentialRequest: Fido2CredentialRequest,
+        val fido2CreateCredentialRequest: Fido2CreateCredentialRequest,
     ) : RootNavState()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -12,7 +12,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
 import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
@@ -449,7 +449,7 @@ class VaultAddEditViewModel @Inject constructor(
     }
 
     private fun handleFido2RequestSpecialCircumstance(
-        request: Fido2CredentialRequest,
+        request: Fido2CreateCredentialRequest,
         cipherView: CipherView,
     ) {
         if (cipherView.isActiveWithFido2Credentials) {
@@ -462,7 +462,7 @@ class VaultAddEditViewModel @Inject constructor(
     }
 
     private fun registerFido2Credential(
-        request: Fido2CredentialRequest,
+        request: Fido2CreateCredentialRequest,
         cipherView: CipherView,
     ) {
 
@@ -494,7 +494,7 @@ class VaultAddEditViewModel @Inject constructor(
     }
 
     private fun registerFido2CredentialToCipher(
-        request: Fido2CredentialRequest,
+        request: Fido2CreateCredentialRequest,
         cipherView: CipherView,
     ) {
         viewModelScope.launch {
@@ -506,7 +506,7 @@ class VaultAddEditViewModel @Inject constructor(
             val result: Fido2RegisterCredentialResult =
                 fido2CredentialManager.registerFido2Credential(
                     userId = userId,
-                    fido2CredentialRequest = request,
+                    fido2CreateCredentialRequest = request,
                     selectedCipherView = cipherView,
                 )
             sendAction(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CreateCredentialRequestExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CreateCredentialRequestExtensions.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.platform.util.toUriOrNull
 import com.x8bit.bitwarden.ui.platform.base.util.toAndroidAppUriString
@@ -12,7 +12,7 @@ import java.util.UUID
  * Returns pre-filled content that may be used for an "add" type
  * [VaultAddEditState.ViewState.Content] during FIDO 2 credential creation.
  */
-fun Fido2CredentialRequest.toDefaultAddTypeContent(
+fun Fido2CreateCredentialRequest.toDefaultAddTypeContent(
     attestationOptions: PasskeyAttestationOptions?,
     isIndividualVaultDisabled: Boolean,
 ): VaultAddEditState.ViewState.Content {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -15,7 +15,7 @@ import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySele
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
@@ -133,7 +133,7 @@ class VaultItemListingViewModel @Inject constructor(
             autofillSelectionData = specialCircumstance?.toAutofillSelectionDataOrNull(),
             hasMasterPassword = userState.activeAccount.hasMasterPassword,
             totpData = specialCircumstance?.toTotpDataOrNull(),
-            fido2CredentialRequest = fido2CredentialRequest,
+            fido2CreateCredentialRequest = fido2CredentialRequest,
             fido2CredentialAssertionRequest = specialCircumstance?.toFido2AssertionRequestOrNull(),
             fido2GetCredentialsRequest = specialCircumstance?.toFido2GetCredentialsRequestOrNull(),
             isPremium = userState.activeAccount.isPremium,
@@ -156,7 +156,7 @@ class VaultItemListingViewModel @Inject constructor(
 
         viewModelScope.launch {
             state
-                .fido2CredentialRequest
+                .fido2CreateCredentialRequest
                 ?.let { request ->
                     sendAction(
                         VaultItemListingsAction.Internal.Fido2RegisterCredentialRequestReceive(
@@ -625,7 +625,7 @@ class VaultItemListingViewModel @Inject constructor(
 
     private fun registerFido2Credential(cipherView: CipherView) {
         val credentialRequest = state
-            .fido2CredentialRequest
+            .fido2CreateCredentialRequest
             ?: run {
                 // This scenario should not occur because `isFido2Creation` is false when
                 // `fido2CredentialRequest` is null. We show the FIDO 2 error dialog to inform
@@ -653,7 +653,7 @@ class VaultItemListingViewModel @Inject constructor(
     }
 
     private fun performUserVerificationIfRequired(
-        credentialRequest: Fido2CredentialRequest,
+        credentialRequest: Fido2CreateCredentialRequest,
         cipherView: CipherView,
     ) {
         val attestationOptions = fido2CredentialManager
@@ -691,7 +691,7 @@ class VaultItemListingViewModel @Inject constructor(
     }
 
     private fun registerFido2CredentialToCipher(
-        request: Fido2CredentialRequest,
+        request: Fido2CreateCredentialRequest,
         cipherView: CipherView,
     ) {
         val activeUserId = authRepository.activeUserId
@@ -703,7 +703,7 @@ class VaultItemListingViewModel @Inject constructor(
             val result: Fido2RegisterCredentialResult =
                 fido2CredentialManager.registerFido2Credential(
                     userId = activeUserId,
-                    fido2CredentialRequest = request,
+                    fido2CreateCredentialRequest = request,
                     selectedCipherView = cipherView,
                 )
             sendAction(
@@ -826,7 +826,7 @@ class VaultItemListingViewModel @Inject constructor(
     private fun handleDismissFido2ErrorDialogClick() {
         clearDialogState()
         when {
-            state.fido2CredentialRequest != null -> {
+            state.fido2CreateCredentialRequest != null -> {
                 sendEvent(
                     VaultItemListingEvent.CompleteFido2Registration(
                         result = Fido2RegisterCredentialResult.Error,
@@ -1575,7 +1575,7 @@ class VaultItemListingViewModel @Inject constructor(
                             baseIconUrl = state.baseIconUrl,
                             isIconLoadingDisabled = state.isIconLoadingDisabled,
                             autofillSelectionData = state.autofillSelectionData,
-                            fido2CreationData = state.fido2CredentialRequest,
+                            fido2CreationData = state.fido2CreateCredentialRequest,
                             fido2CredentialAutofillViews = vaultData
                                 .fido2CredentialAutofillViewList,
                             totpData = state.totpData,
@@ -1636,7 +1636,7 @@ class VaultItemListingViewModel @Inject constructor(
      */
     @Suppress("MaxLineLength")
     private suspend fun DataState<VaultData>.filterForFido2CreationIfNecessary(): DataState<VaultData> {
-        val request = state.fido2CredentialRequest ?: return this
+        val request = state.fido2CreateCredentialRequest ?: return this
         return this.map { vaultData ->
             val matchUri = request.origin
                 ?: request.packageName
@@ -1739,7 +1739,7 @@ data class VaultItemListingState(
     private val isPullToRefreshSettingEnabled: Boolean,
     val totpData: TotpData? = null,
     val autofillSelectionData: AutofillSelectionData? = null,
-    val fido2CredentialRequest: Fido2CredentialRequest? = null,
+    val fido2CreateCredentialRequest: Fido2CreateCredentialRequest? = null,
     val fido2CredentialAssertionRequest: Fido2CredentialAssertionRequest? = null,
     val fido2GetCredentialsRequest: Fido2GetCredentialsRequest? = null,
     val hasMasterPassword: Boolean,
@@ -1763,7 +1763,7 @@ data class VaultItemListingState(
      * Whether or not this represents a listing screen for FIDO2 creation.
      */
     val isFido2Creation: Boolean
-        get() = fido2CredentialRequest != null
+        get() = fido2CreateCredentialRequest != null
 
     /**
      * Whether or not this represents a listing screen for totp.
@@ -1778,7 +1778,7 @@ data class VaultItemListingState(
             ?.uri
             ?.toHostOrPathOrNull()
             ?.let { R.string.items_for_uri.asText(it) }
-            ?: fido2CredentialRequest
+            ?: fido2CreateCredentialRequest
                 ?.callingAppInfo
                 ?.getFido2RpIdOrNull()
                 ?.let { R.string.items_for_uri.asText(it) }
@@ -2549,7 +2549,7 @@ sealed class VaultItemListingsAction {
          * Indicates that a FIDO 2 credential registration has been received.
          */
         data class Fido2RegisterCredentialRequestReceive(
-            val request: Fido2CredentialRequest,
+            val request: Fido2CreateCredentialRequest,
         ) : Internal()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -12,7 +12,7 @@ import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.CollectionView
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
 import com.x8bit.bitwarden.data.platform.util.subtitle
@@ -107,7 +107,7 @@ fun VaultData.toViewState(
     baseIconUrl: String,
     isIconLoadingDisabled: Boolean,
     autofillSelectionData: AutofillSelectionData?,
-    fido2CreationData: Fido2CredentialRequest?,
+    fido2CreationData: Fido2CreateCredentialRequest?,
     fido2CredentialAutofillViews: List<Fido2CredentialAutofillView>?,
     totpData: TotpData?,
     isPremiumUser: Boolean,

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -17,7 +17,7 @@ import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySele
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
@@ -602,19 +602,19 @@ class MainViewModelTest : BaseViewModelTest() {
     @Test
     fun `on ReceiveFirstIntent with fido2 request data should set the special circumstance to Fido2Save`() {
         val viewModel = createViewModel()
-        val fido2CredentialRequest = Fido2CredentialRequest(
+        val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = DEFAULT_USER_STATE.activeUserId,
             requestJson = """{"mockRequestJson":1}""",
             packageName = "com.x8bit.bitwarden",
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
         )
-        val fido2Intent = createMockIntent(mockFido2CredentialRequest = fido2CredentialRequest)
+        val fido2Intent = createMockIntent(mockFido2CreateCredentialRequest = fido2CreateCredentialRequest)
 
         coEvery {
             fido2CredentialManager.validateOrigin(
-                fido2CredentialRequest.callingAppInfo,
-                fido2CredentialRequest.requestJson,
+                fido2CreateCredentialRequest.callingAppInfo,
+                fido2CreateCredentialRequest.requestJson,
             )
         } returns Fido2ValidateOriginResult.Success
 
@@ -626,7 +626,7 @@ class MainViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = fido2CredentialRequest,
+                fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             ),
             specialCircumstanceManager.specialCircumstance,
         )
@@ -636,7 +636,7 @@ class MainViewModelTest : BaseViewModelTest() {
     fun `on ReceiveFirstIntent with fido2 request data should set the user to unverified`() {
         val viewModel = createViewModel()
         val fido2Intent = createMockIntent(
-            mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1),
+            mockFido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
         )
 
         viewModel.trySendAction(
@@ -655,18 +655,18 @@ class MainViewModelTest : BaseViewModelTest() {
     fun `on ReceiveFirstIntent with fido2 request data should switch users if active user is not selected`() {
         mutableUserStateFlow.value = DEFAULT_USER_STATE
         val viewModel = createViewModel()
-        val fido2CredentialRequest = Fido2CredentialRequest(
+        val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = "selectedUserId",
             requestJson = """{"mockRequestJson":1}""",
             packageName = "com.x8bit.bitwarden",
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
         )
-        val mockIntent = createMockIntent(mockFido2CredentialRequest = fido2CredentialRequest)
+        val mockIntent = createMockIntent(mockFido2CreateCredentialRequest = fido2CreateCredentialRequest)
         coEvery {
             fido2CredentialManager.validateOrigin(
-                fido2CredentialRequest.callingAppInfo,
-                fido2CredentialRequest.requestJson,
+                fido2CreateCredentialRequest.callingAppInfo,
+                fido2CreateCredentialRequest.requestJson,
             )
         } returns Fido2ValidateOriginResult.Success
 
@@ -676,25 +676,25 @@ class MainViewModelTest : BaseViewModelTest() {
             ),
         )
 
-        verify(exactly = 1) { authRepository.switchAccount(fido2CredentialRequest.userId) }
+        verify(exactly = 1) { authRepository.switchAccount(fido2CreateCredentialRequest.userId) }
     }
 
     @Suppress("MaxLineLength")
     @Test
     fun `on ReceiveFirstIntent with fido2 request data should not switch users if active user is selected`() {
         val viewModel = createViewModel()
-        val fido2CredentialRequest = Fido2CredentialRequest(
+        val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = DEFAULT_USER_STATE.activeUserId,
             requestJson = """{"mockRequestJson":1}""",
             packageName = "com.x8bit.bitwarden",
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
         )
-        val mockIntent = createMockIntent(mockFido2CredentialRequest = fido2CredentialRequest)
+        val mockIntent = createMockIntent(mockFido2CreateCredentialRequest = fido2CreateCredentialRequest)
         coEvery {
             fido2CredentialManager.validateOrigin(
-                fido2CredentialRequest.callingAppInfo,
-                fido2CredentialRequest.requestJson,
+                fido2CreateCredentialRequest.callingAppInfo,
+                fido2CreateCredentialRequest.requestJson,
             )
         } returns Fido2ValidateOriginResult.Success
 
@@ -704,7 +704,7 @@ class MainViewModelTest : BaseViewModelTest() {
             ),
         )
 
-        verify(exactly = 0) { authRepository.switchAccount(fido2CredentialRequest.userId) }
+        verify(exactly = 0) { authRepository.switchAccount(fido2CreateCredentialRequest.userId) }
     }
 
     @Suppress("MaxLineLength")
@@ -1078,7 +1078,7 @@ private fun createMockIntent(
     mockAutofillSelectionData: AutofillSelectionData? = null,
     mockCompleteRegistrationData: CompleteRegistrationData? = null,
     mockFido2CredentialAssertionRequest: Fido2CredentialAssertionRequest? = null,
-    mockFido2CredentialRequest: Fido2CredentialRequest? = null,
+    mockFido2CreateCredentialRequest: Fido2CreateCredentialRequest? = null,
     mockFido2GetCredentialsRequest: Fido2GetCredentialsRequest? = null,
     mockIsMyVaultShortcut: Boolean = false,
     mockIsPasswordGeneratorShortcut: Boolean = false,
@@ -1091,7 +1091,7 @@ private fun createMockIntent(
     every { getAutofillSelectionDataOrNull() } returns mockAutofillSelectionData
     every { getCompleteRegistrationDataIntentOrNull() } returns mockCompleteRegistrationData
     every { getFido2AssertionRequestOrNull() } returns mockFido2CredentialAssertionRequest
-    every { getFido2CredentialRequestOrNull() } returns mockFido2CredentialRequest
+    every { getFido2CredentialRequestOrNull() } returns mockFido2CreateCredentialRequest
     every { getFido2GetCredentialsRequestOrNull() } returns mockFido2GetCredentialsRequest
     every { isMyVaultShortcut } returns mockIsMyVaultShortcut
     every { isPasswordGeneratorShortcut } returns mockIsPasswordGeneratorShortcut

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
@@ -14,7 +14,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.Digita
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2AttestationResponse
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2PublicKeyCredential
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
@@ -85,7 +85,7 @@ class Fido2CredentialManagerTest {
         every { isOriginPopulated() } returns true
         every { getOrigin(any()) } returns DEFAULT_PACKAGE_NAME
     }
-    private val mockPrivilegedAppRequest = mockk<Fido2CredentialRequest> {
+    private val mockPrivilegedAppRequest = mockk<Fido2CreateCredentialRequest> {
         every { callingAppInfo } returns mockPrivilegedCallingAppInfo
         every { requestJson } returns "{}"
     }
@@ -98,7 +98,7 @@ class Fido2CredentialManagerTest {
         signingInfo = mockSigningInfo,
         origin = null,
     )
-    private val mockUnprivilegedAppRequest = mockk<Fido2CredentialRequest> {
+    private val mockUnprivilegedAppRequest = mockk<Fido2CreateCredentialRequest> {
         every { callingAppInfo } returns mockUnprivilegedCallingAppInfo
         every { requestJson } returns "{}"
     }
@@ -419,7 +419,7 @@ class Fido2CredentialManagerTest {
 
             fido2CredentialManager.registerFido2Credential(
                 userId = "mockUserId",
-                fido2CredentialRequest = mockFido2CreateCredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CreateCredentialRequest,
                 selectedCipherView = mockCipherView,
             )
 
@@ -457,7 +457,7 @@ class Fido2CredentialManagerTest {
 
             fido2CredentialManager.registerFido2Credential(
                 userId = "mockUserId",
-                fido2CredentialRequest = mockFido2Request,
+                fido2CreateCredentialRequest = mockFido2Request,
                 selectedCipherView = createMockCipherView(1),
             )
         }
@@ -492,7 +492,7 @@ class Fido2CredentialManagerTest {
 
             fido2CredentialManager.registerFido2Credential(
                 userId = "mockUserId",
-                fido2CredentialRequest = mockFido2CreateCredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CreateCredentialRequest,
                 selectedCipherView = mockCipherView,
             )
 
@@ -532,7 +532,7 @@ class Fido2CredentialManagerTest {
 
             fido2CredentialManager.registerFido2Credential(
                 userId = "mockUserId",
-                fido2CredentialRequest = mockFido2CreateCredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CreateCredentialRequest,
                 selectedCipherView = mockCipherView,
             )
 
@@ -562,7 +562,7 @@ class Fido2CredentialManagerTest {
 
             val result = fido2CredentialManager.registerFido2Credential(
                 userId = "mockUserId",
-                fido2CredentialRequest = mockFido2CredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CredentialRequest,
                 selectedCipherView = createMockCipherView(number = 1),
             )
 
@@ -586,7 +586,7 @@ class Fido2CredentialManagerTest {
 
             val result = fido2CredentialManager.registerFido2Credential(
                 userId = "mockUserId",
-                fido2CredentialRequest = mockFido2CredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CredentialRequest,
                 selectedCipherView = createMockCipherView(number = 1),
             )
 
@@ -611,7 +611,7 @@ class Fido2CredentialManagerTest {
 
             val result = fido2CredentialManager.registerFido2Credential(
                 userId = "mockUserId",
-                fido2CredentialRequest = mockFido2CredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CredentialRequest,
                 selectedCipherView = createMockCipherView(number = 1),
             )
 
@@ -654,7 +654,7 @@ class Fido2CredentialManagerTest {
 
             val result = fido2CredentialManager.registerFido2Credential(
                 userId = "mockUserId",
-                fido2CredentialRequest = mockFido2CredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CredentialRequest,
                 selectedCipherView = createMockCipherView(number = 1),
             )
 
@@ -680,7 +680,7 @@ class Fido2CredentialManagerTest {
 
         val result = fido2CredentialManager.registerFido2Credential(
             userId = "activeUserId",
-            fido2CredentialRequest = mockAssertionRequest,
+            fido2CreateCredentialRequest = mockAssertionRequest,
             selectedCipherView = mockSelectedCipher,
         )
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialRequestUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialRequestUtil.kt
@@ -3,14 +3,14 @@ package com.x8bit.bitwarden.data.autofill.fido2.model
 import android.content.pm.SigningInfo
 
 /**
- * Creates a mock [Fido2CredentialRequest] with a given [number].
+ * Creates a mock [Fido2CreateCredentialRequest] with a given [number].
  */
 fun createMockFido2CredentialRequest(
     number: Int,
     origin: String? = null,
     signingInfo: SigningInfo = SigningInfo(),
-): Fido2CredentialRequest =
-    Fido2CredentialRequest(
+): Fido2CreateCredentialRequest =
+    Fido2CreateCredentialRequest(
         userId = "mockUserId-$number",
         requestJson = """{"request": {"number": $number}}""",
         packageName = "com.x8bit.bitwarden",

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtilsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtilsTest.kt
@@ -15,7 +15,7 @@ import androidx.credentials.provider.PendingIntentHandler
 import androidx.credentials.provider.ProviderCreateCredentialRequest
 import androidx.credentials.provider.ProviderGetCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_CIPHER_ID
@@ -77,7 +77,7 @@ class Fido2IntentUtilsTest {
 
         val createRequest = intent.getFido2CredentialRequestOrNull()
         assertEquals(
-            Fido2CredentialRequest(
+            Fido2CreateCredentialRequest(
                 userId = "mockUserId",
                 requestJson = mockCallingRequest.requestJson,
                 packageName = mockCallingAppInfo.packageName,

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager.util
 
 import android.content.pm.SigningInfo
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
@@ -45,7 +45,7 @@ class SpecialCircumstanceExtensionsTest {
                 shouldFinishWhenComplete = true,
             ),
             SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = mockk(),
+                fido2CreateCredentialRequest = mockk(),
             ),
             SpecialCircumstance.Fido2Assertion(
                 fido2AssertionRequest = mockk(),
@@ -95,7 +95,7 @@ class SpecialCircumstanceExtensionsTest {
                 shouldFinishWhenComplete = true,
             ),
             SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = mockk(),
+                fido2CreateCredentialRequest = mockk(),
             ),
             SpecialCircumstance.Fido2Assertion(
                 fido2AssertionRequest = mockk(),
@@ -146,7 +146,7 @@ class SpecialCircumstanceExtensionsTest {
 
     @Test
     fun `toFido2RequestOrNull should return a non-null value for Fido2Save`() {
-        val fido2CredentialRequest = Fido2CredentialRequest(
+        val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = "mockUserId",
             requestJson = "mockRequestJson",
             packageName = "mockPackageName",
@@ -154,10 +154,10 @@ class SpecialCircumstanceExtensionsTest {
             origin = "mockOrigin",
         )
         assertEquals(
-            fido2CredentialRequest,
+            fido2CreateCredentialRequest,
             SpecialCircumstance
                 .Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
                 .toFido2RequestOrNull(),
         )
@@ -198,7 +198,7 @@ class SpecialCircumstanceExtensionsTest {
                 shouldFinishWhenComplete = true,
             ),
             SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = mockk(),
+                fido2CreateCredentialRequest = mockk(),
             ),
             SpecialCircumstance.Fido2GetCredentials(
                 fido2GetCredentialsRequest = mockk(),
@@ -245,7 +245,7 @@ class SpecialCircumstanceExtensionsTest {
                 shouldFinishWhenComplete = true,
             ),
             SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = mockk(),
+                fido2CreateCredentialRequest = mockk(),
             ),
             SpecialCircumstance.Fido2Assertion(
                 fido2AssertionRequest = mockk(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -198,7 +198,7 @@ class RootNavScreenTest : BaseComposeTest() {
         rootNavStateFlow.value =
             RootNavState.VaultUnlockedForFido2Save(
                 activeUserId = "activeUserId",
-                fido2CredentialRequest = mockk(),
+                fido2CreateCredentialRequest = mockk(),
             )
         composeTestRule.runOnIdle {
             fakeNavHostController.assertLastNavigation(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -8,7 +8,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.JwtTokenDataJson
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.util.parseJwtTokenDataOrNull
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
@@ -662,7 +662,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `when the active user has an unlocked vault but there is a Fido2Save special circumstance the nav state should be VaultUnlockedForFido2Save`() {
-        val fido2CredentialRequest = Fido2CredentialRequest(
+        val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = "activeUserId",
             requestJson = "{}",
             packageName = "com.x8bit.bitwarden",
@@ -670,7 +670,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
             origin = "mockOrigin",
         )
         specialCircumstanceManager.specialCircumstance =
-            SpecialCircumstance.Fido2Save(fido2CredentialRequest)
+            SpecialCircumstance.Fido2Save(fido2CreateCredentialRequest)
         mutableUserStateFlow.tryEmit(
             UserState(
                 activeUserId = "activeUserId",
@@ -703,7 +703,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
         assertEquals(
             RootNavState.VaultUnlockedForFido2Save(
                 activeUserId = "activeUserId",
-                fido2CredentialRequest = fido2CredentialRequest,
+                fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             ),
             viewModel.stateFlow.value,
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -18,7 +18,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
 import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
@@ -344,7 +344,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `initial add state should be correct when fido2 save`() = runTest {
-        val fido2CredentialRequest = Fido2CredentialRequest(
+        val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = "mockUserId-1",
             requestJson = "mockRequestJson-1",
             packageName = "mockPackageName-1",
@@ -352,9 +352,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             origin = null,
         )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CredentialRequest = fido2CredentialRequest,
+            fido2CreateCredentialRequest = fido2CreateCredentialRequest,
         )
-        val fido2ContentState = fido2CredentialRequest.toDefaultAddTypeContent(
+        val fido2ContentState = fido2CreateCredentialRequest.toDefaultAddTypeContent(
             attestationOptions = createMockPasskeyAttestationOptions(number = 1),
             isIndividualVaultDisabled = false,
         )
@@ -766,7 +766,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2 registration, SaveClick should show saving dialog, and request user verification when required`() =
         runTest {
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
                 requestJson = "mockRequestJson",
                 packageName = "mockPackageName",
@@ -775,7 +775,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
             val stateWithSavingDialog = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
@@ -818,12 +818,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 fido2CredentialManager.registerFido2Credential(
                     userId = "mockUserId",
                     selectedCipherView = any(),
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
             } returns mockCreateResult
             every {
                 fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
-                    requestJson = fido2CredentialRequest.requestJson,
+                    requestJson = fido2CreateCredentialRequest.requestJson,
                 )
             } returns mockAttestationOptions
             every { authRepository.activeUserId } returns "mockUserId"
@@ -845,7 +845,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     fun `in add mode during fido2, SaveClick should show saving dialog, remove it once item is saved, skip user verification when not required, and emit ExitApp`() =
         runTest {
             val mockUserId = "mockUserId"
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = mockUserId,
                 requestJson = "mockRequestJson",
                 packageName = "mockPackageName",
@@ -854,7 +854,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
             val stateWithSavingDialog = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
@@ -893,12 +893,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 fido2CredentialManager.registerFido2Credential(
                     userId = mockUserId,
                     selectedCipherView = any(),
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
             } returns mockCreateResult
             every {
                 fido2CredentialManager.getPasskeyAttestationOptionsOrNull(
-                    requestJson = fido2CredentialRequest.requestJson,
+                    requestJson = fido2CreateCredentialRequest.requestJson,
                 )
             } returns mockAttestationOptions
             every { authRepository.activeUserId } returns mockUserId
@@ -921,7 +921,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CredentialManager.registerFido2Credential(
                         userId = mockUserId,
                         selectedCipherView = any(),
-                        fido2CredentialRequest = fido2CredentialRequest,
+                        fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                     )
                 }
             }
@@ -934,7 +934,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CredentialRequest,
                 )
             val stateWithName = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
@@ -959,7 +959,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             coEvery {
                 fido2CredentialManager.registerFido2Credential(
                     userId = fido2CredentialRequest.userId,
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CredentialRequest,
                     selectedCipherView = any(),
                 )
             } returns Fido2RegisterCredentialResult.Success(registrationResponse = "mockResponse")
@@ -969,7 +969,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             coVerify {
                 fido2CredentialManager.registerFido2Credential(
                     userId = fido2CredentialRequest.userId,
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CredentialRequest,
                     selectedCipherView = any(),
                 )
             }
@@ -986,7 +986,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CredentialRequest,
                 )
             val stateWithName = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
@@ -1030,7 +1030,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CredentialRequest,
                 )
             val stateWithName = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
@@ -1075,7 +1075,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CredentialRequest,
                 )
             val stateWithName = createVaultAddItemState(
                 vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
@@ -1801,7 +1801,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = mockFido2CredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CredentialRequest,
             )
             every {
                 cipherView.toViewState(
@@ -1851,12 +1851,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         )
         val mockFidoRequest = createMockFido2CredentialRequest(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CredentialRequest = mockFidoRequest,
+            fido2CreateCredentialRequest = mockFidoRequest,
         )
         coEvery {
             fido2CredentialManager.registerFido2Credential(
                 userId = mockFidoRequest.userId,
-                fido2CredentialRequest = mockFidoRequest,
+                fido2CreateCredentialRequest = mockFidoRequest,
                 selectedCipherView = any(),
             )
         } returns Fido2RegisterCredentialResult.Success("mockResponse")
@@ -1890,7 +1890,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             fido2CredentialManager.isUserVerified
             fido2CredentialManager.registerFido2Credential(
                 userId = mockFidoRequest.userId,
-                fido2CredentialRequest = mockFidoRequest,
+                fido2CreateCredentialRequest = mockFidoRequest,
                 selectedCipherView = any(),
             )
         }
@@ -1922,7 +1922,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
             val mockFidoRequest = createMockFido2CredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = mockFidoRequest,
+                fido2CreateCredentialRequest = mockFidoRequest,
             )
             every {
                 cipherView.toViewState(
@@ -4084,7 +4084,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     registrationResponse = "mockResponse",
                 )
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = mockRequest,
+                    fido2CreateCredentialRequest = mockRequest,
                 )
                 every { authRepository.activeUserId } returns "activeUserId"
                 coEvery {
@@ -4102,7 +4102,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CredentialManager.isUserVerified = true
                     fido2CredentialManager.registerFido2Credential(
                         userId = any(),
-                        fido2CredentialRequest = mockRequest,
+                        fido2CreateCredentialRequest = mockRequest,
                         selectedCipherView = any(),
                     )
                 }
@@ -4126,7 +4126,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 val mockRequest = createMockFido2CredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Error
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = mockRequest,
+                    fido2CreateCredentialRequest = mockRequest,
                 )
                 every { authRepository.activeUserId } returns "activeUserId"
                 coEvery {
@@ -4165,7 +4165,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     registrationResponse = "mockResponse",
                 )
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = mockRequest,
+                    fido2CreateCredentialRequest = mockRequest,
                 )
                 every { authRepository.activeUserId } returns "activeUserId"
                 coEvery {
@@ -4202,7 +4202,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 val mockRequest = createMockFido2CredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Cancelled
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = mockRequest,
+                    fido2CreateCredentialRequest = mockRequest,
                 )
                 every { authRepository.activeUserId } returns "activeUserId"
                 coEvery {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensionsTest.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
 import android.content.pm.SigningInfo
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
 import io.mockk.every
@@ -47,7 +47,7 @@ class Fido2CredentialRequestExtensionsTest {
                     ),
                 ),
             ),
-            Fido2CredentialRequest(
+            Fido2CreateCredentialRequest(
                 userId = "mockUserId-1",
                 requestJson = "mockRequestJson-1",
                 packageName = "mockPackageName-1",
@@ -83,7 +83,7 @@ class Fido2CredentialRequestExtensionsTest {
                     ),
                 ),
             ),
-            Fido2CredentialRequest(
+            Fido2CreateCredentialRequest(
                 userId = "mockUserId-1",
                 requestJson = "mockRequestJson-1",
                 packageName = "mockPackageName-1",

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -19,7 +19,7 @@ import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySele
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
@@ -195,7 +195,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `initial dialog state should be correct when fido2Request is present`() = runTest {
-        val fido2CredentialRequest = Fido2CredentialRequest(
+        val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             "mockUserId",
             "{}",
             "com.x8bit.bitwarden",
@@ -203,7 +203,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             origin = null,
         )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CredentialRequest = fido2CredentialRequest,
+            fido2CreateCredentialRequest = fido2CreateCredentialRequest,
         )
 
         val viewModel = createVaultItemListingViewModel()
@@ -211,7 +211,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         viewModel.stateFlow.test {
             assertEquals(
                 initialState.copy(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                     dialogState = VaultItemListingState.DialogState.Loading(
                         message = R.string.loading.asText(),
                     ),
@@ -449,7 +449,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `ItemClick for vault item during FIDO 2 registration should show FIDO 2 error dialog when cipherView is null`() {
         val cipherView = createMockCipherView(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CredentialRequest = createMockFido2CredentialRequest(number = 1),
+            fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
         )
         mutableVaultDataStateFlow.value = DataState.Loaded(
             data = VaultData(
@@ -478,7 +478,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         setupMockUri()
         val cipherView = createMockCipherView(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CredentialRequest = createMockFido2CredentialRequest(number = 1),
+            fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
         )
         mutableVaultDataStateFlow.value = DataState.Loaded(
             data = VaultData(
@@ -513,7 +513,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2Credentials = createMockSdkFido2CredentialList(number = 1),
             )
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -556,7 +556,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1, fido2Credentials = null)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -606,7 +606,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val cipherView = createMockCipherView(number = 1)
             val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = mockFido2CredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CredentialRequest,
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -636,7 +636,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             coVerify {
                 fido2CredentialManager.registerFido2Credential(
                     userId = DEFAULT_USER_STATE.activeUserId,
-                    fido2CredentialRequest = mockFido2CredentialRequest,
+                    fido2CreateCredentialRequest = mockFido2CredentialRequest,
                     selectedCipherView = cipherView,
                 )
             }
@@ -649,7 +649,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         val cipherView = createMockCipherView(number = 1)
         val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CredentialRequest = mockFido2CredentialRequest,
+            fido2CreateCredentialRequest = mockFido2CredentialRequest,
         )
         mutableVaultDataStateFlow.value = DataState.Loaded(
             data = VaultData(
@@ -681,7 +681,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         coVerify(exactly = 1) {
             fido2CredentialManager.registerFido2Credential(
                 userId = DEFAULT_USER_STATE.activeUserId,
-                fido2CredentialRequest = mockFido2CredentialRequest,
+                fido2CreateCredentialRequest = mockFido2CredentialRequest,
                 selectedCipherView = cipherView,
             )
         }
@@ -1567,7 +1567,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
             mockFilteredCiphers = listOf(cipherView1)
 
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "activeUserId",
                 requestJson = "{}",
                 packageName = "com.x8bit.bitwarden",
@@ -1577,7 +1577,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
-                    fido2CredentialRequest = fido2CredentialRequest,
+                    fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
             val dataState = DataState.Loaded(
                 data = VaultData(
@@ -1611,7 +1611,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         displayFolderList = emptyList(),
                     ),
                 )
-                    .copy(fido2CredentialRequest = fido2CredentialRequest),
+                    .copy(fido2CreateCredentialRequest = fido2CreateCredentialRequest),
                 viewModel.stateFlow.value,
             )
             coVerify {
@@ -2149,7 +2149,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `Fido2Request should be evaluated before observing vault data`() {
-        val fido2CredentialRequest = Fido2CredentialRequest(
+        val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             "mockUserId",
             "{}",
             "com.x8bit.bitwarden",
@@ -2157,7 +2157,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             origin = "com.x8bit.bitwarden",
         )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CredentialRequest,
+            fido2CreateCredentialRequest,
         )
 
         createVaultItemListingViewModel()
@@ -2171,13 +2171,13 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `Fido2ValidateOriginResult should update dialog state on Unknown error`() = runTest {
         val mockCallingAppInfo = mockk<CallingAppInfo>(relaxed = true)
-        val mock = mockk<Fido2CredentialRequest> {
+        val mock = mockk<Fido2CreateCredentialRequest> {
             every { callingAppInfo } returns mockCallingAppInfo
             every { requestJson } returns "{}"
         }
 
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CredentialRequest = mock,
+            fido2CreateCredentialRequest = mock,
         )
 
         coEvery {
@@ -2199,7 +2199,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `Fido2ValidateOriginResult should update dialog state on PrivilegedAppNotAllowed error`() =
         runTest {
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
                 requestJson = "{}",
                 packageName = "com.x8bit.bitwarden",
@@ -2208,7 +2208,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = fido2CredentialRequest,
+                fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
             coEvery {
@@ -2230,7 +2230,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `Fido2ValidateOriginResult should update dialog state on PrivilegedAppSignatureNotFound error`() =
         runTest {
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
                 requestJson = "{}",
                 packageName = "com.x8bit.bitwarden",
@@ -2239,7 +2239,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = fido2CredentialRequest,
+                fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
             coEvery {
@@ -2261,7 +2261,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `Fido2ValidateOriginResult should update dialog state on PasskeyNotSupportedForApp error`() =
         runTest {
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
                 requestJson = "{}",
                 packageName = "com.x8bit.bitwarden",
@@ -2270,7 +2270,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = fido2CredentialRequest,
+                fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
             coEvery {
@@ -2292,7 +2292,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `Fido2ValidateOriginResult should update dialog state on ApplicationNotFound error`() =
         runTest {
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
                 requestJson = "{}",
                 packageName = "com.x8bit.bitwarden",
@@ -2301,7 +2301,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = fido2CredentialRequest,
+                fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
             coEvery {
@@ -2323,7 +2323,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `Fido2ValidateOriginResult should update dialog state on AssetLinkNotFound error`() =
         runTest {
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
                 requestJson = "{}",
                 packageName = "com.x8bit.bitwarden",
@@ -2332,7 +2332,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = fido2CredentialRequest,
+                fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
             coEvery {
@@ -2354,7 +2354,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `Fido2ValidateOriginResult should update dialog state on ApplicationNotVerified error`() =
         runTest {
-            val fido2CredentialRequest = Fido2CredentialRequest(
+            val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
                 requestJson = "{}",
                 packageName = "com.x8bit.bitwarden",
@@ -2363,7 +2363,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = fido2CredentialRequest,
+                fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
             coEvery {
@@ -3275,7 +3275,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             val mockRequest = createMockFido2CredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = mockRequest,
+                fido2CreateCredentialRequest = mockRequest,
             )
             coEvery {
                 fido2CredentialManager.registerFido2Credential(
@@ -3298,7 +3298,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2CredentialManager.isUserVerified = true
                 fido2CredentialManager.registerFido2Credential(
                     userId = DEFAULT_ACCOUNT.userId,
-                    fido2CredentialRequest = mockRequest,
+                    fido2CreateCredentialRequest = mockRequest,
                     selectedCipherView = any(),
                 )
             }
@@ -3933,7 +3933,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -3967,7 +3967,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -4076,7 +4076,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             autofillSelectionData = null,
             policyDisablesSend = false,
             hasMasterPassword = true,
-            fido2CredentialRequest = null,
+            fido2CreateCredentialRequest = null,
             isPremium = true,
             isRefreshing = false,
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
@@ -8,7 +8,7 @@ import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.baseIconUrl
@@ -792,7 +792,7 @@ class VaultItemListingDataExtensionsTest {
                 baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
                 isIconLoadingDisabled = false,
                 autofillSelectionData = null,
-                fido2CreationData = Fido2CredentialRequest(
+                fido2CreationData = Fido2CreateCredentialRequest(
                     userId = "",
                     requestJson = "",
                     packageName = "",


### PR DESCRIPTION
## 🎟️ Tracking

PM-15057

## 📔 Objective

Rename `Fido2CredentialRequest` to `Fido2CreateCredentialRequest` for clarity and consistency. This change reflects the specific purpose of the request, which is to create a new FIDO2 credential.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
