### PR TITLE
PM-16053 - Text in Prompt to Restart App After Changing Language in Settings 

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -126,7 +126,7 @@ private fun LanguageSelectionRow(
     languageChangedDialogOption?.let {
         BitwardenBasicDialog(
             title = stringResource(id = R.string.language),
-            message = stringResource(id = R.string.language_change_x_description, it),
+            message = stringResource(id = R.string.language_change_x_description, it.invoke()),
             onDismissRequest = { languageChangedDialogOption = null },
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16053](https://bitwarden.atlassian.net/browse/PM-16053)

## 📔 Objective

- Previously, the dialog used the Text value directly within the string resource. This update leverages the `invoke` function to correctly resolve and display the actual string of the language correctly.

## 📸 Screenshots

## Before
https://github.com/user-attachments/assets/a9b4a601-ca1a-4ebc-900a-919d1addf4ed

## After
https://github.com/user-attachments/assets/a2f30bd6-cc9b-47ad-ade5-d77f94e3975f

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16053]: https://bitwarden.atlassian.net/browse/PM-16053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ