### PR TITLE
PM-15147 - `MasterPasswordGuidanceScreen` PR Cleanup

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceScreen.kt
@@ -76,23 +76,25 @@ fun MasterPasswordGuidanceScreen(
         },
     ) {
         MasterPasswordGuidanceContent(
+            onTryPasswordGeneratorAction = remember(viewModel) {
+                {
+                    viewModel.trySendAction(
+                        MasterPasswordGuidanceAction.TryPasswordGeneratorAction,
+                    )
+                }
+            },
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
                 .standardHorizontalMargin(),
-            onTryPasswordGeneratorAction = {
-                viewModel.trySendAction(
-                    MasterPasswordGuidanceAction.TryPasswordGeneratorAction,
-                )
-            },
         )
     }
 }
 
 @Composable
 private fun MasterPasswordGuidanceContent(
-    modifier: Modifier = Modifier,
     onTryPasswordGeneratorAction: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
         Spacer(modifier = Modifier.height(24.dp))


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15147](https://bitwarden.atlassian.net/browse/PM-15147)

## 📔 Objective

- Address PR comments from previous [PR](https://github.com/bitwarden/android/pull/4383)
- Remembering viewModel to prevent unnecessary recompositions and fix order of function parameters

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15147]: https://bitwarden.atlassian.net/browse/PM-15147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ