### PR TITLE
Remove unused lastDatabaseSchemeChangeInstant from settings disk source

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -69,17 +69,6 @@ interface SettingsDiskSource {
     val hasUserLoggedInOrCreatedAccountFlow: Flow<Boolean?>
 
     /**
-     * The instant when the last database scheme change was applied. `null` if no scheme changes
-     * have been applied yet.
-     */
-    var lastDatabaseSchemeChangeInstant: Instant?
-
-    /**
-     * Emits updates that track [lastDatabaseSchemeChangeInstant].
-     */
-    val lastDatabaseSchemeChangeInstantFlow: Flow<Instant?>
-
-    /**
      * Clears all the settings data for the given user.
      */
     fun clearData(userId: String)

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -36,7 +36,6 @@ private const val HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY = "hasUserLoggedI
 private const val SHOW_AUTOFILL_SETTING_BADGE = "showAutofillSettingBadge"
 private const val SHOW_UNLOCK_SETTING_BADGE = "showUnlockSettingBadge"
 private const val SHOW_IMPORT_LOGINS_SETTING_BADGE = "showImportLoginsSettingBadge"
-private const val LAST_SCHEME_CHANGE_INSTANT = "lastDatabaseSchemeChangeInstant"
 private const val IS_VAULT_REGISTERED_FOR_EXPORT = "isVaultRegisteredForExport"
 
 /**
@@ -75,8 +74,6 @@ class SettingsDiskSourceImpl(
     private val mutableIsCrashLoggingEnabledFlow = bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableHasUserLoggedInOrCreatedAccountFlow = bufferedMutableSharedFlow<Boolean?>()
-
-    private val mutableLastDatabaseSchemeChangeInstantFlow = bufferedMutableSharedFlow<Instant?>()
 
     private val mutableScreenCaptureAllowedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -161,17 +158,6 @@ class SettingsDiskSourceImpl(
     override val hasUserLoggedInOrCreatedAccountFlow: Flow<Boolean?>
         get() = mutableHasUserLoggedInOrCreatedAccountFlow
             .onSubscription { emit(getBoolean(HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY)) }
-
-    override var lastDatabaseSchemeChangeInstant: Instant?
-        get() = getLong(LAST_SCHEME_CHANGE_INSTANT)?.let { Instant.ofEpochMilli(it) }
-        set(value) {
-            putLong(LAST_SCHEME_CHANGE_INSTANT, value?.toEpochMilli())
-            mutableLastDatabaseSchemeChangeInstantFlow.tryEmit(value)
-        }
-
-    override val lastDatabaseSchemeChangeInstantFlow: Flow<Instant?>
-        get() = mutableLastDatabaseSchemeChangeInstantFlow
-            .onSubscription { emit(lastDatabaseSchemeChangeInstant) }
 
     override fun clearData(userId: String) {
         storeVaultTimeoutInMinutes(userId = userId, vaultTimeoutInMinutes = null)

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1118,55 +1118,6 @@ class SettingsDiskSourceTest {
     }
 
     @Test
-    fun `lastDatabaseSchemeChangeInstant should pull from SharedPreferences`() {
-        val schemeChangeKey = "bwPreferencesStorage:lastDatabaseSchemeChangeInstant"
-        val expected: Long = Instant.now().toEpochMilli()
-
-        fakeSharedPreferences
-            .edit {
-                remove(schemeChangeKey)
-            }
-        assertEquals(0, fakeSharedPreferences.getLong(schemeChangeKey, 0))
-        assertNull(settingsDiskSource.lastDatabaseSchemeChangeInstant)
-
-        // Updating the shared preferences should update disk source.
-        fakeSharedPreferences
-            .edit {
-                putLong(
-                    schemeChangeKey,
-                    expected,
-                )
-            }
-        val actual = settingsDiskSource.lastDatabaseSchemeChangeInstant
-        assertEquals(
-            expected,
-            actual?.toEpochMilli(),
-        )
-    }
-
-    @Test
-    fun `setting lastDatabaseSchemeChangeInstant should update SharedPreferences`() {
-        val schemeChangeKey = "bwPreferencesStorage:lastDatabaseSchemeChangeInstant"
-        val schemeChangeInstant = Instant.now()
-
-        // Setting to null should update disk source
-        settingsDiskSource.lastDatabaseSchemeChangeInstant = null
-        assertEquals(0, fakeSharedPreferences.getLong(schemeChangeKey, 0))
-        assertNull(settingsDiskSource.lastDatabaseSchemeChangeInstant)
-
-        // Setting to value should update disk source
-        settingsDiskSource.lastDatabaseSchemeChangeInstant = schemeChangeInstant
-        val actual = fakeSharedPreferences.getLong(
-            schemeChangeKey,
-            0,
-        )
-        assertEquals(
-            schemeChangeInstant.toEpochMilli(),
-            actual,
-        )
-    }
-
-    @Test
     fun `getShowImportLoginsSettingBadge should pull from shared preferences`() {
         val mockUserId = "mockUserId"
         val showImportLoginsSettingBadgeKey =

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -42,9 +42,6 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val mutableScreenCaptureAllowedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
-    private val mutableLastDatabaseSchemeChangeInstant =
-        bufferedMutableSharedFlow<Instant?>()
-
     private var storedAppTheme: AppTheme = AppTheme.DEFAULT
     private val storedLastSyncTime = mutableMapOf<String, Instant?>()
     private val storedVaultTimeoutActions = mutableMapOf<String, VaultTimeoutAction?>()
@@ -67,7 +64,6 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val userShowAutoFillBadge = mutableMapOf<String, Boolean?>()
     private val userShowUnlockBadge = mutableMapOf<String, Boolean?>()
     private val userShowImportLoginsBadge = mutableMapOf<String, Boolean?>()
-    private var storedLastDatabaseSchemeChangeInstant: Instant? = null
     private val vaultRegisteredForExport = mutableMapOf<String, Boolean?>()
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
@@ -142,17 +138,6 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     override val hasUserLoggedInOrCreatedAccountFlow: Flow<Boolean?>
         get() = mutableHasUserLoggedInOrCreatedAccount.onSubscription {
             emit(hasUserLoggedInOrCreatedAccount)
-        }
-
-    override var lastDatabaseSchemeChangeInstant: Instant?
-        get() = storedLastDatabaseSchemeChangeInstant
-        set(value) {
-            storedLastDatabaseSchemeChangeInstant = value
-        }
-
-    override val lastDatabaseSchemeChangeInstantFlow: Flow<Instant?>
-        get() = mutableLastDatabaseSchemeChangeInstant.onSubscription {
-            emit(lastDatabaseSchemeChangeInstant)
         }
 
     override fun getAccountBiometricIntegrityValidity(


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the `lastDatabaseSchemeChangeInstant ` and `lastDatabaseSchemeChangeInstantFlow` from the `SettingDiskSource` as it is not used anymore.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
