### PR TITLE
Ensure DebugTree is only planted once

### DIFF
--- a/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/LogsManagerImpl.kt
+++ b/app/src/standard/java/com/x8bit/bitwarden/data/platform/manager/LogsManagerImpl.kt
@@ -25,9 +25,6 @@ class LogsManagerImpl(
         set(value) {
             settingsRepository.isCrashLoggingEnabled = value
             Firebase.crashlytics.isCrashlyticsCollectionEnabled = value
-            if (BuildConfig.HAS_LOGS_ENABLED) {
-                Timber.plant(Timber.DebugTree())
-            }
             if (value) {
                 Timber.plant(nonfatalErrorTree)
             } else if (Timber.forest().contains(nonfatalErrorTree)) {
@@ -51,6 +48,9 @@ class LogsManagerImpl(
 
     init {
         legacyAppCenterMigrator.migrateIfNecessary()
+        if (BuildConfig.HAS_LOGS_ENABLED) {
+            Timber.plant(Timber.DebugTree())
+        }
         isEnabled = settingsRepository.isCrashLoggingEnabled
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes a bug where we would plant duplicate DebugTrees for Timber every time the user toggles the logging flag. This change will ensure we only plant the tree once at start up.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
