### PR TITLE
PM-16058 add test tag parameter to be applied to the text field

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
@@ -290,9 +290,9 @@ private fun CompleteRegistrationContent(
                     ?: R.string.master_password_hint_description,
             ),
             modifier = Modifier
-                .testTag("MasterPasswordHintLabel")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
+            textFieldTestTag = "MasterPasswordHintLabel",
         )
         if (showNewOnboardingUi) {
             BitwardenClickableText(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
@@ -187,10 +187,10 @@ fun CreateAccountScreen(
                     { viewModel.trySendAction(EmailInputChange(it)) }
                 },
                 modifier = Modifier
-                    .testTag("EmailAddressEntry")
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 keyboardType = KeyboardType.Email,
+                textFieldTestTag = "EmailAddressEntry",
             )
             Spacer(modifier = Modifier.height(16.dp))
             var showPassword by rememberSaveable { mutableStateOf(false) }
@@ -239,9 +239,9 @@ fun CreateAccountScreen(
                 },
                 hint = stringResource(id = R.string.master_password_hint_description),
                 modifier = Modifier
-                    .testTag("MasterPasswordHintLabel")
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "MasterPasswordHintLabel",
             )
             Spacer(modifier = Modifier.height(24.dp))
             BitwardenSwitch(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
@@ -159,11 +159,11 @@ private fun EnterpriseSignOnScreenContent(
         BitwardenTextField(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
-                .fillMaxWidth()
-                .testTag("OrgSSOIdentifierEntry"),
+                .fillMaxWidth(),
             value = state.orgIdentifierInput,
             onValueChange = onOrgIdentifierInputChange,
             label = stringResource(id = R.string.org_identifier),
+            textFieldTestTag = "OrgSSOIdentifierEntry",
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
@@ -129,8 +129,8 @@ fun EnvironmentScreen(
                 keyboardType = KeyboardType.Uri,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag("ServerUrlEntry")
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "ServerUrlEntry",
             )
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -153,8 +153,8 @@ fun EnvironmentScreen(
                 keyboardType = KeyboardType.Uri,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag("WebVaultUrlEntry")
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "WebVaultUrlEntry",
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -183,8 +183,8 @@ fun EnvironmentScreen(
                 keyboardType = KeyboardType.Uri,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag("IdentityUrlEntry")
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "IdentityUrlEntry",
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -199,8 +199,8 @@ fun EnvironmentScreen(
                 keyboardType = KeyboardType.Uri,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag("IconsUrlEntry")
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "IconsUrlEntry",
             )
 
             Spacer(modifier = Modifier.navigationBarsPadding())

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
@@ -242,13 +242,13 @@ private fun LandingScreenContent(
 
         BitwardenTextField(
             modifier = Modifier
-                .testTag("EmailAddressEntry")
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth(),
             value = state.emailInput,
             onValueChange = onEmailInputChange,
             label = stringResource(id = R.string.email_address),
             keyboardType = KeyboardType.Email,
+            textFieldTestTag = "EmailAddressEntry",
         )
 
         Spacer(modifier = Modifier.height(2.dp))

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordScreen.kt
@@ -228,9 +228,9 @@ private fun ResetPasswordScreenContent(
             onValueChange = onPasswordHintInputChanged,
             hint = stringResource(id = R.string.master_password_hint_description),
             modifier = Modifier
-                .testTag("MasterPasswordHintLabel")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "MasterPasswordHintLabel",
         )
 
         Spacer(modifier = Modifier.navigationBarsPadding())

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreen.kt
@@ -172,9 +172,9 @@ private fun SetPasswordScreenContent(
             onValueChange = onPasswordHintInputChanged,
             hint = stringResource(id = R.string.master_password_hint_description),
             modifier = Modifier
-                .testTag("MasterPasswordHintLabel")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "MasterPasswordHintLabel",
         )
 
         Spacer(modifier = Modifier.navigationBarsPadding())

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -212,9 +212,9 @@ private fun StartRegistrationContent(
             value = nameInput,
             onValueChange = handler.onNameInputChange,
             modifier = Modifier
-                .testTag("NameEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
+            textFieldTestTag = "NameEntry",
         )
         Spacer(modifier = Modifier.height(16.dp))
         BitwardenTextField(
@@ -225,10 +225,10 @@ private fun StartRegistrationContent(
             value = emailInput,
             onValueChange = handler.onEmailInputChange,
             modifier = Modifier
-                .testTag("EmailAddressEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
             keyboardType = KeyboardType.Email,
+            textFieldTestTag = "EmailAddressEntry",
         )
         Spacer(modifier = Modifier.height(2.dp))
         Row(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenTextEntryDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenTextEntryDialog.kt
@@ -78,11 +78,11 @@ fun BitwardenTextEntryDialog(
                 value = text,
                 onValueChange = { text = it },
                 modifier = Modifier
-                    .testTag("AlertContentText")
                     .focusRequester(focusRequester)
                     .onGloballyPositioned {
                         shouldRequestFocus = true
                     },
+                textFieldTestTag = "AlertContentText",
             )
         },
         shape = BitwardenTheme.shapes.dialog,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.TextToolbar
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -89,7 +90,8 @@ fun BitwardenTextField(
     autoFocus: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     textToolbarType: TextToolbarType = TextToolbarType.DEFAULT,
-    autoCompleteOptions: ImmutableList<String> = persistentListOf<String>(),
+    autoCompleteOptions: ImmutableList<String> = persistentListOf(),
+    textFieldTestTag: String? = null,
 ) {
     var widthPx by remember { mutableIntStateOf(0) }
     val focusRequester = remember { FocusRequester() }
@@ -127,7 +129,8 @@ fun BitwardenTextField(
         Box(modifier = modifier) {
             OutlinedTextField(
                 colors = bitwardenTextFieldColors(),
-                modifier = Modifier
+                modifier = modifier
+                    .testTag(textFieldTestTag.orEmpty())
                     .onGloballyPositioned { widthPx = it.size.width }
                     .onFocusEvent { focusState -> hasFocused = focusState.hasFocus }
                     .focusRequester(focusRequester)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextFieldWithActions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextFieldWithActions.kt
@@ -71,9 +71,7 @@ fun BitwardenTextFieldWithActions(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         BitwardenTextField(
-            modifier = Modifier
-                .semantics { textFieldTestTag?.let { testTag = it } }
-                .weight(1f),
+            modifier = Modifier.weight(1f),
             label = label,
             value = value,
             readOnly = readOnly,
@@ -85,6 +83,7 @@ fun BitwardenTextFieldWithActions(
             shouldAddCustomLineBreaks = shouldAddCustomLineBreaks,
             visualTransformation = visualTransformation,
             textToolbarType = textToolbarType,
+            textFieldTestTag = textFieldTestTag,
         )
         BitwardenRowOfActions(
             modifier = Modifier.run { actionsTestTag?.let { testTag(it) } ?: this },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
@@ -116,8 +116,8 @@ fun PinInputDialog(
                     },
                     keyboardType = KeyboardType.Number,
                     modifier = Modifier
-                        .testTag(tag = "AlertInputField")
                         .fillMaxWidth(),
+                    textFieldTestTag = "AlertInputField",
                 )
                 Spacer(modifier = Modifier.height(height = 16.dp))
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -752,9 +752,9 @@ private fun PassphraseWordSeparatorInputItem(
             }
         },
         modifier = modifier
-            .testTag("WordSeparatorEntry")
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
+        textFieldTestTag = "WordSeparatorEntry",
     )
 }
 
@@ -917,8 +917,8 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 onValueChange = forwardedEmailAliasHandlers.onAddyIoDomainNameTextChange,
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
-                    .testTag("AnonAddyDomainNameEntry")
                     .fillMaxWidth(),
+                textFieldTestTag = "AnonAddyDomainNameEntry",
             )
         }
 
@@ -981,8 +981,8 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 onValueChange = forwardedEmailAliasHandlers.onForwardEmailDomainNameTextChange,
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
-                    .testTag("ForwardedEmailDomainNameEntry")
                     .fillMaxWidth(),
+                textFieldTestTag = "ForwardedEmailDomainNameEntry",
             )
         }
 
@@ -1069,8 +1069,8 @@ private fun PlusAddressedEmailTextInputItem(
         onValueChange = onPlusAddressedEmailTextChange,
         modifier = modifier
             .fillMaxWidth()
-            .testTag("PlusAddressedEmailEntry")
             .padding(horizontal = 16.dp),
+        textFieldTestTag = "PlusAddressedEmailEntry",
     )
 }
 
@@ -1103,8 +1103,8 @@ private fun CatchAllEmailTextInputItem(
         onValueChange = onDomainTextChange,
         modifier = modifier
             .fillMaxWidth()
-            .testTag("CatchAllEmailDomainEntry")
             .padding(horizontal = 16.dp),
+        textFieldTestTag = "CatchAllEmailDomainEntry",
     )
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendContent.kt
@@ -95,7 +95,6 @@ fun AddSendContent(
 
         BitwardenTextField(
             modifier = Modifier
-                .testTag(tag = "SendNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
             label = stringResource(id = R.string.name),
@@ -103,6 +102,7 @@ fun AddSendContent(
             readOnly = policyDisablesSend,
             value = state.common.name,
             onValueChange = addSendHandlers.onNamChange,
+            textFieldTestTag = "SendNameEntry",
         )
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -203,7 +203,6 @@ fun AddSendContent(
             is AddSendState.ViewState.Content.SendType.Text -> {
                 BitwardenTextField(
                     modifier = Modifier
-                        .testTag(tag = "SendTextContentEntry")
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
                     label = stringResource(id = R.string.text),
@@ -212,6 +211,7 @@ fun AddSendContent(
                     value = type.input,
                     singleLine = false,
                     onValueChange = addSendHandlers.onTextChange,
+                    textFieldTestTag = "SendTextContentEntry",
                 )
                 Spacer(modifier = Modifier.height(16.dp))
                 BitwardenSwitch(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
@@ -52,9 +52,9 @@ fun LazyListScope.vaultAddEditCardItems(
             value = commonState.name,
             onValueChange = commonHandlers.onNameTextChange,
             modifier = Modifier
-                .testTag("ItemNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNameEntry",
         )
     }
     item {
@@ -64,9 +64,9 @@ fun LazyListScope.vaultAddEditCardItems(
             value = cardState.cardHolderName,
             onValueChange = cardHandlers.onCardHolderNameTextChange,
             modifier = Modifier
-                .testTag("CardholderNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "CardholderNameEntry",
         )
     }
     item {
@@ -140,9 +140,9 @@ fun LazyListScope.vaultAddEditCardItems(
             onValueChange = cardHandlers.onExpirationYearTextChange,
             keyboardType = KeyboardType.Number,
             modifier = Modifier
-                .testTag("CardExpirationYearEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "CardExpirationYearEntry",
         )
     }
     item {
@@ -253,9 +253,9 @@ fun LazyListScope.vaultAddEditCardItems(
             value = commonState.notes,
             onValueChange = commonHandlers.onNotesTextChange,
             modifier = Modifier
-                .testTag("ItemNotesEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNotesEntry",
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
@@ -45,9 +45,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = commonState.name,
             onValueChange = commonTypeHandlers.onNameTextChange,
             modifier = Modifier
-                .testTag("ItemNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNameEntry",
         )
     }
     item {
@@ -68,9 +68,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.firstName,
             onValueChange = identityItemTypeHandlers.onFirstNameTextChange,
             modifier = Modifier
-                .testTag("IdentityFirstNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityFirstNameEntry",
         )
     }
     item {
@@ -80,9 +80,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.middleName,
             onValueChange = identityItemTypeHandlers.onMiddleNameTextChange,
             modifier = Modifier
-                .testTag("IdentityMiddleNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityMiddleNameEntry",
         )
     }
     item {
@@ -92,9 +92,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.lastName,
             onValueChange = identityItemTypeHandlers.onLastNameTextChange,
             modifier = Modifier
-                .testTag("IdentityLastNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityLastNameEntry",
         )
     }
     item {
@@ -104,9 +104,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.username,
             onValueChange = identityItemTypeHandlers.onUsernameTextChange,
             modifier = Modifier
-                .testTag("IdentityUsernameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityUsernameEntry",
         )
     }
     item {
@@ -116,9 +116,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.company,
             onValueChange = identityItemTypeHandlers.onCompanyTextChange,
             modifier = Modifier
-                .testTag("IdentityCompanyEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityCompanyEntry",
         )
     }
     item {
@@ -128,9 +128,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.ssn,
             onValueChange = identityItemTypeHandlers.onSsnTextChange,
             modifier = Modifier
-                .testTag("IdentitySsnEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentitySsnEntry",
         )
     }
     item {
@@ -140,9 +140,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.passportNumber,
             onValueChange = identityItemTypeHandlers.onPassportNumberTextChange,
             modifier = Modifier
-                .testTag("IdentityPassportNumberEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityPassportNumberEntry",
         )
     }
     item {
@@ -152,9 +152,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.licenseNumber,
             onValueChange = identityItemTypeHandlers.onLicenseNumberTextChange,
             modifier = Modifier
-                .testTag("IdentityLicenseNumberEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityLicenseNumberEntry",
         )
     }
     item {
@@ -164,9 +164,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.email,
             onValueChange = identityItemTypeHandlers.onEmailTextChange,
             modifier = Modifier
-                .testTag("IdentityEmailEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityEmailEntry",
         )
     }
     item {
@@ -176,9 +176,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.phone,
             onValueChange = identityItemTypeHandlers.onPhoneTextChange,
             modifier = Modifier
-                .testTag("IdentityPhoneEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityPhoneEntry",
         )
     }
     item {
@@ -188,9 +188,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.address1,
             onValueChange = identityItemTypeHandlers.onAddress1TextChange,
             modifier = Modifier
-                .testTag("IdentityAddressOneEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityAddressOneEntry",
         )
     }
     item {
@@ -200,9 +200,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.address2,
             onValueChange = identityItemTypeHandlers.onAddress2TextChange,
             modifier = Modifier
-                .testTag("IdentityAddressTwoEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityAddressTwoEntry",
         )
     }
     item {
@@ -212,9 +212,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.address3,
             onValueChange = identityItemTypeHandlers.onAddress3TextChange,
             modifier = Modifier
-                .testTag("IdentityAddressThreeEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityAddressThreeEntry",
         )
     }
     item {
@@ -224,9 +224,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.city,
             onValueChange = identityItemTypeHandlers.onCityTextChange,
             modifier = Modifier
-                .testTag("IdentityCityEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityCityEntry",
         )
     }
     item {
@@ -236,9 +236,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.state,
             onValueChange = identityItemTypeHandlers.onStateTextChange,
             modifier = Modifier
-                .testTag("IdentityStateEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityStateEntry",
         )
     }
     item {
@@ -248,9 +248,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.zip,
             onValueChange = identityItemTypeHandlers.onZipTextChange,
             modifier = Modifier
-                .testTag("IdentityPostalCodeEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityPostalCodeEntry",
         )
     }
     item {
@@ -260,9 +260,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = identityState.country,
             onValueChange = identityItemTypeHandlers.onCountryTextChange,
             modifier = Modifier
-                .testTag("IdentityCountryEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "IdentityCountryEntry",
         )
     }
     item {
@@ -354,9 +354,9 @@ fun LazyListScope.vaultAddEditIdentityItems(
             value = commonState.notes,
             onValueChange = commonTypeHandlers.onNotesTextChange,
             modifier = Modifier
-                .testTag("ItemNotesEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNotesEntry",
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
@@ -57,9 +57,9 @@ fun LazyListScope.vaultAddEditLoginItems(
             value = commonState.name,
             onValueChange = commonActionHandler.onNameTextChange,
             modifier = Modifier
-                .testTag("ItemNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNameEntry",
         )
     }
 
@@ -274,9 +274,9 @@ fun LazyListScope.vaultAddEditLoginItems(
             value = commonState.notes,
             onValueChange = commonActionHandler.onNotesTextChange,
             modifier = Modifier
-                .testTag("ItemNotesEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNotesEntry",
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSecureNotesItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSecureNotesItems.kt
@@ -39,9 +39,9 @@ fun LazyListScope.vaultAddEditSecureNotesItems(
             value = commonState.name,
             onValueChange = commonTypeHandlers.onNameTextChange,
             modifier = Modifier
-                .testTag("ItemNameEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNameEntry",
         )
     }
 
@@ -133,9 +133,9 @@ fun LazyListScope.vaultAddEditSecureNotesItems(
             value = commonState.notes,
             onValueChange = commonTypeHandlers.onNotesTextChange,
             modifier = Modifier
-                .testTag("ItemNotesEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNotesEntry",
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSshKeyItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSshKeyItems.kt
@@ -45,9 +45,9 @@ fun LazyListScope.vaultAddEditSshKeyItems(
             value = commonState.name,
             onValueChange = commonTypeHandlers.onNameTextChange,
             modifier = Modifier
-                .testTag("ItemNameEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
+            textFieldTestTag = "ItemNameEntry",
         )
     }
 
@@ -59,9 +59,9 @@ fun LazyListScope.vaultAddEditSshKeyItems(
             readOnly = true,
             onValueChange = { },
             modifier = Modifier
-                .testTag("PublicKeyEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
+            textFieldTestTag = "PublicKeyEntry",
         )
     }
 
@@ -90,9 +90,9 @@ fun LazyListScope.vaultAddEditSshKeyItems(
             readOnly = true,
             onValueChange = { /* no-op */ },
             modifier = Modifier
-                .testTag("FingerprintEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
+            textFieldTestTag = "FingerprintEntry",
         )
     }
 
@@ -185,9 +185,9 @@ fun LazyListScope.vaultAddEditSshKeyItems(
             value = commonState.notes,
             onValueChange = commonTypeHandlers.onNotesTextChange,
             modifier = Modifier
-                .testTag("ItemNotesEntry")
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
+            textFieldTestTag = "ItemNotesEntry",
         )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
@@ -53,9 +53,9 @@ fun VaultItemCardContent(
                 readOnly = true,
                 singleLine = false,
                 modifier = Modifier
-                    .testTag("CardItemNameEntry")
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "CardItemNameEntry",
             )
         }
         cardState.cardholderName?.let { cardholderName ->
@@ -68,9 +68,9 @@ fun VaultItemCardContent(
                     readOnly = true,
                     singleLine = false,
                     modifier = Modifier
-                        .testTag("CardholderNameEntry")
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
+                    textFieldTestTag = "CardholderNameEntry",
                 )
             }
         }
@@ -112,9 +112,9 @@ fun VaultItemCardContent(
                     readOnly = true,
                     singleLine = false,
                     modifier = Modifier
-                        .testTag("CardBrandEntry")
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
+                    textFieldTestTag = "CardBrandEntry",
                 )
             }
         }
@@ -129,9 +129,9 @@ fun VaultItemCardContent(
                     readOnly = true,
                     singleLine = false,
                     modifier = Modifier
-                        .testTag("CardExpirationEntry")
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
+                    textFieldTestTag = "CardExpirationEntry",
                 )
             }
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
@@ -50,9 +50,9 @@ fun VaultItemIdentityContent(
                 readOnly = true,
                 singleLine = false,
                 modifier = Modifier
-                    .testTag("ItemNameEntry")
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "ItemNameEntry",
             )
         }
         identityState.identityName?.let { identityName ->

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
@@ -63,9 +63,9 @@ fun VaultItemLoginContent(
                 readOnly = true,
                 singleLine = false,
                 modifier = Modifier
-                    .testTag("LoginItemNameEntry")
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "LoginItemNameEntry",
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSecureNoteContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSecureNoteContent.kt
@@ -52,9 +52,9 @@ fun VaultItemSecureNoteContent(
                 readOnly = true,
                 singleLine = false,
                 modifier = Modifier
-                    .testTag("ItemNameEntry")
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "ItemNameEntry",
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSshKeyContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSshKeyContent.kt
@@ -53,9 +53,9 @@ fun VaultItemSshKeyContent(
                 readOnly = true,
                 singleLine = false,
                 modifier = Modifier
-                    .testTag("SshKeyItemNameEntry")
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
+                textFieldTestTag = "SshKeyItemNameEntry",
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -153,8 +153,8 @@ fun ManualCodeEntryScreen(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .testTag("AddManualTOTPField"),
+                    .padding(horizontal = 16.dp),
+                textFieldTestTag = "AddManualTOTPField",
             )
 
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-16058
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Adding the autocomplete menu changed the structure of the of the `BitwardendTextField` composbale. Adding in an explicit parameter for the test tag that should be applied to the actual editable field.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
