### PR TITLE
PM-16058 - Add default environments via autocomplete dropdown

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
@@ -35,6 +36,7 @@ import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import kotlinx.collections.immutable.persistentListOf
 
 /**
  * Displays the about self-hosted/custom environment screen.
@@ -114,6 +116,15 @@ fun EnvironmentScreen(
                 hint = stringResource(id = R.string.self_hosted_environment_footer),
                 onValueChange = remember(viewModel) {
                     { viewModel.trySendAction(EnvironmentAction.ServerUrlChange(it)) }
+                },
+                autoCompleteOptions = if (BuildConfig.BUILD_TYPE != "release") {
+                    persistentListOf(
+                        "https://vault.qa.bitwarden.pw",
+                        "https://qa-team.sh.bitwarden.pw",
+                        "https://vault.usdev.bitwarden.pw",
+                    )
+                } else {
+                    persistentListOf()
                 },
                 keyboardType = KeyboardType.Uri,
                 modifier = Modifier


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16058](https://bitwarden.atlassian.net/browse/PM-16058)

## 📔 Objective

This PR adds an auto-complete style dropdown to the environments UI for a few default URLs. These are only available in the debug configuration for ease of testing.

## 📸 Screenshots

<img src="https://github.com/user-attachments/assets/970772b0-6f22-48a4-b4b2-69c2cb46ff23" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16059]: https://bitwarden.atlassian.net/browse/PM-16059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-16058]: https://bitwarden.atlassian.net/browse/PM-16058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ