### PR TITLE
PM-15037 Add missing title to empty sync import logins error dialog

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
@@ -132,7 +132,8 @@ class ImportLoginsViewModel @Inject constructor(
                         it.copy(
                             isVaultSyncing = false,
                             dialogState = ImportLoginsState.DialogState.Error(
-                                R.string.no_logins_were_imported.asText(),
+                                message = R.string.no_logins_were_imported.asText(),
+                                title = R.string.import_error.asText(),
                             ),
                         )
                     }
@@ -259,9 +260,8 @@ data class ImportLoginsState(
          */
         data class Error(
             override val message: Text = R.string.generic_error_message.asText(),
-        ) : DialogState() {
-            override val title: Text? = null
-        }
+            override val title: Text? = null,
+        ) : DialogState()
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1074,6 +1074,7 @@ Do you want to switch to this account?</string>
   <string name="bitwarden_tools">Bitwarden Tools</string>
   <string name="got_it">Got it</string>
   <string name="no_logins_were_imported">No logins were imported</string>
+  <string name="import_error">Import error</string>
   <string name="verified_sso_domain_verified">Verified SSO Domain Endpoint</string>
   <string name="logins_imported">Logins imported</string>
   <string name="remember_to_delete_your_imported_password_file_from_your_computer">Remember to delete your imported password file from your computer</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
@@ -419,7 +419,10 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
                 )
                 assertEquals(
                     ImportLoginsState(
-                        dialogState = ImportLoginsState.DialogState.Error(R.string.no_logins_were_imported.asText()),
+                        dialogState = ImportLoginsState.DialogState.Error(
+                            message = R.string.no_logins_were_imported.asText(),
+                            title = R.string.import_error.asText(),
+                        ),
                         viewState = ImportLoginsState.ViewState.InitialContent,
                         isVaultSyncing = false,
                         showBottomSheet = false,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15037
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Add title "Import error" to the dialog shown when a sync after the import logins flow is empty.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
