### PR TITLE
PM-15383 PM-15381 show review prompt if criteria met

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -196,6 +196,7 @@ dependencies {
     implementation(libs.androidx.credentials)
     implementation(libs.google.hilt.android)
     ksp(libs.google.hilt.compiler)
+    implementation(libs.google.play.review)
     implementation(libs.kotlinx.collections.immutable)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization)

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -325,4 +325,44 @@ interface SettingsDiskSource {
      * Emits updates that track [getVaultRegisteredForExport] for the given [userId].
      */
     fun getVaultRegisteredForExportFlow(userId: String): Flow<Boolean?>
+
+    /**
+     * Gets the number of qualifying add actions for the given [userId].
+     */
+    fun getAddCipherActionCount(userId: String): Int?
+
+    /**
+     * Stores the given [count] completed "add" actions for the given [userId].
+     */
+    fun storeAddCipherActionCount(userId: String, count: Int?)
+
+    /**
+     * Gets the number of qualifying copy actions for the given [userId].
+     */
+    fun getCopyGeneratedResultActionCount(userId: String): Int?
+
+    /**
+     * Stores the given [count] completed "copy" actions for the given [userId].
+     */
+    fun storeCopyGeneratedResultActionCount(userId: String, count: Int?)
+
+    /**
+     * Gets the number of qualifying create actions for the given [userId].
+     */
+    fun getCreateSendActionCount(userId: String): Int?
+
+    /**
+     * Stores the given [count] completed "create" actions for the given [userId].
+     */
+    fun storeCreateSendActionCount(userId: String, count: Int?)
+
+    /**
+     * Gets whether the given [userId] has been prompted for an app review.
+     */
+    fun getUserHasBeenPromptedForReview(userId: String): Boolean?
+
+    /**
+     * Stores whether the given [userId] has been prompted for an app review.
+     */
+    fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -327,42 +327,33 @@ interface SettingsDiskSource {
     fun getVaultRegisteredForExportFlow(userId: String): Flow<Boolean?>
 
     /**
-     * Gets the number of qualifying add actions for the given [userId].
+     * Gets the number of qualifying add cipher actions for the device.
      */
-    fun getAddCipherActionCount(userId: String): Int?
+    fun getAddCipherActionCount(): Int?
 
     /**
-     * Stores the given [count] completed "add" actions for the given [userId].
+     * Stores the given [count] completed "add" cipher actions taken place on the device.
      */
-    fun storeAddCipherActionCount(userId: String, count: Int?)
+    fun storeAddCipherActionCount(count: Int?)
 
     /**
-     * Gets the number of qualifying copy actions for the given [userId].
+     * Gets the number of qualifying generated result actions for the device.
      */
-    fun getCopyGeneratedResultActionCount(userId: String): Int?
+    fun getGeneratedResultActionCount(): Int?
 
     /**
-     * Stores the given [count] completed "copy" actions for the given [userId].
+     * Stores the given [count] completed generated password or username result actions taken
+     * for the device.
      */
-    fun storeCopyGeneratedResultActionCount(userId: String, count: Int?)
+    fun storeGeneratedResultActionCount(count: Int?)
 
     /**
-     * Gets the number of qualifying create actions for the given [userId].
+     * Gets the number of qualifying create send actions for the device.
      */
-    fun getCreateSendActionCount(userId: String): Int?
+    fun getCreateSendActionCount(): Int?
 
     /**
-     * Stores the given [count] completed "create" actions for the given [userId].
+     * Stores the given [count] completed create send actions for the device.
      */
-    fun storeCreateSendActionCount(userId: String, count: Int?)
-
-    /**
-     * Gets whether the given [userId] has been prompted for an app review.
-     */
-    fun getUserHasBeenPromptedForReview(userId: String): Boolean?
-
-    /**
-     * Stores whether the given [userId] has been prompted for an app review.
-     */
-    fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?)
+    fun storeCreateSendActionCount(count: Int?)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -40,7 +40,6 @@ private const val IS_VAULT_REGISTERED_FOR_EXPORT = "isVaultRegisteredForExport"
 private const val ADD_ACTION_COUNT = "addActionCount"
 private const val COPY_ACTION_COUNT = "copyActionCount"
 private const val CREATE_ACTION_COUNT = "createActionCount"
-private const val HAS_BEEN_PROMPTED_FOR_REVIEW = "hasBeenPromptedForReview"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -176,10 +175,6 @@ class SettingsDiskSourceImpl(
         storeClearClipboardFrequencySeconds(userId = userId, frequency = null)
         removeWithPrefix(prefix = ACCOUNT_BIOMETRIC_INTEGRITY_VALID_KEY.appendIdentifier(userId))
         storeVaultRegisteredForExport(userId = userId, isRegistered = null)
-        storeAddCipherActionCount(userId = userId, count = null)
-        storeCopyGeneratedResultActionCount(userId = userId, count = null)
-        storeCreateSendActionCount(userId = userId, count = null)
-        storeUserHasBeenPromptedForReview(userId = userId, value = null)
 
         // The following are intentionally not cleared so they can be
         // restored after logging out and back in:
@@ -454,46 +449,36 @@ class SettingsDiskSourceImpl(
         getMutableVaultRegisteredForExportFlow(userId)
             .onSubscription { emit(getVaultRegisteredForExport(userId)) }
 
-    override fun getAddCipherActionCount(userId: String): Int? = getInt(
-        key = ADD_ACTION_COUNT.appendIdentifier(userId),
+    override fun getAddCipherActionCount(): Int? = getInt(
+        key = ADD_ACTION_COUNT,
     )
 
-    override fun storeAddCipherActionCount(userId: String, count: Int?) {
+    override fun storeAddCipherActionCount(count: Int?) {
         putInt(
-            key = ADD_ACTION_COUNT.appendIdentifier(userId),
+            key = ADD_ACTION_COUNT,
             value = count,
         )
     }
 
-    override fun getCopyGeneratedResultActionCount(userId: String): Int? = getInt(
-        key = COPY_ACTION_COUNT.appendIdentifier(userId),
+    override fun getGeneratedResultActionCount(): Int? = getInt(
+        key = COPY_ACTION_COUNT,
     )
 
-    override fun storeCopyGeneratedResultActionCount(userId: String, count: Int?) {
+    override fun storeGeneratedResultActionCount(count: Int?) {
         putInt(
-            key = COPY_ACTION_COUNT.appendIdentifier(userId),
+            key = COPY_ACTION_COUNT,
             value = count,
         )
     }
 
-    override fun getCreateSendActionCount(userId: String): Int? = getInt(
-        key = CREATE_ACTION_COUNT.appendIdentifier(userId),
+    override fun getCreateSendActionCount(): Int? = getInt(
+        key = CREATE_ACTION_COUNT,
     )
 
-    override fun storeCreateSendActionCount(userId: String, count: Int?) {
+    override fun storeCreateSendActionCount(count: Int?) {
         putInt(
-            key = CREATE_ACTION_COUNT.appendIdentifier(userId),
+            key = CREATE_ACTION_COUNT,
             value = count,
-        )
-    }
-
-    override fun getUserHasBeenPromptedForReview(userId: String): Boolean? =
-        getBoolean(key = HAS_BEEN_PROMPTED_FOR_REVIEW.appendIdentifier(userId))
-
-    override fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?) {
-        putBoolean(
-            key = HAS_BEEN_PROMPTED_FOR_REVIEW.appendIdentifier(userId),
-            value = value,
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -37,6 +37,10 @@ private const val SHOW_AUTOFILL_SETTING_BADGE = "showAutofillSettingBadge"
 private const val SHOW_UNLOCK_SETTING_BADGE = "showUnlockSettingBadge"
 private const val SHOW_IMPORT_LOGINS_SETTING_BADGE = "showImportLoginsSettingBadge"
 private const val IS_VAULT_REGISTERED_FOR_EXPORT = "isVaultRegisteredForExport"
+private const val ADD_ACTION_COUNT = "addActionCount"
+private const val COPY_ACTION_COUNT = "copyActionCount"
+private const val CREATE_ACTION_COUNT = "createActionCount"
+private const val HAS_BEEN_PROMPTED_FOR_REVIEW = "hasBeenPromptedForReview"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -172,6 +176,10 @@ class SettingsDiskSourceImpl(
         storeClearClipboardFrequencySeconds(userId = userId, frequency = null)
         removeWithPrefix(prefix = ACCOUNT_BIOMETRIC_INTEGRITY_VALID_KEY.appendIdentifier(userId))
         storeVaultRegisteredForExport(userId = userId, isRegistered = null)
+        storeAddCipherActionCount(userId = userId, count = null)
+        storeCopyGeneratedResultActionCount(userId = userId, count = null)
+        storeCreateSendActionCount(userId = userId, count = null)
+        storeUserHasBeenPromptedForReview(userId = userId, value = null)
 
         // The following are intentionally not cleared so they can be
         // restored after logging out and back in:
@@ -445,6 +453,49 @@ class SettingsDiskSourceImpl(
     override fun getVaultRegisteredForExportFlow(userId: String): Flow<Boolean?> =
         getMutableVaultRegisteredForExportFlow(userId)
             .onSubscription { emit(getVaultRegisteredForExport(userId)) }
+
+    override fun getAddCipherActionCount(userId: String): Int? = getInt(
+        key = ADD_ACTION_COUNT.appendIdentifier(userId),
+    )
+
+    override fun storeAddCipherActionCount(userId: String, count: Int?) {
+        putInt(
+            key = ADD_ACTION_COUNT.appendIdentifier(userId),
+            value = count,
+        )
+    }
+
+    override fun getCopyGeneratedResultActionCount(userId: String): Int? = getInt(
+        key = COPY_ACTION_COUNT.appendIdentifier(userId),
+    )
+
+    override fun storeCopyGeneratedResultActionCount(userId: String, count: Int?) {
+        putInt(
+            key = COPY_ACTION_COUNT.appendIdentifier(userId),
+            value = count,
+        )
+    }
+
+    override fun getCreateSendActionCount(userId: String): Int? = getInt(
+        key = CREATE_ACTION_COUNT.appendIdentifier(userId),
+    )
+
+    override fun storeCreateSendActionCount(userId: String, count: Int?) {
+        putInt(
+            key = CREATE_ACTION_COUNT.appendIdentifier(userId),
+            value = count,
+        )
+    }
+
+    override fun getUserHasBeenPromptedForReview(userId: String): Boolean? =
+        getBoolean(key = HAS_BEEN_PROMPTED_FOR_REVIEW.appendIdentifier(userId))
+
+    override fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?) {
+        putBoolean(
+            key = HAS_BEEN_PROMPTED_FOR_REVIEW.appendIdentifier(userId),
+            value = value,
+        )
+    }
 
     private fun getMutableLastSyncFlow(
         userId: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManager.kt
@@ -1,0 +1,27 @@
+package com.x8bit.bitwarden.data.platform.manager
+
+/**
+ * Responsible for managing whether or not the app review prompt should be shown.
+ */
+interface ReviewPromptManager {
+    /**
+     * Increments the add cipher item action count for the active user.
+     */
+    fun incrementAddCipherActionCount()
+
+    /**
+     * Increments the copied generated result action count for the active user.
+     */
+    fun incrementCopyGeneratedResultActionCount()
+
+    /**
+     * Increments the created send action count for the active user.
+     */
+    fun incrementCreateSendActionCount()
+
+    /**
+     * Returns a boolean value indicating whether or not the user should be prompted to
+     * review the app.
+     */
+    fun shouldPromptForAppReview(): Boolean
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManager.kt
@@ -5,19 +5,19 @@ package com.x8bit.bitwarden.data.platform.manager
  */
 interface ReviewPromptManager {
     /**
-     * Increments the add cipher item action count for the active user.
+     * Register an add cipher item action.
      */
-    fun incrementAddCipherActionCount()
+    fun registerAddCipherActionCount()
 
     /**
-     * Increments the copied generated result action count for the active user.
+     * Register a generated result action.
      */
-    fun incrementCopyGeneratedResultActionCount()
+    fun registerGeneratedResultActionCount()
 
     /**
-     * Increments the created send action count for the active user.
+     * Register a create send action.
      */
-    fun incrementCreateSendActionCount()
+    fun registerCreateSendActionCount()
 
     /**
      * Returns a boolean value indicating whether or not the user should be prompted to

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerImpl.kt
@@ -20,60 +20,54 @@ class ReviewPromptManagerImpl(
     private val accessibilityEnabledManager: AccessibilityEnabledManager,
 ) : ReviewPromptManager {
 
-    override fun incrementAddCipherActionCount() {
-        val activeUserId = authDiskSource.userState?.activeUserId ?: return
-        if (isMinimumAddActionsMet(activeUserId)) return
-        val currentValue = settingsDiskSource.getAddCipherActionCount(activeUserId).orZero()
+    override fun registerAddCipherActionCount() {
+        authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumAddActionsMet()) return
+        val currentValue = settingsDiskSource.getAddCipherActionCount().orZero()
         settingsDiskSource.storeAddCipherActionCount(
-            userId = activeUserId,
             count = currentValue + 1,
         )
     }
 
-    override fun incrementCopyGeneratedResultActionCount() {
-        val activeUserId = authDiskSource.userState?.activeUserId ?: return
-        if (isMinimumCopyActionsMet(activeUserId)) return
+    override fun registerGeneratedResultActionCount() {
+        authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumCopyActionsMet()) return
         val currentValue = settingsDiskSource
-            .getCopyGeneratedResultActionCount(activeUserId)
+            .getGeneratedResultActionCount()
             .orZero()
-        settingsDiskSource.storeCopyGeneratedResultActionCount(
-            userId = activeUserId,
+        settingsDiskSource.storeGeneratedResultActionCount(
             count = currentValue + 1,
         )
     }
 
-    override fun incrementCreateSendActionCount() {
-        val activeUserId = authDiskSource.userState?.activeUserId ?: return
-        if (isMinimumCreateActionsMet(activeUserId)) return
-        val currentValue = settingsDiskSource.getCreateSendActionCount(activeUserId).orZero()
+    override fun registerCreateSendActionCount() {
+        authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumCreateActionsMet()) return
+        val currentValue = settingsDiskSource.getCreateSendActionCount().orZero()
         settingsDiskSource.storeCreateSendActionCount(
-            userId = activeUserId,
             count = currentValue + 1,
         )
     }
 
     override fun shouldPromptForAppReview(): Boolean {
-        val activeUserId = authDiskSource.userState?.activeUserId ?: return false
-        val promptHasNotBeenShown =
-            settingsDiskSource.getUserHasBeenPromptedForReview(activeUserId) != true
+        authDiskSource.userState?.activeUserId ?: return false
         val autofillEnabled = autofillEnabledManager.isAutofillEnabledStateFlow.value
         val accessibilityEnabled = accessibilityEnabledManager.isAccessibilityEnabledStateFlow.value
-        val minAddActionsMet = isMinimumAddActionsMet(activeUserId)
-        val minCopyActionsMet = isMinimumCopyActionsMet(activeUserId)
-        val minCreateActionsMet = isMinimumCreateActionsMet(activeUserId)
+        val minAddActionsMet = isMinimumAddActionsMet()
+        val minCopyActionsMet = isMinimumCopyActionsMet()
+        val minCreateActionsMet = isMinimumCreateActionsMet()
         return (autofillEnabled || accessibilityEnabled) &&
-            (minAddActionsMet || minCopyActionsMet || minCreateActionsMet) &&
-            promptHasNotBeenShown
+            (minAddActionsMet || minCopyActionsMet || minCreateActionsMet)
     }
 
-    private fun isMinimumAddActionsMet(userId: String): Boolean =
-        settingsDiskSource.getAddCipherActionCount(userId).orZero() >= ADD_ACTION_REQUIREMENT
+    private fun isMinimumAddActionsMet(): Boolean =
+        settingsDiskSource.getAddCipherActionCount().orZero() >= ADD_ACTION_REQUIREMENT
 
-    private fun isMinimumCopyActionsMet(userId: String): Boolean =
+    private fun isMinimumCopyActionsMet(): Boolean =
         settingsDiskSource
-            .getCopyGeneratedResultActionCount(userId)
+            .getGeneratedResultActionCount()
             .orZero() >= COPY_ACTION_REQUIREMENT
 
-    private fun isMinimumCreateActionsMet(userId: String): Boolean =
-        settingsDiskSource.getCreateSendActionCount(userId).orZero() >= CREATE_ACTION_REQUIREMENT
+    private fun isMinimumCreateActionsMet(): Boolean =
+        settingsDiskSource.getCreateSendActionCount().orZero() >= CREATE_ACTION_REQUIREMENT
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerImpl.kt
@@ -1,0 +1,79 @@
+package com.x8bit.bitwarden.data.platform.manager
+
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.ui.platform.util.orZero
+
+private const val ADD_ACTION_REQUIREMENT = 3
+private const val COPY_ACTION_REQUIREMENT = 3
+private const val CREATE_ACTION_REQUIREMENT = 3
+
+/**
+ * Default implementation of [ReviewPromptManager].
+ */
+class ReviewPromptManagerImpl(
+    private val authDiskSource: AuthDiskSource,
+    private val settingsDiskSource: SettingsDiskSource,
+    private val autofillEnabledManager: AutofillEnabledManager,
+    private val accessibilityEnabledManager: AccessibilityEnabledManager,
+) : ReviewPromptManager {
+
+    override fun incrementAddCipherActionCount() {
+        val activeUserId = authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumAddActionsMet(activeUserId)) return
+        val currentValue = settingsDiskSource.getAddCipherActionCount(activeUserId).orZero()
+        settingsDiskSource.storeAddCipherActionCount(
+            userId = activeUserId,
+            count = currentValue + 1,
+        )
+    }
+
+    override fun incrementCopyGeneratedResultActionCount() {
+        val activeUserId = authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumCopyActionsMet(activeUserId)) return
+        val currentValue = settingsDiskSource
+            .getCopyGeneratedResultActionCount(activeUserId)
+            .orZero()
+        settingsDiskSource.storeCopyGeneratedResultActionCount(
+            userId = activeUserId,
+            count = currentValue + 1,
+        )
+    }
+
+    override fun incrementCreateSendActionCount() {
+        val activeUserId = authDiskSource.userState?.activeUserId ?: return
+        if (isMinimumCreateActionsMet(activeUserId)) return
+        val currentValue = settingsDiskSource.getCreateSendActionCount(activeUserId).orZero()
+        settingsDiskSource.storeCreateSendActionCount(
+            userId = activeUserId,
+            count = currentValue + 1,
+        )
+    }
+
+    override fun shouldPromptForAppReview(): Boolean {
+        val activeUserId = authDiskSource.userState?.activeUserId ?: return false
+        val promptHasNotBeenShown =
+            settingsDiskSource.getUserHasBeenPromptedForReview(activeUserId) != true
+        val autofillEnabled = autofillEnabledManager.isAutofillEnabledStateFlow.value
+        val accessibilityEnabled = accessibilityEnabledManager.isAccessibilityEnabledStateFlow.value
+        val minAddActionsMet = isMinimumAddActionsMet(activeUserId)
+        val minCopyActionsMet = isMinimumCopyActionsMet(activeUserId)
+        val minCreateActionsMet = isMinimumCreateActionsMet(activeUserId)
+        return (autofillEnabled || accessibilityEnabled) &&
+            (minAddActionsMet || minCopyActionsMet || minCreateActionsMet) &&
+            promptHasNotBeenShown
+    }
+
+    private fun isMinimumAddActionsMet(userId: String): Boolean =
+        settingsDiskSource.getAddCipherActionCount(userId).orZero() >= ADD_ACTION_REQUIREMENT
+
+    private fun isMinimumCopyActionsMet(userId: String): Boolean =
+        settingsDiskSource
+            .getCopyGeneratedResultActionCount(userId)
+            .orZero() >= COPY_ACTION_REQUIREMENT
+
+    private fun isMinimumCreateActionsMet(userId: String): Boolean =
+        settingsDiskSource.getCreateSendActionCount(userId).orZero() >= CREATE_ACTION_REQUIREMENT
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -6,6 +6,7 @@ import androidx.core.content.getSystemService
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.manager.AddTotpItemFromAuthenticatorManager
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.EventDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
@@ -39,6 +40,8 @@ import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.PushManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.ResourceCacheManager
 import com.x8bit.bitwarden.data.platform.manager.ResourceCacheManagerImpl
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.SdkClientManager
 import com.x8bit.bitwarden.data.platform.manager.SdkClientManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
@@ -309,5 +312,19 @@ object PlatformManagerModule {
     ): DatabaseSchemeManager = DatabaseSchemeManagerImpl(
         authDiskSource = authDiskSource,
         settingsDiskSource = settingsDiskSource,
+    )
+
+    @Provides
+    @Singleton
+    fun provideReviewPromptManager(
+        authDiskSource: AuthDiskSource,
+        settingsDiskSource: SettingsDiskSource,
+        autofillEnabledManager: AutofillEnabledManager,
+        accessibilityEnabledManager: AccessibilityEnabledManager,
+    ): ReviewPromptManager = ReviewPromptManagerImpl(
+        authDiskSource = authDiskSource,
+        settingsDiskSource = settingsDiskSource,
+        autofillEnabledManager = autofillEnabledManager,
+        accessibilityEnabledManager = accessibilityEnabledManager,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryImpl.kt
@@ -71,7 +71,7 @@ class GeneratorRepositoryImpl(
     override val generatorResultFlow: Flow<GeneratorResult>
         get() = generatorResultChannel
             .receiveAsFlow()
-            .onEach { reviewPromptManager.incrementCopyGeneratedResultActionCount() }
+            .onEach { reviewPromptManager.registerGeneratedResultActionCount() }
 
     init {
         mutablePasswordHistoryStateFlow

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryImpl.kt
@@ -7,7 +7,7 @@ import com.bitwarden.generators.PasswordGeneratorRequest
 import com.bitwarden.generators.UsernameGeneratorRequest
 import com.bitwarden.vault.PasswordHistoryView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
-import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.model.LocalDataState
 import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAndLoggedIn
@@ -54,7 +54,7 @@ class GeneratorRepositoryImpl(
     private val authDiskSource: AuthDiskSource,
     private val vaultSdkSource: VaultSdkSource,
     private val passwordHistoryDiskSource: PasswordHistoryDiskSource,
-    private val policyManager: PolicyManager,
+    private val reviewPromptManager: ReviewPromptManager,
     dispatcherManager: DispatcherManager,
 ) : GeneratorRepository {
 
@@ -69,7 +69,9 @@ class GeneratorRepositoryImpl(
         get() = mutablePasswordHistoryStateFlow.asStateFlow()
 
     override val generatorResultFlow: Flow<GeneratorResult>
-        get() = generatorResultChannel.receiveAsFlow()
+        get() = generatorResultChannel
+            .receiveAsFlow()
+            .onEach { reviewPromptManager.incrementCopyGeneratedResultActionCount() }
 
     init {
         mutablePasswordHistoryStateFlow

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/di/GeneratorRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/di/GeneratorRepositoryModule.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.tools.generator.repository.di
 
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
-import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.GeneratorDiskSource
 import com.x8bit.bitwarden.data.tools.generator.datasource.disk.PasswordHistoryDiskSource
@@ -33,7 +33,7 @@ object GeneratorRepositoryModule {
         vaultSdkSource: VaultSdkSource,
         passwordHistoryDiskSource: PasswordHistoryDiskSource,
         dispatcherManager: DispatcherManager,
-        policyManager: PolicyManager,
+        reviewPromptManager: ReviewPromptManager,
     ): GeneratorRepository = GeneratorRepositoryImpl(
         clock = clock,
         generatorSdkSource = generatorSdkSource,
@@ -42,6 +42,6 @@ object GeneratorRepositoryModule {
         vaultSdkSource = vaultSdkSource,
         passwordHistoryDiskSource = passwordHistoryDiskSource,
         dispatcherManager = dispatcherManager,
-        policyManager = policyManager,
+        reviewPromptManager = reviewPromptManager,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
@@ -6,6 +6,7 @@ import com.bitwarden.vault.AttachmentView
 import com.bitwarden.vault.Cipher
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
 import com.x8bit.bitwarden.data.platform.util.flatMap
@@ -35,7 +36,7 @@ import java.time.Clock
 /**
  * The default implementation of the [CipherManager].
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 class CipherManagerImpl(
     private val fileManager: FileManager,
     private val authDiskSource: AuthDiskSource,
@@ -43,6 +44,7 @@ class CipherManagerImpl(
     private val vaultDiskSource: VaultDiskSource,
     private val vaultSdkSource: VaultSdkSource,
     private val clock: Clock,
+    private val reviewPromptManager: ReviewPromptManager,
 ) : CipherManager {
     private val activeUserId: String? get() = authDiskSource.userState?.activeUserId
 
@@ -57,7 +59,10 @@ class CipherManagerImpl(
             .onSuccess { vaultDiskSource.saveCipher(userId = userId, cipher = it) }
             .fold(
                 onFailure = { CreateCipherResult.Error },
-                onSuccess = { CreateCipherResult.Success },
+                onSuccess = {
+                    reviewPromptManager.incrementAddCipherActionCount()
+                    CreateCipherResult.Success
+                },
             )
     }
 
@@ -87,7 +92,10 @@ class CipherManagerImpl(
             }
             .fold(
                 onFailure = { CreateCipherResult.Error },
-                onSuccess = { CreateCipherResult.Success },
+                onSuccess = {
+                    reviewPromptManager.incrementAddCipherActionCount()
+                    CreateCipherResult.Success
+                },
             )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
@@ -60,7 +60,7 @@ class CipherManagerImpl(
             .fold(
                 onFailure = { CreateCipherResult.Error },
                 onSuccess = {
-                    reviewPromptManager.incrementAddCipherActionCount()
+                    reviewPromptManager.registerAddCipherActionCount()
                     CreateCipherResult.Success
                 },
             )
@@ -93,7 +93,7 @@ class CipherManagerImpl(
             .fold(
                 onFailure = { CreateCipherResult.Error },
                 onSuccess = {
-                    reviewPromptManager.incrementAddCipherActionCount()
+                    reviewPromptManager.registerAddCipherActionCount()
                     CreateCipherResult.Success
                 },
             )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
@@ -6,6 +6,7 @@ import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.platform.manager.AppStateManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
@@ -44,6 +45,7 @@ object VaultManagerModule {
         authDiskSource: AuthDiskSource,
         fileManager: FileManager,
         clock: Clock,
+        reviewPromptManager: ReviewPromptManager,
     ): CipherManager = CipherManagerImpl(
         fileManager = fileManager,
         authDiskSource = authDiskSource,
@@ -51,6 +53,7 @@ object VaultManagerModule {
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
         clock = clock,
+        reviewPromptManager = reviewPromptManager,
     )
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.network.util.isNoConnectionError
 import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.manager.model.SyncCipherDeleteData
 import com.x8bit.bitwarden.data.platform.manager.model.SyncCipherUpsertData
@@ -144,6 +145,7 @@ class VaultRepositoryImpl(
     pushManager: PushManager,
     private val clock: Clock,
     dispatcherManager: DispatcherManager,
+    private val reviewPromptManager: ReviewPromptManager,
 ) : VaultRepository,
     CipherManager by cipherManager,
     VaultLockManager by vaultLockManager {
@@ -632,7 +634,10 @@ class VaultRepositoryImpl(
             }
             .fold(
                 onFailure = { CreateSendResult.Error(message = null) },
-                onSuccess = { CreateSendResult.Success(it) },
+                onSuccess = {
+                    reviewPromptManager.incrementCreateSendActionCount()
+                    CreateSendResult.Success(it)
+                },
             )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -635,7 +635,7 @@ class VaultRepositoryImpl(
             .fold(
                 onFailure = { CreateSendResult.Error(message = null) },
                 onSuccess = {
-                    reviewPromptManager.incrementCreateSendActionCount()
+                    reviewPromptManager.registerCreateSendActionCount()
                     CreateSendResult.Success(it)
                 },
             )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
@@ -5,6 +5,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.network.service.CiphersService
@@ -52,6 +53,7 @@ object VaultRepositoryModule {
         userLogoutManager: UserLogoutManager,
         databaseSchemeManager: DatabaseSchemeManager,
         clock: Clock,
+        reviewPromptManager: ReviewPromptManager,
     ): VaultRepository = VaultRepositoryImpl(
         syncService = syncService,
         sendsService = sendsService,
@@ -70,5 +72,6 @@ object VaultRepositoryModule {
         userLogoutManager = userLogoutManager,
         databaseSchemeManager = databaseSchemeManager,
         clock = clock,
+        reviewPromptManager = reviewPromptManager,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/util/ClipboardDataEffect.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/util/ClipboardDataEffect.kt
@@ -1,12 +1,15 @@
 package com.x8bit.bitwarden.ui.platform.components.util
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.onEach
 
 /**
  * Side effect which is triggered when the clipboard data's text changes.
@@ -18,11 +21,22 @@ fun ClipboardDataEffect(
     onClipboardDataUpdated: (String) -> Unit,
 ) {
     val localClipboardManager: ClipboardManager = LocalClipboardManager.current
-    LaunchedEffect(localClipboardManager) {
-        snapshotFlow { localClipboardManager.getText()?.text }
-            .filterNotNull()
-            .onEach {
-                onClipboardDataUpdated(it)
+    var clipDataText: String? by rememberSaveable { mutableStateOf(null) }
+    val listener: android.content.ClipboardManager.OnPrimaryClipChangedListener =
+        remember(localClipboardManager) {
+            android.content.ClipboardManager.OnPrimaryClipChangedListener {
+                clipDataText = localClipboardManager.getText().toString()
             }
+        }
+    LaunchedEffect(clipDataText) {
+        clipDataText?.let {
+            onClipboardDataUpdated(it)
+        }
+    }
+    DisposableEffect(localClipboardManager) {
+        localClipboardManager.nativeClipboard.addPrimaryClipChangedListener(listener)
+        onDispose {
+            localClipboardManager.nativeClipboard.removePrimaryClipChangedListener(listener)
+        }
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/util/ClipboardDataEffect.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/util/ClipboardDataEffect.kt
@@ -1,0 +1,28 @@
+package com.x8bit.bitwarden.ui.platform.components.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.onEach
+
+/**
+ * Side effect which is triggered when the clipboard data's text changes.
+ *
+ * @param onClipboardDataUpdated the action to perform when the clipboard data's text changes
+ */
+@Composable
+fun ClipboardDataEffect(
+    onClipboardDataUpdated: (String) -> Unit,
+) {
+    val localClipboardManager: ClipboardManager = LocalClipboardManager.current
+    LaunchedEffect(localClipboardManager) {
+        snapshotFlow { localClipboardManager.getText()?.text }
+            .filterNotNull()
+            .onEach {
+                onClipboardDataUpdated(it)
+            }
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
@@ -25,6 +25,8 @@ import com.x8bit.bitwarden.ui.platform.manager.nfc.NfcManager
 import com.x8bit.bitwarden.ui.platform.manager.nfc.NfcManagerImpl
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManagerImpl
+import com.x8bit.bitwarden.ui.platform.manager.review.AppReviewManager
+import com.x8bit.bitwarden.ui.platform.manager.review.AppReviewManagerImpl
 
 /**
  * Helper [Composable] that wraps a [content] and provides manager classes via [CompositionLocal].
@@ -48,6 +50,7 @@ fun LocalManagerProvider(
         LocalBiometricsManager provides BiometricsManagerImpl(activity),
         LocalNfcManager provides NfcManagerImpl(activity),
         LocalFido2CompletionManager provides fido2CompletionManager,
+        LocalAppReviewManager provides AppReviewManagerImpl(activity),
     ) {
         content()
     }
@@ -88,7 +91,17 @@ val LocalNfcManager: ProvidableCompositionLocal<NfcManager> = compositionLocalOf
     error("CompositionLocal NfcManager not present")
 }
 
+/**
+ * Provides access to the FIDO2 completion manager throughout the app.
+ */
 val LocalFido2CompletionManager: ProvidableCompositionLocal<Fido2CompletionManager> =
     compositionLocalOf {
         error("CompositionLocal Fido2CompletionManager not present")
     }
+
+/**
+ * Provides access to the app review manager throughout the app.
+ */
+val LocalAppReviewManager: ProvidableCompositionLocal<AppReviewManager> = compositionLocalOf {
+    error("CompositionLocal AppReviewManager not present")
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/review/AppReviewManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/review/AppReviewManager.kt
@@ -1,0 +1,12 @@
+package com.x8bit.bitwarden.ui.platform.manager.review
+
+/**
+ * Manager for prompting the user to review the app.
+ */
+interface AppReviewManager {
+
+    /**
+     * Prompts the user to review the app.
+     */
+    fun promptForReview()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/review/AppReviewManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/review/AppReviewManagerImpl.kt
@@ -1,0 +1,41 @@
+package com.x8bit.bitwarden.ui.platform.manager.review
+
+import android.app.Activity
+import android.widget.Toast
+import com.google.android.play.core.review.ReviewManagerFactory
+import com.x8bit.bitwarden.BuildConfig
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
+import com.x8bit.bitwarden.data.platform.util.isFdroid
+import timber.log.Timber
+
+/**
+ * Default implementation of [AppReviewManager].
+ */
+@OmitFromCoverage
+class AppReviewManagerImpl(
+    private val activity: Activity,
+) : AppReviewManager {
+    override fun promptForReview() {
+        if (isFdroid) return
+        val manager = ReviewManagerFactory.create(activity)
+        val request = manager.requestReviewFlow()
+        request.addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val reviewInfo = task.result
+                manager.launchReviewFlow(activity, reviewInfo)
+                if (BuildConfig.DEBUG) {
+                    Toast
+                        .makeText(
+                            activity,
+                            activity.getString(R.string.review_flow_launched),
+                            Toast.LENGTH_SHORT,
+                        )
+                        .show()
+                }
+            } else {
+                Timber.e(task.exception)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/IntExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/IntExtensions.kt
@@ -1,0 +1,7 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+/**
+ * Extension to be applied to a nullable [Int] type where if the value is null, a default
+ * value of "0" is returned.
+ */
+fun Int?.orZero() = this ?: 0

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -58,6 +58,7 @@ import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
 import com.x8bit.bitwarden.ui.platform.components.snackbar.rememberBitwardenSnackbarHostState
 import com.x8bit.bitwarden.ui.platform.components.stepper.BitwardenStepper
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
+import com.x8bit.bitwarden.ui.platform.components.util.ClipboardDataEffect
 import com.x8bit.bitwarden.ui.platform.components.util.nonLetterColorVisualTransformation
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
@@ -101,7 +102,14 @@ fun GeneratorScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val snackbarHostState = rememberBitwardenSnackbarHostState()
-
+    val onTextCopiedToClipboard: (String) -> Unit = remember(viewModel) {
+        {
+            if (it == state.generatedText) {
+                viewModel.trySendAction(GeneratorAction.GeneratorTextFieldCopied)
+            }
+        }
+    }
+    ClipboardDataEffect(onClipboardDataUpdated = onTextCopiedToClipboard)
     LivecycleEventEffect { _, event ->
         when (event) {
             Lifecycle.Event.ON_RESUME -> {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -13,6 +13,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.util.getActivePolicies
 import com.x8bit.bitwarden.data.platform.manager.util.getActivePoliciesFlow
@@ -53,7 +54,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import kotlin.collections.filter
 import kotlin.math.max
 
 private const val KEY_STATE = "state"
@@ -76,6 +76,7 @@ class GeneratorViewModel @Inject constructor(
     private val generatorRepository: GeneratorRepository,
     private val authRepository: AuthRepository,
     private val policyManager: PolicyManager,
+    private val reviewPromptManager: ReviewPromptManager,
 ) : BaseViewModel<GeneratorState, GeneratorEvent, GeneratorAction>(
     initialState = savedStateHandle[KEY_STATE] ?: run {
         val generatorMode = GeneratorArgs(savedStateHandle).type
@@ -133,7 +134,12 @@ class GeneratorViewModel @Inject constructor(
             is GeneratorAction.MainType -> handleMainTypeAction(action)
             is GeneratorAction.Internal -> handleInternalAction(action)
             GeneratorAction.LifecycleResume -> handleOnResumed()
+            GeneratorAction.GeneratorTextFieldCopied -> handleTextFieldCopied()
         }
+    }
+
+    private fun handleTextFieldCopied() {
+        reviewPromptManager.registerGeneratedResultActionCount()
     }
 
     private fun handleOnResumed() {
@@ -636,6 +642,7 @@ class GeneratorViewModel @Inject constructor(
     }
 
     private fun handleCopyClick() {
+        reviewPromptManager.registerGeneratedResultActionCount()
         clipboardManager.setText(text = state.generatedText)
     }
 
@@ -2170,6 +2177,11 @@ sealed class GeneratorAction {
     data class MainTypeOptionSelect(
         val mainTypeOption: GeneratorState.MainTypeOption,
     ) : GeneratorAction()
+
+    /**
+     * Represents the action of copying the generated field via the system select/copy.
+     */
+    data object GeneratorTextFieldCopied : GeneratorAction()
 
     /**
      * Represents actions related to the [GeneratorState.MainType] in the generator feature.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
@@ -75,7 +76,8 @@ class VaultViewModel @Inject constructor(
     private val vaultRepository: VaultRepository,
     private val firstTimeActionManager: FirstTimeActionManager,
     private val snackbarRelayManager: SnackbarRelayManager,
-    featureFlagManager: FeatureFlagManager,
+    private val reviewPromptManager: ReviewPromptManager,
+    private val featureFlagManager: FeatureFlagManager,
 ) : BaseViewModel<VaultState, VaultEvent, VaultAction>(
     initialState = run {
         val userState = requireNotNull(authRepository.userStateFlow.value)
@@ -201,6 +203,15 @@ class VaultViewModel @Inject constructor(
             is VaultAction.Internal -> handleInternalAction(action)
             VaultAction.DismissImportActionCard -> handleDismissImportActionCard()
             VaultAction.ImportActionCardClick -> handleImportActionCardClick()
+            VaultAction.LifecycleResumed -> handleLifecycleResumed()
+        }
+    }
+
+    private fun handleLifecycleResumed() {
+        val shouldShowPrompt = reviewPromptManager.shouldPromptForAppReview() &&
+            featureFlagManager.getFeatureFlag(FlagKey.AppReviewPrompt)
+        if (shouldShowPrompt) {
+            sendEvent(VaultEvent.PromptForAppReview)
         }
     }
 
@@ -1089,6 +1100,11 @@ sealed class VaultEvent {
     data object NavigateToImportLogins : VaultEvent()
 
     /**
+     * Indicates that we should prompt the user for app review.
+     */
+    data object PromptForAppReview : VaultEvent()
+
+    /**
      * Show a toast with the given [message].
      */
     data class ShowToast(val message: Text) : VaultEvent()
@@ -1261,6 +1277,11 @@ sealed class VaultAction {
         val overflowAction: ListingItemOverflowAction.VaultAction,
         val password: String,
     ) : VaultAction()
+
+    /**
+     * The lifecycle of the VaultScreen has entered a resumed state.
+     */
+    data object LifecycleResumed : VaultAction()
 
     /**
      * Models actions that the [VaultViewModel] itself might send.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1112,4 +1112,5 @@ Do you want to switch to this account?</string>
   <string name="add_a_number_or_symbol_highlight">Add a number or symbol</string>
   <string name="need_some_inspiration">"Need some inspiration?"</string>
   <string name="check_out_the_passphrase_generator">"Check out the passphrase generator"</string>
+    <string name="review_flow_launched">Review flow launched!</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1196,73 +1196,47 @@ class SettingsDiskSourceTest {
 
     @Test
     fun `getAddCipherActionCount should pull from SharedPreferences`() {
-        val mockUserId = "mockUserId"
-        val addActionCountKey = "bwPreferencesStorage:addActionCount_$mockUserId"
+        val addActionCountKey = "bwPreferencesStorage:addActionCount"
         fakeSharedPreferences.edit { putInt(addActionCountKey, 1) }
         assertEquals(
-            1, settingsDiskSource.getAddCipherActionCount(mockUserId),
+            1, settingsDiskSource.getAddCipherActionCount(),
         )
     }
 
     @Test
     fun `storeAddCipherActionCount should update SharedPreferences`() {
-        val mockUserId = "mockUserId"
-        val addActionCountKey = "bwPreferencesStorage:addActionCount_$mockUserId"
-        settingsDiskSource.storeAddCipherActionCount(mockUserId, 1)
+        val addActionCountKey = "bwPreferencesStorage:addActionCount"
+        settingsDiskSource.storeAddCipherActionCount(count = 1)
         assertEquals(1, fakeSharedPreferences.getInt(addActionCountKey, 0))
     }
 
     @Test
     fun `getCopyGeneratedResultActionCount should pull from SharedPreferences`() {
-        val mockUserId = "mockUserId"
-        val copyActionCountKey = "bwPreferencesStorage:copyActionCount_$mockUserId"
+        val copyActionCountKey = "bwPreferencesStorage:copyActionCount"
         fakeSharedPreferences.edit { putInt(copyActionCountKey, 1) }
         assertEquals(
-            1, settingsDiskSource.getCopyGeneratedResultActionCount(mockUserId),
+            1, settingsDiskSource.getGeneratedResultActionCount(),
         )
     }
 
     @Test
     fun `storeCopyGeneratedResultCount should update SharedPreferences`() {
-        val mockUserId = "mockUserId"
-        val copyActionCountKey = "bwPreferencesStorage:copyActionCount_$mockUserId"
-        settingsDiskSource.storeCopyGeneratedResultActionCount(mockUserId, 1)
+        val copyActionCountKey = "bwPreferencesStorage:copyActionCount"
+        settingsDiskSource.storeGeneratedResultActionCount(count = 1)
         assertEquals(1, fakeSharedPreferences.getInt(copyActionCountKey, 0))
     }
 
     @Test
     fun `getCreateSendActionCount should pull from SharedPreferences`() {
-        val mockUserId = "mockUserId"
-        val createActionCountKey = "bwPreferencesStorage:createActionCount_$mockUserId"
+        val createActionCountKey = "bwPreferencesStorage:createActionCount"
         fakeSharedPreferences.edit { putInt(createActionCountKey, 1) }
-        assertEquals(1, settingsDiskSource.getCreateSendActionCount(mockUserId))
+        assertEquals(1, settingsDiskSource.getCreateSendActionCount())
     }
 
     @Test
     fun `storeCreateSendActionCount should update SharedPreferences`() {
-        val mockUserId = "mockUserId"
-        val createActionCountKey = "bwPreferencesStorage:createActionCount_$mockUserId"
-        settingsDiskSource.storeCreateSendActionCount(mockUserId, 1)
+        val createActionCountKey = "bwPreferencesStorage:createActionCount"
+        settingsDiskSource.storeCreateSendActionCount(count = 1)
         assertEquals(1, fakeSharedPreferences.getInt(createActionCountKey, 0))
-    }
-
-    @Test
-    fun `getUserHasBeenPromptedForReview should pull from SharedPreferences`() {
-        val mockUserId = "mockUserId"
-        val hasUserBeenPromptedToReviewKey =
-            "bwPreferencesStorage:hasBeenPromptedForReview_$mockUserId"
-        fakeSharedPreferences.edit { putBoolean(hasUserBeenPromptedToReviewKey, true) }
-        assertTrue(settingsDiskSource.getUserHasBeenPromptedForReview(mockUserId)!!)
-    }
-
-    @Test
-    fun `storeUserHasBeenPromptedForReview should update SharedPreferences`() {
-        val mockUserId = "mockUserId"
-        val hasUserBeenPromptedToReviewKey =
-            "bwPreferencesStorage:hasBeenPromptedForReview_$mockUserId"
-        settingsDiskSource.storeUserHasBeenPromptedForReview(mockUserId, true)
-        assertTrue(
-            fakeSharedPreferences.getBoolean(hasUserBeenPromptedToReviewKey, false),
-        )
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1193,4 +1193,76 @@ class SettingsDiskSourceTest {
             assertFalse(awaitItem() ?: true)
         }
     }
+
+    @Test
+    fun `getAddCipherActionCount should pull from SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val addActionCountKey = "bwPreferencesStorage:addActionCount_$mockUserId"
+        fakeSharedPreferences.edit { putInt(addActionCountKey, 1) }
+        assertEquals(
+            1, settingsDiskSource.getAddCipherActionCount(mockUserId),
+        )
+    }
+
+    @Test
+    fun `storeAddCipherActionCount should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val addActionCountKey = "bwPreferencesStorage:addActionCount_$mockUserId"
+        settingsDiskSource.storeAddCipherActionCount(mockUserId, 1)
+        assertEquals(1, fakeSharedPreferences.getInt(addActionCountKey, 0))
+    }
+
+    @Test
+    fun `getCopyGeneratedResultActionCount should pull from SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val copyActionCountKey = "bwPreferencesStorage:copyActionCount_$mockUserId"
+        fakeSharedPreferences.edit { putInt(copyActionCountKey, 1) }
+        assertEquals(
+            1, settingsDiskSource.getCopyGeneratedResultActionCount(mockUserId),
+        )
+    }
+
+    @Test
+    fun `storeCopyGeneratedResultCount should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val copyActionCountKey = "bwPreferencesStorage:copyActionCount_$mockUserId"
+        settingsDiskSource.storeCopyGeneratedResultActionCount(mockUserId, 1)
+        assertEquals(1, fakeSharedPreferences.getInt(copyActionCountKey, 0))
+    }
+
+    @Test
+    fun `getCreateSendActionCount should pull from SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val createActionCountKey = "bwPreferencesStorage:createActionCount_$mockUserId"
+        fakeSharedPreferences.edit { putInt(createActionCountKey, 1) }
+        assertEquals(1, settingsDiskSource.getCreateSendActionCount(mockUserId))
+    }
+
+    @Test
+    fun `storeCreateSendActionCount should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val createActionCountKey = "bwPreferencesStorage:createActionCount_$mockUserId"
+        settingsDiskSource.storeCreateSendActionCount(mockUserId, 1)
+        assertEquals(1, fakeSharedPreferences.getInt(createActionCountKey, 0))
+    }
+
+    @Test
+    fun `getUserHasBeenPromptedForReview should pull from SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val hasUserBeenPromptedToReviewKey =
+            "bwPreferencesStorage:hasBeenPromptedForReview_$mockUserId"
+        fakeSharedPreferences.edit { putBoolean(hasUserBeenPromptedToReviewKey, true) }
+        assertTrue(settingsDiskSource.getUserHasBeenPromptedForReview(mockUserId)!!)
+    }
+
+    @Test
+    fun `storeUserHasBeenPromptedForReview should update SharedPreferences`() {
+        val mockUserId = "mockUserId"
+        val hasUserBeenPromptedToReviewKey =
+            "bwPreferencesStorage:hasBeenPromptedForReview_$mockUserId"
+        settingsDiskSource.storeUserHasBeenPromptedForReview(mockUserId, true)
+        assertTrue(
+            fakeSharedPreferences.getBoolean(hasUserBeenPromptedToReviewKey, false),
+        )
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -65,10 +65,9 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val userShowUnlockBadge = mutableMapOf<String, Boolean?>()
     private val userShowImportLoginsBadge = mutableMapOf<String, Boolean?>()
     private val vaultRegisteredForExport = mutableMapOf<String, Boolean?>()
-    private val addActionCount = mutableMapOf<String, Int?>()
-    private val copyActionCount = mutableMapOf<String, Int?>()
-    private val createActionCount = mutableMapOf<String, Int?>()
-    private val userHasBeenPromptedForReview = mutableMapOf<String, Boolean?>()
+    private var addCipherActionCount: Int? = null
+    private var generatedActionCount: Int? = null
+    private var createSendActionCount: Int? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -357,36 +356,28 @@ class FakeSettingsDiskSource : SettingsDiskSource {
             emit(getVaultRegisteredForExport(userId = userId))
         }
 
-    override fun getAddCipherActionCount(userId: String): Int? {
-        return addActionCount[userId]
+    override fun getAddCipherActionCount(): Int? {
+        return addCipherActionCount
     }
 
-    override fun storeAddCipherActionCount(userId: String, count: Int?) {
-        addActionCount[userId] = count
+    override fun storeAddCipherActionCount(count: Int?) {
+        addCipherActionCount = count
     }
 
-    override fun getCopyGeneratedResultActionCount(userId: String): Int? {
-        return copyActionCount[userId]
+    override fun getGeneratedResultActionCount(): Int? {
+        return generatedActionCount
     }
 
-    override fun storeCopyGeneratedResultActionCount(userId: String, count: Int?) {
-        copyActionCount[userId] = count
+    override fun storeGeneratedResultActionCount(count: Int?) {
+        generatedActionCount = count
     }
 
-    override fun getCreateSendActionCount(userId: String): Int? {
-        return createActionCount[userId]
+    override fun getCreateSendActionCount(): Int? {
+        return createSendActionCount
     }
 
-    override fun storeCreateSendActionCount(userId: String, count: Int?) {
-        createActionCount[userId] = count
-    }
-
-    override fun getUserHasBeenPromptedForReview(userId: String): Boolean? {
-        return userHasBeenPromptedForReview[userId]
-    }
-
-    override fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?) {
-        userHasBeenPromptedForReview[userId] = value
+    override fun storeCreateSendActionCount(count: Int?) {
+        createSendActionCount = count
     }
 
     //region Private helper functions

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -65,6 +65,10 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val userShowUnlockBadge = mutableMapOf<String, Boolean?>()
     private val userShowImportLoginsBadge = mutableMapOf<String, Boolean?>()
     private val vaultRegisteredForExport = mutableMapOf<String, Boolean?>()
+    private val addActionCount = mutableMapOf<String, Int?>()
+    private val copyActionCount = mutableMapOf<String, Int?>()
+    private val createActionCount = mutableMapOf<String, Int?>()
+    private val userHasBeenPromptedForReview = mutableMapOf<String, Boolean?>()
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -352,6 +356,38 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         getMutableVaultRegisteredForExportFlow(userId = userId).onSubscription {
             emit(getVaultRegisteredForExport(userId = userId))
         }
+
+    override fun getAddCipherActionCount(userId: String): Int? {
+        return addActionCount[userId]
+    }
+
+    override fun storeAddCipherActionCount(userId: String, count: Int?) {
+        addActionCount[userId] = count
+    }
+
+    override fun getCopyGeneratedResultActionCount(userId: String): Int? {
+        return copyActionCount[userId]
+    }
+
+    override fun storeCopyGeneratedResultActionCount(userId: String, count: Int?) {
+        copyActionCount[userId] = count
+    }
+
+    override fun getCreateSendActionCount(userId: String): Int? {
+        return createActionCount[userId]
+    }
+
+    override fun storeCreateSendActionCount(userId: String, count: Int?) {
+        createActionCount[userId] = count
+    }
+
+    override fun getUserHasBeenPromptedForReview(userId: String): Boolean? {
+        return userHasBeenPromptedForReview[userId]
+    }
+
+    override fun storeUserHasBeenPromptedForReview(userId: String, value: Boolean?) {
+        userHasBeenPromptedForReview[userId] = value
+    }
 
     //region Private helper functions
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerTest.kt
@@ -30,100 +30,76 @@ class ReviewPromptManagerTest {
     @Test
     fun `incrementAddCipherActionCount increments stored value as expected`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
-        reviewPromptManager.incrementAddCipherActionCount()
+        reviewPromptManager.registerAddCipherActionCount()
         assertEquals(
             1,
-            fakeSettingsDiskSource.getAddCipherActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getAddCipherActionCount(),
         )
-        reviewPromptManager.incrementAddCipherActionCount()
+        reviewPromptManager.registerAddCipherActionCount()
         assertEquals(
             2,
-            fakeSettingsDiskSource.getAddCipherActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getAddCipherActionCount(),
         )
-        reviewPromptManager.incrementAddCipherActionCount()
+        reviewPromptManager.registerAddCipherActionCount()
         assertEquals(
             3,
-            fakeSettingsDiskSource.getAddCipherActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getAddCipherActionCount(),
         )
-        reviewPromptManager.incrementAddCipherActionCount()
+        reviewPromptManager.registerAddCipherActionCount()
         // Should not increment over 3.
         assertEquals(
             3,
-            fakeSettingsDiskSource.getAddCipherActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getAddCipherActionCount(),
         )
     }
 
     @Test
     fun `incrementCopyGeneratedResultActionCount increments stored value as expected`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
-        reviewPromptManager.incrementCopyGeneratedResultActionCount()
+        reviewPromptManager.registerGeneratedResultActionCount()
         assertEquals(
             1,
-            fakeSettingsDiskSource.getCopyGeneratedResultActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getGeneratedResultActionCount(),
         )
-        reviewPromptManager.incrementCopyGeneratedResultActionCount()
+        reviewPromptManager.registerGeneratedResultActionCount()
         assertEquals(
             2,
-            fakeSettingsDiskSource.getCopyGeneratedResultActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getGeneratedResultActionCount(),
         )
-        reviewPromptManager.incrementCopyGeneratedResultActionCount()
+        reviewPromptManager.registerGeneratedResultActionCount()
         assertEquals(
             3,
-            fakeSettingsDiskSource.getCopyGeneratedResultActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getGeneratedResultActionCount(),
         )
-        reviewPromptManager.incrementCopyGeneratedResultActionCount()
+        reviewPromptManager.registerGeneratedResultActionCount()
         assertEquals(
             3,
-            fakeSettingsDiskSource.getCopyGeneratedResultActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getGeneratedResultActionCount(),
         )
     }
 
     @Test
     fun `incrementCreateSendActionCount increments stored value as expected`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
-        reviewPromptManager.incrementCreateSendActionCount()
+        reviewPromptManager.registerCreateSendActionCount()
         assertEquals(
             1,
-            fakeSettingsDiskSource.getCreateSendActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getCreateSendActionCount(),
         )
-        reviewPromptManager.incrementCreateSendActionCount()
+        reviewPromptManager.registerCreateSendActionCount()
         assertEquals(
             2,
-            fakeSettingsDiskSource.getCreateSendActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getCreateSendActionCount(),
         )
-        reviewPromptManager.incrementCreateSendActionCount()
+        reviewPromptManager.registerCreateSendActionCount()
         assertEquals(
             3,
-            fakeSettingsDiskSource.getCreateSendActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getCreateSendActionCount(),
         )
-        reviewPromptManager.incrementCreateSendActionCount()
+        reviewPromptManager.registerCreateSendActionCount()
         assertEquals(
             3,
-            fakeSettingsDiskSource.getCreateSendActionCount(
-                userId = USER_ID,
-            ),
+            fakeSettingsDiskSource.getCreateSendActionCount(),
         )
     }
 
@@ -138,20 +114,10 @@ class ReviewPromptManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
         autofillEnabledManager.isAutofillEnabled = false
-        fakeSettingsDiskSource.storeCopyGeneratedResultActionCount(USER_ID, 0)
-        fakeSettingsDiskSource.storeCreateSendActionCount(USER_ID, 0)
-        fakeSettingsDiskSource.storeAddCipherActionCount(USER_ID, 4)
+        fakeSettingsDiskSource.storeGeneratedResultActionCount(count = 0)
+        fakeSettingsDiskSource.storeCreateSendActionCount(count = 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(count = 4)
         assertTrue(reviewPromptManager.shouldPromptForAppReview())
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `shouldPromptForAppReview should return false if prompt has been shown but other criteria is met`() {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
-        fakeSettingsDiskSource.storeUserHasBeenPromptedForReview(USER_ID, true)
-        fakeSettingsDiskSource.storeAddCipherActionCount(USER_ID, 4)
-        assertFalse(reviewPromptManager.shouldPromptForAppReview())
     }
 
     @Test
@@ -159,9 +125,9 @@ class ReviewPromptManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         fakeAccessibilityEnabledManager.isAccessibilityEnabled = false
         autofillEnabledManager.isAutofillEnabled = false
-        fakeSettingsDiskSource.storeCopyGeneratedResultActionCount(USER_ID, 0)
-        fakeSettingsDiskSource.storeCreateSendActionCount(USER_ID, 0)
-        fakeSettingsDiskSource.storeAddCipherActionCount(USER_ID, 4)
+        fakeSettingsDiskSource.storeGeneratedResultActionCount(count = 0)
+        fakeSettingsDiskSource.storeCreateSendActionCount(count = 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(count = 4)
         assertFalse(reviewPromptManager.shouldPromptForAppReview())
     }
 
@@ -170,9 +136,9 @@ class ReviewPromptManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
         autofillEnabledManager.isAutofillEnabled = true
-        fakeSettingsDiskSource.storeCopyGeneratedResultActionCount(USER_ID, 1)
-        fakeSettingsDiskSource.storeCreateSendActionCount(USER_ID, 0)
-        fakeSettingsDiskSource.storeAddCipherActionCount(USER_ID, 2)
+        fakeSettingsDiskSource.storeGeneratedResultActionCount(count = 1)
+        fakeSettingsDiskSource.storeCreateSendActionCount(count = 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(count = 2)
         assertFalse(reviewPromptManager.shouldPromptForAppReview())
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/ReviewPromptManagerTest.kt
@@ -1,0 +1,183 @@
+package com.x8bit.bitwarden.data.platform.manager
+
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.autofill.accessibility.manager.FakeAccessibilityEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManagerImpl
+import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ReviewPromptManagerTest {
+
+    private val autofillEnabledManager: AutofillEnabledManager = AutofillEnabledManagerImpl()
+    private val fakeAccessibilityEnabledManager = FakeAccessibilityEnabledManager()
+    private val fakeAuthDiskSource = FakeAuthDiskSource()
+    private val fakeSettingsDiskSource = FakeSettingsDiskSource()
+
+    private val reviewPromptManager = ReviewPromptManagerImpl(
+        autofillEnabledManager = autofillEnabledManager,
+        accessibilityEnabledManager = fakeAccessibilityEnabledManager,
+        authDiskSource = fakeAuthDiskSource,
+        settingsDiskSource = fakeSettingsDiskSource,
+    )
+
+    @Test
+    fun `incrementAddCipherActionCount increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        reviewPromptManager.incrementAddCipherActionCount()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getAddCipherActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementAddCipherActionCount()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getAddCipherActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementAddCipherActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getAddCipherActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementAddCipherActionCount()
+        // Should not increment over 3.
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getAddCipherActionCount(
+                userId = USER_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `incrementCopyGeneratedResultActionCount increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        reviewPromptManager.incrementCopyGeneratedResultActionCount()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getCopyGeneratedResultActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementCopyGeneratedResultActionCount()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getCopyGeneratedResultActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementCopyGeneratedResultActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCopyGeneratedResultActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementCopyGeneratedResultActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCopyGeneratedResultActionCount(
+                userId = USER_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `incrementCreateSendActionCount increments stored value as expected`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        reviewPromptManager.incrementCreateSendActionCount()
+        assertEquals(
+            1,
+            fakeSettingsDiskSource.getCreateSendActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementCreateSendActionCount()
+        assertEquals(
+            2,
+            fakeSettingsDiskSource.getCreateSendActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementCreateSendActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCreateSendActionCount(
+                userId = USER_ID,
+            ),
+        )
+        reviewPromptManager.incrementCreateSendActionCount()
+        assertEquals(
+            3,
+            fakeSettingsDiskSource.getCreateSendActionCount(
+                userId = USER_ID,
+            ),
+        )
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should default to false if no active user`() {
+        assertFalse(reviewPromptManager.shouldPromptForAppReview())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldPromptForAppReview should return true if one auto fill service is enabled and one actions requirement is met`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
+        autofillEnabledManager.isAutofillEnabled = false
+        fakeSettingsDiskSource.storeCopyGeneratedResultActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeCreateSendActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(USER_ID, 4)
+        assertTrue(reviewPromptManager.shouldPromptForAppReview())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `shouldPromptForAppReview should return false if prompt has been shown but other criteria is met`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
+        fakeSettingsDiskSource.storeUserHasBeenPromptedForReview(USER_ID, true)
+        fakeSettingsDiskSource.storeAddCipherActionCount(USER_ID, 4)
+        assertFalse(reviewPromptManager.shouldPromptForAppReview())
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should return false if no auto fill service is enabled`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = false
+        autofillEnabledManager.isAutofillEnabled = false
+        fakeSettingsDiskSource.storeCopyGeneratedResultActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeCreateSendActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(USER_ID, 4)
+        assertFalse(reviewPromptManager.shouldPromptForAppReview())
+    }
+
+    @Test
+    fun `shouldPromptForAppReview should return false if no action count is met`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAccessibilityEnabledManager.isAccessibilityEnabled = true
+        autofillEnabledManager.isAutofillEnabled = true
+        fakeSettingsDiskSource.storeCopyGeneratedResultActionCount(USER_ID, 1)
+        fakeSettingsDiskSource.storeCreateSendActionCount(USER_ID, 0)
+        fakeSettingsDiskSource.storeAddCipherActionCount(USER_ID, 2)
+        assertFalse(reviewPromptManager.shouldPromptForAppReview())
+    }
+}
+
+private const val USER_ID = "user_id"
+private val MOCK_USER_STATE = mockk<UserStateJson>() {
+    every { activeUserId } returns USER_ID
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryTest.kt
@@ -73,7 +73,7 @@ class GeneratorRepositoryTest {
     private val vaultSdkSource: VaultSdkSource = mockk()
     private val dispatcherManager = FakeDispatcherManager()
     private val reviewPromptManager: ReviewPromptManager = mockk {
-        every { incrementCopyGeneratedResultActionCount() } just runs
+        every { registerGeneratedResultActionCount() } just runs
     }
 
     private val repository = GeneratorRepositoryImpl(
@@ -753,7 +753,7 @@ class GeneratorRepositoryTest {
                 repository.emitGeneratorResult(GeneratorResult.Password("foo"))
                 assertEquals(GeneratorResult.Password("foo"), awaitItem())
             }
-            verify(exactly = 1) { reviewPromptManager.incrementCopyGeneratedResultActionCount() }
+            verify(exactly = 1) { reviewPromptManager.registerGeneratedResultActionCount() }
         }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
@@ -49,6 +50,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkStatic
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -73,6 +75,9 @@ class CipherManagerTest {
     private val ciphersService: CiphersService = mockk()
     private val vaultDiskSource: VaultDiskSource = mockk()
     private val vaultSdkSource: VaultSdkSource = mockk()
+    private val reviewPromptManager: ReviewPromptManager = mockk {
+        every { incrementAddCipherActionCount() } just runs
+    }
 
     private val cipherManager: CipherManager = CipherManagerImpl(
         ciphersService = ciphersService,
@@ -81,6 +86,7 @@ class CipherManagerTest {
         authDiskSource = fakeAuthDiskSource,
         fileManager = fileManager,
         clock = clock,
+        reviewPromptManager = reviewPromptManager,
     )
 
     @BeforeEach
@@ -147,7 +153,7 @@ class CipherManagerTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `createCipher with ciphersService createCipher success should return CreateCipherResult success`() =
+    fun `createCipher with ciphersService createCipher success should return CreateCipherResult success and increment addCipherActionCount`() =
         runTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val userId = "mockId-1"
@@ -169,6 +175,7 @@ class CipherManagerTest {
             val result = cipherManager.createCipher(cipherView = mockCipherView)
 
             assertEquals(CreateCipherResult.Success, result)
+            verify(exactly = 1) { reviewPromptManager.incrementAddCipherActionCount() }
         }
 
     @Test
@@ -238,7 +245,7 @@ class CipherManagerTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `createCipherInOrganization with ciphersService createCipher success should return CreateCipherResult success`() =
+    fun `createCipherInOrganization with ciphersService createCipher success should return CreateCipherResult success and increment addCipherActionCount`() =
         runTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val userId = "mockId-1"
@@ -271,6 +278,7 @@ class CipherManagerTest {
             )
 
             assertEquals(CreateCipherResult.Success, result)
+            verify(exactly = 1) { reviewPromptManager.incrementAddCipherActionCount() }
         }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
@@ -76,7 +76,7 @@ class CipherManagerTest {
     private val vaultDiskSource: VaultDiskSource = mockk()
     private val vaultSdkSource: VaultSdkSource = mockk()
     private val reviewPromptManager: ReviewPromptManager = mockk {
-        every { incrementAddCipherActionCount() } just runs
+        every { registerAddCipherActionCount() } just runs
     }
 
     private val cipherManager: CipherManager = CipherManagerImpl(
@@ -175,7 +175,7 @@ class CipherManagerTest {
             val result = cipherManager.createCipher(cipherView = mockCipherView)
 
             assertEquals(CreateCipherResult.Success, result)
-            verify(exactly = 1) { reviewPromptManager.incrementAddCipherActionCount() }
+            verify(exactly = 1) { reviewPromptManager.registerAddCipherActionCount() }
         }
 
     @Test
@@ -278,7 +278,7 @@ class CipherManagerTest {
             )
 
             assertEquals(CreateCipherResult.Success, result)
-            verify(exactly = 1) { reviewPromptManager.incrementAddCipherActionCount() }
+            verify(exactly = 1) { reviewPromptManager.registerAddCipherActionCount() }
         }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -199,7 +199,7 @@ class VaultRepositoryTest {
         every { databaseSchemeChangeFlow } returns mutableDatabaseSchemeChangeFlow
     }
     private val reviewPromptManager: ReviewPromptManager = mockk {
-        every { incrementCreateSendActionCount() } just runs
+        every { registerCreateSendActionCount() } just runs
     }
 
     private val mutableFullSyncFlow = bufferedMutableSharedFlow<Unit>()
@@ -2078,7 +2078,7 @@ class VaultRepositoryTest {
 
             assertEquals(CreateSendResult.Success(mockSendViewResult), result)
 
-            verify(exactly = 1) { reviewPromptManager.incrementCreateSendActionCount() }
+            verify(exactly = 1) { reviewPromptManager.registerCreateSendActionCount() }
         }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -27,6 +27,7 @@ import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.manager.model.SyncCipherDeleteData
 import com.x8bit.bitwarden.data.platform.manager.model.SyncCipherUpsertData
@@ -197,6 +198,9 @@ class VaultRepositoryTest {
     private val databaseSchemeManager: DatabaseSchemeManager = mockk {
         every { databaseSchemeChangeFlow } returns mutableDatabaseSchemeChangeFlow
     }
+    private val reviewPromptManager: ReviewPromptManager = mockk {
+        every { incrementCreateSendActionCount() } just runs
+    }
 
     private val mutableFullSyncFlow = bufferedMutableSharedFlow<Unit>()
     private val mutableSyncCipherDeleteFlow = bufferedMutableSharedFlow<SyncCipherDeleteData>()
@@ -233,6 +237,7 @@ class VaultRepositoryTest {
         clock = clock,
         userLogoutManager = userLogoutManager,
         databaseSchemeManager = databaseSchemeManager,
+        reviewPromptManager = reviewPromptManager,
     )
 
     @BeforeEach
@@ -2046,7 +2051,7 @@ class VaultRepositoryTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `createSend with TEXT and sendsService createTextSend success should return CreateSendResult success`() =
+    fun `createSend with TEXT and sendsService createTextSend success should return CreateSendResult success and increment send action count`() =
         runTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val userId = "mockId-1"
@@ -2072,6 +2077,8 @@ class VaultRepositoryTest {
             val result = vaultRepository.createSend(sendView = mockSendView, fileUri = null)
 
             assertEquals(CreateSendResult.Success(mockSendViewResult), result)
+
+            verify(exactly = 1) { reviewPromptManager.incrementCreateSendActionCount() }
         }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/IntExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/IntExtensionsTest.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IntExtensionsTest {
+    @Test
+    fun `orZero returns zero when null`() {
+        val nullInt: Int? = null
+        assertEquals(0, nullInt.orZero())
+    }
+
+    @Test
+    fun `orZero returns value when not null`() {
+        val nonNullInt = 42
+        assertEquals(42, nonNullInt.orZero())
+        val negativeNonNullInt = -42
+        assertEquals(-42, negativeNonNullInt.orZero())
+        assertEquals(0, 0.orZero())
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
@@ -102,6 +103,10 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     private val policyManager: PolicyManager = mockk {
         every { getActivePolicies(PolicyTypeJson.PASSWORD_GENERATOR) } returns emptyList()
         every { getActivePoliciesFlow(PolicyTypeJson.PASSWORD_GENERATOR) } returns mutablePolicyFlow
+    }
+
+    private val reviewPromptManager: ReviewPromptManager = mockk {
+        every { registerGeneratedResultActionCount() } just runs
     }
 
     @Test
@@ -517,7 +522,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `CopyClick should call setText on ClipboardManager`() {
+    fun `CopyClick should call setText on ClipboardManager and register generator action`() {
         val viewModel = createViewModel()
         every { clipboardManager.setText(viewModel.stateFlow.value.generatedText) } just runs
 
@@ -525,6 +530,16 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
         verify(exactly = 1) {
             clipboardManager.setText(text = viewModel.stateFlow.value.generatedText)
+            reviewPromptManager.registerGeneratedResultActionCount()
+        }
+    }
+
+    @Test
+    fun `GeneratorTextFieldCopied action should register generator action`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(GeneratorAction.GeneratorTextFieldCopied)
+        verify(exactly = 1) {
+            reviewPromptManager.registerGeneratedResultActionCount()
         }
     }
 
@@ -2372,6 +2387,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         generatorRepository = fakeGeneratorRepository,
         authRepository = authRepository,
         policyManager = policyManager,
+        reviewPromptManager = reviewPromptManager,
     )
 
     private fun createViewModel(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ detekt = "1.23.7"
 firebaseBom = "33.6.0"
 glide = "1.0.0-beta01"
 googleServices = "4.4.2"
+googleReview = "2.0.2"
 hilt = "2.53"
 junit5 = "5.11.3"
 jvmTarget = "17"
@@ -94,6 +95,7 @@ google-firebase-crashlytics = { module = "com.google.firebase:firebase-crashlyti
 google-hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 google-hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 google-hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
+google-play-review = { module = "com.google.android.play:review", version.ref = "googleReview"}
 junit-junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
 junit-vintage = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15381
https://bitwarden.atlassian.net/browse/PM-15383
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- When the user is on the vault screen and has met the criteria for prompting for review (3 qualifying actions, auto fill/accessibility on) and the flag is on after 3 seconds prmpt for review
- shows a toast in debug mode for ease of testing.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
