### PR TITLE
[PM-13349] Hide edit button unless item is in at least one non-readOnly collection

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -31,6 +31,7 @@ import com.x8bit.bitwarden.ui.vault.feature.item.model.VaultItemStateData
 import com.x8bit.bitwarden.ui.vault.feature.item.util.toViewState
 import com.x8bit.bitwarden.ui.vault.feature.util.canAssignToCollections
 import com.x8bit.bitwarden.ui.vault.feature.util.hasDeletePermissionInAtLeastOneCollection
+import com.x8bit.bitwarden.ui.vault.feature.util.hasEditPermissionInAtLeastOneCollection
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -116,11 +117,18 @@ class VaultItemViewModel @Inject constructor(
                             .data
                             .canAssignToCollections(cipherViewState.data?.collectionIds)
 
+                        val canEdit = collectionsState
+                            .data
+                            .hasEditPermissionInAtLeastOneCollection(
+                                cipherViewState.data?.collectionIds,
+                            )
+
                         VaultItemStateData(
                             cipher = cipherViewState.data,
                             totpCodeItemData = totpCodeData,
                             canDelete = canDelete,
                             canAssociateToCollections = canAssignToCollections,
+                            canEdit = canEdit,
                         )
                     },
             )
@@ -1040,6 +1048,7 @@ class VaultItemViewModel @Inject constructor(
                 totpCodeItemData = this.data?.totpCodeItemData,
                 canDelete = this.data?.canDelete == true,
                 canAssignToCollections = this.data?.canAssociateToCollections == true,
+                canEdit = this.data?.canEdit == true,
             )
         }
         ?: VaultItemState.ViewState.Error(message = errorText)
@@ -1277,11 +1286,16 @@ data class VaultItemState(
             ?.currentCipher
             ?.deletedDate != null
 
+    private val isCipherEditable: Boolean
+        get() = viewState.asContentOrNull()
+            ?.common
+            ?.canEdit == true
+
     /**
      * Whether or not the fab is visible.
      */
     val isFabVisible: Boolean
-        get() = viewState is ViewState.Content && !isCipherDeleted
+        get() = viewState is ViewState.Content && !isCipherDeleted && isCipherEditable
 
     /**
      * Whether or not the cipher is in a collection.
@@ -1377,6 +1391,7 @@ data class VaultItemState(
                 val attachments: List<AttachmentItem>?,
                 val canDelete: Boolean,
                 val canAssignToCollections: Boolean,
+                val canEdit: Boolean,
             ) : Parcelable {
 
                 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/model/VaultItemStateData.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/model/VaultItemStateData.kt
@@ -9,10 +9,12 @@ import com.bitwarden.vault.CipherView
  * @property totpCodeItemData The data for the totp code.
  * @property canDelete Whether the item can be deleted.
  * @property canAssociateToCollections Whether the item can be associated to a collection.
+ * @property canEdit Whether the item can be edited.
  */
 data class VaultItemStateData(
     val cipher: CipherView?,
     val totpCodeItemData: TotpCodeItemData?,
     val canDelete: Boolean,
     val canAssociateToCollections: Boolean,
+    val canEdit: Boolean,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensions.kt
@@ -41,6 +41,7 @@ fun CipherView.toViewState(
     clock: Clock = Clock.systemDefaultZone(),
     canDelete: Boolean,
     canAssignToCollections: Boolean,
+    canEdit: Boolean,
 ): VaultItemState.ViewState =
     VaultItemState.ViewState.Content(
         common = VaultItemState.ViewState.Content.Common(
@@ -83,6 +84,7 @@ fun CipherView.toViewState(
                 .orEmpty(),
             canDelete = canDelete,
             canAssignToCollections = canAssignToCollections,
+            canEdit = canEdit,
         ),
         type = when (type) {
             CipherType.LOGIN -> {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
@@ -122,3 +122,20 @@ fun List<CollectionView>?.canAssignToCollections(currentCollectionIds: List<Stri
             itemIsInCollection && (!it.manage || it.readOnly)
         }
         ?: true
+
+/**
+ * Checks if the user has edit permission in at least one collection.
+ *
+ * Editing is allowed when the item is in any collection that isn't read-only.
+ */
+fun List<CollectionView>?.hasEditPermissionInAtLeastOneCollection(
+    collectionIds: List<String>?,
+): Boolean {
+    if (this.isNullOrEmpty() || collectionIds.isNullOrEmpty()) return true
+    return this
+        .any { collectionView ->
+            collectionIds
+                .contains(collectionView.id)
+                .let { isInCollection -> isInCollection && !collectionView.readOnly }
+        }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -2698,6 +2698,7 @@ private val DEFAULT_COMMON: VaultItemState.ViewState.Content.Common =
         ),
         canDelete = true,
         canAssignToCollections = true,
+        canEdit = true,
     )
 
 private val DEFAULT_PASSKEY = R.string.created_xy.asText(
@@ -2781,6 +2782,7 @@ private val EMPTY_COMMON: VaultItemState.ViewState.Content.Common =
         attachments = emptyList(),
         canDelete = true,
         canAssignToCollections = true,
+        canEdit = true,
     )
 
 private val EMPTY_LOGIN_TYPE: VaultItemState.ViewState.Content.ItemType.Login =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -170,6 +170,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns DEFAULT_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -195,6 +196,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
             }
@@ -214,6 +216,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns loginState
 
@@ -258,6 +261,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns loginState
 
@@ -291,6 +295,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns loginViewState
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -335,6 +340,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns loginViewState
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -382,6 +388,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns loginViewState
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -421,6 +428,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = createTotpCodeData(),
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns DEFAULT_VIEW_STATE
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -455,6 +463,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns viewState
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -493,6 +502,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns DEFAULT_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -534,6 +544,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = createTotpCodeData(),
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns DEFAULT_VIEW_STATE
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -584,6 +595,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = createTotpCodeData(),
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns DEFAULT_VIEW_STATE
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -617,6 +629,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns loginViewState
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -635,6 +648,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
                 assertEquals(
@@ -660,7 +674,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns loginViewState
 
@@ -722,7 +738,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns loginViewState
 
@@ -776,7 +794,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns loginViewState
 
@@ -841,7 +861,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns DEFAULT_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -865,7 +887,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 }
             }
@@ -880,7 +904,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     isPremiumUser = true,
                     hasMasterPassword = true,
                     canDelete = true,
-                    canAssignToCollections = true, totpCodeItemData = null,
+                    canAssignToCollections = true,
+                    canEdit = true,
+                    totpCodeItemData = null,
                 )
             } returns createViewState(common = DEFAULT_COMMON.copy(requiresReprompt = false))
             every { clipboardManager.setText(text = field) } just runs
@@ -898,7 +924,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     isPremiumUser = true,
                     hasMasterPassword = true,
                     canDelete = true,
-                    canAssignToCollections = true, totpCodeItemData = null,
+                    canAssignToCollections = true,
+                    canEdit = true,
+                    totpCodeItemData = null,
                 )
                 organizationEventManager.trackEvent(
                     event = OrganizationEvent.CipherClientCopiedHiddenField(
@@ -937,7 +965,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns DEFAULT_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -969,7 +999,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 }
             }
@@ -1004,6 +1036,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns loginViewState
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1035,7 +1068,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                     organizationEventManager.trackEvent(
                         event = OrganizationEvent.CipherClientToggledHiddenFieldVisible(
@@ -1055,7 +1090,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns DEFAULT_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1079,7 +1116,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 }
             }
@@ -1098,7 +1137,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns loginViewState
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1132,7 +1173,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     isPremiumUser = true,
                     hasMasterPassword = true,
                     canDelete = true,
-                    canAssignToCollections = true, totpCodeItemData = null,
+                    canAssignToCollections = true,
+                    canEdit = true,
+                    totpCodeItemData = null,
                 )
             } returns loginViewState
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1158,7 +1201,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     isPremiumUser = true,
                     hasMasterPassword = true,
                     canDelete = true,
-                    canAssignToCollections = true, totpCodeItemData = null,
+                    canAssignToCollections = true,
+                    canEdit = true,
+                    totpCodeItemData = null,
                 )
             }
         }
@@ -1181,7 +1226,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     isPremiumUser = true,
                     hasMasterPassword = true,
                     canDelete = true,
-                    canAssignToCollections = true, totpCodeItemData = null,
+                    canAssignToCollections = true,
+                    canEdit = true,
+                    totpCodeItemData = null,
                 )
             } returns loginViewState
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1229,7 +1276,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     isPremiumUser = true,
                     hasMasterPassword = true,
                     canDelete = true,
-                    canAssignToCollections = true, totpCodeItemData = null,
+                    canAssignToCollections = true,
+                    canEdit = true,
+                    totpCodeItemData = null,
                 )
             } returns DEFAULT_VIEW_STATE
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1253,7 +1302,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     isPremiumUser = true,
                     hasMasterPassword = true,
                     canDelete = true,
-                    canAssignToCollections = true, totpCodeItemData = null,
+                    canAssignToCollections = true,
+                    canEdit = true,
+                    totpCodeItemData = null,
                 )
             }
         }
@@ -1272,7 +1323,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns loginViewState
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1303,7 +1356,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 } returns DEFAULT_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1327,7 +1382,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         isPremiumUser = true,
                         hasMasterPassword = true,
                         canDelete = true,
-                        canAssignToCollections = true, totpCodeItemData = null,
+                        canAssignToCollections = true,
+                        canEdit = true,
+                        totpCodeItemData = null,
                     )
                 }
             }
@@ -1347,6 +1404,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         hasMasterPassword = true,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                         totpCodeItemData = null,
                     )
                 } returns loginViewState
@@ -1390,6 +1448,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         hasMasterPassword = true,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                         totpCodeItemData = null,
                     )
                 } returns loginViewState
@@ -1447,6 +1506,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         hasMasterPassword = true,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                         totpCodeItemData = null,
                     )
                 } returns loginViewState
@@ -1513,6 +1573,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         hasMasterPassword = true,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                         totpCodeItemData = null,
                     )
                 } returns loginViewState
@@ -1681,6 +1742,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns DEFAULT_VIEW_STATE
 
@@ -1719,6 +1781,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     hasMasterPassword = true,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                     totpCodeItemData = createTotpCodeData(),
                 )
             } returns DEFAULT_VIEW_STATE
@@ -1760,6 +1823,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     hasMasterPassword = true,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                     totpCodeItemData = createTotpCodeData(),
                 )
             }
@@ -1779,6 +1843,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         hasMasterPassword = true,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                         totpCodeItemData = createTotpCodeData(),
                     )
                 } returns DEFAULT_VIEW_STATE
@@ -1807,6 +1872,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         hasMasterPassword = true,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                         totpCodeItemData = createTotpCodeData(),
                     )
                 }
@@ -1822,6 +1888,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     hasMasterPassword = true,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                     totpCodeItemData = createTotpCodeData(),
                 )
             } returns createViewState(common = DEFAULT_COMMON.copy(requiresReprompt = false))
@@ -1842,6 +1909,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     hasMasterPassword = true,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                     totpCodeItemData = createTotpCodeData(),
                 )
             }
@@ -1884,6 +1952,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     hasMasterPassword = true,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                     totpCodeItemData = createTotpCodeData(),
                 )
             } returns createViewState(common = DEFAULT_COMMON.copy(requiresReprompt = false))
@@ -1904,6 +1973,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = createTotpCodeData(),
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             }
         }
@@ -1929,6 +1999,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns DEFAULT_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -1955,6 +2026,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
             }
@@ -1971,6 +2043,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
                     .returns(
@@ -1999,6 +2072,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
             }
@@ -2016,6 +2090,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns DEFAULT_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2046,6 +2121,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
             }
@@ -2066,6 +2142,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns loginViewState
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2099,6 +2176,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = createTotpCodeData(),
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                     organizationEventManager.trackEvent(
                         event = OrganizationEvent.CipherClientToggledPasswordVisible(
@@ -2134,6 +2212,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns CARD_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2161,6 +2240,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
             }
@@ -2176,6 +2256,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns createViewState(
                 common = DEFAULT_COMMON.copy(requiresReprompt = false),
@@ -2197,6 +2278,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             }
         }
@@ -2213,6 +2295,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns CARD_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2240,6 +2323,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
             }
@@ -2255,6 +2339,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns createViewState(
                 common = DEFAULT_COMMON.copy(requiresReprompt = false),
@@ -2282,6 +2367,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             }
         }
@@ -2298,6 +2384,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns CARD_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2325,6 +2412,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
             }
@@ -2340,6 +2428,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns createViewState(
                 common = DEFAULT_COMMON.copy(requiresReprompt = false),
@@ -2361,6 +2450,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             }
         }
@@ -2377,6 +2467,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns CARD_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2404,6 +2495,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 }
             }
@@ -2419,6 +2511,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns createViewState(
                 common = DEFAULT_COMMON.copy(requiresReprompt = false),
@@ -2446,6 +2539,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             }
         }
@@ -2475,6 +2569,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns SSH_KEY_VIEW_STATE
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2504,6 +2599,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         totpCodeItemData = null,
                         canDelete = true,
                         canAssignToCollections = true,
+                        canEdit = true,
                     )
                 } returns SSH_KEY_VIEW_STATE
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2540,6 +2636,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns SSH_KEY_VIEW_STATE
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2573,6 +2670,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns IDENTITY_VIEW_STATE
             mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
@@ -2722,6 +2820,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns viewState
             val viewModel = createViewModel(state = null)
@@ -2763,6 +2862,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns viewState
             val viewModel = createViewModel(state = null)
@@ -2802,6 +2902,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns viewState
             val viewModel = createViewModel(state = null)
@@ -2838,6 +2939,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     totpCodeItemData = null,
                     canDelete = true,
                     canAssignToCollections = true,
+                    canEdit = true,
                 )
             } returns viewState
             val viewModel = createViewModel(state = null)
@@ -3066,6 +3168,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                 ),
                 canDelete = true,
                 canAssignToCollections = true,
+                canEdit = true,
             )
 
         private val DEFAULT_VIEW_STATE: VaultItemState.ViewState.Content =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensionsTest.kt
@@ -47,6 +47,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -84,6 +85,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -114,6 +116,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -144,6 +147,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -180,6 +184,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -206,6 +211,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -230,6 +236,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -253,6 +260,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -286,6 +294,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -324,6 +333,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -364,6 +374,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         assertEquals(
@@ -388,6 +399,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
 
         val expectedState = VaultItemState.ViewState.Content(
@@ -410,6 +422,7 @@ class CipherViewExtensionsTest {
             clock = fixedClock,
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
         assertEquals(
             VaultItemState.ViewState.Content(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/util/VaultItemTestUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/util/VaultItemTestUtil.kt
@@ -172,6 +172,7 @@ fun createCommonContent(
             attachments = emptyList(),
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
     } else {
         VaultItemState.ViewState.Content.Common(
@@ -217,6 +218,7 @@ fun createCommonContent(
             ),
             canDelete = true,
             canAssignToCollections = true,
+            canEdit = true,
         )
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
@@ -166,4 +166,66 @@ class CollectionViewExtensionsTest {
         )
         assertTrue(collectionList.canAssignToCollections(null))
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasEditPermissionInAtLeastOneCollection should return true if the item is in at least one non-readOnly collection`() {
+        val collectionList: List<CollectionView> = listOf(
+            createMockCollectionView(number = 1, readOnly = true),
+            createMockCollectionView(number = 2, readOnly = false),
+        )
+
+        val collectionIds = listOf("mockId-1", "mockId-2")
+
+        assertTrue(collectionList.hasEditPermissionInAtLeastOneCollection(collectionIds))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasEditPermissionInAtLeastOneCollection should return false if the item isn't in at least one non-readOnly collection`() {
+        val collectionList: List<CollectionView> = listOf(
+            createMockCollectionView(number = 1, readOnly = true),
+            createMockCollectionView(number = 2, readOnly = true),
+        )
+        val collectionIds = listOf("mockId-1", "mockId-2")
+        assertFalse(collectionList.hasEditPermissionInAtLeastOneCollection(collectionIds))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasEditPermissionInAtLeastOneCollection should return true if the collectionView list is null`() {
+        val collectionIds = listOf("mockId-1", "mockId-2")
+        assertTrue(null.hasEditPermissionInAtLeastOneCollection(collectionIds))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasEditPermissionInAtLeastOneCollection should return true if the collectionIds list is null`() {
+        val collectionList: List<CollectionView> = listOf(
+            createMockCollectionView(number = 1, readOnly = true),
+            createMockCollectionView(number = 2, readOnly = false),
+        )
+        assertTrue(collectionList.hasEditPermissionInAtLeastOneCollection(null))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasEditPermissionInAtLeastOneCollection should return true if the collectionIds list is empty`() {
+        val collectionList: List<CollectionView> = listOf(
+            createMockCollectionView(number = 1, readOnly = true),
+            createMockCollectionView(number = 2, readOnly = false),
+        )
+        assertTrue(collectionList.hasEditPermissionInAtLeastOneCollection(emptyList()))
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasEditPermissionInAtLeastOneCollection should return true if the collectionView list is empty`() {
+        val collectionIds = listOf("mockId-1", "mockId-2")
+        assertTrue(
+            emptyList<CollectionView>().hasEditPermissionInAtLeastOneCollection(
+                collectionIds,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
Hide edit button unless item is in at least one non-readOnly collection

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13349

## 📔 Objective

Hide the edit button (FAB) if an item is in a readOnly collection, or in the case of multiple collections at lease one has to be non-readOnly or the button remains hidden.

## 📸 Screenshots

Item view from within non-readOnly (editable) collection:

![Screenshot 2024-12-06 at 4 33 20 PM](https://github.com/user-attachments/assets/decfb185-dbe5-4b7f-a2ca-7025739a5089)

Item view from within readOnly (non-editable) collection:

![Screenshot 2024-12-06 at 4 32 54 PM](https://github.com/user-attachments/assets/00b3f995-4fdd-49e9-8819-72dbd0c82acf)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
