### PR TITLE
[PM-13072] Centralize passkey entry construction

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
@@ -8,10 +8,14 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManagerImpl
+import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2OriginManager
+import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2OriginManagerImpl
 import com.x8bit.bitwarden.data.autofill.fido2.processor.Fido2ProviderProcessor
 import com.x8bit.bitwarden.data.autofill.fido2.processor.Fido2ProviderProcessorImpl
 import com.x8bit.bitwarden.data.platform.manager.AssetManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
@@ -37,8 +41,6 @@ object Fido2ProviderModule {
     fun provideCredentialProviderProcessor(
         @ApplicationContext context: Context,
         authRepository: AuthRepository,
-        vaultRepository: VaultRepository,
-        fido2CredentialStore: Fido2CredentialStore,
         fido2CredentialManager: Fido2CredentialManager,
         dispatcherManager: DispatcherManager,
         intentManager: IntentManager,
@@ -47,8 +49,6 @@ object Fido2ProviderModule {
         Fido2ProviderProcessorImpl(
             context,
             authRepository,
-            vaultRepository,
-            fido2CredentialStore,
             fido2CredentialManager,
             intentManager,
             clock,
@@ -58,17 +58,38 @@ object Fido2ProviderModule {
     @Provides
     @Singleton
     fun provideFido2CredentialManager(
-        assetManager: AssetManager,
-        digitalAssetLinkService: DigitalAssetLinkService,
+        @ApplicationContext context: Context,
+        intentManager: IntentManager,
         vaultSdkSource: VaultSdkSource,
+        vaultRepository: VaultRepository,
+        settingsRepository: SettingsRepository,
+        environmentRepository: EnvironmentRepository,
         fido2CredentialStore: Fido2CredentialStore,
+        fido2OriginManager: Fido2OriginManager,
+        dispatcherManager: DispatcherManager,
         json: Json,
     ): Fido2CredentialManager =
         Fido2CredentialManagerImpl(
+            context = context,
+            intentManager = intentManager,
+            vaultSdkSource = vaultSdkSource,
+            vaultRepository = vaultRepository,
+            settingsRepository = settingsRepository,
+            environmentRepository = environmentRepository,
+            fido2CredentialStore = fido2CredentialStore,
+            fido2OriginManager = fido2OriginManager,
+            dispatcherManager = dispatcherManager,
+            json = json,
+        )
+
+    @Provides
+    @Singleton
+    fun provideFido2OriginManager(
+        assetManager: AssetManager,
+        digitalAssetLinkService: DigitalAssetLinkService,
+    ): Fido2OriginManager =
+        Fido2OriginManagerImpl(
             assetManager = assetManager,
             digitalAssetLinkService = digitalAssetLinkService,
-            vaultSdkSource = vaultSdkSource,
-            fido2CredentialStore = fido2CredentialStore,
-            json = json,
         )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
@@ -1,14 +1,14 @@
 package com.x8bit.bitwarden.data.autofill.fido2.manager
 
-import androidx.credentials.provider.CallingAppInfo
 import com.bitwarden.vault.CipherView
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
+import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 
 /**
  * Responsible for managing FIDO 2 credential registration and authentication.
@@ -27,26 +27,11 @@ interface Fido2CredentialManager {
     var authenticationAttempts: Int
 
     /**
-     * Attempt to validate the RP and origin of the provided [callingAppInfo] and [relyingPartyId].
-     */
-    suspend fun validateOrigin(
-        callingAppInfo: CallingAppInfo,
-        relyingPartyId: String,
-    ): Fido2ValidateOriginResult
-
-    /**
      * Attempt to extract FIDO 2 passkey attestation options from the system [requestJson], or null.
      */
     fun getPasskeyAttestationOptionsOrNull(
         requestJson: String,
     ): PasskeyAttestationOptions?
-
-    /**
-     * Attempt to extract FIDO 2 passkey assertion options from the system [requestJson], or null.
-     */
-    fun getPasskeyAssertionOptionsOrNull(
-        requestJson: String,
-    ): PasskeyAssertionOptions?
 
     /**
      * Register a new FIDO 2 credential to a users vault.
@@ -58,16 +43,49 @@ interface Fido2CredentialManager {
     ): Fido2RegisterCredentialResult
 
     /**
+     * Retrieve FIDO 2 credentials for a given relying party.
+     */
+    suspend fun getFido2CredentialsForRelyingParty(
+        fido2GetCredentialsRequest: Fido2GetCredentialsRequest,
+    ): Fido2GetCredentialsResult
+
+    /**
      * Authenticate a FIDO credential against a cipher in the users vault.
      */
     suspend fun authenticateFido2Credential(
-        userId: String,
         request: Fido2CredentialAssertionRequest,
-        selectedCipherView: CipherView,
     ): Fido2CredentialAssertionResult
 
     /**
      * Whether or not the user has authentication attempts remaining.
      */
     fun hasAuthenticationAttemptsRemaining(): Boolean
+
+    /**
+     * Determines the user verification requirement for a given FIDO2 assertion request.
+     *
+     * @param request The FIDO2 credential assertion request.
+     * @param fallbackRequirement The fallback requirement to use if the request doesn't specify
+     * one.
+     * Defaults to [UserVerificationRequirement.REQUIRED].
+     * @return The user verification requirement for the request.
+     */
+    fun getUserVerificationRequirementForAssertion(
+        request: Fido2CredentialAssertionRequest,
+        fallbackRequirement: UserVerificationRequirement = UserVerificationRequirement.REQUIRED,
+    ): UserVerificationRequirement
+
+    /**
+     * Determines the user verification requirement for a given FIDO2 registration request.
+     *
+     * @param request The FIDO2 credential request.
+     * @param fallbackRequirement The fallback requirement to use if the request doesn't specify
+     * one.
+     * Defaults to [UserVerificationRequirement.REQUIRED].
+     * @return The user verification requirement for the request.
+     */
+    fun getUserVerificationRequirementForRegistration(
+        request: Fido2CreateCredentialRequest,
+        fallbackRequirement: UserVerificationRequirement = UserVerificationRequirement.REQUIRED,
+    ): UserVerificationRequirement
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
@@ -1,51 +1,71 @@
 package com.x8bit.bitwarden.data.autofill.fido2.manager
 
-import androidx.credentials.provider.CallingAppInfo
+import android.content.Context
+import androidx.credentials.provider.PublicKeyCredentialEntry
 import com.bitwarden.fido.ClientData
+import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.fido.Origin
 import com.bitwarden.fido.UnverifiedAssetLink
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.vault.CipherView
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
-import com.x8bit.bitwarden.data.platform.manager.AssetManager
+import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
+import com.x8bit.bitwarden.data.autofill.fido2.processor.GET_PASSKEY_INTENT
+import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.platform.repository.util.baseIconUrl
 import com.x8bit.bitwarden.data.platform.util.decodeFromStringOrNull
 import com.x8bit.bitwarden.data.platform.util.getAppOrigin
-import com.x8bit.bitwarden.data.platform.util.getAppSigningSignatureFingerprint
+import com.x8bit.bitwarden.data.platform.util.getAppSigningSignatureFingerprintOrNull
 import com.x8bit.bitwarden.data.platform.util.getSignatureFingerprintAsHexString
-import com.x8bit.bitwarden.data.platform.util.validatePrivilegedApp
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.AuthenticateFido2CredentialRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.RegisterFido2CredentialRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.util.toAndroidAttestationResponse
 import com.x8bit.bitwarden.data.vault.datasource.sdk.util.toAndroidFido2PublicKeyCredential
+import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.data.vault.repository.model.DecryptFido2CredentialAutofillViewResult
+import com.x8bit.bitwarden.ui.autofill.fido2.util.createFido2IconCompatFromIconDataOrDefault
+import com.x8bit.bitwarden.ui.autofill.fido2.util.createFido2IconCompatFromResource
 import com.x8bit.bitwarden.ui.platform.base.util.toHostOrPathOrNull
-import kotlinx.serialization.SerializationException
+import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.x8bit.bitwarden.ui.vault.feature.vault.util.toLoginIconData
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-
-private const val GOOGLE_ALLOW_LIST_FILE_NAME = "fido2_privileged_google.json"
-private const val COMMUNITY_ALLOW_LIST_FILE_NAME = "fido2_privileged_community.json"
+import kotlin.random.Random
 
 /**
  * Primary implementation of [Fido2CredentialManager].
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 class Fido2CredentialManagerImpl(
-    private val assetManager: AssetManager,
-    private val digitalAssetLinkService: DigitalAssetLinkService,
+    @ApplicationContext private val context: Context,
     private val vaultSdkSource: VaultSdkSource,
     private val fido2CredentialStore: Fido2CredentialStore,
+    private val vaultRepository: VaultRepository,
+    private val settingsRepository: SettingsRepository,
+    private val environmentRepository: EnvironmentRepository,
+    private val intentManager: IntentManager,
+    private val fido2OriginManager: Fido2OriginManager,
     private val json: Json,
+    dispatcherManager: DispatcherManager,
 ) : Fido2CredentialManager,
     Fido2CredentialStore by fido2CredentialStore {
+
+    private val ioScope = CoroutineScope(dispatcherManager.io)
 
     override var isUserVerified: Boolean = false
 
@@ -56,10 +76,21 @@ class Fido2CredentialManagerImpl(
         fido2CreateCredentialRequest: Fido2CreateCredentialRequest,
         selectedCipherView: CipherView,
     ): Fido2RegisterCredentialResult {
+        val requestOptions =
+            getPasskeyAttestationOptionsOrNull(fido2CreateCredentialRequest.requestJson)
+                ?: return Fido2RegisterCredentialResult.Error
+
+        fido2OriginManager.validateOrigin(
+            callingAppInfo = fido2CreateCredentialRequest.callingAppInfo,
+            relyingPartyId = requestOptions.relyingParty.id,
+        )
+            as? Fido2ValidateOriginResult.Success
+            ?: return Fido2RegisterCredentialResult.Error
+
         val clientData = if (fido2CreateCredentialRequest.callingAppInfo.isOriginPopulated()) {
             fido2CreateCredentialRequest
                 .callingAppInfo
-                .getAppSigningSignatureFingerprint()
+                .getAppSigningSignatureFingerprintOrNull()
                 ?.let { ClientData.DefaultWithCustomHash(hash = it) }
                 ?: return Fido2RegisterCredentialResult.Error
         } else {
@@ -69,10 +100,8 @@ class Fido2CredentialManagerImpl(
                     .packageName,
             )
         }
-        val assetLinkUrl = fido2CreateCredentialRequest
-            .origin
-            ?: getOriginUrlFromAttestationOptionsOrNull(fido2CreateCredentialRequest.requestJson)
-            ?: return Fido2RegisterCredentialResult.Error
+        val assetLinkUrl = fido2CreateCredentialRequest.origin
+            ?: "$HTTPS${requestOptions.relyingParty.id}"
 
         val origin = Origin.Android(
             UnverifiedAssetLink(
@@ -108,43 +137,107 @@ class Fido2CredentialManagerImpl(
             )
     }
 
-    override suspend fun validateOrigin(
-        callingAppInfo: CallingAppInfo,
-        relyingPartyId: String,
-    ): Fido2ValidateOriginResult {
-        return if (callingAppInfo.isOriginPopulated()) {
-            validatePrivilegedAppOrigin(callingAppInfo)
-        } else {
-            validateCallingApplicationAssetLinks(callingAppInfo, relyingPartyId)
-        }
-    }
+    override fun getUserVerificationRequirementForAssertion(
+        request: Fido2CredentialAssertionRequest,
+        fallbackRequirement: UserVerificationRequirement,
+    ) = getPasskeyAssertionOptionsOrNull(request.requestJson)
+        ?.userVerification
+        ?: fallbackRequirement
+
+    override fun getUserVerificationRequirementForRegistration(
+        request: Fido2CreateCredentialRequest,
+        fallbackRequirement: UserVerificationRequirement,
+    ) = getPasskeyAttestationOptionsOrNull(request.requestJson)
+        ?.authenticatorSelection
+        ?.userVerification
+        ?: fallbackRequirement
 
     override fun getPasskeyAttestationOptionsOrNull(
         requestJson: String,
     ): PasskeyAttestationOptions? =
-        try {
-            json.decodeFromString<PasskeyAttestationOptions>(requestJson)
-        } catch (e: SerializationException) {
-            null
-        } catch (e: IllegalArgumentException) {
-            null
-        }
+        json.decodeFromStringOrNull<PasskeyAttestationOptions>(requestJson)
 
-    override fun getPasskeyAssertionOptionsOrNull(
+    private fun getPasskeyAssertionOptionsOrNull(
         requestJson: String,
     ): PasskeyAssertionOptions? =
-        try {
-            json.decodeFromString<PasskeyAssertionOptions>(requestJson)
-        } catch (e: SerializationException) {
-            null
-        } catch (e: IllegalArgumentException) {
-            null
+        json.decodeFromStringOrNull<PasskeyAssertionOptions>(requestJson)
+
+    override suspend fun getFido2CredentialsForRelyingParty(
+        fido2GetCredentialsRequest: Fido2GetCredentialsRequest,
+    ): Fido2GetCredentialsResult = withContext(ioScope.coroutineContext) {
+
+        val requestOptions =
+            getPasskeyAssertionOptionsOrNull(requestJson = fido2GetCredentialsRequest.requestJson)
+                ?: return@withContext Fido2GetCredentialsResult.Error
+
+        val relyingPartyId = requestOptions.relyingPartyId
+            ?: return@withContext Fido2GetCredentialsResult.Error
+
+        fido2OriginManager.validateOrigin(
+            callingAppInfo = fido2GetCredentialsRequest.callingAppInfo,
+            relyingPartyId = relyingPartyId,
+        )
+            as? Fido2ValidateOriginResult.Success
+            ?: return@withContext Fido2GetCredentialsResult.Error
+
+        getFido2Credentials(
+            relyingPartyId = relyingPartyId,
+            fido2GetCredentialsRequest = fido2GetCredentialsRequest,
+            options = requestOptions,
+            baseIconUrl = environmentRepository.environment.environmentUrlData.baseIconUrl,
+            isIconLoadingDisabled = settingsRepository.isIconLoadingDisabled,
+        )
+    }
+
+    private suspend fun getFido2Credentials(
+        relyingPartyId: String,
+        fido2GetCredentialsRequest: Fido2GetCredentialsRequest,
+        options: PasskeyAssertionOptions,
+        baseIconUrl: String,
+        isIconLoadingDisabled: Boolean,
+    ): Fido2GetCredentialsResult = withContext(ioScope.coroutineContext) {
+
+        val ciphersWithFido2Credentials = fido2CredentialStore
+            .findCredentials(
+                ids = options.allowCredentials?.map { it.id.toByteArray() },
+                ripId = relyingPartyId,
+            )
+        val decryptResult = vaultRepository
+            .getDecryptedFido2CredentialAutofillViews(ciphersWithFido2Credentials)
+
+        when (decryptResult) {
+            is DecryptFido2CredentialAutofillViewResult.Error -> {
+                Fido2GetCredentialsResult.Error
+            }
+
+            is DecryptFido2CredentialAutofillViewResult.Success -> {
+                val credentialEntries = decryptResult
+                    .fido2CredentialAutofillViews
+                    .filter { it.rpId == relyingPartyId }
+                    .associate {
+                        // Locate the cipher associated with the autofill view
+                        ciphersWithFido2Credentials
+                            .find { cipher -> cipher.id == it.cipherId }
+                            ?.let { cipher -> it to cipher }
+                            ?: return@withContext Fido2GetCredentialsResult.Error
+                    }
+                    .toCredentialEntries(
+                        isIconLoadingDisabled = isIconLoadingDisabled,
+                        baseIconUrl = baseIconUrl,
+                        fido2GetCredentialsRequest = fido2GetCredentialsRequest,
+                    )
+
+                Fido2GetCredentialsResult.Success(
+                    userId = fido2GetCredentialsRequest.userId,
+                    options = fido2GetCredentialsRequest.option,
+                    credentialEntries = credentialEntries,
+                )
+            }
         }
+    }
 
     override suspend fun authenticateFido2Credential(
-        userId: String,
         request: Fido2CredentialAssertionRequest,
-        selectedCipherView: CipherView,
     ): Fido2CredentialAssertionResult {
         val callingAppInfo = request.callingAppInfo
         val clientData = request.clientDataHash
@@ -157,169 +250,45 @@ class Fido2CredentialManagerImpl(
             .decodeFromStringOrNull<PasskeyAssertionOptions>(request.requestJson)
             ?.relyingPartyId
             ?: return Fido2CredentialAssertionResult.Error
-
-        val validateOriginResult = validateOrigin(
+        fido2OriginManager.validateOrigin(
             callingAppInfo = callingAppInfo,
             relyingPartyId = relyingPartyId,
         )
+            as? Fido2ValidateOriginResult.Success
+            ?: return Fido2CredentialAssertionResult.Error
 
-        return when (validateOriginResult) {
-            is Fido2ValidateOriginResult.Error -> {
-                Fido2CredentialAssertionResult.Error
-            }
+        val selectedCipherView = vaultRepository.ciphersStateFlow.value.data
+            ?.let { ciphers -> ciphers.find { it.id == request.cipherId } }
+            ?: return Fido2CredentialAssertionResult.Error
 
-            Fido2ValidateOriginResult.Success -> {
-                vaultSdkSource
-                    .authenticateFido2Credential(
-                        request = AuthenticateFido2CredentialRequest(
-                            userId = userId,
-                            origin = Origin.Android(
-                                UnverifiedAssetLink(
-                                    callingAppInfo.packageName,
-                                    callingAppInfo.getSignatureFingerprintAsHexString()
-                                        ?: return Fido2CredentialAssertionResult.Error,
-                                    origin.toHostOrPathOrNull()
-                                        ?: return Fido2CredentialAssertionResult.Error,
-                                    origin,
-                                ),
-                            ),
-                            requestJson = """{"publicKey": ${request.requestJson}}""",
-                            clientData = clientData,
-                            selectedCipherView = selectedCipherView,
-                            isUserVerificationSupported = true,
+        return vaultSdkSource
+            .authenticateFido2Credential(
+                request = AuthenticateFido2CredentialRequest(
+                    userId = request.userId,
+                    origin = Origin.Android(
+                        UnverifiedAssetLink(
+                            callingAppInfo.packageName,
+                            callingAppInfo.getSignatureFingerprintAsHexString()
+                                ?: return Fido2CredentialAssertionResult.Error,
+                            origin.toHostOrPathOrNull()
+                                ?: return Fido2CredentialAssertionResult.Error,
+                            origin,
                         ),
-                        fido2CredentialStore = this,
-                    )
-                    .map { it.toAndroidFido2PublicKeyCredential() }
-                    .mapCatching { json.encodeToString(it) }
-                    .fold(
-                        onSuccess = { Fido2CredentialAssertionResult.Success(it) },
-                        onFailure = { Fido2CredentialAssertionResult.Error },
-                    )
-            }
-        }
-    }
-
-    private suspend fun validateCallingApplicationAssetLinks(
-        callingAppInfo: CallingAppInfo,
-        relyingPartyId: String,
-    ): Fido2ValidateOriginResult {
-        return digitalAssetLinkService
-            .getDigitalAssetLinkForRp(relyingParty = relyingPartyId)
-            .onFailure {
-                return Fido2ValidateOriginResult.Error.AssetLinkNotFound
-            }
-            .map { statements ->
-                statements
-                    .filterMatchingAppStatementsOrNull(
-                        rpPackageName = callingAppInfo.packageName,
-                    )
-                    ?: return Fido2ValidateOriginResult.Error.ApplicationNotFound
-            }
-            .map { matchingStatements ->
-                callingAppInfo
-                    .getSignatureFingerprintAsHexString()
-                    ?.let { certificateFingerprint ->
-                        matchingStatements
-                            .filterMatchingAppSignaturesOrNull(
-                                signature = certificateFingerprint,
-                            )
-                    }
-                    ?: return Fido2ValidateOriginResult.Error.ApplicationNotVerified
-            }
-            .fold(
-                onSuccess = {
-                    Fido2ValidateOriginResult.Success
-                },
-                onFailure = {
-                    Fido2ValidateOriginResult.Error.Unknown
-                },
-            )
-    }
-
-    private suspend fun validatePrivilegedAppOrigin(
-        callingAppInfo: CallingAppInfo,
-    ): Fido2ValidateOriginResult {
-        val googleAllowListResult =
-            validatePrivilegedAppSignatureWithGoogleList(callingAppInfo)
-        return when (googleAllowListResult) {
-            is Fido2ValidateOriginResult.Success -> {
-                // Application was found and successfully validated against the Google allow list so
-                // we can return the result as the final validation result.
-                googleAllowListResult
-            }
-
-            is Fido2ValidateOriginResult.Error -> {
-                // Check the community allow list if the Google allow list failed, and return the
-                // result as the final validation result.
-                validatePrivilegedAppSignatureWithCommunityList(callingAppInfo)
-            }
-        }
-    }
-
-    private suspend fun validatePrivilegedAppSignatureWithGoogleList(
-        callingAppInfo: CallingAppInfo,
-    ): Fido2ValidateOriginResult =
-        validatePrivilegedAppSignatureWithAllowList(
-            callingAppInfo = callingAppInfo,
-            fileName = GOOGLE_ALLOW_LIST_FILE_NAME,
-        )
-
-    private suspend fun validatePrivilegedAppSignatureWithCommunityList(
-        callingAppInfo: CallingAppInfo,
-    ): Fido2ValidateOriginResult =
-        validatePrivilegedAppSignatureWithAllowList(
-            callingAppInfo = callingAppInfo,
-            fileName = COMMUNITY_ALLOW_LIST_FILE_NAME,
-        )
-
-    private suspend fun validatePrivilegedAppSignatureWithAllowList(
-        callingAppInfo: CallingAppInfo,
-        fileName: String,
-    ): Fido2ValidateOriginResult =
-        assetManager
-            .readAsset(fileName)
-            .map { allowList ->
-                callingAppInfo.validatePrivilegedApp(
-                    allowList = allowList,
-                )
-            }
-            .fold(
-                onSuccess = { it },
-                onFailure = { Fido2ValidateOriginResult.Error.Unknown },
-            )
-
-    /**
-     * Returns statements targeting the calling Android application, or null.
-     */
-    private fun List<DigitalAssetLinkResponseJson>.filterMatchingAppStatementsOrNull(
-        rpPackageName: String,
-    ): List<DigitalAssetLinkResponseJson>? =
-        filter { statement ->
-            val target = statement.target
-            target.namespace == "android_app" &&
-                target.packageName == rpPackageName &&
-                statement.relation.containsAll(
-                    listOf(
-                        "delegate_permission/common.get_login_creds",
-                        "delegate_permission/common.handle_all_urls",
                     ),
-                )
-        }
-            .takeUnless { it.isEmpty() }
-
-    /**
-     * Returns statements that match the given [signature], or null.
-     */
-    private fun List<DigitalAssetLinkResponseJson>.filterMatchingAppSignaturesOrNull(
-        signature: String,
-    ): List<DigitalAssetLinkResponseJson>? =
-        filter { statement ->
-            statement.target.sha256CertFingerprints
-                ?.contains(signature)
-                ?: false
-        }
-            .takeUnless { it.isEmpty() }
+                    requestJson = """{"publicKey": ${request.requestJson}}""",
+                    clientData = clientData,
+                    selectedCipherView = selectedCipherView,
+                    isUserVerificationSupported = true,
+                ),
+                fido2CredentialStore = this,
+            )
+            .map { it.toAndroidFido2PublicKeyCredential() }
+            .mapCatching { json.encodeToString(it) }
+            .fold(
+                onSuccess = { Fido2CredentialAssertionResult.Success(it) },
+                onFailure = { Fido2CredentialAssertionResult.Error },
+            )
+    }
 
     override fun hasAuthenticationAttemptsRemaining(): Boolean =
         authenticationAttempts < MAX_AUTHENTICATION_ATTEMPTS
@@ -329,11 +298,57 @@ class Fido2CredentialManagerImpl(
             ?.relyingPartyId
             ?.let { "$HTTPS$it" }
 
-    private fun getOriginUrlFromAttestationOptionsOrNull(requestJson: String) =
-        getPasskeyAttestationOptionsOrNull(requestJson)
-            ?.relyingParty
-            ?.id
-            ?.let { "$HTTPS$it" }
+    private suspend fun Map<Fido2CredentialAutofillView, CipherView>.toCredentialEntries(
+        isIconLoadingDisabled: Boolean,
+        baseIconUrl: String,
+        fido2GetCredentialsRequest: Fido2GetCredentialsRequest,
+    ) = map { it.toCredentialEntry(isIconLoadingDisabled, baseIconUrl, fido2GetCredentialsRequest) }
+
+    private suspend fun Map.Entry<Fido2CredentialAutofillView, CipherView>.toCredentialEntry(
+        isIconLoadingDisabled: Boolean,
+        baseIconUrl: String,
+        fido2GetCredentialsRequest: Fido2GetCredentialsRequest,
+    ): PublicKeyCredentialEntry {
+        val autofillView = key
+        val cipherView = value
+
+        val iconCompat = if (isIconLoadingDisabled) {
+            context.createFido2IconCompatFromResource(R.drawable.ic_bw_passkey)
+        } else {
+            cipherView.login
+                ?.uris
+                ?.toLoginIconData(
+                    isIconLoadingDisabled = settingsRepository.isIconLoadingDisabled,
+                    baseIconUrl = baseIconUrl,
+                    usePasskeyDefaultIcon = true,
+                )
+                .let { iconData ->
+                    context.createFido2IconCompatFromIconDataOrDefault(
+                        iconData = iconData,
+                        defaultResourceId = R.drawable.ic_bw_passkey,
+                    )
+                }
+        }
+
+        return PublicKeyCredentialEntry
+            .Builder(
+                context = context,
+                username = autofillView.userNameForUi
+                    ?: context.getString(R.string.no_username),
+                pendingIntent = intentManager.createFido2GetCredentialPendingIntent(
+                    action = GET_PASSKEY_INTENT,
+                    userId = fido2GetCredentialsRequest.userId,
+                    credentialId = autofillView.credentialId.toString(),
+                    requestCode = Random.nextInt(),
+                    cipherId = autofillView.cipherId,
+                ),
+                beginGetPublicKeyCredentialOption = fido2GetCredentialsRequest.option,
+            )
+            .setAutoSelectAllowed(true)
+            .setDisplayName(cipherView.name)
+            .setIcon(iconCompat.toIcon(context))
+            .build()
+    }
 }
 
 private const val MAX_AUTHENTICATION_ATTEMPTS = 5

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManager.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.data.autofill.fido2.manager
+
+import androidx.credentials.provider.CallingAppInfo
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+
+/**
+ * Responsible for managing FIDO2 origin validation.
+ */
+interface Fido2OriginManager {
+
+    /**
+     * Validates the origin of a calling app.
+     * @param callingAppInfo The calling app info.
+     * @param relyingPartyId The relying party ID.
+     * @return The result of the validation.
+     */
+    suspend fun validateOrigin(
+        callingAppInfo: CallingAppInfo,
+        relyingPartyId: String,
+    ): Fido2ValidateOriginResult
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManagerImpl.kt
@@ -1,0 +1,151 @@
+package com.x8bit.bitwarden.data.autofill.fido2.manager
+
+import androidx.credentials.provider.CallingAppInfo
+import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
+import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+import com.x8bit.bitwarden.data.platform.manager.AssetManager
+import com.x8bit.bitwarden.data.platform.util.getSignatureFingerprintAsHexString
+import com.x8bit.bitwarden.data.platform.util.validatePrivilegedApp
+
+private const val GOOGLE_ALLOW_LIST_FILE_NAME = "fido2_privileged_google.json"
+private const val COMMUNITY_ALLOW_LIST_FILE_NAME = "fido2_privileged_community.json"
+
+/**
+ * Primary implementation of [Fido2OriginManager].
+ */
+class Fido2OriginManagerImpl(
+    private val assetManager: AssetManager,
+    private val digitalAssetLinkService: DigitalAssetLinkService,
+) : Fido2OriginManager {
+
+    override suspend fun validateOrigin(
+        callingAppInfo: CallingAppInfo,
+        relyingPartyId: String,
+    ): Fido2ValidateOriginResult {
+        return if (callingAppInfo.isOriginPopulated()) {
+            validatePrivilegedAppOrigin(callingAppInfo)
+        } else {
+            validateCallingApplicationAssetLinks(callingAppInfo, relyingPartyId)
+        }
+    }
+
+    private suspend fun validateCallingApplicationAssetLinks(
+        callingAppInfo: CallingAppInfo,
+        relyingPartyId: String,
+    ): Fido2ValidateOriginResult = digitalAssetLinkService
+        .getDigitalAssetLinkForRp(relyingParty = relyingPartyId)
+        .onFailure {
+            return Fido2ValidateOriginResult.Error.AssetLinkNotFound
+        }
+        .mapCatching { statements ->
+            statements
+                .filterMatchingAppStatementsOrNull(
+                    rpPackageName = callingAppInfo.packageName,
+                )
+                ?: return Fido2ValidateOriginResult.Error.ApplicationNotFound
+        }
+        .mapCatching { matchingStatements ->
+            callingAppInfo
+                .getSignatureFingerprintAsHexString()
+                ?.let { certificateFingerprint ->
+                    matchingStatements
+                        .filterMatchingAppSignaturesOrNull(
+                            signature = certificateFingerprint,
+                        )
+                }
+                ?: return Fido2ValidateOriginResult.Error.ApplicationNotVerified
+        }
+        .fold(
+            onSuccess = {
+                Fido2ValidateOriginResult.Success
+            },
+            onFailure = {
+                Fido2ValidateOriginResult.Error.Unknown
+            },
+        )
+
+    private suspend fun validatePrivilegedAppOrigin(
+        callingAppInfo: CallingAppInfo,
+    ): Fido2ValidateOriginResult {
+        val googleAllowListResult =
+            validatePrivilegedAppSignatureWithGoogleList(callingAppInfo)
+        return when (googleAllowListResult) {
+            is Fido2ValidateOriginResult.Success -> {
+                // Application was found and successfully validated against the Google allow list so
+                // we can return the result as the final validation result.
+                googleAllowListResult
+            }
+
+            is Fido2ValidateOriginResult.Error -> {
+                // Check the community allow list if the Google allow list failed, and return the
+                // result as the final validation result.
+                validatePrivilegedAppSignatureWithCommunityList(callingAppInfo)
+            }
+        }
+    }
+
+    private suspend fun validatePrivilegedAppSignatureWithGoogleList(
+        callingAppInfo: CallingAppInfo,
+    ): Fido2ValidateOriginResult =
+        validatePrivilegedAppSignatureWithAllowList(
+            callingAppInfo = callingAppInfo,
+            fileName = GOOGLE_ALLOW_LIST_FILE_NAME,
+        )
+
+    private suspend fun validatePrivilegedAppSignatureWithCommunityList(
+        callingAppInfo: CallingAppInfo,
+    ): Fido2ValidateOriginResult =
+        validatePrivilegedAppSignatureWithAllowList(
+            callingAppInfo = callingAppInfo,
+            fileName = COMMUNITY_ALLOW_LIST_FILE_NAME,
+        )
+
+    private suspend fun validatePrivilegedAppSignatureWithAllowList(
+        callingAppInfo: CallingAppInfo,
+        fileName: String,
+    ): Fido2ValidateOriginResult =
+        assetManager
+            .readAsset(fileName)
+            .mapCatching { allowList ->
+                callingAppInfo.validatePrivilegedApp(
+                    allowList = allowList,
+                )
+            }
+            .fold(
+                onSuccess = { it },
+                onFailure = { Fido2ValidateOriginResult.Error.Unknown },
+            )
+
+    /**
+     * Returns statements targeting the calling Android application, or null.
+     */
+    private fun List<DigitalAssetLinkResponseJson>.filterMatchingAppStatementsOrNull(
+        rpPackageName: String,
+    ): List<DigitalAssetLinkResponseJson>? =
+        filter { statement ->
+            val target = statement.target
+            target.namespace == "android_app" &&
+                target.packageName == rpPackageName &&
+                statement.relation.containsAll(
+                    listOf(
+                        "delegate_permission/common.get_login_creds",
+                        "delegate_permission/common.handle_all_urls",
+                    ),
+                )
+        }
+            .takeUnless { it.isEmpty() }
+
+    /**
+     * Returns statements that match the given [signature], or null.
+     */
+    private fun List<DigitalAssetLinkResponseJson>.filterMatchingAppSignaturesOrNull(
+        signature: String,
+    ): List<DigitalAssetLinkResponseJson>? =
+        filter { statement ->
+            statement.target.sha256CertFingerprints
+                ?.contains(signature)
+                ?: false
+        }
+            .takeUnless { it.isEmpty() }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2GetCredentialsResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2GetCredentialsResult.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.autofill.fido2.model
 
 import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
-import com.bitwarden.fido.Fido2CredentialAutofillView
+import androidx.credentials.provider.CredentialEntry
 
 /**
  * Represents the result of a FIDO 2 Get Credentials request.
@@ -12,13 +12,13 @@ sealed class Fido2GetCredentialsResult {
      *
      * @param userId ID of the user whose credentials were queried.
      * @param options Original request options provided by the relying party.
-     * @param credentials Collection of [Fido2CredentialAutofillView]s matching the original request
+     * @param credentialEntries Collection of [CredentialEntry] matching the original request
      * parameters. This may be an empty list if no matching values were found.
      */
     data class Success(
         val userId: String,
         val options: BeginGetPublicKeyCredentialOption,
-        val credentials: List<Fido2CredentialAutofillView>,
+        val credentialEntries: List<CredentialEntry>,
     ) : Fido2GetCredentialsResult()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensions.kt
@@ -29,7 +29,7 @@ fun SpecialCircumstance.toAutofillSelectionDataOrNull(): AutofillSelectionData? 
 /**
  * Returns [Fido2CreateCredentialRequest] when contained in the given [SpecialCircumstance].
  */
-fun SpecialCircumstance.toFido2RequestOrNull(): Fido2CreateCredentialRequest? =
+fun SpecialCircumstance.toFido2CreateRequestOrNull(): Fido2CreateCredentialRequest? =
     when (this) {
         is SpecialCircumstance.Fido2Save -> this.fido2CreateCredentialRequest
         else -> null

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensions.kt
@@ -24,7 +24,7 @@ fun CallingAppInfo.getFido2RpIdOrNull(): String? =
  */
 @OptIn(ExperimentalStdlibApi::class)
 fun CallingAppInfo.getSignatureFingerprintAsHexString(): String? {
-    return getAppSigningSignatureFingerprint()
+    return getAppSigningSignatureFingerprintOrNull()
         ?.joinToString(":") { b ->
             b.toHexString(HexFormat.UpperCase)
         }
@@ -62,7 +62,7 @@ fun CallingAppInfo.validatePrivilegedApp(allowList: String): Fido2ValidateOrigin
  * unprivileged application.
  */
 fun CallingAppInfo.getAppOrigin(): String {
-    val certHash = getAppSigningSignatureFingerprint()
+    val certHash = getAppSigningSignatureFingerprintOrNull()
     return "android:apk-key-hash:${Base64.encodeToString(certHash, ENCODING_FLAGS)}"
 }
 
@@ -70,7 +70,7 @@ fun CallingAppInfo.getAppOrigin(): String {
  * Returns a [ByteArray] containing the application's signing certificate signature hash. If
  * multiple signers are identified `null` is returned.
  */
-fun CallingAppInfo.getAppSigningSignatureFingerprint(): ByteArray? {
+fun CallingAppInfo.getAppSigningSignatureFingerprintOrNull(): ByteArray? {
     if (signingInfo.hasMultipleSigners()) return null
 
     val signature = signingInfo.apkContentsSigners.first()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
@@ -39,7 +39,7 @@ fun LocalManagerProvider(
         if (isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
             Fido2CompletionManagerUnsupportedApiImpl
         } else {
-            Fido2CompletionManagerImpl(activity, fido2IntentManager)
+            Fido2CompletionManagerImpl(activity)
         }
     CompositionLocalProvider(
         LocalPermissionsManager provides PermissionsManagerImpl(activity),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -23,7 +23,7 @@ import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSaveItemOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSelectionDataOrNull
-import com.x8bit.bitwarden.data.platform.manager.util.toFido2RequestOrNull
+import com.x8bit.bitwarden.data.platform.manager.util.toFido2CreateRequestOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toTotpDataOrNull
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.DataState
@@ -121,7 +121,7 @@ class VaultAddEditViewModel @Inject constructor(
             // Check for totp data to pre-populate
             val totpData = specialCircumstance?.toTotpDataOrNull()
             // Check for Fido2 data to pre-populate
-            val fido2CreationRequest = specialCircumstance?.toFido2RequestOrNull()
+            val fido2CreationRequest = specialCircumstance?.toFido2CreateRequestOrNull()
             val fido2AttestationOptions = fido2CreationRequest?.let { request ->
                 fido2CredentialManager.getPasskeyAttestationOptionsOrNull(request.requestJson)
             }
@@ -419,7 +419,7 @@ class VaultAddEditViewModel @Inject constructor(
         }
 
         specialCircumstanceManager.specialCircumstance
-            ?.toFido2RequestOrNull()
+            ?.toFido2CreateRequestOrNull()
             ?.let { request ->
                 handleFido2RequestSpecialCircumstance(request, content.toCipherView())
                 return@onContent
@@ -583,7 +583,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleConfirmOverwriteExistingPasskeyClick() {
         specialCircumstanceManager
             .specialCircumstance
-            ?.toFido2RequestOrNull()
+            ?.toFido2CreateRequestOrNull()
             ?.let { request ->
                 onContent { content ->
                     registerFido2Credential(request, content.toCipherView())
@@ -605,7 +605,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun getRequestAndRegisterCredential() =
         specialCircumstanceManager
             .specialCircumstance
-            ?.toFido2RequestOrNull()
+            ?.toFido2CreateRequestOrNull()
             ?.let { request ->
                 onContent { content ->
                     registerFido2CredentialToCipher(

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -16,12 +16,11 @@ import com.x8bit.bitwarden.data.auth.util.getPasswordlessRequestDataIntentOrNull
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.fido2.util.getFido2AssertionRequestOrNull
 import com.x8bit.bitwarden.data.autofill.fido2.util.getFido2CredentialRequestOrNull
@@ -609,14 +608,10 @@ class MainViewModelTest : BaseViewModelTest() {
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
         )
-        val fido2Intent = createMockIntent(mockFido2CreateCredentialRequest = fido2CreateCredentialRequest)
+        val fido2Intent =
+            createMockIntent(mockFido2CreateCredentialRequest = fido2CreateCredentialRequest)
 
-        coEvery {
-            fido2CredentialManager.validateOrigin(
-                fido2CreateCredentialRequest.callingAppInfo,
-                fido2CreateCredentialRequest.requestJson,
-            )
-        } returns Fido2ValidateOriginResult.Success
+        every { intentManager.getShareDataFromIntent(fido2Intent) } returns null
 
         viewModel.trySendAction(
             MainAction.ReceiveFirstIntent(
@@ -636,7 +631,7 @@ class MainViewModelTest : BaseViewModelTest() {
     fun `on ReceiveFirstIntent with fido2 request data should set the user to unverified`() {
         val viewModel = createViewModel()
         val fido2Intent = createMockIntent(
-            mockFido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+            mockFido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
         )
 
         viewModel.trySendAction(
@@ -662,13 +657,10 @@ class MainViewModelTest : BaseViewModelTest() {
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
         )
-        val mockIntent = createMockIntent(mockFido2CreateCredentialRequest = fido2CreateCredentialRequest)
-        coEvery {
-            fido2CredentialManager.validateOrigin(
-                fido2CreateCredentialRequest.callingAppInfo,
-                fido2CreateCredentialRequest.requestJson,
+        val mockIntent =
+            createMockIntent(
+                mockFido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
-        } returns Fido2ValidateOriginResult.Success
 
         viewModel.trySendAction(
             MainAction.ReceiveFirstIntent(
@@ -690,13 +682,9 @@ class MainViewModelTest : BaseViewModelTest() {
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
         )
-        val mockIntent = createMockIntent(mockFido2CreateCredentialRequest = fido2CreateCredentialRequest)
-        coEvery {
-            fido2CredentialManager.validateOrigin(
-                fido2CreateCredentialRequest.callingAppInfo,
-                fido2CreateCredentialRequest.requestJson,
-            )
-        } returns Fido2ValidateOriginResult.Success
+        val mockIntent = createMockIntent(
+            mockFido2CreateCredentialRequest = fido2CreateCredentialRequest,
+        )
 
         viewModel.trySendAction(
             MainAction.ReceiveFirstIntent(

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManagerTest.kt
@@ -1,0 +1,332 @@
+package com.x8bit.bitwarden.data.autofill.fido2.manager
+
+import android.content.pm.Signature
+import android.util.Base64
+import androidx.credentials.provider.CallingAppInfo
+import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
+import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
+import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+import com.x8bit.bitwarden.data.platform.manager.AssetManager
+import com.x8bit.bitwarden.data.platform.util.asFailure
+import com.x8bit.bitwarden.data.platform.util.asSuccess
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.security.MessageDigest
+
+class Fido2OriginManagerTest {
+
+    private val mockAssetManager = mockk<AssetManager>()
+    private val mockDigitalAssetLinkService = mockk<DigitalAssetLinkService>()
+    private val mockPrivilegedAppInfo = mockk<CallingAppInfo> {
+        every { isOriginPopulated() } returns true
+        every { packageName } returns DEFAULT_PACKAGE_NAME
+        every { getOrigin(any()) } returns DEFAULT_ORIGIN
+    }
+    private val mockNonPrivilegedAppInfo = mockk<CallingAppInfo> {
+        every { isOriginPopulated() } returns false
+        every { packageName } returns DEFAULT_PACKAGE_NAME
+        every { getOrigin(any()) } returns null
+        every { signingInfo } returns mockk {
+            every { apkContentsSigners } returns arrayOf(Signature(DEFAULT_APP_SIGNATURE))
+            every { hasMultipleSigners() } returns false
+        }
+    }
+    private val mockMessageDigest = mockk<MessageDigest> {
+        every { digest(any()) } returns DEFAULT_APP_SIGNATURE.toByteArray()
+    }
+
+    private val fido2OriginManager = Fido2OriginManagerImpl(
+        assetManager = mockAssetManager,
+        digitalAssetLinkService = mockDigitalAssetLinkService,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(
+            MessageDigest::class,
+            Base64::class,
+        )
+        every { MessageDigest.getInstance(any()) } returns mockMessageDigest
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(
+            MessageDigest::class,
+            Base64::class,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return Success when calling app is Privileged and is in Google allow list`() =
+        runTest {
+            coEvery {
+                mockAssetManager.readAsset(GOOGLE_ALLOW_LIST_FILENAME)
+            } returns DEFAULT_ALLOW_LIST.asSuccess()
+
+            val result = fido2OriginManager.validateOrigin(
+                callingAppInfo = mockPrivilegedAppInfo,
+                relyingPartyId = "relyingPartyId",
+            )
+            coVerify(exactly = 1) {
+                mockAssetManager.readAsset(GOOGLE_ALLOW_LIST_FILENAME)
+            }
+            assertEquals(
+                Fido2ValidateOriginResult.Success,
+                result,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return Success when calling app is Privileged and is in the Community allow list but not the Google allow list`() =
+        runTest {
+            coEvery {
+                mockAssetManager.readAsset(GOOGLE_ALLOW_LIST_FILENAME)
+            } returns FAIL_ALLOW_LIST.asSuccess()
+            coEvery {
+                mockAssetManager.readAsset(COMMUNITY_ALLOW_LIST_FILENAME)
+            } returns DEFAULT_ALLOW_LIST.asSuccess()
+
+            val result = fido2OriginManager.validateOrigin(
+                callingAppInfo = mockPrivilegedAppInfo,
+                relyingPartyId = "relyingPartyId",
+            )
+            coVerify(exactly = 1) {
+                mockAssetManager.readAsset(GOOGLE_ALLOW_LIST_FILENAME)
+                mockAssetManager.readAsset(COMMUNITY_ALLOW_LIST_FILENAME)
+            }
+            assertEquals(
+                Fido2ValidateOriginResult.Success,
+                result,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return ApplicationNotFound when calling app is Privileged but not in either allow list`() =
+        runTest {
+            coEvery {
+                mockAssetManager.readAsset(GOOGLE_ALLOW_LIST_FILENAME)
+            } returns FAIL_ALLOW_LIST.asSuccess()
+            coEvery {
+                mockAssetManager.readAsset(COMMUNITY_ALLOW_LIST_FILENAME)
+            } returns FAIL_ALLOW_LIST.asSuccess()
+
+            val result = fido2OriginManager.validateOrigin(
+                callingAppInfo = mockPrivilegedAppInfo,
+                relyingPartyId = "relyingPartyId",
+            )
+
+            coVerify(exactly = 1) {
+                mockAssetManager.readAsset(GOOGLE_ALLOW_LIST_FILENAME)
+                mockAssetManager.readAsset(COMMUNITY_ALLOW_LIST_FILENAME)
+            }
+            assertEquals(
+                Fido2ValidateOriginResult.Error.PrivilegedAppNotAllowed,
+                result,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return Success when calling app is NonPrivileged and has a valid asset link entry`() =
+        runTest {
+            coEvery {
+                mockDigitalAssetLinkService.getDigitalAssetLinkForRp(relyingParty = DEFAULT_RP_ID)
+            } returns listOf(DEFAULT_STATEMENT).asSuccess()
+
+            val result = fido2OriginManager.validateOrigin(
+                callingAppInfo = mockNonPrivilegedAppInfo,
+                relyingPartyId = DEFAULT_RP_ID,
+            )
+
+            assertEquals(
+                Fido2ValidateOriginResult.Success,
+                result,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return ApplicationNotVerified when calling app is NonPrivileged but signature does not match asset link entry`() =
+        runTest {
+            coEvery {
+                mockDigitalAssetLinkService.getDigitalAssetLinkForRp(relyingParty = DEFAULT_RP_ID)
+            } returns listOf(
+                DEFAULT_STATEMENT.copy(
+                    target = DEFAULT_STATEMENT.target.copy(
+                        sha256CertFingerprints = listOf("invalid_fingerprint"),
+                    ),
+                ),
+            )
+                .asSuccess()
+
+            assertEquals(
+                Fido2ValidateOriginResult.Error.ApplicationNotVerified,
+                fido2OriginManager.validateOrigin(
+                    callingAppInfo = mockNonPrivilegedAppInfo,
+                    relyingPartyId = DEFAULT_RP_ID,
+                ),
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return ApplicationNotFound when calling app is NonPrivileged and packageName has no asset link entry`() =
+        runTest {
+            coEvery {
+                mockDigitalAssetLinkService.getDigitalAssetLinkForRp(relyingParty = DEFAULT_RP_ID)
+            } returns listOf(
+                DEFAULT_STATEMENT.copy(
+                    target = DEFAULT_STATEMENT.target.copy(
+                        packageName = "invalid_package_name",
+                    ),
+                ),
+            )
+                .asSuccess()
+
+            assertEquals(
+                Fido2ValidateOriginResult.Error.ApplicationNotFound,
+                fido2OriginManager.validateOrigin(
+                    callingAppInfo = mockNonPrivilegedAppInfo,
+                    relyingPartyId = DEFAULT_RP_ID,
+                ),
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return AssetLinkNotFound when calling app is NonPrivileged and asset link does not exist`() =
+        runTest {
+            coEvery {
+                mockDigitalAssetLinkService.getDigitalAssetLinkForRp(relyingParty = DEFAULT_RP_ID)
+            } returns RuntimeException().asFailure()
+
+            assertEquals(
+                Fido2ValidateOriginResult.Error.AssetLinkNotFound,
+                fido2OriginManager.validateOrigin(
+                    callingAppInfo = mockNonPrivilegedAppInfo,
+                    relyingPartyId = DEFAULT_RP_ID,
+                ),
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return Unknown error when calling app is NonPrivileged and exception is caught while filtering asset links`() =
+        runTest {
+            coEvery {
+                mockDigitalAssetLinkService.getDigitalAssetLinkForRp(relyingParty = DEFAULT_RP_ID)
+            } returns listOf(DEFAULT_STATEMENT).asSuccess()
+            every {
+                mockNonPrivilegedAppInfo.packageName
+            } throws IllegalStateException()
+
+            assertEquals(
+                Fido2ValidateOriginResult.Error.Unknown,
+                fido2OriginManager.validateOrigin(
+                    callingAppInfo = mockNonPrivilegedAppInfo,
+                    relyingPartyId = DEFAULT_RP_ID,
+                ),
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return Unknown error when calling app is Privileged and allow list file read fails`() =
+        runTest {
+            coEvery {
+                mockDigitalAssetLinkService.getDigitalAssetLinkForRp(relyingParty = DEFAULT_RP_ID)
+            } returns listOf(DEFAULT_STATEMENT).asSuccess()
+            coEvery {
+                mockAssetManager.readAsset(GOOGLE_ALLOW_LIST_FILENAME)
+            } returns IllegalStateException().asFailure()
+            coEvery {
+                mockAssetManager.readAsset(COMMUNITY_ALLOW_LIST_FILENAME)
+            } returns IllegalStateException().asFailure()
+
+            assertEquals(
+                Fido2ValidateOriginResult.Error.Unknown,
+                fido2OriginManager.validateOrigin(
+                    callingAppInfo = mockPrivilegedAppInfo,
+                    relyingPartyId = DEFAULT_RP_ID,
+                ),
+            )
+        }
+}
+
+private const val DEFAULT_PACKAGE_NAME = "com.x8bit.bitwarden"
+private const val DEFAULT_APP_SIGNATURE = "0987654321ABCDEF"
+private const val DEFAULT_CERT_FINGERPRINT = "30:39:38:37:36:35:34:33:32:31:41:42:43:44:45:46"
+private const val DEFAULT_RP_ID = "bitwarden.com"
+private const val DEFAULT_ORIGIN = "bitwarden.com"
+private const val GOOGLE_ALLOW_LIST_FILENAME = "fido2_privileged_google.json"
+private const val COMMUNITY_ALLOW_LIST_FILENAME = "fido2_privileged_community.json"
+private const val DEFAULT_ALLOW_LIST = """
+{
+  "apps": [
+    {
+      "type": "android",
+      "info": {
+        "package_name": "com.x8bit.bitwarden",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "F0:FD:6C:5B:41:0F:25:CB:25:C3:B5:33:46:C8:97:2F:AE:30:F8:EE:74:11:DF:91:04:80:AD:6B:2D:60:DB:83"
+          },
+          {
+            "build": "userdebug",
+            "cert_fingerprint_sha256": "19:75:B2:F1:71:77:BC:89:A5:DF:F3:1F:9E:64:A6:CA:E2:81:A5:3D:C1:D1:D5:9B:1D:14:7F:E1:C8:2A:FA:00"
+          }
+        ]
+      }
+    }
+  ]
+}
+"""
+private const val FAIL_ALLOW_LIST = """
+{
+  "apps": [
+    {
+      "type": "android",
+      "info": {
+        "package_name": "com.not.bitwarden",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF"
+          },
+          {
+            "build": "userdebug",
+            "cert_fingerprint_sha256": "FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF"
+          }
+        ]
+      }
+    }
+  ]
+} 
+"""
+private val DEFAULT_STATEMENT = DigitalAssetLinkResponseJson(
+    relation = listOf(
+        "delegate_permission/common.get_login_creds",
+        "delegate_permission/common.handle_all_urls",
+    ),
+    target = DigitalAssetLinkResponseJson.Target(
+        namespace = "android_app",
+        packageName = DEFAULT_PACKAGE_NAME,
+        sha256CertFingerprints = listOf(
+            DEFAULT_CERT_FINGERPRINT,
+        ),
+    ),
+)

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialRequestUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialRequestUtil.kt
@@ -5,7 +5,7 @@ import android.content.pm.SigningInfo
 /**
  * Creates a mock [Fido2CreateCredentialRequest] with a given [number].
  */
-fun createMockFido2CredentialRequest(
+fun createMockFido2CreateCredentialRequest(
     number: Int,
     origin: String? = null,
     signingInfo: SigningInfo = SigningInfo(),

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2GetCredentialsRequestUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2GetCredentialsRequestUtil.kt
@@ -8,11 +8,12 @@ fun createMockFido2GetCredentialsRequest(
     userId: String = "mockUserId-$number",
     signingInfo: SigningInfo = SigningInfo(),
     origin: String? = null,
+    requestJson: String = "requestJson-$number",
 ): Fido2GetCredentialsRequest = Fido2GetCredentialsRequest(
     candidateQueryData = Bundle(),
     id = "mockId-$number",
     userId = userId,
-    requestJson = "requestJson-$number",
+    requestJson = requestJson,
     clientDataHash = null,
     packageName = "mockPackageName-$number",
     signingInfo = signingInfo,

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/processor/Fido2ProviderProcessorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/processor/Fido2ProviderProcessorTest.kt
@@ -76,9 +76,7 @@ class Fido2ProviderProcessorTest {
         every { ciphersStateFlow } returns mutableCiphersStateFlow
     }
     private val passkeyAssertionOptions = createMockPasskeyAssertionOptions(number = 1)
-    private val fido2CredentialManager: Fido2CredentialManager = mockk {
-        every { getPasskeyAssertionOptionsOrNull(any()) } returns passkeyAssertionOptions
-    }
+    private val fido2CredentialManager: Fido2CredentialManager = mockk()
     private val fido2CredentialStore: Fido2CredentialStore = mockk()
     private val intentManager: IntentManager = mockk()
     private val dispatcherManager: DispatcherManager = FakeDispatcherManager()
@@ -92,8 +90,6 @@ class Fido2ProviderProcessorTest {
         fido2Processor = Fido2ProviderProcessorImpl(
             context,
             authRepository,
-            vaultRepository,
-            fido2CredentialStore,
             fido2CredentialManager,
             intentManager,
             clock,
@@ -366,9 +362,6 @@ class Fido2ProviderProcessorTest {
         val request: BeginGetCredentialRequest = mockk {
             every { beginGetCredentialOptions } returns listOf(mockOption)
         }
-        every {
-            fido2CredentialManager.getPasskeyAssertionOptionsOrNull(any())
-        } returns null
         val callback: OutcomeReceiver<BeginGetCredentialResponse, GetCredentialException> = mockk()
         val captureSlot = slot<GetCredentialException>()
         mutableUserStateFlow.value = DEFAULT_USER_STATE

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
@@ -140,7 +140,7 @@ class SpecialCircumstanceExtensionsTest {
             SpecialCircumstance.VaultShortcut,
         )
             .forEach { specialCircumstance ->
-                assertNull(specialCircumstance.toFido2RequestOrNull())
+                assertNull(specialCircumstance.toFido2CreateRequestOrNull())
             }
     }
 
@@ -159,7 +159,7 @@ class SpecialCircumstanceExtensionsTest {
                 .Fido2Save(
                     fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
-                .toFido2RequestOrNull(),
+                .toFido2CreateRequestOrNull(),
         )
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensionsTest.kt
@@ -218,7 +218,7 @@ class CallingAppInfoExtensionsTest {
             }
         }
 
-        assertNull(mockAppInfo.getAppSigningSignatureFingerprint())
+        assertNull(mockAppInfo.getAppSigningSignatureFingerprintOrNull())
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherViewUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherViewUtil.kt
@@ -125,13 +125,14 @@ fun createMockSdkFido2CredentialList(
 fun createMockSdkFido2Credential(
     number: Int,
     clock: Clock = FIXED_CLOCK,
+    rpId: String = "mockRpId-$number",
 ): Fido2Credential = Fido2Credential(
     credentialId = "mockCredentialId-$number",
     keyType = "mockKeyType-$number",
     keyAlgorithm = "mockKeyAlgorithm-$number",
     keyCurve = "mockKeyCurve-$number",
     keyValue = "mockKeyValue-$number",
-    rpId = "mockRpId-$number",
+    rpId = rpId,
     userHandle = "mockUserHandle-$number",
     userName = "mockUserName-$number",
     counter = "mockCounter-$number",
@@ -147,11 +148,12 @@ fun createMockSdkFido2Credential(
 fun createMockFido2CredentialAutofillView(
     number: Int,
     cipherId: String? = null,
+    rpId: String = "mockRpId-$number",
 ): Fido2CredentialAutofillView =
     Fido2CredentialAutofillView(
         credentialId = "mockCredentialId-$number".encodeToByteArray(),
         cipherId = cipherId ?: "mockCipherId-$number",
-        rpId = "mockRpId-$number",
+        rpId = rpId,
         userNameForUi = "mockUserNameForUi-$number",
         userHandle = "mockUserHandle-$number".encodeToByteArray(),
     )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -21,7 +21,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
-import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
@@ -931,7 +931,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2, SaveClick should skip user verification when user is verified`() =
         runTest {
-            val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val fido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = fido2CredentialRequest,
@@ -983,7 +983,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2, SaveClick should show fido2 error dialog when create options are null`() =
         runTest {
-            val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val fido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = fido2CredentialRequest,
@@ -1027,7 +1027,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2, SaveClick should emit fido user verification as optional when verification is PREFERRED`() =
         runTest {
-            val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val fido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = fido2CredentialRequest,
@@ -1072,7 +1072,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2, SaveClick should emit fido user verification as required when request user verification option is REQUIRED`() =
         runTest {
-            val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val fido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = fido2CredentialRequest,
@@ -1798,7 +1798,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     ),
                 ),
             )
-            val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = mockFido2CredentialRequest,
@@ -1849,7 +1849,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 notes = "mockNotes-1",
             ),
         )
-        val mockFidoRequest = createMockFido2CredentialRequest(number = 1)
+        val mockFidoRequest = createMockFido2CreateCredentialRequest(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
             fido2CreateCredentialRequest = mockFidoRequest,
         )
@@ -1920,7 +1920,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     notes = "mockNotes-1",
                 ),
             )
-            val mockFidoRequest = createMockFido2CredentialRequest(number = 1)
+            val mockFidoRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = mockFidoRequest,
             )
@@ -4062,7 +4062,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         fun `UserVerificationSuccess should display Fido2ErrorDialog when activeUserId is null`() {
             every { authRepository.activeUserId } returns null
             specialCircumstanceManager.specialCircumstance =
-                SpecialCircumstance.Fido2Save(createMockFido2CredentialRequest(number = 1))
+                SpecialCircumstance.Fido2Save(createMockFido2CreateCredentialRequest(number = 1))
 
             viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationSuccess)
 
@@ -4079,7 +4079,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `UserVerificationSuccess should set isUserVerified to true, and register FIDO 2 credential`() =
             runTest {
-                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Success(
                     registrationResponse = "mockResponse",
                 )
@@ -4123,7 +4123,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `Fido2RegisterCredentialResult Error should show toast and emit CompleteFido2Registration result`() =
             runTest {
-                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Error
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = mockRequest,
@@ -4160,7 +4160,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `Fido2RegisterCredentialResult Success should show toast and emit CompleteFido2Registration result`() =
             runTest {
-                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Success(
                     registrationResponse = "mockResponse",
                 )
@@ -4199,7 +4199,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `Fido2RegisterCredentialResult Cancelled should emit CompleteFido2Registration result`() =
             runTest {
-                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Cancelled
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = mockRequest,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -1892,7 +1892,7 @@ class VaultItemListingScreenTest : BaseComposeTest() {
         val result = Fido2GetCredentialsResult.Success(
             userId = "mockUserId",
             options = mockk(),
-            credentials = mockk(),
+            credentialEntries = mockk(),
         )
         mutableEventFlow.tryEmit(VaultItemListingEvent.CompleteFido2GetCredentialsRequest(result))
         verify {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -22,10 +22,9 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionRes
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
-import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
@@ -64,7 +63,6 @@ import com.x8bit.bitwarden.ui.platform.base.util.concat
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAssertionOptions
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAttestationOptions
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.util.createMockDisplayItemForCipher
@@ -165,7 +163,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         every { getActivePoliciesFlow(type = PolicyTypeJson.DISABLE_SEND) } returns emptyFlow()
     }
     private val fido2CredentialManager: Fido2CredentialManager = mockk {
-        coEvery { validateOrigin(any(), any()) } returns Fido2ValidateOriginResult.Success
         every { isUserVerified } returns false
         every { isUserVerified = any() } just runs
         every { authenticationAttempts } returns 0
@@ -449,7 +446,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `ItemClick for vault item during FIDO 2 registration should show FIDO 2 error dialog when cipherView is null`() {
         val cipherView = createMockCipherView(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+            fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
         )
         mutableVaultDataStateFlow.value = DataState.Loaded(
             data = VaultData(
@@ -478,7 +475,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         setupMockUri()
         val cipherView = createMockCipherView(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+            fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
         )
         mutableVaultDataStateFlow.value = DataState.Loaded(
             data = VaultData(
@@ -513,7 +510,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2Credentials = createMockSdkFido2CredentialList(number = 1),
             )
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -556,7 +553,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1, fido2Credentials = null)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -604,7 +601,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1)
-            val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = mockFido2CredentialRequest,
             )
@@ -647,7 +644,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `ItemClick for vault item during FIDO 2 registration should skip user verification when user is verified`() {
         setupMockUri()
         val cipherView = createMockCipherView(number = 1)
-        val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+        val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
             fido2CreateCredentialRequest = mockFido2CredentialRequest,
         )
@@ -1561,9 +1558,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     cipherViewList = listOf(cipherView1, cipherView2),
                 )
             } returns DecryptFido2CredentialAutofillViewResult.Success(emptyList())
-            coEvery {
-                fido2CredentialManager.validateOrigin(any(), any())
-            } returns Fido2ValidateOriginResult.Success
 
             mockFilteredCiphers = listOf(cipherView1)
 
@@ -1618,7 +1612,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 vaultRepository.getDecryptedFido2CredentialAutofillViews(
                     cipherViewList = listOf(cipherView1, cipherView2),
                 )
-                fido2CredentialManager.validateOrigin(any(), any())
             }
         }
 
@@ -1637,11 +1630,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2Credentials = createMockSdkFido2CredentialList(number = 1),
             )
 
-            every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns createMockPasskeyAssertionOptions(
-                number = 1,
-            )
             coEvery {
                 vaultRepository.getDecryptedFido2CredentialAutofillViews(
                     cipherViewList = listOf(cipherView1, cipherView2),
@@ -2163,7 +2151,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         createVaultItemListingViewModel()
 
         coVerify(ordering = Ordering.ORDERED) {
-            fido2CredentialManager.validateOrigin(any(), any())
             vaultRepository.vaultDataStateFlow
         }
     }
@@ -2179,10 +2166,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
             fido2CreateCredentialRequest = mock,
         )
-
-        coEvery {
-            fido2CredentialManager.validateOrigin(any(), any())
-        } returns Fido2ValidateOriginResult.Error.Unknown
 
         val viewModel = createVaultItemListingViewModel()
 
@@ -2211,10 +2194,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
-            coEvery {
-                fido2CredentialManager.validateOrigin(any(), any())
-            } returns Fido2ValidateOriginResult.Error.PrivilegedAppNotAllowed
-
             val viewModel = createVaultItemListingViewModel()
 
             assertEquals(
@@ -2241,10 +2220,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
-
-            coEvery {
-                fido2CredentialManager.validateOrigin(any(), any())
-            } returns Fido2ValidateOriginResult.Error.PrivilegedAppSignatureNotFound
 
             val viewModel = createVaultItemListingViewModel()
 
@@ -2273,10 +2248,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
-            coEvery {
-                fido2CredentialManager.validateOrigin(any(), any())
-            } returns Fido2ValidateOriginResult.Error.PasskeyNotSupportedForApp
-
             val viewModel = createVaultItemListingViewModel()
 
             assertEquals(
@@ -2303,10 +2274,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
-
-            coEvery {
-                fido2CredentialManager.validateOrigin(any(), any())
-            } returns Fido2ValidateOriginResult.Error.ApplicationNotFound
 
             val viewModel = createVaultItemListingViewModel()
 
@@ -2335,10 +2302,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
 
-            coEvery {
-                fido2CredentialManager.validateOrigin(any(), any())
-            } returns Fido2ValidateOriginResult.Error.AssetLinkNotFound
-
             val viewModel = createVaultItemListingViewModel()
 
             assertEquals(
@@ -2365,10 +2328,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = fido2CreateCredentialRequest,
             )
-
-            coEvery {
-                fido2CredentialManager.validateOrigin(any(), any())
-            } returns Fido2ValidateOriginResult.Error.ApplicationNotVerified
 
             val viewModel = createVaultItemListingViewModel()
 
@@ -2461,7 +2420,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `DismissFido2ErrorDialogClick should clear the dialog state then complete FIDO 2 registration based on state`() =
         runTest {
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                createMockFido2CredentialRequest(number = 1),
+                createMockFido2CreateCredentialRequest(number = 1),
             )
             val viewModel = createVaultItemListingViewModel()
             viewModel.trySendAction(VaultItemListingsAction.DismissFido2ErrorDialogClick)
@@ -2539,14 +2498,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 mockAssertionRequest,
             )
             every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    mockAssertionRequest.requestJson,
-                )
-            } returns createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.REQUIRED,
-            )
-            every {
                 vaultRepository
                     .ciphersStateFlow
                     .value
@@ -2590,14 +2541,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 mockAssertionRequest,
             )
             every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    mockAssertionRequest.requestJson,
-                )
-            } returns createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-            )
-            every {
                 vaultRepository
                     .ciphersStateFlow
                     .value
@@ -2633,22 +2576,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val mockAssertionRequest = createMockFido2CredentialAssertionRequest(number = 1)
                 .copy(cipherId = "mockId-1")
             val mockFido2CredentialList = createMockSdkFido2CredentialList(number = 1)
-            val mockCipherView = createMockCipherView(
-                number = 1,
-                fido2Credentials = mockFido2CredentialList,
-            )
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Assertion(
                 mockAssertionRequest,
             )
             every { authRepository.activeUserId } returns "activeUserId"
-            every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    mockAssertionRequest.requestJson,
-                )
-            } returns createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
-            )
             every {
                 vaultRepository
                     .ciphersStateFlow
@@ -2661,22 +2592,14 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             coEvery {
-                fido2CredentialManager.authenticateFido2Credential(
-                    userId = "activeUserId",
-                    request = mockAssertionRequest,
-                    selectedCipherView = mockCipherView,
-                )
+                fido2CredentialManager.authenticateFido2Credential(request = mockAssertionRequest)
             } returns Fido2CredentialAssertionResult.Success(responseJson = "responseJson")
 
             createVaultItemListingViewModel()
 
             coVerify {
                 fido2CredentialManager.isUserVerified
-                fido2CredentialManager.authenticateFido2Credential(
-                    userId = "activeUserId",
-                    request = mockAssertionRequest,
-                    selectedCipherView = mockCipherView,
-                )
+                fido2CredentialManager.authenticateFido2Credential(request = mockAssertionRequest)
             }
         }
 
@@ -2701,13 +2624,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     fido2Credentials = mockFido2CredentialList,
                 ),
             )
-            every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    mockAssertionRequest.requestJson,
-                )
-            } returns null
 
             val viewModel = createVaultItemListingViewModel()
+
             assertEquals(
                 VaultItemListingState.DialogState.Fido2OperationFail(
                     title = R.string.an_error_has_occurred.asText(),
@@ -2738,17 +2657,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2Credentials = mockFido2CredentialList,
             ),
         )
-        every {
-            fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                mockAssertionRequest.requestJson,
-            )
-        } returns createMockPasskeyAssertionOptions(
-            number = 1,
-            userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
-            relyingPartyId = null,
-        )
 
         val viewModel = createVaultItemListingViewModel()
+
         assertEquals(
             VaultItemListingState.DialogState.Fido2OperationFail(
                 title = R.string.an_error_has_occurred.asText(),
@@ -2765,10 +2676,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             val mockAssertionRequest = createMockFido2CredentialAssertionRequest(number = 1)
                 .copy(cipherId = "mockId-1")
-            val mockAssertionOptions = createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
-            )
             val mockFido2CredentialList = createMockSdkFido2CredentialList(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Assertion(
                 mockAssertionRequest,
@@ -2784,14 +2691,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     fido2Credentials = mockFido2CredentialList,
                 ),
             )
-            every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    requestJson = mockAssertionRequest.requestJson,
-                )
-            } returns mockAssertionOptions
-            coEvery {
-                fido2CredentialManager.validateOrigin(any(), any())
-            } returns Fido2ValidateOriginResult.Error.Unknown
 
             val viewModel = createVaultItemListingViewModel()
 
@@ -2831,11 +2730,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             createVaultItemListingViewModel()
 
             verify { vaultRepository.vaultDataStateFlow }
-            verify(exactly = 0) {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    requestJson = mockAssertionRequest.requestJson,
-                )
-            }
         }
 
     @Test
@@ -2900,28 +2794,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         val mockAssertionRequest = createMockFido2CredentialAssertionRequest(number = 1)
             .copy(cipherId = "mockId-1")
         val mockFido2CredentialList = createMockSdkFido2CredentialList(number = 1)
-        val mockCipherView = createMockCipherView(
-            number = 1,
-            fido2Credentials = mockFido2CredentialList,
-        )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Assertion(
             mockAssertionRequest,
         )
         every { fido2CredentialManager.isUserVerified } returns true
-        every {
-            fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                mockAssertionRequest.requestJson,
-            )
-        } returns createMockPasskeyAssertionOptions(
-            number = 1,
-            userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-        )
         coEvery {
-            fido2CredentialManager.authenticateFido2Credential(
-                userId = "activeUserId",
-                request = mockAssertionRequest,
-                selectedCipherView = mockCipherView,
-            )
+            fido2CredentialManager.authenticateFido2Credential(request = mockAssertionRequest)
         } returns Fido2CredentialAssertionResult.Success(responseJson = "responseJson")
 
         every {
@@ -2935,22 +2813,13 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2Credentials = mockFido2CredentialList,
             ),
         )
-        every {
-            fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                mockAssertionRequest.requestJson,
-            )
-        } returns createMockPasskeyAssertionOptions(number = 1)
         every { authRepository.activeUserId } returns "activeUserId"
 
         createVaultItemListingViewModel()
 
         coVerify {
             fido2CredentialManager.isUserVerified
-            fido2CredentialManager.authenticateFido2Credential(
-                userId = any(),
-                request = any(),
-                selectedCipherView = any(),
-            )
+            fido2CredentialManager.authenticateFido2Credential(request = any())
         }
     }
 
@@ -2964,14 +2833,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         )
         every { fido2CredentialManager.isUserVerified } returns true
         every {
-            fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                mockAssertionRequest.requestJson,
-            )
-        } returns createMockPasskeyAssertionOptions(
-            number = 1,
-            userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-        )
-        every {
             vaultRepository
                 .ciphersStateFlow
                 .value
@@ -2982,21 +2843,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2Credentials = mockFido2CredentialList,
             ),
         )
-        every {
-            fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                mockAssertionRequest.requestJson,
-            )
-        } returns createMockPasskeyAssertionOptions(number = 1)
         every { authRepository.activeUserId } returns null
 
         val viewModel = createVaultItemListingViewModel()
 
         coVerify(exactly = 0) {
-            fido2CredentialManager.authenticateFido2Credential(
-                userId = any(),
-                request = any(),
-                selectedCipherView = any(),
-            )
+            fido2CredentialManager.authenticateFido2Credential(request = any())
         }
 
         assertEquals(
@@ -3020,14 +2872,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         )
         every { fido2CredentialManager.isUserVerified } returns true
         every {
-            fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                mockAssertionRequest.requestJson,
-            )
-        } returns createMockPasskeyAssertionOptions(
-            number = 1,
-            userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-        )
-        every {
             vaultRepository
                 .ciphersStateFlow
                 .value
@@ -3039,11 +2883,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 repromptType = CipherRepromptType.PASSWORD,
             ),
         )
-        every {
-            fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                mockAssertionRequest.requestJson,
-            )
-        } returns createMockPasskeyAssertionOptions(number = 1)
         every { authRepository.activeUserId } returns null
 
         val viewModel = createVaultItemListingViewModel()
@@ -3088,40 +2927,19 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
             every { fido2CredentialManager.isUserVerified } returns true
             every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    mockAssertionRequest.requestJson,
-                )
-            } returns createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-            )
-            every {
                 vaultRepository
                     .ciphersStateFlow
                     .value
                     .data
             } returns listOf(mockCipherView)
-            every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    mockAssertionRequest.requestJson,
-                )
-            } returns createMockPasskeyAssertionOptions(number = 1)
             coEvery {
-                fido2CredentialManager.authenticateFido2Credential(
-                    DEFAULT_USER_STATE.activeUserId,
-                    mockAssertionRequest,
-                    mockCipherView,
-                )
+                fido2CredentialManager.authenticateFido2Credential(mockAssertionRequest)
             } returns Fido2CredentialAssertionResult.Success("responseJson")
 
             createVaultItemListingViewModel()
 
             coVerify {
-                fido2CredentialManager.authenticateFido2Credential(
-                    userId = any(),
-                    request = any(),
-                    selectedCipherView = any(),
-                )
+                fido2CredentialManager.authenticateFido2Credential(request = any())
             }
         }
 
@@ -3250,7 +3068,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `UserVerificationSuccess should display Fido2ErrorDialog when activeUserId is null`() {
         every { authRepository.activeUserId } returns null
         specialCircumstanceManager.specialCircumstance =
-            SpecialCircumstance.Fido2Save(createMockFido2CredentialRequest(number = 1))
+            SpecialCircumstance.Fido2Save(createMockFido2CreateCredentialRequest(number = 1))
 
         val viewModel = createVaultItemListingViewModel()
         viewModel.trySendAction(
@@ -3273,7 +3091,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `UserVerificationSuccess should set isUserVerified to true, and register FIDO 2 credential when verification result is received`() =
         runTest {
-            val mockRequest = createMockFido2CredentialRequest(number = 1)
+            val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = mockRequest,
             )
@@ -3326,20 +3144,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     fido2Credentials = mockFido2CredentialList,
                 ),
             )
-            every {
-                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(
-                    mockAssertionRequest.requestJson,
-                )
-            } returns createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-            )
             coEvery {
-                fido2CredentialManager.authenticateFido2Credential(
-                    any(),
-                    any(),
-                    any(),
-                )
+                fido2CredentialManager.authenticateFido2Credential(any())
             } returns Fido2CredentialAssertionResult.Success(
                 responseJson = "mockResponse",
             )
@@ -3353,11 +3159,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
             coVerify {
                 fido2CredentialManager.isUserVerified = true
-                fido2CredentialManager.authenticateFido2Credential(
-                    userId = DEFAULT_ACCOUNT.userId,
-                    request = mockAssertionRequest,
-                    selectedCipherView = any(),
-                )
+                fido2CredentialManager.authenticateFido2Credential(request = mockAssertionRequest)
             }
         }
 
@@ -3933,7 +3735,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -3967,7 +3769,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(


### PR DESCRIPTION
## 🎟️ Tracking

PM-13072

## 📔 Objective

This commit is part one of a multi-part UX improvement effort for passkeys. The following changes are made to prepare for extracting passkey authentication out of the vault item listing screen.

- Encapsulate more logic into `Fido2CredentialManagerImpl`.
- Change `Fido2GetCredentialsResult` to contain `List<CredentialEntry>` instead of `List<Fido2CredentialAutofillView>`.
- Add/update tests where appropriate.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
