### PR TITLE
[PM-15116] Add common fields to SSH Key add/edit screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSshKeyItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSshKeyItems.kt
@@ -3,8 +3,10 @@ package com.x8bit.bitwarden.ui.vault.feature.addedit
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -13,15 +15,23 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
+import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
+import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
+import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCommonHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditSshKeyTypeHandlers
+import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * The UI for adding and editing a SSH key cipher.
  */
+@Suppress("LongMethod")
 fun LazyListScope.vaultAddEditSshKeyItems(
     commonState: VaultAddEditState.ViewState.Content.Common,
     sshKeyState: VaultAddEditState.ViewState.Content.ItemType.SshKey,
@@ -83,6 +93,138 @@ fun LazyListScope.vaultAddEditSshKeyItems(
                 .testTag("FingerprintEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        Spacer(modifier = Modifier.height(24.dp))
+        BitwardenListHeaderText(
+            label = stringResource(id = R.string.miscellaneous),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+    }
+
+    item {
+        Spacer(modifier = Modifier.height(8.dp))
+        BitwardenMultiSelectButton(
+            label = stringResource(id = R.string.folder),
+            options = commonState
+                .availableFolders
+                .map { it.name }
+                .toImmutableList(),
+            selectedOption = commonState.selectedFolder?.name,
+            onOptionSelected = { selectedFolderName ->
+                commonTypeHandlers.onFolderSelected(
+                    commonState
+                        .availableFolders
+                        .first { it.name == selectedFolderName },
+                )
+            },
+            modifier = Modifier
+                .testTag("FolderPicker")
+                .padding(horizontal = 16.dp),
+        )
+    }
+
+    item {
+        Spacer(modifier = Modifier.height(16.dp))
+        BitwardenSwitch(
+            label = stringResource(
+                id = R.string.favorite,
+            ),
+            isChecked = commonState.favorite,
+            onCheckedChange = commonTypeHandlers.onToggleFavorite,
+            modifier = Modifier
+                .testTag("ItemFavoriteToggle")
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+    }
+    if (commonState.isUnlockWithPasswordEnabled) {
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+            BitwardenSwitch(
+                label = stringResource(id = R.string.password_prompt),
+                isChecked = commonState.masterPasswordReprompt,
+                onCheckedChange = commonTypeHandlers.onToggleMasterPasswordReprompt,
+                modifier = Modifier
+                    .testTag("MasterPasswordRepromptToggle")
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                actions = {
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_question_circle_small,
+                        contentDescription = stringResource(
+                            id = R.string.master_password_re_prompt_help,
+                        ),
+                        onClick = commonTypeHandlers.onTooltipClick,
+                        contentColor = BitwardenTheme.colorScheme.icon.secondary,
+                    )
+                },
+            )
+        }
+    }
+
+    item {
+        Spacer(modifier = Modifier.height(24.dp))
+        BitwardenListHeaderText(
+            label = stringResource(id = R.string.notes),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+    }
+
+    item {
+        Spacer(modifier = Modifier.height(8.dp))
+        BitwardenTextField(
+            singleLine = false,
+            label = stringResource(id = R.string.notes),
+            value = commonState.notes,
+            onValueChange = commonTypeHandlers.onNotesTextChange,
+            modifier = Modifier
+                .testTag("ItemNotesEntry")
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+    }
+
+    item {
+        Spacer(modifier = Modifier.height(24.dp))
+        BitwardenListHeaderText(
+            label = stringResource(id = R.string.custom_fields),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+    }
+
+    items(commonState.customFieldData) { customItem ->
+        Spacer(modifier = Modifier.height(8.dp))
+        VaultAddEditCustomField(
+            customField = customItem,
+            onCustomFieldValueChange = commonTypeHandlers.onCustomFieldValueChange,
+            onCustomFieldAction = commonTypeHandlers.onCustomFieldActionSelect,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            supportedLinkedTypes = persistentListOf(
+                VaultLinkedFieldType.PASSWORD,
+                VaultLinkedFieldType.USERNAME,
+            ),
+            onHiddenVisibilityChanged = commonTypeHandlers.onHiddenFieldVisibilityChange,
+        )
+    }
+
+    item {
+        Spacer(modifier = Modifier.height(16.dp))
+        VaultAddEditCustomFieldsButton(
+            onFinishNamingClick = commonTypeHandlers.onAddNewCustomFieldClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-15116

## 📔 Objective

Add the common cipher fields to the add/edit screen so they can be modified when editing an existing SSH key.

## 📸 Screenshots

<img width="375" alt="image" src="https://github.com/user-attachments/assets/cbfca168-e59e-4ca8-bf45-0d59e170589b">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
