### PR TITLE
[PM-9328] Mobile team owns changes to the .github folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 * @bitwarden/team-android @brian-livefront @david-livefront @dseverns-livefront @ahaisting-livefront
 
 # Actions and workflow changes.
-.github/workflows @bitwarden/dept-development-mobile
+.github/ @bitwarden/dept-development-mobile
 
 # Auth
 # app/src/main/java/com/x8bit/bitwarden/data/auth @bitwarden/team-auth-dev


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9328

## 📔 Objective

Updates CODEOWNERS to assign everything inside `.github` folder to the mobile team. This was previously done in the ios repo but android was missing it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
