### PR TITLE
[PM-15057] Rename toFido2RequestOrNull to toFido2CreateRequestOrNull

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensions.kt
@@ -29,7 +29,7 @@ fun SpecialCircumstance.toAutofillSelectionDataOrNull(): AutofillSelectionData? 
 /**
  * Returns [Fido2CreateCredentialRequest] when contained in the given [SpecialCircumstance].
  */
-fun SpecialCircumstance.toFido2RequestOrNull(): Fido2CreateCredentialRequest? =
+fun SpecialCircumstance.toFido2CreateRequestOrNull(): Fido2CreateCredentialRequest? =
     when (this) {
         is SpecialCircumstance.Fido2Save -> this.fido2CreateCredentialRequest
         else -> null

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -23,7 +23,7 @@ import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSaveItemOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSelectionDataOrNull
-import com.x8bit.bitwarden.data.platform.manager.util.toFido2RequestOrNull
+import com.x8bit.bitwarden.data.platform.manager.util.toFido2CreateRequestOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toTotpDataOrNull
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.DataState
@@ -121,7 +121,7 @@ class VaultAddEditViewModel @Inject constructor(
             // Check for totp data to pre-populate
             val totpData = specialCircumstance?.toTotpDataOrNull()
             // Check for Fido2 data to pre-populate
-            val fido2CreationRequest = specialCircumstance?.toFido2RequestOrNull()
+            val fido2CreationRequest = specialCircumstance?.toFido2CreateRequestOrNull()
             val fido2AttestationOptions = fido2CreationRequest?.let { request ->
                 fido2CredentialManager.getPasskeyAttestationOptionsOrNull(request.requestJson)
             }
@@ -419,7 +419,7 @@ class VaultAddEditViewModel @Inject constructor(
         }
 
         specialCircumstanceManager.specialCircumstance
-            ?.toFido2RequestOrNull()
+            ?.toFido2CreateRequestOrNull()
             ?.let { request ->
                 handleFido2RequestSpecialCircumstance(request, content.toCipherView())
                 return@onContent
@@ -583,7 +583,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleConfirmOverwriteExistingPasskeyClick() {
         specialCircumstanceManager
             .specialCircumstance
-            ?.toFido2RequestOrNull()
+            ?.toFido2CreateRequestOrNull()
             ?.let { request ->
                 onContent { content ->
                     registerFido2Credential(request, content.toCipherView())
@@ -605,7 +605,7 @@ class VaultAddEditViewModel @Inject constructor(
     private fun getRequestAndRegisterCredential() =
         specialCircumstanceManager
             .specialCircumstance
-            ?.toFido2RequestOrNull()
+            ?.toFido2CreateRequestOrNull()
             ?.let { request ->
                 onContent { content ->
                     registerFido2CredentialToCipher(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -33,7 +33,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSelectionDataOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toFido2AssertionRequestOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toFido2GetCredentialsRequestOrNull
-import com.x8bit.bitwarden.data.platform.manager.util.toFido2RequestOrNull
+import com.x8bit.bitwarden.data.platform.manager.util.toFido2CreateRequestOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toTotpDataOrNull
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -113,7 +113,7 @@ class VaultItemListingViewModel @Inject constructor(
         val activeAccountSummary = userState.toActiveAccountSummary()
         val accountSummaries = userState.toAccountSummaries()
         val specialCircumstance = specialCircumstanceManager.specialCircumstance
-        val fido2CredentialRequest = specialCircumstance?.toFido2RequestOrNull()
+        val fido2CredentialRequest = specialCircumstance?.toFido2CreateRequestOrNull()
         VaultItemListingState(
             itemListingType = VaultItemListingArgs(savedStateHandle = savedStateHandle)
                 .vaultItemListingType
@@ -1263,7 +1263,7 @@ class VaultItemListingViewModel @Inject constructor(
     private fun continueFido2Operation(cipherView: CipherView) {
         specialCircumstanceManager
             .specialCircumstance
-            ?.toFido2RequestOrNull()
+            ?.toFido2CreateRequestOrNull()
             ?.let { request ->
                 registerFido2CredentialToCipher(
                     request = request,

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
@@ -140,7 +140,7 @@ class SpecialCircumstanceExtensionsTest {
             SpecialCircumstance.VaultShortcut,
         )
             .forEach { specialCircumstance ->
-                assertNull(specialCircumstance.toFido2RequestOrNull())
+                assertNull(specialCircumstance.toFido2CreateRequestOrNull())
             }
     }
 
@@ -159,7 +159,7 @@ class SpecialCircumstanceExtensionsTest {
                 .Fido2Save(
                     fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
-                .toFido2RequestOrNull(),
+                .toFido2CreateRequestOrNull(),
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-15057

## 📔 Objective

Renamed `toFido2RequestOrNull` to `toFido2CreateRequestOrNull` to better reflect its purpose of retrieving a Fido2CreateCredentialRequest from a SpecialCircumstance.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
