### PR TITLE
PM-15431 allow background activities to start by NFC manager for the …

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/nfc/NfcManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/nfc/NfcManagerImpl.kt
@@ -1,10 +1,12 @@
 package com.x8bit.bitwarden.ui.platform.manager.nfc
 
 import android.app.Activity
+import android.app.ActivityOptions
 import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
 import android.nfc.NfcAdapter
+import android.os.Build
 import com.x8bit.bitwarden.AuthCallbackActivity
 import com.x8bit.bitwarden.data.autofill.util.toPendingIntentMutabilityFlag
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
@@ -23,6 +25,14 @@ class NfcManagerImpl(
 
     override fun start() {
         if (!supportsNfc) return
+        val options = ActivityOptions.makeBasic()
+        // When targeting API 35, we need to explicitly allow background activities to start on
+        // devices using API 34 and higher.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            options.setPendingIntentCreatorBackgroundActivityStartMode(
+                ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED,
+            )
+        }
         nfcAdapter?.enableForegroundDispatch(
             activity,
             PendingIntent.getActivity(
@@ -32,6 +42,7 @@ class NfcManagerImpl(
                     Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP,
                 ),
                 PendingIntent.FLAG_UPDATE_CURRENT.toPendingIntentMutabilityFlag(),
+                options.toBundle(),
             ),
             arrayOf(
                 IntentFilter(NfcAdapter.ACTION_NDEF_DISCOVERED).apply {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15431
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Since upgrading the target API to `35` the NFC tap of the YubiKey 2FA is not working, this is due to a [change](https://developer.android.com/about/versions/15/behavior-changes-15#other_changes) in the way devices running API 34 and 35 handle background activity launches.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
