### PR TITLE
PM-15976 - App crashes when non-english language user tries to create account

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/Text.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/Text.kt
@@ -199,6 +199,12 @@ fun createClickableAnnotatedString(
                     mainString.lastIndexOf(text, ignoreCase = true)
                 }
             }
+
+            // Skip adding the link if the text to highlight is not found in the main string.
+            // This can happen if the highlighted text is correctly translated, but the main string
+            // is not yet translated, causing the startIndex to be -1.
+            if (startIndex < 0) { continue }
+
             val endIndex = startIndex + highlight.textToHighlight.length
             val link = LinkAnnotation.Clickable(
                 tag = highlight.textToHighlight,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15976](https://bitwarden.atlassian.net/browse/PM-15976)

## 📔 Objective

- This PR addresses a crash caused by an IndexOutOfBoundsException in the `createClickableAnnotatedString` function. The crash occurred when attempting to create links for text highlights that were not present in the main string, which could happen in scenarios where translations were incomplete or mismatched.

We did have translations for `strTerms` and `strPrivacy` but not for `strTermsAndPrivacy` which was breaking out logic since `startIndex` came back as `-1` which caused the `java.lang.IndexOutOfBoundsException: setSpan (-1 ... 0) starts before 0`
```
val strTerms = stringResource(id = R.string.terms_of_service)
val strPrivacy = stringResource(id = R.string.privacy_policy)
val strTermsAndPrivacy = stringResource(
    id = R.string.by_continuing_you_agree_to_the_terms_of_service_and_privacy_policy,
)
```

## 📸 Screenshots

https://github.com/user-attachments/assets/b0c185bb-5a82-4c1a-8e47-d1fdf8ccb4de

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
