### PR TITLE
PM-15599: Update copy toast to not display copied value

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
@@ -46,14 +46,10 @@ class BitwardenClipboardManagerImpl(
                 },
         )
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-            val descriptor = toastDescriptorOverride ?: text
-            Toast
-                .makeText(
-                    context,
-                    context.resources.getString(R.string.value_has_been_copied, descriptor),
-                    Toast.LENGTH_SHORT,
-                )
-                .show()
+            val descriptor = toastDescriptorOverride
+                ?.let { context.resources.getString(R.string.value_has_been_copied, it) }
+                ?: context.resources.getString(R.string.copied_to_clipboard)
+            Toast.makeText(context, descriptor, Toast.LENGTH_SHORT).show()
         }
 
         val frequency = clearClipboardFrequencySeconds ?: return

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1112,4 +1112,5 @@ Do you want to switch to this account?</string>
   <string name="add_a_number_or_symbol_highlight">Add a number or symbol</string>
   <string name="need_some_inspiration">"Need some inspiration?"</string>
   <string name="check_out_the_passphrase_generator">"Check out the passphrase generator"</string>
+  <string name="copied_to_clipboard">Copied to clipboard.</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15599](https://bitwarden.atlassian.net/browse/PM-15599)

## 📔 Objective

This PR updates the toast when copying a password to no longer display the value being copied.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15599]: https://bitwarden.atlassian.net/browse/PM-15599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ