### PR TITLE
Ensure lastSyncTime is updated before resyncing the vault

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -1352,11 +1352,11 @@ class VaultRepositoryImpl(
                             if (serverRevisionDate < lastSyncTimeMs) {
                                 // We can skip the actual sync call if there is no new data or
                                 // database scheme changes since the last sync.
-                                vaultDiskSource.resyncVaultData(userId = userId)
                                 settingsDiskSource.storeLastSyncTime(
                                     userId = userId,
                                     lastSyncTime = clock.instant(),
                                 )
+                                vaultDiskSource.resyncVaultData(userId = userId)
                                 val itemsAvailable = vaultDiskSource
                                     .getCiphers(userId)
                                     .firstOrNull()


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR ensures that the `lastSyncTime` is updated before re-syncing the vault. This is to make sure the vault does not re-emit while the `lastSyncTime` is null as that can cause an incorrect loading state.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
