### PR TITLE
PM-15380 Store qualifying events for showing the review prompt

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -325,4 +325,44 @@ interface SettingsDiskSource {
      * Emits updates that track [getVaultRegisteredForExport] for the given [userId].
      */
     fun getVaultRegisteredForExportFlow(userId: String): Flow<Boolean?>
+
+    /**
+     * Gets the number of qualifying add actions for the given [userId].
+     */
+    fun getAddActionCount(userId: String): Int?
+
+    /**
+     * Stores the given [count] completed "add" actions for the given [userId].
+     */
+    fun storeAddActionCount(userId: String, count: Int?)
+
+    /**
+     * Gets the number of qualifying copy actions for the given [userId].
+     */
+    fun getCopyActionCount(userId: String): Int?
+
+    /**
+     * Stores the given [count] completed "copy" actions for the given [userId].
+     */
+    fun storeCopyActionCount(userId: String, count: Int?)
+
+    /**
+     * Gets the number of qualifying create actions for the given [userId].
+     */
+    fun getCreateActionCount(userId: String): Int?
+
+    /**
+     * Stores the given [count] completed "create" actions for the given [userId].
+     */
+    fun storeCreateActionCount(userId: String, count: Int?)
+
+    /**
+     * Gets whether the given [userId] has been prompted for an app review.
+     */
+    fun getUserHasBeenPromptedForReview(userId: String): Boolean?
+
+    /**
+     * Stores whether the given [userId] has been prompted for an app review.
+     */
+    fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -37,6 +37,10 @@ private const val SHOW_AUTOFILL_SETTING_BADGE = "showAutofillSettingBadge"
 private const val SHOW_UNLOCK_SETTING_BADGE = "showUnlockSettingBadge"
 private const val SHOW_IMPORT_LOGINS_SETTING_BADGE = "showImportLoginsSettingBadge"
 private const val IS_VAULT_REGISTERED_FOR_EXPORT = "isVaultRegisteredForExport"
+private const val ADD_ACTION_COUNT = "addActionCount"
+private const val COPY_ACTION_COUNT = "copyActionCount"
+private const val CREATE_ACTION_COUNT = "createActionCount"
+private const val HAS_BEEN_PROMPTED_FOR_REVIEW = "hasBeenPromptedForReview"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -172,6 +176,10 @@ class SettingsDiskSourceImpl(
         storeClearClipboardFrequencySeconds(userId = userId, frequency = null)
         removeWithPrefix(prefix = ACCOUNT_BIOMETRIC_INTEGRITY_VALID_KEY.appendIdentifier(userId))
         storeVaultRegisteredForExport(userId = userId, isRegistered = null)
+        storeAddActionCount(userId = userId, count = null)
+        storeCopyActionCount(userId = userId, count = null)
+        storeCreateActionCount(userId = userId, count = null)
+        storeUserHasBeenPromptedForReview(userId = userId, value = null)
 
         // The following are intentionally not cleared so they can be
         // restored after logging out and back in:
@@ -445,6 +453,49 @@ class SettingsDiskSourceImpl(
     override fun getVaultRegisteredForExportFlow(userId: String): Flow<Boolean?> =
         getMutableVaultRegisteredForExportFlow(userId)
             .onSubscription { emit(getVaultRegisteredForExport(userId)) }
+
+    override fun getAddActionCount(userId: String): Int? = getInt(
+        key = ADD_ACTION_COUNT.appendIdentifier(userId),
+    )
+
+    override fun storeAddActionCount(userId: String, count: Int?) {
+        putInt(
+            key = ADD_ACTION_COUNT.appendIdentifier(userId),
+            value = count,
+        )
+    }
+
+    override fun getCopyActionCount(userId: String): Int? = getInt(
+        key = COPY_ACTION_COUNT.appendIdentifier(userId),
+    )
+
+    override fun storeCopyActionCount(userId: String, count: Int?) {
+        putInt(
+            key = COPY_ACTION_COUNT.appendIdentifier(userId),
+            value = count,
+        )
+    }
+
+    override fun getCreateActionCount(userId: String): Int? = getInt(
+        key = CREATE_ACTION_COUNT.appendIdentifier(userId),
+    )
+
+    override fun storeCreateActionCount(userId: String, count: Int?) {
+        putInt(
+            key = CREATE_ACTION_COUNT.appendIdentifier(userId),
+            value = count,
+        )
+    }
+
+    override fun getUserHasBeenPromptedForReview(userId: String): Boolean? =
+        getBoolean(key = HAS_BEEN_PROMPTED_FOR_REVIEW.appendIdentifier(userId))
+
+    override fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?) {
+        putBoolean(
+            key = HAS_BEEN_PROMPTED_FOR_REVIEW.appendIdentifier(userId),
+            value = value,
+        )
+    }
 
     private fun getMutableLastSyncFlow(
         userId: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -281,4 +281,25 @@ interface SettingsRepository {
      * Gets updates for the [isVaultRegisteredForExport] value for the given [userId].
      */
     fun getVaultRegisteredForExportFlow(userId: String): StateFlow<Boolean>
+
+    /**
+     * Increments the add action count for the active user.
+     */
+    fun incrementAddActionCount()
+
+    /**
+     * Increments the copy action count for the active user.
+     */
+    fun incrementCopyActionCount()
+
+    /**
+     * Increments the create action count for the active user.
+     */
+    fun incrementCreateActionCount()
+
+    /**
+     * Returns a boolean value indicating whether or not the user should be prompted to
+     * review the app.
+     */
+    fun shouldPromptForAppReview(): Boolean
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/IntExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/IntExtensions.kt
@@ -1,0 +1,7 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+/**
+ * Extension to be applied to a nullable [Int] type where if the value is null, a default
+ * value of "0" is returned.
+ */
+fun Int?.orZero() = this ?: 0

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1193,4 +1193,76 @@ class SettingsDiskSourceTest {
             assertFalse(awaitItem() ?: true)
         }
     }
+
+    @Test
+    fun `getAddActionCount should pull from SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val addActionCountKey = "bwPreferencesStorage:addActionCount_$mockUserId"
+        fakeSharedPreferences.edit { putInt(addActionCountKey, 1) }
+        assertEquals(
+            1, settingsDiskSource.getAddActionCount(mockUserId),
+        )
+    }
+
+    @Test
+    fun `storeAddActionCount should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val addActionCountKey = "bwPreferencesStorage:addActionCount_$mockUserId"
+        settingsDiskSource.storeAddActionCount(mockUserId, 1)
+        assertEquals(1, fakeSharedPreferences.getInt(addActionCountKey, 0))
+    }
+
+    @Test
+    fun `getCopyActionCount should pull from SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val copyActionCountKey = "bwPreferencesStorage:copyActionCount_$mockUserId"
+        fakeSharedPreferences.edit { putInt(copyActionCountKey, 1) }
+        assertEquals(
+            1, settingsDiskSource.getCopyActionCount(mockUserId),
+        )
+    }
+
+    @Test
+    fun `storeCopyActionCount should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val copyActionCountKey = "bwPreferencesStorage:copyActionCount_$mockUserId"
+        settingsDiskSource.storeCopyActionCount(mockUserId, 1)
+        assertEquals(1, fakeSharedPreferences.getInt(copyActionCountKey, 0))
+    }
+
+    @Test
+    fun `getCreateActionCount should pull from SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val createActionCountKey = "bwPreferencesStorage:createActionCount_$mockUserId"
+        fakeSharedPreferences.edit { putInt(createActionCountKey, 1) }
+        assertEquals(1, settingsDiskSource.getCreateActionCount(mockUserId))
+    }
+
+    @Test
+    fun `storeCreateActionCount should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val createActionCountKey = "bwPreferencesStorage:createActionCount_$mockUserId"
+        settingsDiskSource.storeCreateActionCount(mockUserId, 1)
+        assertEquals(1, fakeSharedPreferences.getInt(createActionCountKey, 0))
+    }
+
+    @Test
+    fun `getUserHasBeenPromptedForReview should pull from SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val hasUserBeenPromptedToReviewKey =
+            "bwPreferencesStorage:hasBeenPromptedForReview_$mockUserId"
+        fakeSharedPreferences.edit { putBoolean(hasUserBeenPromptedToReviewKey, true) }
+        assertTrue(settingsDiskSource.getUserHasBeenPromptedForReview(mockUserId)!!)
+    }
+
+    @Test
+    fun `storeUserHasBeenPromptedForReview should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val hasUserBeenPromptedToReviewKey =
+            "bwPreferencesStorage:hasBeenPromptedForReview_$mockUserId"
+        settingsDiskSource.storeUserHasBeenPromptedForReview(mockUserId, true)
+        assertTrue(
+            fakeSharedPreferences.getBoolean(hasUserBeenPromptedToReviewKey, false),
+        )
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -65,6 +65,10 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val userShowUnlockBadge = mutableMapOf<String, Boolean?>()
     private val userShowImportLoginsBadge = mutableMapOf<String, Boolean?>()
     private val vaultRegisteredForExport = mutableMapOf<String, Boolean?>()
+    private val addActionCount = mutableMapOf<String, Int?>()
+    private val copyActionCount = mutableMapOf<String, Int?>()
+    private val createActionCount = mutableMapOf<String, Int?>()
+    private val userHasBeenPromptedForReview = mutableMapOf<String, Boolean?>()
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -352,6 +356,38 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         getMutableVaultRegisteredForExportFlow(userId = userId).onSubscription {
             emit(getVaultRegisteredForExport(userId = userId))
         }
+
+    override fun getAddActionCount(userId: String): Int? {
+        return addActionCount[userId]
+    }
+
+    override fun storeAddActionCount(userId: String, count: Int?) {
+        addActionCount[userId] = count
+    }
+
+    override fun getCopyActionCount(userId: String): Int? {
+        return copyActionCount[userId]
+    }
+
+    override fun storeCopyActionCount(userId: String, count: Int?) {
+        copyActionCount[userId] = count
+    }
+
+    override fun getCreateActionCount(userId: String): Int? {
+        return createActionCount[userId]
+    }
+
+    override fun storeCreateActionCount(userId: String, count: Int?) {
+        createActionCount[userId] = count
+    }
+
+    override fun getUserHasBeenPromptedForReview(userId: String): Boolean? {
+        return userHasBeenPromptedForReview[userId]
+    }
+
+    override fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?) {
+        userHasBeenPromptedForReview[userId] = value
+    }
 
     //region Private helper functions
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1224,6 +1224,155 @@ class SettingsRepositoryTest {
                     assertFalse(awaitItem())
                 }
         }
+
+    @Test
+    fun `incrementAddActionCount increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        settingsRepository.incrementAddActionCount()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getAddActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementAddActionCount()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getAddActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementAddActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getAddActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementAddActionCount()
+        // Should not increment over 3.
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getAddActionCount(
+                userId = USER_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `incrementCopyActionCount increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        settingsRepository.incrementCopyActionCount()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getCopyActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementCopyActionCount()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getCopyActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementCopyActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCopyActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementCopyActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCopyActionCount(
+                userId = USER_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `incrementCreateActionCount increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        settingsRepository.incrementCreateActionCount()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getCreateActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementCreateActionCount()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getCreateActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementCreateActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCreateActionCount(
+                userId = USER_ID,
+            ),
+        )
+        settingsRepository.incrementCreateActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCreateActionCount(
+                userId = USER_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should default to false if no active user`() {
+        assertFalse(settingsRepository.shouldPromptForAppReview())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldPromptForAppReview should return true if one auto fill service is enabled and one actions requirement is met`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
+        autofillEnabledManager.isAutofillEnabled = false
+        fakeSettingsDiskSource.storeCopyActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeCreateActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeAddActionCount(USER_ID, 4)
+        assertTrue(settingsRepository.shouldPromptForAppReview())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldPromptForAppReview should return false if prompt has been shown but other criteria is met`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
+        fakeSettingsDiskSource.storeUserHasBeenPromptedForReview(USER_ID, true)
+        fakeSettingsDiskSource.storeAddActionCount(USER_ID, 4)
+        assertFalse(settingsRepository.shouldPromptForAppReview())
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should return false if no auto fill service is enabled`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = false
+        autofillEnabledManager.isAutofillEnabled = false
+        fakeSettingsDiskSource.storeCopyActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeCreateActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeAddActionCount(USER_ID, 4)
+        assertFalse(settingsRepository.shouldPromptForAppReview())
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should return false if no action count is met`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
+        autofillEnabledManager.isAutofillEnabled = true
+        fakeSettingsDiskSource.storeCopyActionCount(USER_ID, 1)
+        fakeSettingsDiskSource.storeCreateActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeAddActionCount(USER_ID, 2)
+        assertFalse(settingsRepository.shouldPromptForAppReview())
+    }
 }
 
 private const val USER_ID: String = "userId"

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/IntExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/IntExtensionsTest.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IntExtensionsTest {
+    @Test
+    fun `orZero returns zero when null`() {
+        val nullInt: Int? = null
+        assertEquals(0, nullInt.orZero())
+    }
+
+    @Test
+    fun `orZero returns value when not null`() {
+        val nonNullInt = 42
+        assertEquals(42, nonNullInt.orZero())
+        val negativeNonNullInt = -42
+        assertEquals(-42, negativeNonNullInt.orZero())
+        assertEquals(0, 0.orZero())
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking
This is part 1 of https://bitwarden.atlassian.net/browse/PM-15380, second change will be placing the calls to increment the counts.
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- store when a qualifying action has been completed by a user and be able to retrieve it to determine if we should show the app review prompt.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
