### PR TITLE
[PM-15113] Disable add button in SSH Keys screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -2084,7 +2084,7 @@ data class VaultItemListingState(
              */
             data object SshKey : Vault() {
                 override val titleText: Text get() = R.string.ssh_keys.asText()
-                override val hasFab: Boolean get() = true
+                override val hasFab: Boolean get() = false
             }
 
             /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -200,6 +200,7 @@ fun VaultData.toViewState(
         val shouldShowAddButton = when (itemListingType) {
             is VaultItemListingState.ItemListingType.Vault.Folder,
             VaultItemListingState.ItemListingType.Vault.Trash,
+            VaultItemListingState.ItemListingType.Vault.SshKey,
                 -> false
 
             else -> true

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -651,6 +651,16 @@ class VaultItemListingScreenTest : BaseComposeTest() {
         composeTestRule
             .onNodeWithContentDescription("Add item")
             .assertDoesNotExist()
+
+        mutableStateFlow.update {
+            it.copy(
+                itemListingType = VaultItemListingState.ItemListingType.Vault.SshKey,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Add item")
+            .assertDoesNotExist()
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
@@ -729,6 +729,28 @@ class VaultItemListingDataExtensionsTest {
             ),
         )
 
+        // SSH keys
+        assertEquals(
+            VaultItemListingState.ViewState.NoItems(
+                header = R.string.save_and_protect_your_data.asText(),
+                message = R.string.no_items.asText(),
+                shouldShowAddButton = false,
+                buttonText = R.string.add_an_item.asText(),
+            ),
+            vaultData.toViewState(
+                itemListingType = VaultItemListingState.ItemListingType.Vault.SshKey,
+                vaultFilterType = VaultFilterType.AllVaults,
+                hasMasterPassword = true,
+                baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
+                isIconLoadingDisabled = false,
+                autofillSelectionData = null,
+                fido2CreationData = null,
+                fido2CredentialAutofillViews = null,
+                totpData = null,
+                isPremiumUser = true,
+            ),
+        )
+
         // Other ciphers
         assertEquals(
             VaultItemListingState.ViewState.NoItems(


### PR DESCRIPTION
## 🎟️ Tracking

PM-15113

## 📔 Objective

Disable the add button in the SSH Keys screen. This fixes a bug that allowed creation of SSH keys after selecting the SSH key filter.

## 📸 Screenshots

<img width="274" alt="image" src="https://github.com/user-attachments/assets/fe1bf3c8-2dd7-4344-916a-3557073d920c">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
