### PR TITLE
[PM-15970] Allow assigning collections if user has correct permissions

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/model/CollectionPermission.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/model/CollectionPermission.kt
@@ -1,0 +1,12 @@
+package com.x8bit.bitwarden.ui.vault.feature.util.model
+
+/**
+ * Represents the permission levels a user can be assigned to a collection.
+ */
+enum class CollectionPermission {
+    VIEW,
+    VIEW_EXCEPT_PASSWORDS,
+    EDIT,
+    EDIT_EXCEPT_PASSWORD,
+    MANAGE,
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CollectionViewUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CollectionViewUtil.kt
@@ -10,13 +10,64 @@ fun createMockCollectionView(
     name: String? = null,
     readOnly: Boolean = false,
     manage: Boolean = true,
+    hidePasswords: Boolean = false,
 ): CollectionView =
     CollectionView(
         id = "mockId-$number",
         organizationId = "mockOrganizationId-$number",
-        hidePasswords = false,
+        hidePasswords = hidePasswords,
         name = name ?: "mockName-$number",
         externalId = "mockExternalId-$number",
         readOnly = readOnly,
         manage = manage,
     )
+
+/**
+ * Create a [CollectionView] configured to reflect MANAGE permission.
+ */
+fun createManageCollectionView(number: Int) = createMockCollectionView(
+    number = number,
+    manage = true,
+    readOnly = false,
+    hidePasswords = false,
+)
+
+/**
+ * Create a [CollectionView] configured to reflect EDIT permission.
+ */
+fun createEditCollectionView(number: Int) = createMockCollectionView(
+    number = number,
+    manage = false,
+    readOnly = false,
+    hidePasswords = false,
+)
+
+/**
+ * Create a [CollectionView] configured to reflect EDIT_EXCEPT_PASSWORDS permission.
+ */
+fun createEditExceptPasswordsCollectionView(number: Int) = createMockCollectionView(
+    number = number,
+    manage = false,
+    readOnly = false,
+    hidePasswords = true,
+)
+
+/**
+ * Create a [CollectionView] configured to reflect VIEW permission.
+ */
+fun createViewCollectionView(number: Int) = createMockCollectionView(
+    number = number,
+    manage = false,
+    readOnly = true,
+    hidePasswords = false,
+)
+
+/**
+ * Create a [CollectionView] configured to reflect VIEW_EXCEPT_PASSWORDS permission.
+ */
+fun createViewExceptPasswordsCollectionView(number: Int) = createMockCollectionView(
+    number = number,
+    manage = false,
+    readOnly = true,
+    hidePasswords = true,
+)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
@@ -1,7 +1,13 @@
 package com.x8bit.bitwarden.ui.vault.feature.util
 
 import com.bitwarden.vault.CollectionView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createEditCollectionView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createEditExceptPasswordsCollectionView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createManageCollectionView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCollectionView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createViewCollectionView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createViewExceptPasswordsCollectionView
+import com.x8bit.bitwarden.ui.vault.feature.util.model.CollectionPermission
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -73,11 +79,14 @@ class CollectionViewExtensionsTest {
     @Test
     fun `hasDeletePermissionInAtLeastOneCollection should return true if the user has manage permission in at least one collection`() {
         val collectionList: List<CollectionView> = listOf(
-            createMockCollectionView(number = 1, manage = true),
-            createMockCollectionView(number = 2, manage = false),
+            createManageCollectionView(number = 1),
+            createEditCollectionView(number = 2),
+            createEditExceptPasswordsCollectionView(number = 3),
+            createViewCollectionView(number = 4),
+            createViewExceptPasswordsCollectionView(number = 5),
         )
 
-        val collectionIds = listOf("mockId-1", "mockId-2")
+        val collectionIds = collectionList.mapNotNull { it.id }
 
         assertTrue(collectionList.hasDeletePermissionInAtLeastOneCollection(collectionIds))
     }
@@ -86,10 +95,12 @@ class CollectionViewExtensionsTest {
     @Test
     fun `hasDeletePermissionInAtLeastOneCollection should return false if the user does not have manage permission in at least one collection`() {
         val collectionList: List<CollectionView> = listOf(
-            createMockCollectionView(number = 1, manage = false),
-            createMockCollectionView(number = 2, manage = false),
+            createEditCollectionView(number = 1),
+            createEditExceptPasswordsCollectionView(number = 2),
+            createViewCollectionView(number = 3),
+            createViewExceptPasswordsCollectionView(number = 4),
         )
-        val collectionIds = listOf("mockId-1", "mockId-2")
+        val collectionIds = collectionList.mapNotNull { it.id }
         assertFalse(collectionList.hasDeletePermissionInAtLeastOneCollection(collectionIds))
     }
 
@@ -104,8 +115,8 @@ class CollectionViewExtensionsTest {
     @Test
     fun `hasDeletePermissionInAtLeastOneCollection should return true if the collectionIds list is null`() {
         val collectionList: List<CollectionView> = listOf(
-            createMockCollectionView(number = 1, manage = true),
-            createMockCollectionView(number = 2, manage = false),
+            createManageCollectionView(number = 1),
+            createEditCollectionView(number = 2),
         )
         assertTrue(collectionList.hasDeletePermissionInAtLeastOneCollection(null))
     }
@@ -135,20 +146,24 @@ class CollectionViewExtensionsTest {
     @Test
     fun `canAssociateToCollections should return true if the user has edit and manage permission`() {
         val collectionList: List<CollectionView> = listOf(
-            createMockCollectionView(number = 1, manage = true, readOnly = false),
+            createEditCollectionView(number = 1),
+            createManageCollectionView(number = 2),
         )
-        val collectionIds = listOf("mockId-1", "mockId-2")
+        val collectionIds = collectionList.mapNotNull { it.id }
         assertTrue(collectionList.canAssignToCollections(collectionIds))
     }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `canAssociateToCollections should return false if the user does not have manage or edit permission in at least one collection`() {
+    fun `canAssociateToCollections should return false if the user has except password permission at least one collection`() {
         val collectionList: List<CollectionView> = listOf(
-            createMockCollectionView(number = 1, manage = false, readOnly = true),
-            createMockCollectionView(number = 2, manage = false, readOnly = true),
+            createEditExceptPasswordsCollectionView(number = 1),
+            createViewCollectionView(number = 2),
+            createViewExceptPasswordsCollectionView(number = 3),
+            createManageCollectionView(number = 4),
+            createEditCollectionView(number = 5),
         )
-        val collectionIds = listOf("mockId-1", "mockId-2")
+        val collectionIds = collectionList.mapNotNull { it.id }
         assertFalse(collectionList.canAssignToCollections(collectionIds))
     }
 
@@ -165,5 +180,20 @@ class CollectionViewExtensionsTest {
             createMockCollectionView(number = 2, manage = false),
         )
         assertTrue(collectionList.canAssignToCollections(null))
+    }
+
+    @Test
+    fun `permission should return correct value`() {
+        assertEquals(CollectionPermission.MANAGE, createManageCollectionView(number = 1).permission)
+        assertEquals(CollectionPermission.EDIT, createEditCollectionView(number = 1).permission)
+        assertEquals(
+            CollectionPermission.EDIT_EXCEPT_PASSWORD,
+            createEditExceptPasswordsCollectionView(number = 1).permission,
+        )
+        assertEquals(CollectionPermission.VIEW, createViewCollectionView(number = 1).permission)
+        assertEquals(
+            CollectionPermission.VIEW_EXCEPT_PASSWORDS,
+            createViewExceptPasswordsCollectionView(number = 1).permission,
+        )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15970](https://bitwarden.atlassian.net/browse/PM-15970)
[PM-15969](https://bitwarden.atlassian.net/browse/PM-15969)

## 📔 Objective

Allows assigning items to collections if the user has manage permissions and is not restricted from viewing or editing password in the collection. This fixes an issue where collection assignment would be blocked if the user could view the item and its passwords.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15970]: https://bitwarden.atlassian.net/browse/PM-15970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-15969]: https://bitwarden.atlassian.net/browse/PM-15969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ