### PR TITLE
[PM-15176] Update build output filenames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: com.x8bit.bitwarden.aab
-          path: app/build/outputs/bundle/standardRelease/com.x8bit.bitwarden-standard-release.aab
+          path: app/build/outputs/bundle/standardRelease/com.x8bit.bitwarden.aab
           if-no-files-found: error
 
       - name: Upload beta Play Store .aab artifact
@@ -255,7 +255,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: com.x8bit.bitwarden.beta.aab
-          path: app/build/outputs/bundle/standardBeta/com.x8bit.bitwarden-standard-beta.aab
+          path: app/build/outputs/bundle/standardBeta/com.x8bit.bitwarden.beta.aab
           if-no-files-found: error
 
       - name: Upload release .apk artifact
@@ -263,7 +263,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: com.x8bit.bitwarden.apk
-          path: app/build/outputs/apk/standard/release/com.x8bit.bitwarden-standard-release.apk
+          path: app/build/outputs/apk/standard/release/com.x8bit.bitwarden.apk
           if-no-files-found: error
 
       - name: Upload beta .apk artifact
@@ -271,7 +271,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: com.x8bit.bitwarden.beta.apk
-          path: app/build/outputs/apk/standard/beta/com.x8bit.bitwarden-standard-beta.apk
+          path: app/build/outputs/apk/standard/beta/com.x8bit.bitwarden.beta.apk
           if-no-files-found: error
 
       # When building variants other than 'prod'
@@ -280,37 +280,37 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: com.x8bit.bitwarden.${{ matrix.variant }}.apk
-          path: app/build/outputs/apk/standard/debug/com.x8bit.bitwarden-standard-debug.apk
+          path: app/build/outputs/apk/standard/debug/com.x8bit.bitwarden.dev.apk
           if-no-files-found: error
 
       - name: Create checksum for release .apk artifact
         if: ${{ (matrix.variant == 'prod') && (matrix.artifact == 'apk') }}
         run: |
-          sha256sum "app/build/outputs/apk/standard/release/com.x8bit.bitwarden-standard-release.apk" \
+          sha256sum "app/build/outputs/apk/standard/release/com.x8bit.bitwarden.apk" \
             > ./com.x8bit.bitwarden.apk-sha256.txt
 
       - name: Create checksum for beta .apk artifact
         if: ${{ (matrix.variant == 'prod') && (matrix.artifact == 'apk') }}
         run: |
-          sha256sum "app/build/outputs/apk/standard/beta/com.x8bit.bitwarden-standard-beta.apk" \
+          sha256sum "app/build/outputs/apk/standard/beta/com.x8bit.bitwarden.beta.apk" \
             > ./com.x8bit.bitwarden.beta.apk-sha256.txt
 
       - name: Create checksum for release .aab artifact
         if: ${{ (matrix.variant == 'prod') && (matrix.artifact == 'aab') }}
         run: |
-          sha256sum "app/build/outputs/bundle/standardRelease/com.x8bit.bitwarden-standard-release.aab" \
+          sha256sum "app/build/outputs/bundle/standardRelease/com.x8bit.bitwarden.aab" \
             > ./com.x8bit.bitwarden.aab-sha256.txt
 
       - name: Create checksum for beta .aab artifact
         if: ${{ (matrix.variant == 'prod') && (matrix.artifact == 'aab') }}
         run: |
-          sha256sum "app/build/outputs/bundle/standardBeta/com.x8bit.bitwarden-standard-beta.aab" \
+          sha256sum "app/build/outputs/bundle/standardBeta/com.x8bit.bitwarden.beta.aab" \
             > ./com.x8bit.bitwarden.beta.aab-sha256.txt
 
       - name: Create checksum for Debug .apk artifact
         if: ${{ (matrix.variant != 'prod') && (matrix.artifact == 'apk') }}
         run: |
-          sha256sum "app/build/outputs/apk/standard/debug/com.x8bit.bitwarden-standard-debug.apk" \
+          sha256sum "app/build/outputs/apk/standard/debug/com.x8bit.bitwarden.dev.apk" \
            > ./com.x8bit.bitwarden.${{ matrix.variant }}.apk-sha256.txt
 
       - name: Upload .apk SHA file for release
@@ -500,12 +500,12 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: com.x8bit.bitwarden-fdroid.apk
-          path: app/build/outputs/apk/fdroid/release/com.x8bit.bitwarden-fdroid-release.apk
+          path: app/build/outputs/apk/fdroid/release/com.x8bit.bitwarden-fdroid.apk
           if-no-files-found: error
 
       - name: Create checksum for F-Droid artifact
         run: |
-          sha256sum "app/build/outputs/apk/fdroid/release/com.x8bit.bitwarden-fdroid-release.apk" \
+          sha256sum "app/build/outputs/apk/fdroid/release/com.x8bit.bitwarden-fdroid.apk" \
           > ./com.x8bit.bitwarden-fdroid.apk-sha256.txt
 
       - name: Upload F-Droid SHA file
@@ -519,12 +519,12 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: com.x8bit.bitwarden.beta-fdroid.apk
-          path: app/build/outputs/apk/fdroid/beta/com.x8bit.bitwarden-fdroid-beta.apk
+          path: app/build/outputs/apk/fdroid/beta/com.x8bit.bitwarden.beta-fdroid.apk
           if-no-files-found: error
 
       - name: Create checksum for F-Droid Beta artifact
         run: |
-          sha256sum "app/build/outputs/apk/fdroid/beta/com.x8bit.bitwarden-fdroid-beta.apk" \
+          sha256sum "app/build/outputs/apk/fdroid/beta/com.x8bit.bitwarden.beta-fdroid.apk" \
           > ./com.x8bit.bitwarden.beta-fdroid.apk-sha256.txt
 
       - name: Upload F-Droid Beta SHA file

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.api.BaseVariantOutputImpl
 import com.google.firebase.crashlytics.buildtools.gradle.tasks.InjectMappingFileIdTask
 import com.google.firebase.crashlytics.buildtools.gradle.tasks.UploadMappingFileTask
 import com.google.gms.googleservices.GoogleServicesTask
@@ -113,6 +114,18 @@ android {
         create("fdroid") {
             dimension = "mode"
         }
+    }
+
+    applicationVariants.all {
+        outputs
+            .mapNotNull { it as? BaseVariantOutputImpl }
+            .forEach { output ->
+                output.outputFileName = when (flavorName) {
+                    "fdroid" -> "$applicationId-$flavorName.apk"
+                    "standard" -> "$applicationId.apk"
+                    else -> output.outputFileName
+                }
+            }
     }
 
     compileOptions {


### PR DESCRIPTION
## 🎟️ Tracking

PM-15176

## 📔 Objective

This change updates the build output filenames to align with established conventions and expectations. 

The new expected output filenames are:
```
standardRelease -> com.x8bit.bitwarden.apk
standardBeta    -> com.x8bit.bitwarden.beta.apk
standardDebug   -> com.x8bit.bitwarden.dev.apk

fdroidRelease   -> com.x8bit.bitwarden-fdroid.apk
fdroidBeta      -> com.x8bit.bitwarden.beta-fdroid.apk
fdroidDebug     -> com.x8bit.bitwarden.dev-fdroid.apk
```

## 📸 Screenshots

<img width="312" alt="image" src="https://github.com/user-attachments/assets/76a49be1-d929-4bc3-b2b0-c525c5ef3fc9">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
