### PR TITLE
PM-15831 - 🍒 Enable remote configuration of `enable-authenticator-sync-android` feature flag

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -43,7 +43,7 @@ sealed class FlagKey<out T : Any> {
     data object AuthenticatorSync : FlagKey<Boolean>() {
         override val keyName: String = "enable-authenticator-sync-android"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
+        override val isRemotelyConfigured: Boolean = true
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -43,7 +43,7 @@ sealed class FlagKey<out T : Any> {
     data object AuthenticatorSync : FlagKey<Boolean>() {
         override val keyName: String = "enable-authenticator-sync-android"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
+        override val isRemotelyConfigured: Boolean = false
     }
 
     /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.data.platform.manager
 
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class FlagKeyTest {
@@ -10,11 +9,6 @@ class FlagKeyTest {
     @Test
     fun `AuthenticatorSync default value should be false`() {
         assertFalse(FlagKey.AuthenticatorSync.defaultValue)
-    }
-
-    @Test
-    fun `AuthenticatorSync is remotely configured value should be true`() {
-        assertTrue(FlagKey.AuthenticatorSync.isRemotelyConfigured)
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.manager
 
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class FlagKeyTest {
@@ -9,6 +10,11 @@ class FlagKeyTest {
     @Test
     fun `AuthenticatorSync default value should be false`() {
         assertFalse(FlagKey.AuthenticatorSync.defaultValue)
+    }
+
+    @Test
+    fun `AuthenticatorSync is remotely configured value should be true`() {
+        assertTrue(FlagKey.AuthenticatorSync.isRemotelyConfigured)
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15831](https://bitwarden.atlassian.net/browse/PM-15831)

## 📔 Objective

- Cherry pick the commit from the previous [PR](https://github.com/bitwarden/android/pull/4441)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15831]: https://bitwarden.atlassian.net/browse/PM-15831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ