### PR TITLE
PM-15356: Resolve biometrics bypass

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
@@ -173,6 +173,16 @@ interface AuthDiskSource {
     )
 
     /**
+     * Gets the biometrics initialization vector for the given [userId].
+     */
+    fun getUserBiometricInitVector(userId: String): ByteArray?
+
+    /**
+     * Stores the biometrics initialization vector for the given [userId].
+     */
+    fun storeUserBiometricInitVector(userId: String, iv: ByteArray?)
+
+    /**
      * Gets the biometrics key for the given [userId].
      */
     fun getUserBiometricUnlockKey(userId: String): String?

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
@@ -23,6 +23,7 @@ import java.util.UUID
 private const val ACCOUNT_TOKENS_KEY = "accountTokens"
 private const val AUTHENTICATOR_SYNC_SYMMETRIC_KEY = "authenticatorSyncSymmetric"
 private const val AUTHENTICATOR_SYNC_UNLOCK_KEY = "authenticatorSyncUnlock"
+private const val BIOMETRICS_INIT_VECTOR_KEY = "biometricInitializationVector"
 private const val BIOMETRICS_UNLOCK_KEY = "userKeyBiometricUnlock"
 private const val USER_AUTO_UNLOCK_KEY_KEY = "userKeyAutoUnlock"
 private const val DEVICE_KEY_KEY = "deviceKey"
@@ -145,6 +146,7 @@ class AuthDiskSourceImpl(
         storePrivateKey(userId = userId, privateKey = null)
         storeOrganizationKeys(userId = userId, organizationKeys = null)
         storeOrganizations(userId = userId, organizations = null)
+        storeUserBiometricInitVector(userId = userId, iv = null)
         storeUserBiometricUnlockKey(userId = userId, biometricsKey = null)
         storeMasterPasswordHash(userId = userId, passwordHash = null)
         storePolicies(userId = userId, policies = null)
@@ -277,6 +279,17 @@ class AuthDiskSourceImpl(
         putEncryptedString(
             key = PENDING_ADMIN_AUTH_REQUEST_KEY.appendIdentifier(userId),
             value = pendingAuthRequest?.let { json.encodeToString(it) },
+        )
+    }
+
+    override fun getUserBiometricInitVector(userId: String): ByteArray? =
+        getEncryptedString(key = BIOMETRICS_INIT_VECTOR_KEY.appendIdentifier(userId))
+            ?.toByteArray(Charsets.ISO_8859_1)
+
+    override fun storeUserBiometricInitVector(userId: String, iv: ByteArray?) {
+        putEncryptedString(
+            key = BIOMETRICS_INIT_VECTOR_KEY.appendIdentifier(userId),
+            value = iv?.toString(Charsets.ISO_8859_1),
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/BiometricsEncryptionManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/BiometricsEncryptionManager.kt
@@ -21,12 +21,6 @@ interface BiometricsEncryptionManager {
     ): Cipher?
 
     /**
-     * Sets up biometrics to ensure future integrity checks work properly. If this method has never
-     * been called [isBiometricIntegrityValid] will return false.
-     */
-    fun setupBiometrics(userId: String)
-
-    /**
      * Checks to verify that the biometrics integrity is still valid. This returns `true` if the
      * biometrics data has not changed since the app setup biometrics; `false` will be returned if
      * it has changed.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/BiometricsEncryptionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/BiometricsEncryptionManagerImpl.kt
@@ -4,9 +4,9 @@ import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.KeyProperties
 import com.x8bit.bitwarden.BuildConfig
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
-import java.io.IOException
 import java.security.InvalidAlgorithmParameterException
 import java.security.InvalidKeyException
 import java.security.KeyStore
@@ -15,12 +15,12 @@ import java.security.NoSuchAlgorithmException
 import java.security.NoSuchProviderException
 import java.security.ProviderException
 import java.security.UnrecoverableKeyException
-import java.security.cert.CertificateException
 import java.util.UUID
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.NoSuchPaddingException
 import javax.crypto.SecretKey
+import javax.crypto.spec.IvParameterSpec
 
 /**
  * Default implementation of [BiometricsEncryptionManager] for managing Android keystore encryption
@@ -28,6 +28,7 @@ import javax.crypto.SecretKey
  */
 @OmitFromCoverage
 class BiometricsEncryptionManagerImpl(
+    private val authDiskSource: AuthDiskSource,
     private val settingsDiskSource: SettingsDiskSource,
 ) : BiometricsEncryptionManager {
     private val keystore = KeyStore
@@ -50,7 +51,7 @@ class BiometricsEncryptionManagerImpl(
         val secretKey: SecretKey = generateKeyOrNull()
             ?: run {
                 // user removed all biometrics from the device
-                settingsDiskSource.systemBiometricIntegritySource = null
+                destroyBiometrics(userId = userId)
                 return null
             }
         val cipher = try {
@@ -60,35 +61,25 @@ class BiometricsEncryptionManagerImpl(
         } catch (_: NoSuchPaddingException) {
             return null
         }
+        // Instantiate integrity values.
+        createIntegrityValues(userId = userId)
         // This should never fail to initialize / return false because the cipher is newly generated
-        initializeCipher(
-            userId = userId,
-            cipher = cipher,
-            secretKey = secretKey,
-        )
+        cipher.initializeCipher(userId = userId, secretKey = secretKey)
         return cipher
     }
 
     override fun getOrCreateCipher(userId: String): Cipher? {
-        val secretKey = getSecretKeyOrNull()
+        val secretKey: SecretKey = getSecretKeyOrNull()
             ?: generateKeyOrNull()
             ?: run {
                 // user removed all biometrics from the device
-                settingsDiskSource.systemBiometricIntegritySource = null
+                destroyBiometrics(userId = userId)
                 return null
             }
 
         val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
-        val isCipherInitialized = initializeCipher(
-            userId = userId,
-            cipher = cipher,
-            secretKey = secretKey,
-        )
+        val isCipherInitialized = cipher.initializeCipher(userId = userId, secretKey = secretKey)
         return cipher?.takeIf { isCipherInitialized }
-    }
-
-    override fun setupBiometrics(userId: String) {
-        createIntegrityValues(userId)
     }
 
     override fun isBiometricIntegrityValid(userId: String, cipher: Cipher?): Boolean =
@@ -112,10 +103,7 @@ class BiometricsEncryptionManagerImpl(
      */
     private fun generateKeyOrNull(): SecretKey? {
         val keyGen = try {
-            KeyGenerator.getInstance(
-                KeyProperties.KEY_ALGORITHM_AES,
-                ENCRYPTION_KEYSTORE_NAME,
-            )
+            KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ENCRYPTION_KEYSTORE_NAME)
         } catch (_: NoSuchAlgorithmException) {
             return null
         } catch (_: NoSuchProviderException) {
@@ -124,40 +112,24 @@ class BiometricsEncryptionManagerImpl(
             return null
         }
 
-        try {
+        return try {
             keyGen.init(keyGenParameterSpec)
             keyGen.generateKey()
         } catch (_: InvalidAlgorithmParameterException) {
-            return null
+            null
         } catch (_: ProviderException) {
-            return null
+            null
         }
-
-        return getSecretKeyOrNull()
     }
 
     /**
      * Returns the [SecretKey] stored in the keystore, or null if there isn't one.
      */
-    private fun getSecretKeyOrNull(): SecretKey? {
+    private fun getSecretKeyOrNull(): SecretKey? =
         try {
-            keystore.load(null)
-        } catch (_: IllegalArgumentException) {
-            // keystore could not be loaded because [param] is unrecognized.
-            return null
-        } catch (_: IOException) {
-            // keystore data format is invalid or the password is incorrect.
-            return null
-        } catch (_: NoSuchAlgorithmException) {
-            // keystore integrity could not be checked due to missing algorithm.
-            return null
-        } catch (_: CertificateException) {
-            // keystore certificates could not be loaded
-            return null
-        }
-
-        return try {
-            keystore.getKey(ENCRYPTION_KEY_NAME, null) as? SecretKey
+            keystore
+                .getKey(ENCRYPTION_KEY_NAME, null)
+                ?.let { it as SecretKey }
         } catch (_: KeyStoreException) {
             // keystore was not loaded
             null
@@ -168,30 +140,31 @@ class BiometricsEncryptionManagerImpl(
             // key could not be recovered
             null
         }
-    }
 
     /**
      * Initialize a [Cipher] and return a boolean indicating whether it is valid.
      */
-    private fun initializeCipher(
+    private fun Cipher.initializeCipher(
         userId: String,
-        cipher: Cipher,
         secretKey: SecretKey,
     ): Boolean =
         try {
-            cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+            authDiskSource
+                .getUserBiometricInitVector(userId = userId)
+                ?.let { init(Cipher.DECRYPT_MODE, secretKey, IvParameterSpec(it)) }
+                ?: init(Cipher.ENCRYPT_MODE, secretKey)
             true
         } catch (_: KeyPermanentlyInvalidatedException) {
             // Biometric has changed
-            settingsDiskSource.systemBiometricIntegritySource = null
+            destroyBiometrics(userId = userId)
             false
         } catch (_: UnrecoverableKeyException) {
             // Biometric was disabled and re-enabled
-            settingsDiskSource.systemBiometricIntegritySource = null
+            destroyBiometrics(userId = userId)
             false
         } catch (_: InvalidKeyException) {
-            // Fallback for old Bitwarden users without a key
-            createIntegrityValues(userId)
+            // User has no key
+            destroyBiometrics(userId = userId)
             true
         }
 
@@ -201,11 +174,7 @@ class BiometricsEncryptionManagerImpl(
     private fun isSystemBiometricIntegrityValid(userId: String, cipher: Cipher?): Boolean {
         val secretKey = getSecretKeyOrNull()
         return if (cipher != null && secretKey != null) {
-            initializeCipher(
-                userId = userId,
-                cipher = cipher,
-                secretKey = secretKey,
-            )
+            cipher.initializeCipher(userId = userId, secretKey = secretKey)
         } else {
             false
         }
@@ -215,7 +184,6 @@ class BiometricsEncryptionManagerImpl(
      * Creates the initial values to be used for biometrics, including the key from which the
      * master [Cipher] will be generated.
      */
-    @Suppress("TooGenericExceptionCaught")
     private fun createIntegrityValues(userId: String) {
         val systemBiometricIntegritySource = settingsDiskSource
             .systemBiometricIntegritySource
@@ -226,10 +194,20 @@ class BiometricsEncryptionManagerImpl(
             systemBioIntegrityState = systemBiometricIntegritySource,
             value = true,
         )
+    }
 
-        // Ignore result so biometrics function on devices that are in a state where key generation
-        // is not functioning
-        createCipherOrNull(userId)
+    private fun destroyBiometrics(userId: String) {
+        settingsDiskSource.systemBiometricIntegritySource?.let { systemBioIntegrityState ->
+            settingsDiskSource.storeAccountBiometricIntegrityValidity(
+                userId = userId,
+                systemBioIntegrityState = systemBioIntegrityState,
+                value = null,
+            )
+        }
+        settingsDiskSource.systemBiometricIntegritySource = null
+        authDiskSource.storeUserBiometricUnlockKey(userId = userId, biometricsKey = null)
+        authDiskSource.storeUserBiometricInitVector(userId = userId, iv = null)
+        keystore.deleteEntry(ENCRYPTION_KEY_NAME)
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -141,8 +141,10 @@ object PlatformManagerModule {
     @Provides
     @Singleton
     fun provideBiometricsEncryptionManager(
+        authDiskSource: AuthDiskSource,
         settingsDiskSource: SettingsDiskSource,
     ): BiometricsEncryptionManager = BiometricsEncryptionManagerImpl(
+        authDiskSource = authDiskSource,
         settingsDiskSource = settingsDiskSource,
     )
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppThem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import java.time.Instant
+import javax.crypto.Cipher
 
 /**
  * Provides an API for observing and modifying settings state.
@@ -234,7 +235,7 @@ interface SettingsRepository {
      * Stores the encrypted user key for biometrics, allowing it to be used to unlock the current
      * user's vault.
      */
-    suspend fun setupBiometricsKey(): BiometricsKeyResult
+    suspend fun setupBiometricsKey(cipher: Cipher): BiometricsKeyResult
 
     /**
      * Stores the given PIN, allowing it to be used to unlock the current user's vault.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -10,7 +10,6 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.EnvironmentDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.network.service.ConfigService
-import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.AuthenticatorBridgeRepository
@@ -92,7 +91,6 @@ object PlatformRepositoryModule {
         authDiskSource: AuthDiskSource,
         settingsDiskSource: SettingsDiskSource,
         vaultSdkSource: VaultSdkSource,
-        encryptionManager: BiometricsEncryptionManager,
         accessibilityEnabledManager: AccessibilityEnabledManager,
         dispatcherManager: DispatcherManager,
         policyManager: PolicyManager,
@@ -103,7 +101,6 @@ object PlatformRepositoryModule {
             authDiskSource = authDiskSource,
             settingsDiskSource = settingsDiskSource,
             vaultSdkSource = vaultSdkSource,
-            biometricsEncryptionManager = encryptionManager,
             accessibilityEnabledManager = accessibilityEnabledManager,
             dispatcherManager = dispatcherManager,
             policyManager = policyManager,

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
@@ -33,6 +33,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import javax.crypto.Cipher
 
 /**
  * Responsible for managing vault data inside the network layer.
@@ -189,7 +190,7 @@ interface VaultRepository : CipherManager, VaultLockManager {
     /**
      * Attempt to unlock the vault using the stored biometric key for the currently active user.
      */
-    suspend fun unlockVaultWithBiometrics(): VaultUnlockResult
+    suspend fun unlockVaultWithBiometrics(cipher: Cipher): VaultUnlockResult
 
     /**
      * Attempt to unlock the vault with the given [masterPassword] and for the currently active

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreen.kt
@@ -75,7 +75,7 @@ fun SetupUnlockScreen(
                 showBiometricsPrompt = true
                 biometricsManager.promptBiometrics(
                     onSuccess = {
-                        handler.unlockWithBiometricToggle()
+                        handler.unlockWithBiometricToggle(it)
                         showBiometricsPrompt = false
                     },
                     onCancel = { showBiometricsPrompt = false },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/handlers/SetupUnlockHandler.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/handlers/SetupUnlockHandler.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.auth.feature.accountsetup.handlers
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupUnlockAction
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupUnlockViewModel
 import com.x8bit.bitwarden.ui.platform.components.toggle.UnlockWithPinState
+import javax.crypto.Cipher
 
 /**
  * A collection of handler functions for managing actions within the context of the Setup Unlock
@@ -14,7 +15,7 @@ data class SetupUnlockHandler(
     val onUnlockWithPinToggle: (UnlockWithPinState) -> Unit,
     val onContinueClick: () -> Unit,
     val onSetUpLaterClick: () -> Unit,
-    val unlockWithBiometricToggle: () -> Unit,
+    val unlockWithBiometricToggle: (cipher: Cipher) -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -25,9 +26,7 @@ data class SetupUnlockHandler(
         fun create(viewModel: SetupUnlockViewModel): SetupUnlockHandler =
             SetupUnlockHandler(
                 onDisableBiometrics = {
-                    viewModel.trySendAction(
-                        SetupUnlockAction.UnlockWithBiometricToggle(isEnabled = false),
-                    )
+                    viewModel.trySendAction(SetupUnlockAction.UnlockWithBiometricToggleDisabled)
                 },
                 onEnableBiometrics = {
                     viewModel.trySendAction(SetupUnlockAction.EnableBiometricsClick)
@@ -39,7 +38,7 @@ data class SetupUnlockHandler(
                 onSetUpLaterClick = { viewModel.trySendAction(SetupUnlockAction.SetUpLaterClick) },
                 unlockWithBiometricToggle = {
                     viewModel.trySendAction(
-                        SetupUnlockAction.UnlockWithBiometricToggle(isEnabled = true),
+                        SetupUnlockAction.UnlockWithBiometricToggleEnabled(cipher = it),
                     )
                 },
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -89,7 +89,7 @@ fun VaultUnlockScreen(
         }
     }
 
-    val onBiometricsUnlockSuccess: (cipher: Cipher?) -> Unit = remember(viewModel) {
+    val onBiometricsUnlockSuccess: (cipher: Cipher) -> Unit = remember(viewModel) {
         { viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(it)) }
     }
     val onBiometricsLockOut: () -> Unit = remember(viewModel) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -67,6 +67,7 @@ import com.x8bit.bitwarden.ui.platform.util.displayLabel
 import com.x8bit.bitwarden.ui.platform.util.minutes
 import com.x8bit.bitwarden.ui.platform.util.toFormattedPattern
 import java.time.LocalTime
+import javax.crypto.Cipher
 
 private const val MINUTES_PER_HOUR = 60
 
@@ -89,12 +90,10 @@ fun AccountSecurityScreen(
     val context = LocalContext.current
     val resources = context.resources
     var showBiometricsPrompt by rememberSaveable { mutableStateOf(false) }
-    val unlockWithBiometricToggle: () -> Unit = remember(viewModel) {
+    val unlockWithBiometricToggle: (cipher: Cipher) -> Unit = remember(viewModel) {
         {
             viewModel.trySendAction(
-                action = AccountSecurityAction.UnlockWithBiometricToggle(
-                    enabled = true,
-                ),
+                action = AccountSecurityAction.UnlockWithBiometricToggleEnabled(cipher = it),
             )
         }
     }
@@ -126,7 +125,7 @@ fun AccountSecurityScreen(
                 showBiometricsPrompt = true
                 biometricsManager.promptBiometrics(
                     onSuccess = {
-                        unlockWithBiometricToggle()
+                        unlockWithBiometricToggle(it)
                         showBiometricsPrompt = false
                     },
                     onCancel = { showBiometricsPrompt = false },
@@ -234,9 +233,7 @@ fun AccountSecurityScreen(
                 onDisableBiometrics = remember(viewModel) {
                     {
                         viewModel.trySendAction(
-                            AccountSecurityAction.UnlockWithBiometricToggle(
-                                enabled = false,
-                            ),
+                            AccountSecurityAction.UnlockWithBiometricToggleDisabled,
                         )
                     }
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManager.kt
@@ -29,7 +29,7 @@ interface BiometricsManager {
      * Display a prompt for setting up or verifying biometrics.
      */
     fun promptBiometrics(
-        onSuccess: (cipher: Cipher?) -> Unit,
+        onSuccess: (cipher: Cipher) -> Unit,
         onCancel: () -> Unit,
         onLockOut: () -> Unit,
         onError: () -> Unit,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
@@ -43,14 +43,14 @@ class BiometricsManagerImpl(
         }
 
     override fun promptBiometrics(
-        onSuccess: (cipher: Cipher?) -> Unit,
+        onSuccess: (cipher: Cipher) -> Unit,
         onCancel: () -> Unit,
         onLockOut: () -> Unit,
         onError: () -> Unit,
         cipher: Cipher,
     ) {
         configureAndDisplayPrompt(
-            onSuccess = onSuccess,
+            onSuccess = { it?.let(block = onSuccess) ?: onError() },
             onCancel = onCancel,
             onLockOut = onLockOut,
             onError = onError,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -263,6 +263,7 @@ class AuthDiskSourceTest {
         authDiskSource.storeIsTdeLoginComplete(userId = userId, isTdeLoginComplete = true)
         val deviceKey = "deviceKey"
         authDiskSource.storeDeviceKey(userId = userId, deviceKey = deviceKey)
+        authDiskSource.storeUserBiometricInitVector(userId = userId, iv = byteArrayOf())
         authDiskSource.storeUserBiometricUnlockKey(
             userId = userId,
             biometricsKey = "1234-9876-0192",
@@ -324,6 +325,7 @@ class AuthDiskSourceTest {
         )
 
         // These should be cleared
+        assertNull(authDiskSource.getUserBiometricInitVector(userId = userId))
         assertNull(authDiskSource.getUserBiometricUnlockKey(userId = userId))
         assertNull(authDiskSource.getPinProtectedUserKey(userId = userId))
         assertNull(authDiskSource.getInvalidUnlockAttempts(userId = userId))
@@ -665,6 +667,33 @@ class AuthDiskSourceTest {
         }
         val actual = authDiskSource.getUserBiometricUnlockKey(userId = mockUserId)
         assertEquals(biometricsKey, actual)
+    }
+
+    @Test
+    fun `storeUserBiometricInitVector for non-null values should update SharedPreferences`() {
+        val biometricsInitVectorBaseKey = "bwSecureStorage:biometricInitializationVector"
+        val mockUserId = "mockUserId"
+        val biometricsInitVectorKey = "${biometricsInitVectorBaseKey}_$mockUserId"
+        val initVector = byteArrayOf(1, 2)
+        authDiskSource.storeUserBiometricInitVector(userId = mockUserId, iv = initVector)
+        val actual = fakeEncryptedSharedPreferences.getString(
+            key = biometricsInitVectorKey,
+            defaultValue = null,
+        )
+        assertEquals(initVector.toString(Charsets.ISO_8859_1), actual)
+    }
+
+    @Test
+    fun `storeUserBiometricInitVector for null values should clear SharedPreferences`() {
+        val biometricsInitVectorBaseKey = "bwSecureStorage:biometricInitializationVector"
+        val mockUserId = "mockUserId"
+        val biometricsInitVectorKey = "${biometricsInitVectorBaseKey}_$mockUserId"
+        val initVector = "1234"
+        fakeEncryptedSharedPreferences.edit {
+            putString(biometricsInitVectorKey, initVector)
+        }
+        authDiskSource.storeUserBiometricInitVector(userId = mockUserId, iv = null)
+        assertFalse(fakeEncryptedSharedPreferences.contains(biometricsInitVectorKey))
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
@@ -56,6 +56,7 @@ class FakeAuthDiskSource : AuthDiskSource {
     private val storedAccountTokens = mutableMapOf<String, AccountTokensJson?>()
     private val storedDeviceKey = mutableMapOf<String, String?>()
     private val storedPendingAuthRequests = mutableMapOf<String, PendingAuthRequestJson?>()
+    private val storedBiometricInitVectors = mutableMapOf<String, ByteArray?>()
     private val storedBiometricKeys = mutableMapOf<String, String?>()
     private val storedMasterPasswordHashes = mutableMapOf<String, String?>()
     private val storedAuthenticationSyncKeys = mutableMapOf<String, String?>()
@@ -84,6 +85,7 @@ class FakeAuthDiskSource : AuthDiskSource {
         storedOrganizations.remove(userId)
         storedPolicies.remove(userId)
         storedAccountTokens.remove(userId)
+        storedBiometricInitVectors.remove(userId)
         storedBiometricKeys.remove(userId)
         storedOrganizationKeys.remove(userId)
 
@@ -222,6 +224,13 @@ class FakeAuthDiskSource : AuthDiskSource {
         pendingAuthRequest: PendingAuthRequestJson?,
     ) {
         storedPendingAuthRequests[userId] = pendingAuthRequest
+    }
+
+    override fun getUserBiometricInitVector(userId: String): ByteArray? =
+        storedBiometricInitVectors[userId]
+
+    override fun storeUserBiometricInitVector(userId: String, iv: ByteArray?) {
+        storedBiometricInitVectors[userId] = iv
     }
 
     override fun getUserBiometricUnlockKey(userId: String): String? =
@@ -419,6 +428,13 @@ class FakeAuthDiskSource : AuthDiskSource {
      */
     fun assertPendingAuthRequest(userId: String, pendingAuthRequest: PendingAuthRequestJson?) {
         assertEquals(pendingAuthRequest, storedPendingAuthRequests[userId])
+    }
+
+    /**
+     * Assert that the [iv] was stored successfully using the [userId].
+     */
+    fun assertBiometricInitVector(userId: String, iv: ByteArray?) {
+        assertEquals(iv, storedBiometricInitVectors[userId])
     }
 
     /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -17,7 +17,6 @@ import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManagerImpl
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
-import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
@@ -48,6 +47,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.ZonedDateTime
+import javax.crypto.Cipher
 
 @Suppress("LargeClass")
 class SettingsRepositoryTest {
@@ -59,7 +59,6 @@ class SettingsRepositoryTest {
     private val fakeAuthDiskSource = FakeAuthDiskSource()
     private val fakeSettingsDiskSource = FakeSettingsDiskSource()
     private val vaultSdkSource: VaultSdkSource = mockk()
-    private val biometricsEncryptionManager: BiometricsEncryptionManager = mockk()
     private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
     private val policyManager: PolicyManager = mockk {
         every {
@@ -73,7 +72,6 @@ class SettingsRepositoryTest {
         authDiskSource = fakeAuthDiskSource,
         settingsDiskSource = fakeSettingsDiskSource,
         vaultSdkSource = vaultSdkSource,
-        biometricsEncryptionManager = biometricsEncryptionManager,
         accessibilityEnabledManager = fakeAccessibilityEnabledManager,
         dispatcherManager = FakeDispatcherManager(),
         policyManager = policyManager,
@@ -802,21 +800,22 @@ class SettingsRepositoryTest {
     @Test
     fun `clearBiometricsKey should remove the stored biometrics key`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
+        fakeAuthDiskSource.storeUserBiometricUnlockKey(userId = USER_ID, "fake key")
+        fakeAuthDiskSource.storeUserBiometricInitVector(userId = USER_ID, byteArrayOf(1))
 
         settingsRepository.clearBiometricsKey()
 
-        fakeAuthDiskSource.assertBiometricsKey(
-            userId = USER_ID,
-            biometricsKey = null,
-        )
+        fakeAuthDiskSource.assertBiometricsKey(userId = USER_ID, biometricsKey = null)
+        fakeAuthDiskSource.assertBiometricInitVector(userId = USER_ID, iv = null)
     }
 
     @Test
     fun `setupBiometricsKey with missing user state should return BiometricsKeyResult Error`() =
         runTest {
+            val cipher = mockk<Cipher>()
             fakeAuthDiskSource.userState = null
 
-            val result = settingsRepository.setupBiometricsKey()
+            val result = settingsRepository.setupBiometricsKey(cipher = cipher)
 
             assertEquals(BiometricsKeyResult.Error, result)
             coVerify(exactly = 0) {
@@ -829,17 +828,14 @@ class SettingsRepositoryTest {
     fun `setupBiometricsKey with getUserEncryptionKey failure should return BiometricsKeyResult Error`() =
         runTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            every { biometricsEncryptionManager.setupBiometrics(USER_ID) } just runs
+            val cipher = mockk<Cipher>()
             coEvery {
                 vaultSdkSource.getUserEncryptionKey(userId = USER_ID)
             } returns Throwable("Fail").asFailure()
 
-            val result = settingsRepository.setupBiometricsKey()
+            val result = settingsRepository.setupBiometricsKey(cipher = cipher)
 
             assertEquals(BiometricsKeyResult.Error, result)
-            verify(exactly = 1) {
-                biometricsEncryptionManager.setupBiometrics(USER_ID)
-            }
             coVerify(exactly = 1) {
                 vaultSdkSource.getUserEncryptionKey(userId = USER_ID)
             }
@@ -851,18 +847,24 @@ class SettingsRepositoryTest {
         runTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val encryptedKey = "asdf1234"
-            every { biometricsEncryptionManager.setupBiometrics(USER_ID) } just runs
+            val encryptedBytes = byteArrayOf(1, 1)
+            val initVector = byteArrayOf(2, 2)
+            val cipher = mockk<Cipher> {
+                every { doFinal(any()) } returns encryptedBytes
+                every { iv } returns initVector
+            }
             coEvery {
                 vaultSdkSource.getUserEncryptionKey(userId = USER_ID)
             } returns encryptedKey.asSuccess()
 
-            val result = settingsRepository.setupBiometricsKey()
+            val result = settingsRepository.setupBiometricsKey(cipher = cipher)
 
             assertEquals(BiometricsKeyResult.Success, result)
-            fakeAuthDiskSource.assertBiometricsKey(userId = USER_ID, biometricsKey = encryptedKey)
-            verify(exactly = 1) {
-                biometricsEncryptionManager.setupBiometrics(USER_ID)
-            }
+            fakeAuthDiskSource.assertBiometricsKey(
+                userId = USER_ID,
+                biometricsKey = encryptedBytes.toString(Charsets.ISO_8859_1),
+            )
+            fakeAuthDiskSource.assertBiometricInitVector(userId = USER_ID, iv = initVector)
             coVerify(exactly = 1) {
                 vaultSdkSource.getUserEncryptionKey(userId = USER_ID)
             }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
@@ -112,7 +112,7 @@ class SetupUnlockScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `on unlock with biometrics toggle should send UnlockWithBiometricToggle`() {
+    fun `on unlock with biometrics toggle should send UnlockWithBiometricToggleDisabled`() {
         mutableStateFlow.update { it.copy(isUnlockWithBiometricsEnabled = true) }
         composeTestRule
             .onNodeWithText(text = "Unlock with Biometrics")
@@ -120,7 +120,7 @@ class SetupUnlockScreenTest : BaseComposeTest() {
             .assertIsOn()
             .performClick()
         verify(exactly = 1) {
-            viewModel.trySendAction(SetupUnlockAction.UnlockWithBiometricToggle(isEnabled = false))
+            viewModel.trySendAction(SetupUnlockAction.UnlockWithBiometricToggleDisabled)
         }
     }
 
@@ -187,8 +187,9 @@ class SetupUnlockScreenTest : BaseComposeTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `on unlock with biometrics toggle should send UnlockWithBiometricToggle on success`() {
+    fun `on unlock with biometrics toggle should send UnlockWithBiometricToggleEnabled on success`() {
         composeTestRule
             .onNodeWithText(text = "Unlock with Biometrics")
             .performScrollTo()
@@ -204,7 +205,7 @@ class SetupUnlockScreenTest : BaseComposeTest() {
             .performScrollTo()
             .assertIsOff()
         verify(exactly = 1) {
-            viewModel.trySendAction(SetupUnlockAction.UnlockWithBiometricToggle(isEnabled = true))
+            viewModel.trySendAction(SetupUnlockAction.UnlockWithBiometricToggleEnabled(CIPHER))
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
@@ -148,15 +148,16 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
             }
         }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `on UnlockWithBiometricToggle false should call clearBiometricsKey and update the state`() {
+    fun `on UnlockWithBiometricToggleDisabled should call clearBiometricsKey and update the state`() {
         val initialState = DEFAULT_STATE.copy(isUnlockWithBiometricsEnabled = true)
         every { settingsRepository.isUnlockWithBiometricsEnabled } returns true
         every { settingsRepository.clearBiometricsKey() } just runs
         val viewModel = createViewModel(initialState)
         assertEquals(initialState, viewModel.stateFlow.value)
 
-        viewModel.trySendAction(SetupUnlockAction.UnlockWithBiometricToggle(isEnabled = false))
+        viewModel.trySendAction(SetupUnlockAction.UnlockWithBiometricToggleDisabled)
 
         assertEquals(
             initialState.copy(isUnlockWithBiometricsEnabled = false),
@@ -169,15 +170,17 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `on UnlockWithBiometricToggle true and setupBiometricsKey error should update the state accordingly`() =
+    fun `on UnlockWithBiometricToggleEnabled and setupBiometricsKey error should update the state accordingly`() =
         runTest {
-            coEvery { settingsRepository.setupBiometricsKey() } returns BiometricsKeyResult.Error
+            coEvery {
+                settingsRepository.setupBiometricsKey(CIPHER)
+            } returns BiometricsKeyResult.Error
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
                 assertEquals(DEFAULT_STATE, awaitItem())
                 viewModel.trySendAction(
-                    SetupUnlockAction.UnlockWithBiometricToggle(isEnabled = true),
+                    SetupUnlockAction.UnlockWithBiometricToggleEnabled(cipher = CIPHER),
                 )
                 assertEquals(
                     DEFAULT_STATE.copy(
@@ -197,21 +200,23 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
                 )
             }
             coVerify(exactly = 1) {
-                settingsRepository.setupBiometricsKey()
+                settingsRepository.setupBiometricsKey(cipher = CIPHER)
             }
         }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `on UnlockWithBiometricToggle true and setupBiometricsKey success should call update the state accordingly`() =
+    fun `on UnlockWithBiometricToggleEnabled and setupBiometricsKey success should call update the state accordingly`() =
         runTest {
-            coEvery { settingsRepository.setupBiometricsKey() } returns BiometricsKeyResult.Success
+            coEvery {
+                settingsRepository.setupBiometricsKey(cipher = CIPHER)
+            } returns BiometricsKeyResult.Success
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
                 assertEquals(DEFAULT_STATE, awaitItem())
                 viewModel.trySendAction(
-                    SetupUnlockAction.UnlockWithBiometricToggle(isEnabled = true),
+                    SetupUnlockAction.UnlockWithBiometricToggleEnabled(cipher = CIPHER),
                 )
                 assertEquals(
                     DEFAULT_STATE.copy(
@@ -231,7 +236,7 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
                 )
             }
             coVerify(exactly = 1) {
-                settingsRepository.setupBiometricsKey()
+                settingsRepository.setupBiometricsKey(cipher = CIPHER)
             }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -1041,7 +1041,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         )
         val viewModel = createViewModel(state = initialState)
         coEvery {
-            vaultRepository.unlockVaultWithBiometrics()
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         } returns VaultUnlockResult.AuthenticationError()
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
@@ -1055,8 +1055,8 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             ),
             viewModel.stateFlow.value,
         )
-        coVerify {
-            vaultRepository.unlockVaultWithBiometrics()
+        coVerify(exactly = 1) {
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         }
     }
 
@@ -1069,7 +1069,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         )
         val viewModel = createViewModel(state = initialState)
         coEvery {
-            vaultRepository.unlockVaultWithBiometrics()
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         } returns VaultUnlockResult.GenericError
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
@@ -1083,8 +1083,8 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             ),
             viewModel.stateFlow.value,
         )
-        coVerify {
-            vaultRepository.unlockVaultWithBiometrics()
+        coVerify(exactly = 1) {
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         }
     }
 
@@ -1097,7 +1097,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         )
         val viewModel = createViewModel(state = initialState)
         coEvery {
-            vaultRepository.unlockVaultWithBiometrics()
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         } returns VaultUnlockResult.InvalidStateError
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
@@ -1111,8 +1111,8 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             ),
             viewModel.stateFlow.value,
         )
-        coVerify {
-            vaultRepository.unlockVaultWithBiometrics()
+        coVerify(exactly = 1) {
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         }
     }
 
@@ -1124,7 +1124,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         )
         val viewModel = createViewModel(state = initialState)
         coEvery {
-            vaultRepository.unlockVaultWithBiometrics()
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         } returns VaultUnlockResult.Success
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
@@ -1133,8 +1133,8 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             initialState.copy(dialog = null),
             viewModel.stateFlow.value,
         )
-        coVerify {
-            vaultRepository.unlockVaultWithBiometrics()
+        coVerify(exactly = 1) {
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         }
     }
 
@@ -1147,7 +1147,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         val resultFlow = bufferedMutableSharedFlow<VaultUnlockResult>()
         val viewModel = createViewModel(state = initialState)
         coEvery {
-            vaultRepository.unlockVaultWithBiometrics()
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         } coAnswers { resultFlow.first() }
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
@@ -1165,34 +1165,9 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         }
         resultFlow.tryEmit(VaultUnlockResult.GenericError)
         assertEquals(initialState.copy(dialog = null), viewModel.stateFlow.value)
-        coVerify {
-            vaultRepository.unlockVaultWithBiometrics()
+        coVerify(exactly = 1) {
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
         }
-    }
-
-    @Test
-    fun `on BiometricsUnlockSuccess should set isBiometricsValid to false with null cipher`() {
-        val initialState = DEFAULT_STATE.copy(
-            isBiometricEnabled = true,
-            isBiometricsValid = true,
-        )
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(DEFAULT_ACCOUNT.copy(isBiometricsEnabled = true)),
-        )
-        val viewModel = createViewModel(state = initialState)
-        coEvery {
-            vaultRepository.unlockVaultWithBiometrics()
-        } returns VaultUnlockResult.Success
-
-        viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(cipher = null))
-
-        assertEquals(
-            initialState.copy(
-                dialog = null,
-                isBiometricsValid = false,
-            ),
-            viewModel.stateFlow.value,
-        )
     }
 
     @Suppress("MaxLineLength")

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -134,7 +134,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `on unlock with biometrics toggle should send UnlockWithBiometricToggle`() {
+    fun `on unlock with biometrics toggle should send UnlockWithBiometricToggleDisabled`() {
         mutableStateFlow.update { it.copy(isUnlockWithBiometricsEnabled = true) }
         composeTestRule
             .onNodeWithText("Unlock with Biometrics")
@@ -145,7 +145,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .performScrollTo()
             .performClick()
         verify(exactly = 1) {
-            viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggle(false))
+            viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggleDisabled)
         }
     }
 
@@ -212,8 +212,9 @@ class AccountSecurityScreenTest : BaseComposeTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `on unlock with biometrics toggle should send UnlockWithBiometricToggle on success`() {
+    fun `on unlock with biometrics toggle should send UnlockWithBiometricToggleEnabled on success`() {
         composeTestRule
             .onNodeWithText("Unlock with Biometrics")
             .performScrollTo()
@@ -229,7 +230,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .performScrollTo()
             .assertIsOff()
         verify(exactly = 1) {
-            viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggle(true))
+            viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggleEnabled(CIPHER))
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -385,7 +385,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(AccountSecurityAction.EnableBiometricsClick)
 
             assertEquals(
-                AccountSecurityEvent.ShowBiometricsPrompt(CIPHER),
+                AccountSecurityEvent.ShowBiometricsPrompt(cipher = CIPHER),
                 awaitItem(),
             )
         }
@@ -426,8 +426,9 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         )
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `on UnlockWithBiometricToggle false should call clearBiometricsKey and update the state`() =
+    fun `on UnlockWithBiometricToggleDisabled should call clearBiometricsKey and update the state`() =
         runTest {
             val initialState = DEFAULT_STATE.copy(isUnlockWithBiometricsEnabled = true)
             every { settingsRepository.isUnlockWithBiometricsEnabled } returns true
@@ -435,7 +436,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel(initialState)
             assertEquals(initialState, viewModel.stateFlow.value)
 
-            viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggle(false))
+            viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggleDisabled)
 
             assertEquals(
                 initialState.copy(isUnlockWithBiometricsEnabled = false),
@@ -448,7 +449,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `on UnlockWithBiometricToggle false should call clearBiometricsKey, reset the vaultTimeoutAction, and update the state`() =
+    fun `on UnlockWithBiometricToggleDisabled should call clearBiometricsKey, reset the vaultTimeoutAction, and update the state`() =
         runTest {
             val initialState = DEFAULT_STATE.copy(
                 isUnlockWithPasswordEnabled = false,
@@ -460,7 +461,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel(initialState)
             assertEquals(initialState, viewModel.stateFlow.value)
 
-            viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggle(false))
+            viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggleDisabled)
 
             assertEquals(
                 initialState.copy(
@@ -477,14 +478,18 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `on UnlockWithBiometricToggle true and setupBiometricsKey error should call update the state accordingly`() =
+    fun `on UnlockWithBiometricToggleEnabled and setupBiometricsKey error should call update the state accordingly`() =
         runTest {
-            coEvery { settingsRepository.setupBiometricsKey() } returns BiometricsKeyResult.Error
+            coEvery {
+                settingsRepository.setupBiometricsKey(cipher = CIPHER)
+            } returns BiometricsKeyResult.Error
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
                 assertEquals(DEFAULT_STATE, awaitItem())
-                viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggle(true))
+                viewModel.trySendAction(
+                    AccountSecurityAction.UnlockWithBiometricToggleEnabled(cipher = CIPHER),
+                )
                 assertEquals(
                     DEFAULT_STATE.copy(
                         dialog = AccountSecurityDialog.Loading(R.string.saving.asText()),
@@ -501,20 +506,24 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                 )
             }
             coVerify(exactly = 1) {
-                settingsRepository.setupBiometricsKey()
+                settingsRepository.setupBiometricsKey(cipher = CIPHER)
             }
         }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `on UnlockWithBiometricToggle true and setupBiometricsKey success should call update the state accordingly`() =
+    fun `on UnlockWithBiometricToggleEnabled and setupBiometricsKey success should call update the state accordingly`() =
         runTest {
-            coEvery { settingsRepository.setupBiometricsKey() } returns BiometricsKeyResult.Success
+            coEvery {
+                settingsRepository.setupBiometricsKey(cipher = CIPHER)
+            } returns BiometricsKeyResult.Success
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
                 assertEquals(DEFAULT_STATE, awaitItem())
-                viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggle(true))
+                viewModel.trySendAction(
+                    AccountSecurityAction.UnlockWithBiometricToggleEnabled(cipher = CIPHER),
+                )
                 assertEquals(
                     DEFAULT_STATE.copy(
                         dialog = AccountSecurityDialog.Loading(R.string.saving.asText()),
@@ -531,7 +540,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                 )
             }
             coVerify(exactly = 1) {
-                settingsRepository.setupBiometricsKey()
+                settingsRepository.setupBiometricsKey(cipher = CIPHER)
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15356](https://bitwarden.atlassian.net/browse/PM-15356)

## 📔 Objective

This PR adds an extra layer of security to the biometrics prompt by signing the user key before storing it, meaning that only a real cipher from the Biometric Prompt can decrypt the data and unlock the vault.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15356]: https://bitwarden.atlassian.net/browse/PM-15356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ