### PR TITLE
[PM-15176] Rename AAB outputs to match APK naming convention

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -311,6 +311,10 @@ tasks {
         dependsOn("detekt")
     }
 
+    getByName("sonar") {
+        dependsOn("check")
+    }
+
     withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         jvmTarget = libs.versions.jvmTarget.get()
     }
@@ -328,12 +332,48 @@ tasks {
 
 afterEvaluate {
     // Disable Fdroid-specific tasks that we want to exclude
-    val tasks = tasks.withType<GoogleServicesTask>() +
+    val fdroidTasksToDisable = tasks.withType<GoogleServicesTask>() +
         tasks.withType<InjectMappingFileIdTask>() +
         tasks.withType<UploadMappingFileTask>()
-    tasks
+    fdroidTasksToDisable
         .filter { it.name.contains("Fdroid") }
         .forEach { it.enabled = false }
+
+    tasks.named("bundle") {
+        finalizedBy("renameAabFiles")
+    }
+    tasks.register("renameAabFiles") {
+        group = "build"
+        doLast {
+            val bundlesDir = "${layout.buildDirectory.get()}/outputs/bundle"
+            println("bundlesDir: $bundlesDir")
+            renameFile(
+                "$bundlesDir/standardDebug/com.x8bit.bitwarden-standard-debug.aab",
+                "com.x8bit.bitwarden.dev.aab"
+            )
+            renameFile(
+                "$bundlesDir/standardBeta/com.x8bit.bitwarden-standard-beta.aab",
+                "com.x8bit.bitwarden.beta.aab"
+            )
+            renameFile(
+                "$bundlesDir/standardRelease/com.x8bit.bitwarden-standard-release.aab",
+                "com.x8bit.bitwarden.aab"
+            )
+
+            renameFile(
+                "$bundlesDir/fdroidDebug/com.x8bit.bitwarden-fdroid-debug.aab",
+                "com.x8bit.bitwarden.dev-fdroid.aab"
+            )
+            renameFile(
+                "$bundlesDir/fdroidBeta/com.x8bit.bitwarden-fdroid-beta.aab",
+                "com.x8bit.bitwarden.beta-fdroid.aab"
+            )
+            renameFile(
+                "$bundlesDir/fdroidRelease/com.x8bit.bitwarden-fdroid-release.aab",
+                "com.x8bit.bitwarden-fdroid.aab"
+            )
+        }
+    }
 }
 
 sonar {
@@ -348,8 +388,17 @@ sonar {
     }
 }
 
-tasks {
-    getByName("sonar") {
-        dependsOn("check")
+private fun renameFile(path: String, newName: String) {
+    val originalFile = File(path)
+    if (!originalFile.exists()) {
+        println("File $originalFile does not exist!")
+        return
+    }
+
+    val newFile = File(originalFile.parentFile, newName)
+    if (originalFile.renameTo(newFile)) {
+        println("Renamed $originalFile to $newFile")
+    } else {
+        throw RuntimeException("Failed to rename $originalFile to $newFile")
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-15176

## 📔 Objective

This commit introduces a new task, `renameAabFiles`, that is executed after the `bundle` task. This task renames the output aab files match the APK naming conventions, such as `com.x8bit.bitwarden.dev.aab` for the standard debug build and `com.x8bit.bitwarden.aab` for the standard release build.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
