### PR TITLE
PM-15380 Track user interactions which would trigger a potential showing of the app review prompt.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -325,4 +325,35 @@ interface SettingsDiskSource {
      * Emits updates that track [getVaultRegisteredForExport] for the given [userId].
      */
     fun getVaultRegisteredForExportFlow(userId: String): Flow<Boolean?>
+
+    /**
+     * Gets the number of qualifying add cipher actions for the device.
+     */
+    fun getAddCipherActionCount(): Int?
+
+    /**
+     * Stores the given [count] completed "add" cipher actions taken place on the device.
+     */
+    fun storeAddCipherActionCount(count: Int?)
+
+    /**
+     * Gets the number of qualifying generated result actions for the device.
+     */
+    fun getGeneratedResultActionCount(): Int?
+
+    /**
+     * Stores the given [count] completed generated password or username result actions taken
+     * for the device.
+     */
+    fun storeGeneratedResultActionCount(count: Int?)
+
+    /**
+     * Gets the number of qualifying create send actions for the device.
+     */
+    fun getCreateSendActionCount(): Int?
+
+    /**
+     * Stores the given [count] completed create send actions for the device.
+     */
+    fun storeCreateSendActionCount(count: Int?)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -37,6 +37,9 @@ private const val SHOW_AUTOFILL_SETTING_BADGE = "showAutofillSettingBadge"
 private const val SHOW_UNLOCK_SETTING_BADGE = "showUnlockSettingBadge"
 private const val SHOW_IMPORT_LOGINS_SETTING_BADGE = "showImportLoginsSettingBadge"
 private const val IS_VAULT_REGISTERED_FOR_EXPORT = "isVaultRegisteredForExport"
+private const val ADD_ACTION_COUNT = "addActionCount"
+private const val COPY_ACTION_COUNT = "copyActionCount"
+private const val CREATE_ACTION_COUNT = "createActionCount"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -445,6 +448,39 @@ class SettingsDiskSourceImpl(
     override fun getVaultRegisteredForExportFlow(userId: String): Flow<Boolean?> =
         getMutableVaultRegisteredForExportFlow(userId)
             .onSubscription { emit(getVaultRegisteredForExport(userId)) }
+
+    override fun getAddCipherActionCount(): Int? = getInt(
+        key = ADD_ACTION_COUNT,
+    )
+
+    override fun storeAddCipherActionCount(count: Int?) {
+        putInt(
+            key = ADD_ACTION_COUNT,
+            value = count,
+        )
+    }
+
+    override fun getGeneratedResultActionCount(): Int? = getInt(
+        key = COPY_ACTION_COUNT,
+    )
+
+    override fun storeGeneratedResultActionCount(count: Int?) {
+        putInt(
+            key = COPY_ACTION_COUNT,
+            value = count,
+        )
+    }
+
+    override fun getCreateSendActionCount(): Int? = getInt(
+        key = CREATE_ACTION_COUNT,
+    )
+
+    override fun storeCreateSendActionCount(count: Int?) {
+        putInt(
+            key = CREATE_ACTION_COUNT,
+            value = count,
+        )
+    }
 
     private fun getMutableLastSyncFlow(
         userId: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManager.kt
@@ -1,0 +1,27 @@
+package com.x8bit.bitwarden.data.platform.manager
+
+/**
+ * Responsible for managing whether or not the app review prompt should be shown.
+ */
+interface ReviewPromptManager {
+    /**
+     * Register an add cipher item action.
+     */
+    fun registerAddCipherAction()
+
+    /**
+     * Register a generated result action.
+     */
+    fun registerGeneratedResultAction()
+
+    /**
+     * Register a create send action.
+     */
+    fun registerCreateSendAction()
+
+    /**
+     * Returns a boolean value indicating whether or not the user should be prompted to
+     * review the app.
+     */
+    fun shouldPromptForAppReview(): Boolean
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerImpl.kt
@@ -1,0 +1,73 @@
+package com.x8bit.bitwarden.data.platform.manager
+
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.ui.platform.util.orZero
+
+private const val ADD_ACTION_REQUIREMENT = 3
+private const val COPY_ACTION_REQUIREMENT = 3
+private const val CREATE_ACTION_REQUIREMENT = 3
+
+/**
+ * Default implementation of [ReviewPromptManager].
+ */
+class ReviewPromptManagerImpl(
+    private val authDiskSource: AuthDiskSource,
+    private val settingsDiskSource: SettingsDiskSource,
+    private val autofillEnabledManager: AutofillEnabledManager,
+    private val accessibilityEnabledManager: AccessibilityEnabledManager,
+) : ReviewPromptManager {
+
+    override fun registerAddCipherAction() {
+        authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumAddActionsMet()) return
+        val currentValue = settingsDiskSource.getAddCipherActionCount().orZero()
+        settingsDiskSource.storeAddCipherActionCount(
+            count = currentValue + 1,
+        )
+    }
+
+    override fun registerGeneratedResultAction() {
+        authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumCopyActionsMet()) return
+        val currentValue = settingsDiskSource
+            .getGeneratedResultActionCount()
+            .orZero()
+        settingsDiskSource.storeGeneratedResultActionCount(
+            count = currentValue + 1,
+        )
+    }
+
+    override fun registerCreateSendAction() {
+        authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumCreateActionsMet()) return
+        val currentValue = settingsDiskSource.getCreateSendActionCount().orZero()
+        settingsDiskSource.storeCreateSendActionCount(
+            count = currentValue + 1,
+        )
+    }
+
+    override fun shouldPromptForAppReview(): Boolean {
+        authDiskSource.userState?.activeUserId ?: return false
+        val autofillEnabled = autofillEnabledManager.isAutofillEnabledStateFlow.value
+        val accessibilityEnabled = accessibilityEnabledManager.isAccessibilityEnabledStateFlow.value
+        val minAddActionsMet = isMinimumAddActionsMet()
+        val minCopyActionsMet = isMinimumCopyActionsMet()
+        val minCreateActionsMet = isMinimumCreateActionsMet()
+        return (autofillEnabled || accessibilityEnabled) &&
+            (minAddActionsMet || minCopyActionsMet || minCreateActionsMet)
+    }
+
+    private fun isMinimumAddActionsMet(): Boolean =
+        settingsDiskSource.getAddCipherActionCount().orZero() >= ADD_ACTION_REQUIREMENT
+
+    private fun isMinimumCopyActionsMet(): Boolean =
+        settingsDiskSource
+            .getGeneratedResultActionCount()
+            .orZero() >= COPY_ACTION_REQUIREMENT
+
+    private fun isMinimumCreateActionsMet(): Boolean =
+        settingsDiskSource.getCreateSendActionCount().orZero() >= CREATE_ACTION_REQUIREMENT
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -6,6 +6,7 @@ import androidx.core.content.getSystemService
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.manager.AddTotpItemFromAuthenticatorManager
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.EventDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
@@ -39,6 +40,8 @@ import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.PushManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.ResourceCacheManager
 import com.x8bit.bitwarden.data.platform.manager.ResourceCacheManagerImpl
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.SdkClientManager
 import com.x8bit.bitwarden.data.platform.manager.SdkClientManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
@@ -309,5 +312,19 @@ object PlatformManagerModule {
     ): DatabaseSchemeManager = DatabaseSchemeManagerImpl(
         authDiskSource = authDiskSource,
         settingsDiskSource = settingsDiskSource,
+    )
+
+    @Provides
+    @Singleton
+    fun provideReviewPromptManager(
+        authDiskSource: AuthDiskSource,
+        settingsDiskSource: SettingsDiskSource,
+        autofillEnabledManager: AutofillEnabledManager,
+        accessibilityEnabledManager: AccessibilityEnabledManager,
+    ): ReviewPromptManager = ReviewPromptManagerImpl(
+        authDiskSource = authDiskSource,
+        settingsDiskSource = settingsDiskSource,
+        autofillEnabledManager = autofillEnabledManager,
+        accessibilityEnabledManager = accessibilityEnabledManager,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryImpl.kt
@@ -7,7 +7,7 @@ import com.bitwarden.generators.PasswordGeneratorRequest
 import com.bitwarden.generators.UsernameGeneratorRequest
 import com.bitwarden.vault.PasswordHistoryView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
-import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.model.LocalDataState
 import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAndLoggedIn
@@ -54,7 +54,7 @@ class GeneratorRepositoryImpl(
     private val authDiskSource: AuthDiskSource,
     private val vaultSdkSource: VaultSdkSource,
     private val passwordHistoryDiskSource: PasswordHistoryDiskSource,
-    private val policyManager: PolicyManager,
+    private val reviewPromptManager: ReviewPromptManager,
     dispatcherManager: DispatcherManager,
 ) : GeneratorRepository {
 
@@ -69,7 +69,9 @@ class GeneratorRepositoryImpl(
         get() = mutablePasswordHistoryStateFlow.asStateFlow()
 
     override val generatorResultFlow: Flow<GeneratorResult>
-        get() = generatorResultChannel.receiveAsFlow()
+        get() = generatorResultChannel
+            .receiveAsFlow()
+            .onEach { reviewPromptManager.registerGeneratedResultAction() }
 
     init {
         mutablePasswordHistoryStateFlow

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/di/GeneratorRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/di/GeneratorRepositoryModule.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.tools.generator.repository.di
 
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
-import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.GeneratorDiskSource
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.PasswordHistoryDiskSource
@@ -33,7 +33,7 @@ object GeneratorRepositoryModule {
         vaultSdkSource: VaultSdkSource,
         passwordHistoryDiskSource: PasswordHistoryDiskSource,
         dispatcherManager: DispatcherManager,
-        policyManager: PolicyManager,
+        reviewPromptManager: ReviewPromptManager,
     ): GeneratorRepository = GeneratorRepositoryImpl(
         clock = clock,
         generatorSdkSource = generatorSdkSource,
@@ -42,6 +42,6 @@ object GeneratorRepositoryModule {
         vaultSdkSource = vaultSdkSource,
         passwordHistoryDiskSource = passwordHistoryDiskSource,
         dispatcherManager = dispatcherManager,
-        policyManager = policyManager,
+        reviewPromptManager = reviewPromptManager,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
@@ -6,6 +6,7 @@ import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.platform.manager.AppStateManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
@@ -44,6 +45,7 @@ object VaultManagerModule {
         authDiskSource: AuthDiskSource,
         fileManager: FileManager,
         clock: Clock,
+        reviewPromptManager: ReviewPromptManager,
     ): CipherManager = CipherManagerImpl(
         fileManager = fileManager,
         authDiskSource = authDiskSource,
@@ -51,6 +53,7 @@ object VaultManagerModule {
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
         clock = clock,
+        reviewPromptManager = reviewPromptManager,
     )
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.network.util.isNoConnectionError
 import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.manager.model.SyncCipherDeleteData
 import com.x8bit.bitwarden.data.platform.manager.model.SyncCipherUpsertData
@@ -144,6 +145,7 @@ class VaultRepositoryImpl(
     pushManager: PushManager,
     private val clock: Clock,
     dispatcherManager: DispatcherManager,
+    private val reviewPromptManager: ReviewPromptManager,
 ) : VaultRepository,
     CipherManager by cipherManager,
     VaultLockManager by vaultLockManager {
@@ -632,7 +634,10 @@ class VaultRepositoryImpl(
             }
             .fold(
                 onFailure = { CreateSendResult.Error(message = null) },
-                onSuccess = { CreateSendResult.Success(it) },
+                onSuccess = {
+                    reviewPromptManager.registerCreateSendAction()
+                    CreateSendResult.Success(it)
+                },
             )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
@@ -5,6 +5,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.network.service.CiphersService
@@ -52,6 +53,7 @@ object VaultRepositoryModule {
         userLogoutManager: UserLogoutManager,
         databaseSchemeManager: DatabaseSchemeManager,
         clock: Clock,
+        reviewPromptManager: ReviewPromptManager,
     ): VaultRepository = VaultRepositoryImpl(
         syncService = syncService,
         sendsService = sendsService,
@@ -70,5 +72,6 @@ object VaultRepositoryModule {
         userLogoutManager = userLogoutManager,
         databaseSchemeManager = databaseSchemeManager,
         clock = clock,
+        reviewPromptManager = reviewPromptManager,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/IntExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/IntExtensions.kt
@@ -1,0 +1,7 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+/**
+ * Extension to be applied to a nullable [Int] type where if the value is null, a default
+ * value of "0" is returned.
+ */
+fun Int?.orZero() = this ?: 0

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -102,7 +102,6 @@ fun GeneratorScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val snackbarHostState = rememberBitwardenSnackbarHostState()
-
     LivecycleEventEffect { _, event ->
         when (event) {
             Lifecycle.Event.ON_RESUME -> {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -13,6 +13,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.util.getActivePolicies
 import com.x8bit.bitwarden.data.platform.manager.util.getActivePoliciesFlow
@@ -53,7 +54,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import kotlin.collections.filter
 import kotlin.math.max
 
 private const val KEY_STATE = "state"
@@ -76,6 +76,7 @@ class GeneratorViewModel @Inject constructor(
     private val generatorRepository: GeneratorRepository,
     private val authRepository: AuthRepository,
     private val policyManager: PolicyManager,
+    private val reviewPromptManager: ReviewPromptManager,
 ) : BaseViewModel<GeneratorState, GeneratorEvent, GeneratorAction>(
     initialState = savedStateHandle[KEY_STATE] ?: run {
         val generatorMode = GeneratorArgs(savedStateHandle).type
@@ -636,6 +637,7 @@ class GeneratorViewModel @Inject constructor(
     }
 
     private fun handleCopyClick() {
+        reviewPromptManager.registerGeneratedResultAction()
         clipboardManager.setText(text = state.generatedText)
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1193,4 +1193,50 @@ class SettingsDiskSourceTest {
             assertFalse(awaitItem() ?: true)
         }
     }
+
+    @Test
+    fun `getAddCipherActionCount should pull from SharedPreferences`() {
+        val addActionCountKey = "bwPreferencesStorage:addActionCount"
+        fakeSharedPreferences.edit { putInt(addActionCountKey, 1) }
+        assertEquals(
+            1, settingsDiskSource.getAddCipherActionCount(),
+        )
+    }
+
+    @Test
+    fun `storeAddCipherActionCount should update SharedPreferences`() {
+        val addActionCountKey = "bwPreferencesStorage:addActionCount"
+        settingsDiskSource.storeAddCipherActionCount(count = 1)
+        assertEquals(1, fakeSharedPreferences.getInt(addActionCountKey, 0))
+    }
+
+    @Test
+    fun `getCopyGeneratedResultActionCount should pull from SharedPreferences`() {
+        val copyActionCountKey = "bwPreferencesStorage:copyActionCount"
+        fakeSharedPreferences.edit { putInt(copyActionCountKey, 1) }
+        assertEquals(
+            1, settingsDiskSource.getGeneratedResultActionCount(),
+        )
+    }
+
+    @Test
+    fun `storeCopyGeneratedResultCount should update SharedPreferences`() {
+        val copyActionCountKey = "bwPreferencesStorage:copyActionCount"
+        settingsDiskSource.storeGeneratedResultActionCount(count = 1)
+        assertEquals(1, fakeSharedPreferences.getInt(copyActionCountKey, 0))
+    }
+
+    @Test
+    fun `getCreateSendActionCount should pull from SharedPreferences`() {
+        val createActionCountKey = "bwPreferencesStorage:createActionCount"
+        fakeSharedPreferences.edit { putInt(createActionCountKey, 1) }
+        assertEquals(1, settingsDiskSource.getCreateSendActionCount())
+    }
+
+    @Test
+    fun `storeCreateSendActionCount should update SharedPreferences`() {
+        val createActionCountKey = "bwPreferencesStorage:createActionCount"
+        settingsDiskSource.storeCreateSendActionCount(count = 1)
+        assertEquals(1, fakeSharedPreferences.getInt(createActionCountKey, 0))
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -65,6 +65,9 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val userShowUnlockBadge = mutableMapOf<String, Boolean?>()
     private val userShowImportLoginsBadge = mutableMapOf<String, Boolean?>()
     private val vaultRegisteredForExport = mutableMapOf<String, Boolean?>()
+    private var addCipherActionCount: Int? = null
+    private var generatedActionCount: Int? = null
+    private var createSendActionCount: Int? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -352,6 +355,30 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         getMutableVaultRegisteredForExportFlow(userId = userId).onSubscription {
             emit(getVaultRegisteredForExport(userId = userId))
         }
+
+    override fun getAddCipherActionCount(): Int? {
+        return addCipherActionCount
+    }
+
+    override fun storeAddCipherActionCount(count: Int?) {
+        addCipherActionCount = count
+    }
+
+    override fun getGeneratedResultActionCount(): Int? {
+        return generatedActionCount
+    }
+
+    override fun storeGeneratedResultActionCount(count: Int?) {
+        generatedActionCount = count
+    }
+
+    override fun getCreateSendActionCount(): Int? {
+        return createSendActionCount
+    }
+
+    override fun storeCreateSendActionCount(count: Int?) {
+        createSendActionCount = count
+    }
 
     //region Private helper functions
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerTest.kt
@@ -1,0 +1,149 @@
+package com.x8bit.bitwarden.data.platform.manager
+
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.FakeAccessibilityEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManagerImpl
+import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ReviewPromptManagerTest {
+
+    private val autofillEnabledManager: AutofillEnabledManager = AutofillEnabledManagerImpl()
+    private val fakeAccessibilityEnabledManager = FakeAccessibilityEnabledManager()
+    private val fakeAuthDiskSource = FakeAuthDiskSource()
+    private val fakeSettingsDiskSource = FakeSettingsDiskSource()
+
+    private val reviewPromptManager = ReviewPromptManagerImpl(
+        autofillEnabledManager = autofillEnabledManager,
+        accessibilityEnabledManager = fakeAccessibilityEnabledManager,
+        authDiskSource = fakeAuthDiskSource,
+        settingsDiskSource = fakeSettingsDiskSource,
+    )
+
+    @Test
+    fun `incrementAddCipherAction increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        reviewPromptManager.registerAddCipherAction()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getAddCipherActionCount(),
+        )
+        reviewPromptManager.registerAddCipherAction()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getAddCipherActionCount(),
+        )
+        reviewPromptManager.registerAddCipherAction()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getAddCipherActionCount(),
+        )
+        reviewPromptManager.registerAddCipherAction()
+        // Should not increment over 3.
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getAddCipherActionCount(),
+        )
+    }
+
+    @Test
+    fun `incrementCopyGeneratedResultAction increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        reviewPromptManager.registerGeneratedResultAction()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getGeneratedResultActionCount(),
+        )
+        reviewPromptManager.registerGeneratedResultAction()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getGeneratedResultActionCount(),
+        )
+        reviewPromptManager.registerGeneratedResultAction()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getGeneratedResultActionCount(),
+        )
+        reviewPromptManager.registerGeneratedResultAction()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getGeneratedResultActionCount(),
+        )
+    }
+
+    @Test
+    fun `incrementCreateSendAction increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        reviewPromptManager.registerCreateSendAction()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getCreateSendActionCount(),
+        )
+        reviewPromptManager.registerCreateSendAction()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getCreateSendActionCount(),
+        )
+        reviewPromptManager.registerCreateSendAction()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCreateSendActionCount(),
+        )
+        reviewPromptManager.registerCreateSendAction()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCreateSendActionCount(),
+        )
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should default to false if no active user`() {
+        assertFalse(reviewPromptManager.shouldPromptForAppReview())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldPromptForAppReview should return true if one auto fill service is enabled and one actions requirement is met`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
+        autofillEnabledManager.isAutofillEnabled = false
+        fakeSettingsDiskSource.storeGeneratedResultActionCount(count = 0)
+        fakeSettingsDiskSource.storeCreateSendActionCount(count = 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(count = 4)
+        assertTrue(reviewPromptManager.shouldPromptForAppReview())
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should return false if no auto fill service is enabled`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = false
+        autofillEnabledManager.isAutofillEnabled = false
+        fakeSettingsDiskSource.storeGeneratedResultActionCount(count = 0)
+        fakeSettingsDiskSource.storeCreateSendActionCount(count = 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(count = 4)
+        assertFalse(reviewPromptManager.shouldPromptForAppReview())
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should return false if no action count is met`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
+        autofillEnabledManager.isAutofillEnabled = true
+        fakeSettingsDiskSource.storeGeneratedResultActionCount(count = 1)
+        fakeSettingsDiskSource.storeCreateSendActionCount(count = 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(count = 2)
+        assertFalse(reviewPromptManager.shouldPromptForAppReview())
+    }
+}
+
+private const val USER_ID = "user_id"
+private val MOCK_USER_STATE = mockk<UserStateJson>() {
+    every { activeUserId } returns USER_ID
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryTest.kt
@@ -19,7 +19,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.KeyConnectorUserDe
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.UserDecryptionOptionsJson
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
-import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.repository.model.LocalDataState
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
@@ -34,6 +34,7 @@ import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratedPassph
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratedPasswordResult
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratedPlusAddressedUsernameResult
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratedRandomWordUsernameResult
+import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratorResult
 import com.x8bit.bitwarden.data.tools.generator.repository.model.PasscodeGenerationOptions
 import com.x8bit.bitwarden.data.tools.generator.repository.model.UsernameGenerationOptions
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
@@ -43,6 +44,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -70,7 +72,9 @@ class GeneratorRepositoryTest {
     private val passwordHistoryDiskSource: PasswordHistoryDiskSource = mockk()
     private val vaultSdkSource: VaultSdkSource = mockk()
     private val dispatcherManager = FakeDispatcherManager()
-    private val policyManager: PolicyManager = mockk()
+    private val reviewPromptManager: ReviewPromptManager = mockk {
+        every { registerGeneratedResultAction() } just runs
+    }
 
     private val repository = GeneratorRepositoryImpl(
         clock = fixedClock,
@@ -80,7 +84,7 @@ class GeneratorRepositoryTest {
         passwordHistoryDiskSource = passwordHistoryDiskSource,
         vaultSdkSource = vaultSdkSource,
         dispatcherManager = dispatcherManager,
-        policyManager = policyManager,
+        reviewPromptManager = reviewPromptManager,
     )
 
     @Suppress("MaxLineLength")
@@ -739,6 +743,17 @@ class GeneratorRepositoryTest {
             coVerify(exactly = 0) {
                 generatorDiskSource.storeUsernameGenerationOptions(any(), any())
             }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `emitGeneratorResult should update the flow and increment the action count as side affect`() =
+        runTest {
+            repository.generatorResultFlow.test {
+                repository.emitGeneratorResult(GeneratorResult.Password("foo"))
+                assertEquals(GeneratorResult.Password("foo"), awaitItem())
+            }
+            verify(exactly = 1) { reviewPromptManager.registerGeneratedResultAction() }
         }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/IntExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/IntExtensionsTest.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IntExtensionsTest {
+    @Test
+    fun `orZero returns zero when null`() {
+        val nullInt: Int? = null
+        assertEquals(0, nullInt.orZero())
+    }
+
+    @Test
+    fun `orZero returns value when not null`() {
+        val nonNullInt = 42
+        assertEquals(42, nonNullInt.orZero())
+        val negativeNonNullInt = -42
+        assertEquals(-42, negativeNonNullInt.orZero())
+        assertEquals(0, 0.orZero())
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
@@ -102,6 +103,10 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     private val policyManager: PolicyManager = mockk {
         every { getActivePolicies(PolicyTypeJson.PASSWORD_GENERATOR) } returns emptyList()
         every { getActivePoliciesFlow(PolicyTypeJson.PASSWORD_GENERATOR) } returns mutablePolicyFlow
+    }
+
+    private val reviewPromptManager: ReviewPromptManager = mockk {
+        every { registerGeneratedResultAction() } just runs
     }
 
     @Test
@@ -517,7 +522,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `CopyClick should call setText on ClipboardManager`() {
+    fun `CopyClick should call setText on ClipboardManager and register generator action`() {
         val viewModel = createViewModel()
         every { clipboardManager.setText(viewModel.stateFlow.value.generatedText) } just runs
 
@@ -525,6 +530,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
         verify(exactly = 1) {
             clipboardManager.setText(text = viewModel.stateFlow.value.generatedText)
+            reviewPromptManager.registerGeneratedResultAction()
         }
     }
 
@@ -2372,6 +2378,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         generatorRepository = fakeGeneratorRepository,
         authRepository = authRepository,
         policyManager = policyManager,
+        reviewPromptManager = reviewPromptManager,
     )
 
     private fun createViewModel(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15380
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Track when a user adds a new cipher item.
- Track when a user creates a new send.
- Track when a user uses a generated value on an existing item.
- If any of these is down 3 or more times that is considered qualifying for the action portion of showing the app review card.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
