### PR TITLE
[PM-15057] Update AndroidX Credentials to 1.5.0-alpha04

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,9 @@ androidxBrowser = "1.8.0"
 androidxCamera = "1.4.0"
 androidxComposeBom = "2024.11.00"
 androidxCore = "1.15.0"
-androidxCredentials = "1.3.0"
+# Versions >= 1.5.0-alpha05 introduce breaking changes and bugs that are not suitable for
+# production. Do not update until https://issuetracker.google.com/issues/355141766 is resolved.
+androidxCredentials = "1.5.0-alpha04"
 androidxHiltNavigationCompose = "1.2.0"
 androidxLifecycle = "2.8.7"
 androidxNavigation = "2.8.0"


### PR DESCRIPTION
## 🎟️ Tracking

PM-15057

## 📔 Objective

This commit updates the AndroidX Credentials dependency to version 1.5.0-alpha04, which includes new features and API changes to improve security for FIDO2 credential creation and retrieval. This introduces biometrics for both request types using the `BiometricPrompt` API. It also adds support for a new `DigitalCredential` type, as well as `RestoreCredential`, used to transfer the credential from the previous device to a new one.

Note: Versions `>= 1.5.0-alpha05` introduce breaking changes and bugs that are not yet suitable for production. This update targets `1.5.0-alpha04` while we wait for those issues to be resolved.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
