### PR TITLE
[PM-15553] Add remote flag to control cipher key encryption.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerImpl.kt
@@ -20,10 +20,7 @@ class FeatureFlagManagerImpl(
     override val sdkFeatureFlags: Map<String, Boolean>
         get() = mapOf(
             CIPHER_KEY_ENCRYPTION_KEY to
-                isServerVersionAtLeast(
-                    serverConfigRepository.serverConfigStateFlow.value,
-                    CIPHER_KEY_ENC_MIN_SERVER_VERSION,
-                ),
+                getCipherKeyEncryptionFlagState(),
         )
 
     override fun <T : Any> getFeatureFlagFlow(key: FlagKey<T>): Flow<T> =
@@ -46,6 +43,16 @@ class FeatureFlagManagerImpl(
             .serverConfigStateFlow
             .value
             .getFlagValueOrDefault(key = key)
+
+    /**
+     * Get the computed value of the cipher key encryption flag based on server version and
+     * remote flag.
+     */
+    private fun getCipherKeyEncryptionFlagState() =
+        isServerVersionAtLeast(
+            serverConfigRepository.serverConfigStateFlow.value,
+            CIPHER_KEY_ENC_MIN_SERVER_VERSION,
+        ) && getFeatureFlag(FlagKey.CipherKeyEncryption)
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -132,6 +132,15 @@ sealed class FlagKey<out T : Any> {
         override val isRemotelyConfigured: Boolean = true
     }
 
+    /**
+     * Data object holding the feature flag key for the Cipher Key Encryption feature.
+     */
+    data object CipherKeyEncryption : FlagKey<Boolean>() {
+        override val keyName: String = "cipher-key-encryption"
+        override val defaultValue: Boolean = true
+        override val isRemotelyConfigured: Boolean = true
+    }
+
     //region Dummy keys for testing
     /**
      * Data object holding the key for a [Boolean] flag to be used in tests.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -32,6 +32,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CredentialExchangeProtocolImport,
     FlagKey.CredentialExchangeProtocolExport,
     FlagKey.AppReviewPrompt,
+    FlagKey.CipherKeyEncryption,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
         key = flagKey as FlagKey<Boolean>,
@@ -79,4 +80,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.CredentialExchangeProtocolImport -> stringResource(R.string.cxp_import)
     FlagKey.CredentialExchangeProtocolExport -> stringResource(R.string.cxp_export)
     FlagKey.AppReviewPrompt -> stringResource(R.string.app_review_prompt)
+    FlagKey.CipherKeyEncryption -> stringResource(R.string.cipher_key_encryption)
 }

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -21,5 +21,6 @@
     <string name="restart_onboarding_carousel">Show Onboarding Carousel</string>
     <string name="restart_onboarding_carousel_details">This will force the change to app state which will cause the first time carousel to show. The carousel will continue to show for any \"new\" account until a login is completed. May need to exit debug menu manually.</string>
     <string name="app_review_prompt">App Review Prompt</string>
+    <string name="cipher_key_encryption">Cipher Key Encryption</string>">
     <!-- /Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15553

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Pass down to the SDK a remote flag value to control the cipher key encryption feature state.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
