### PR TITLE
[PM-13513] Keeping "androidapp" scheme on uri when saving from Android Apps

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensions.kt
@@ -24,7 +24,6 @@ fun AutofillRequest.Fillable.toAutofillSaveItem(): AutofillSaveItem =
                 .uri
                 ?.replace("https://", "")
                 ?.replace("http://", "")
-                ?.replace("androidapp://", "")
 
             AutofillSaveItem.Login(
                 username = partition.usernameSaveValue,

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensionsTest.kt
@@ -75,6 +75,30 @@ class AutofillRequestExtensionsTest {
                 assertEquals(expected, actual)
             }
     }
+
+    @Test
+    fun `toAutofillSaveItem should return AutofillSaveItem Login with androidapp on URI`() {
+
+        val autofillPartition: AutofillPartition.Login = mockk {
+            every { usernameSaveValue } returns SAVE_VALUE_USERNAME
+            every { passwordSaveValue } returns SAVE_VALUE_PASSWORD
+        }
+        val autofillRequest: AutofillRequest.Fillable = mockk {
+            every { partition } returns autofillPartition
+            every { uri } returns RAW_ANDROIDAPP_URI
+        }
+        val expected = AutofillSaveItem.Login(
+            username = SAVE_VALUE_USERNAME,
+            password = SAVE_VALUE_PASSWORD,
+            uri = RAW_ANDROIDAPP_URI,
+        )
+
+        // Test
+        val actual = autofillRequest.toAutofillSaveItem()
+
+        // Verify
+        assertEquals(expected, actual)
+    }
 }
 
 private const val AUTOFILL_REQUEST_EXTENSIONS_PATH =
@@ -91,7 +115,7 @@ private const val SAVE_VALUE_PASSWORD: String = "SAVE_VALUE_PASSWORD"
 private const val SAVE_VALUE_USERNAME: String = "SAVE_VALUE_USERNAME"
 private const val FINAL_URI: String = "URI"
 private val RAW_URI_LIST: List<String> = listOf(
-    "androidapp://URI",
     "https://URI",
     "http://URI",
 )
+private const val RAW_ANDROIDAPP_URI: String = "androidapp://URI"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13513
Closes #4082 

## 📔 Objective

Android apps can't recognize autofill URI's properly without the "androidapp" prefix scheme. 
Keeping it when saving a new login from and Android app

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
