### PR TITLE
[PM-15057] Add utility for loading FIDO2 icons

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/IconCompatUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/IconCompatUtils.kt
@@ -1,0 +1,65 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import android.content.Context
+import androidx.annotation.DrawableRes
+import androidx.core.graphics.drawable.IconCompat
+import com.bumptech.glide.Glide
+import com.x8bit.bitwarden.ui.platform.components.model.IconData
+import timber.log.Timber
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+
+/**
+ * Creates an IconCompat from an IconData, or falls back to a default resource if IconData is null
+ * or is not of type Network.
+ *
+ * @param context The context to use.
+ * @param iconData The IconData to create the IconCompat from.
+ * @param defaultResourceId The resource ID of the default icon to use if IconData is null or not of
+ * type Network.
+ * @return An IconCompat created from the IconData or the default resource.
+ */
+fun createFido2IconCompatFromIconDataOrDefault(
+    context: Context,
+    iconData: IconData?,
+    @DrawableRes defaultResourceId: Int,
+): IconCompat = if (iconData != null && iconData is IconData.Network) {
+    createFido2IconCompatFromRemoteUriOrDefaultResource(
+        context = context,
+        uri = iconData.uri,
+        defaultResourceId = defaultResourceId,
+    )
+} else {
+    createFido2IconCompatFromResource(context, defaultResourceId)
+}
+
+/**
+ * Creates an IconCompat from a drawable resource ID.
+ */
+fun createFido2IconCompatFromResource(context: Context, @DrawableRes resourceId: Int) =
+    IconCompat.createWithResource(context, resourceId)
+
+private fun createFido2IconCompatFromRemoteUriOrDefaultResource(
+    context: Context,
+    uri: String,
+    @DrawableRes defaultResourceId: Int,
+): IconCompat {
+    val futureTargetBitmap = Glide
+        .with(context)
+        .asBitmap()
+        .load(uri)
+        .placeholder(defaultResourceId)
+        .submit()
+    return try {
+        IconCompat.createWithBitmap(futureTargetBitmap.get())
+    } catch (e: CancellationException) {
+        Timber.e(e, "Cancellation exception while loading icon.")
+        IconCompat.createWithResource(context, defaultResourceId)
+    } catch (e: ExecutionException) {
+        Timber.e(e, "Execution exception while loading icon.")
+        IconCompat.createWithResource(context, defaultResourceId)
+    } catch (e: InterruptedException) {
+        Timber.e(e, "Interrupted while loading icon.")
+        IconCompat.createWithResource(context, defaultResourceId)
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/IconCompatUtilsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/IconCompatUtilsTest.kt
@@ -1,0 +1,143 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.Icon
+import android.net.Uri
+import androidx.core.graphics.drawable.IconCompat
+import com.bumptech.glide.Glide
+import com.x8bit.bitwarden.ui.platform.components.model.IconData
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ExecutionException
+
+class IconCompatUtilsTest {
+
+    val mockContext = mockk<Context>()
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(
+            Glide::class,
+            Icon::class,
+            IconCompat::class,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(
+            Glide::class,
+            Icon::class,
+            IconCompat::class,
+            Uri::class,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `createFido2IconCompatFromIconDataOrDefault should return default icon when IconData is null`() {
+        every { IconCompat.createWithResource(mockContext, 0) } returns IconCompat()
+        createFido2IconCompatFromIconDataOrDefault(
+            context = mockContext,
+            iconData = null,
+            defaultResourceId = 0,
+        )
+        verify { IconCompat.createWithResource(mockContext, 0) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `createFido2IconCompatFromIconDataOrDefault should return default icon when IconData is not Network type`() {
+        every { IconCompat.createWithResource(mockContext, 0) } returns IconCompat()
+        createFido2IconCompatFromIconDataOrDefault(
+            context = mockContext,
+            iconData = IconData.Local(0),
+            defaultResourceId = 0,
+        )
+        verify { IconCompat.createWithResource(mockContext, 0) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `createFido2IconCompatFromIconDataOrDefault should load icon from URI when IconData is Network type`() {
+        val mockBitmap = mockk<Bitmap>()
+        setupMockGlide(mockBitmap)
+        every { IconCompat.createWithBitmap(mockBitmap) } returns mockk()
+        createFido2IconCompatFromIconDataOrDefault(
+            context = mockContext,
+            iconData = IconData.Network("https://www.mockuri.com", 0),
+            defaultResourceId = 0,
+        )
+        verify { IconCompat.createWithBitmap(mockBitmap) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `createFido2IconCompatFromIconDataOrDefault should return default icon when loading from URI throws CancellationException`() {
+        val mockBitmap = mockk<Bitmap>()
+        setupMockGlide(mockBitmap)
+        every { IconCompat.createWithResource(mockContext, 0) } returns mockk()
+        every { IconCompat.createWithBitmap(mockBitmap) } throws CancellationException()
+        createFido2IconCompatFromIconDataOrDefault(
+            context = mockContext,
+            iconData = IconData.Network("https://www.mockuri.com", 0),
+            defaultResourceId = 0,
+        )
+        verify { IconCompat.createWithResource(mockContext, 0) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `createFido2IconCompatFromIconDataOrDefault should return default icon when loading from URI throws ExecutionException`() {
+        val mockBitmap = mockk<Bitmap>()
+        setupMockGlide(mockBitmap)
+        every { IconCompat.createWithResource(mockContext, 0) } returns mockk()
+        every {
+            IconCompat.createWithBitmap(mockBitmap)
+        } throws ExecutionException("message", Throwable())
+
+        createFido2IconCompatFromIconDataOrDefault(
+            context = mockContext,
+            iconData = IconData.Network("https://www.mockuri.com", 0),
+            defaultResourceId = 0,
+        )
+        verify { IconCompat.createWithResource(mockContext, 0) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `createFido2IconCompatFromIconDataOrDefault should return default icon when loading from URI throws InterruptedException`() {
+        val mockBitmap = mockk<Bitmap>()
+        setupMockGlide(mockBitmap)
+        every { IconCompat.createWithResource(mockContext, 0) } returns mockk()
+        every { IconCompat.createWithBitmap(mockBitmap) } throws InterruptedException()
+        createFido2IconCompatFromIconDataOrDefault(
+            context = mockContext,
+            iconData = IconData.Network("https://www.mockuri.com", 0),
+            defaultResourceId = 0,
+        )
+        verify { IconCompat.createWithResource(mockContext, 0) }
+    }
+
+    private fun setupMockGlide(mockBitmap: Bitmap) {
+        every { Glide.with(mockContext) } returns mockk {
+            every { asBitmap() } returns mockk {
+                every { load(any<String>()) } returns mockk {
+                    every { placeholder(0) } returns mockk {
+                        every { submit() } returns mockk {
+                            every { get() } returns mockBitmap
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-15057

## 📔 Objective

Add a utility function to load FIDO2 icons from IconData or a default resource. This will be used to provide web based icons for relying parties, when the corresponding setting is enabled.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
