### PR TITLE
PM-15177: Improve destructive fallback logic

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/di/PlatformDiskModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/di/PlatformDiskModule.kt
@@ -37,7 +37,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
-import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -74,7 +73,6 @@ object PlatformDiskModule {
     fun provideEventDatabase(
         app: Application,
         databaseSchemeManager: DatabaseSchemeManager,
-        clock: Clock,
     ): PlatformDatabase =
         Room
             .databaseBuilder(
@@ -84,12 +82,7 @@ object PlatformDiskModule {
             )
             .fallbackToDestructiveMigration()
             .addTypeConverter(ZonedDateTimeTypeConverter())
-            .addCallback(
-                DatabaseSchemeCallback(
-                    databaseSchemeManager = databaseSchemeManager,
-                    clock = clock,
-                ),
-            )
+            .addCallback(DatabaseSchemeCallback(databaseSchemeManager = databaseSchemeManager))
             .build()
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManager.kt
@@ -1,23 +1,18 @@
 package com.x8bit.bitwarden.data.platform.manager
 
 import kotlinx.coroutines.flow.Flow
-import java.time.Instant
 
 /**
  * Manager for tracking changes to database scheme(s).
  */
 interface DatabaseSchemeManager {
+    /**
+     * Clears the sync state for all users and emits on the [databaseSchemeChangeFlow].
+     */
+    fun clearSyncState()
 
     /**
-     * The instant of the last database schema change performed on the database, if any.
-     *
-     * There is only a single scheme change instant tracked for all database schemes. It is expected
-     * that a scheme change to any database will update this value and trigger a sync.
+     * Emits whenever the sync state hs been cleared.
      */
-    var lastDatabaseSchemeChangeInstant: Instant?
-
-    /**
-     * A flow of the last database schema change instant.
-     */
-    val lastDatabaseSchemeChangeInstantFlow: Flow<Instant?>
+    val databaseSchemeChangeFlow: Flow<Unit>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -307,10 +307,10 @@ object PlatformManagerModule {
     @Provides
     @Singleton
     fun provideDatabaseSchemeManager(
+        authDiskSource: AuthDiskSource,
         settingsDiskSource: SettingsDiskSource,
-        dispatcherManager: DispatcherManager,
     ): DatabaseSchemeManager = DatabaseSchemeManagerImpl(
+        authDiskSource = authDiskSource,
         settingsDiskSource = settingsDiskSource,
-        dispatcherManager = dispatcherManager,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/datasource/disk/di/GeneratorDiskModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/datasource/disk/di/GeneratorDiskModule.kt
@@ -17,7 +17,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
-import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -51,7 +50,6 @@ object GeneratorDiskModule {
     fun providePasswordHistoryDatabase(
         app: Application,
         databaseSchemeManager: DatabaseSchemeManager,
-        clock: Clock,
     ): PasswordHistoryDatabase {
         return Room
             .databaseBuilder(
@@ -59,12 +57,7 @@ object GeneratorDiskModule {
                 klass = PasswordHistoryDatabase::class.java,
                 name = "passcode_history_database",
             )
-            .addCallback(
-                DatabaseSchemeCallback(
-                    databaseSchemeManager = databaseSchemeManager,
-                    clock = clock,
-                ),
-            )
+            .addCallback(DatabaseSchemeCallback(databaseSchemeManager = databaseSchemeManager))
             .build()
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/callback/DatabaseSchemeCallback.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/callback/DatabaseSchemeCallback.kt
@@ -3,16 +3,14 @@ package com.x8bit.bitwarden.data.vault.datasource.disk.callback
 import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
-import java.time.Clock
 
 /**
  * A [RoomDatabase.Callback] for tracking database scheme changes.
  */
 class DatabaseSchemeCallback(
     private val databaseSchemeManager: DatabaseSchemeManager,
-    private val clock: Clock,
 ) : RoomDatabase.Callback() {
     override fun onDestructiveMigration(db: SupportSQLiteDatabase) {
-        databaseSchemeManager.lastDatabaseSchemeChangeInstant = clock.instant()
+        databaseSchemeManager.clearSyncState()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/di/VaultDiskModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/disk/di/VaultDiskModule.kt
@@ -19,7 +19,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
-import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -34,7 +33,6 @@ class VaultDiskModule {
     fun provideVaultDatabase(
         app: Application,
         databaseSchemeManager: DatabaseSchemeManager,
-        clock: Clock,
     ): VaultDatabase =
         Room
             .databaseBuilder(
@@ -43,7 +41,7 @@ class VaultDiskModule {
                 name = "vault_database",
             )
             .fallbackToDestructiveMigration()
-            .addCallback(DatabaseSchemeCallback(databaseSchemeManager, clock))
+            .addCallback(DatabaseSchemeCallback(databaseSchemeManager = databaseSchemeManager))
             .addTypeConverter(ZonedDateTimeTypeConverter())
             .build()
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/DatabaseSchemeManagerTest.kt
@@ -1,73 +1,61 @@
 package com.x8bit.bitwarden.data.platform.manager
 
 import app.cash.turbine.test
-import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
-import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
-import io.mockk.every
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
 import io.mockk.mockk
-import io.mockk.verify
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import org.junit.Test
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 
 class DatabaseSchemeManagerTest {
 
-    private val mutableLastDatabaseSchemeChangeInstantFlow = MutableStateFlow<Instant?>(null)
-    private val mockSettingsDiskSource: SettingsDiskSource = mockk {
-        every {
-            lastDatabaseSchemeChangeInstant
-        } returns mutableLastDatabaseSchemeChangeInstantFlow.value
-        every { lastDatabaseSchemeChangeInstant = any() } answers {
-            mutableLastDatabaseSchemeChangeInstantFlow.value = firstArg()
-        }
-        every {
-            lastDatabaseSchemeChangeInstantFlow
-        } returns mutableLastDatabaseSchemeChangeInstantFlow
-    }
-    private val dispatcherManager = FakeDispatcherManager()
+    private val fakeAuthDiskSource = FakeAuthDiskSource()
+    private val fakeSettingsDiskSource = FakeSettingsDiskSource()
     private val databaseSchemeManager = DatabaseSchemeManagerImpl(
-        settingsDiskSource = mockSettingsDiskSource,
-        dispatcherManager = dispatcherManager,
+        authDiskSource = fakeAuthDiskSource,
+        settingsDiskSource = fakeSettingsDiskSource,
     )
 
-    @Suppress("MaxLineLength")
-    @Test
-    fun `setLastDatabaseSchemeChangeInstant persists value in settingsDiskSource`() {
-        databaseSchemeManager.lastDatabaseSchemeChangeInstant = FIXED_CLOCK.instant()
-        verify {
-            mockSettingsDiskSource.lastDatabaseSchemeChangeInstant = FIXED_CLOCK.instant()
-        }
+    @BeforeEach
+    fun setup() {
+        fakeAuthDiskSource.userState = USER_STATE
+        fakeSettingsDiskSource.storeLastSyncTime(USER_ID_1, FIXED_CLOCK.instant())
+        fakeSettingsDiskSource.storeLastSyncTime(USER_ID_2, FIXED_CLOCK.instant())
     }
 
     @Test
-    fun `setLastDatabaseSchemeChangeInstant does emit value`() = runTest {
-        databaseSchemeManager.lastDatabaseSchemeChangeInstantFlow.test {
-            // Assert the value is initialized to null
-            assertEquals(
-                null,
-                awaitItem(),
-            )
-            // Assert the new value is emitted
-            databaseSchemeManager.lastDatabaseSchemeChangeInstant = FIXED_CLOCK.instant()
-            assertEquals(
-                FIXED_CLOCK.instant(),
-                awaitItem(),
-            )
-        }
-    }
+    fun `clearSyncState clears lastSyncTimes and emit`() = runTest {
+        assertNotNull(fakeSettingsDiskSource.getLastSyncTime(USER_ID_1))
+        assertNotNull(fakeSettingsDiskSource.getLastSyncTime(USER_ID_2))
 
-    @Test
-    fun `getLastDatabaseSchemeChangeInstant retrieves stored value from settingsDiskSource`() {
-        databaseSchemeManager.lastDatabaseSchemeChangeInstant
-        verify {
-            mockSettingsDiskSource.lastDatabaseSchemeChangeInstant
+        databaseSchemeManager.databaseSchemeChangeFlow.test {
+            databaseSchemeManager.clearSyncState()
+            awaitItem()
+            expectNoEvents()
         }
+
+        assertNull(fakeSettingsDiskSource.getLastSyncTime(USER_ID_1))
+        assertNull(fakeSettingsDiskSource.getLastSyncTime(USER_ID_2))
     }
 }
+
+private const val USER_ID_1: String = "USER_ID_1"
+private const val USER_ID_2: String = "USER_ID_2"
+
+private val USER_STATE: UserStateJson = UserStateJson(
+    activeUserId = USER_ID_1,
+    accounts = mapOf(
+        USER_ID_1 to mockk(),
+        USER_ID_2 to mockk(),
+    ),
+)
 
 private val FIXED_CLOCK: Clock = Clock.fixed(
     Instant.parse("2023-10-27T12:00:00Z"),

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/disk/callback/DatabaseSchemeCallbackTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/disk/callback/DatabaseSchemeCallbackTest.kt
@@ -7,26 +7,17 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import org.junit.Test
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 
 class DatabaseSchemeCallbackTest {
 
     private val databaseSchemeManager: DatabaseSchemeManager = mockk {
-        every { lastDatabaseSchemeChangeInstant = any() } just runs
+        every { clearSyncState() } just runs
     }
-    private val callback = DatabaseSchemeCallback(databaseSchemeManager, FIXED_CLOCK)
+    private val callback = DatabaseSchemeCallback(databaseSchemeManager)
 
     @Test
-    fun `onDestructiveMigration updates lastDatabaseSchemeChangeInstant`() {
+    fun `onDestructiveMigration calls clearSyncState`() {
         callback.onDestructiveMigration(mockk())
-
-        verify { databaseSchemeManager.lastDatabaseSchemeChangeInstant = FIXED_CLOCK.instant() }
+        verify(exactly = 1) { databaseSchemeManager.clearSyncState() }
     }
 }
-
-private val FIXED_CLOCK: Clock = Clock.fixed(
-    Instant.parse("2023-10-27T12:00:00Z"),
-    ZoneOffset.UTC,
-)

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -193,14 +193,9 @@ class VaultRepositoryTest {
             mutableUnlockedUserIdsStateFlow.first { userId in it }
         }
     }
-    private val mutableLastDatabaseSchemeChangeInstantFlow = MutableStateFlow<Instant?>(null)
+    private val mutableDatabaseSchemeChangeFlow = bufferedMutableSharedFlow<Unit>()
     private val databaseSchemeManager: DatabaseSchemeManager = mockk {
-        every {
-            lastDatabaseSchemeChangeInstant
-        } returns mutableLastDatabaseSchemeChangeInstantFlow.value
-        every {
-            lastDatabaseSchemeChangeInstantFlow
-        } returns mutableLastDatabaseSchemeChangeInstantFlow
+        every { databaseSchemeChangeFlow } returns mutableDatabaseSchemeChangeFlow
     }
 
     private val mutableFullSyncFlow = bufferedMutableSharedFlow<Unit>()
@@ -787,34 +782,14 @@ class VaultRepositoryTest {
     }
 
     @Test
-    fun `lastDatabaseSchemeChangeInstantFlow should trigger sync when new value is not null`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            every {
-                databaseSchemeManager.lastDatabaseSchemeChangeInstant
-            } returns mutableLastDatabaseSchemeChangeInstantFlow.value
-            coEvery { syncService.sync() } just awaits
+    fun `databaseSchemeChangeFlow should trigger sync on emission`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        coEvery { syncService.sync() } just awaits
 
-            mutableLastDatabaseSchemeChangeInstantFlow.value = clock.instant()
+        mutableDatabaseSchemeChangeFlow.tryEmit(Unit)
 
-            coVerify(exactly = 1) { syncService.sync() }
-        }
-
-    @Test
-    fun `lastDatabaseSchemeChangeInstantFlow should not sync when new value is null`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-
-            every {
-                databaseSchemeManager.lastDatabaseSchemeChangeInstant
-            } returns mutableLastDatabaseSchemeChangeInstantFlow.value
-
-            coEvery { syncService.sync() } just awaits
-
-            mutableLastDatabaseSchemeChangeInstantFlow.value = null
-
-            coVerify(exactly = 0) { syncService.sync() }
-        }
+        coVerify(exactly = 1) { syncService.sync() }
+    }
 
     @Test
     fun `sync with forced should skip checks and call the syncService sync`() {
@@ -1121,60 +1096,6 @@ class VaultRepositoryTest {
         vaultRepository.syncIfNecessary()
 
         coVerify(exactly = 0) { syncService.sync() }
-    }
-
-    @Test
-    fun `syncIfNecessary when there is no last scheme change should not sync the vault`() {
-        val userId = "mockId-1"
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        every {
-            settingsDiskSource.getLastSyncTime(userId)
-        } returns clock.instant().minus(1, ChronoUnit.MINUTES)
-        every {
-            databaseSchemeManager.lastDatabaseSchemeChangeInstant
-        } returns null
-        coEvery { syncService.sync() } just awaits
-
-        vaultRepository.syncIfNecessary()
-
-        coVerify(exactly = 0) { syncService.sync() }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `syncIfNecessary when the last scheme change is before the last sync time should not sync the vault`() {
-        val userId = "mockId-1"
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        every {
-            settingsDiskSource.getLastSyncTime(userId)
-        } returns clock.instant().plus(1, ChronoUnit.MINUTES)
-        every {
-            databaseSchemeManager.lastDatabaseSchemeChangeInstant
-        } returns clock.instant().minus(1, ChronoUnit.MINUTES)
-
-        coEvery { syncService.sync() } just awaits
-
-        vaultRepository.syncIfNecessary()
-
-        coVerify(exactly = 0) { syncService.sync() }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `syncIfNecessary when the last scheme change is after the last sync time should sync the vault`() {
-        val userId = "mockId-1"
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        every {
-            settingsDiskSource.getLastSyncTime(userId)
-        } returns clock.instant().minus(1, ChronoUnit.MINUTES)
-        every {
-            databaseSchemeManager.lastDatabaseSchemeChangeInstant
-        } returns clock.instant().plus(1, ChronoUnit.MINUTES)
-        coEvery { syncService.sync() } just awaits
-
-        vaultRepository.syncIfNecessary()
-
-        coVerify { syncService.sync() }
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15177](https://bitwarden.atlassian.net/browse/PM-15177)

## 📔 Objective

This PR update the logic for managing a destructive fallback. The big difference is that we clear the `lasSyncTime` for all users to ensure that vault gets re-synced.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15177]: https://bitwarden.atlassian.net/browse/PM-15177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ