### PR TITLE
PM-16062 Prevent account locks for ongoing autofill requests

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
@@ -2,6 +2,7 @@
 
 package com.x8bit.bitwarden.data.autofill.util
 
+import android.app.Activity
 import android.app.PendingIntent
 import android.app.assist.AssistStructure
 import android.content.Context
@@ -147,3 +148,12 @@ fun Intent.getAutofillSelectionDataOrNull(): AutofillSelectionData? =
 fun Intent.getTotpCopyIntentOrNull(): AutofillTotpCopyData? =
     getBundleExtra(AUTOFILL_BUNDLE_KEY)
         ?.getSafeParcelableExtra(AUTOFILL_TOTP_COPY_DATA_KEY)
+
+/**
+ * Checks if the given [Activity] was created for Autofill. This is useful to avoid locking the
+ * vault if one of the Autofill services starts the only only instance of the [MainActivity].
+ */
+val Activity.createdForAutofill: Boolean
+    get() = intent.getAutofillSelectionDataOrNull() != null ||
+        intent.getAutofillSaveItemOrNull() != null ||
+        intent.getAutofillAssistStructureOrNull() != null

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/AppStateManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/AppStateManagerImpl.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.x8bit.bitwarden.data.autofill.util.createdForAutofill
 import com.x8bit.bitwarden.data.platform.manager.model.AppCreationState
 import com.x8bit.bitwarden.data.platform.manager.model.AppForegroundState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +20,8 @@ class AppStateManagerImpl(
     application: Application,
     processLifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get(),
 ) : AppStateManager {
-    private val mutableAppCreationStateFlow = MutableStateFlow(AppCreationState.DESTROYED)
+    private val mutableAppCreationStateFlow =
+        MutableStateFlow<AppCreationState>(AppCreationState.Destroyed)
     private val mutableAppForegroundStateFlow = MutableStateFlow(AppForegroundState.BACKGROUNDED)
 
     override val appCreatedStateFlow: StateFlow<AppCreationState>
@@ -49,13 +51,15 @@ class AppStateManagerImpl(
         override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
             activityCount++
             // Always be in a created state if we have an activity
-            mutableAppCreationStateFlow.value = AppCreationState.CREATED
+            mutableAppCreationStateFlow.value = AppCreationState.Created(
+                createdForAutofill = activity.createdForAutofill,
+            )
         }
 
         override fun onActivityDestroyed(activity: Activity) {
             activityCount--
             if (activityCount == 0 && !activity.isChangingConfigurations) {
-                mutableAppCreationStateFlow.value = AppCreationState.DESTROYED
+                mutableAppCreationStateFlow.value = AppCreationState.Destroyed
             }
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/AppStateManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/AppStateManagerImpl.kt
@@ -52,7 +52,7 @@ class AppStateManagerImpl(
             activityCount++
             // Always be in a created state if we have an activity
             mutableAppCreationStateFlow.value = AppCreationState.Created(
-                createdForAutofill = activity.createdForAutofill,
+                isAutoFill = activity.createdForAutofill,
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/AppCreationState.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/AppCreationState.kt
@@ -6,6 +6,7 @@ package com.x8bit.bitwarden.data.platform.manager.model
 sealed class AppCreationState {
     /**
      * Denotes that the app is currently created.
+     *
      * @param isAutoFill Whether the app was created for autofill.
      */
     data class Created(val isAutoFill: Boolean) : AppCreationState()

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/AppCreationState.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/AppCreationState.kt
@@ -3,14 +3,15 @@ package com.x8bit.bitwarden.data.platform.manager.model
 /**
  * Represents the creation state of the app.
  */
-enum class AppCreationState {
+sealed class AppCreationState {
     /**
      * Denotes that the app is currently created.
+     * @param createdForAutofill Whether the app was created for autofill.
      */
-    CREATED,
+    data class Created(val createdForAutofill: Boolean) : AppCreationState()
 
     /**
      * Denotes that the app is currently destroyed.
      */
-    DESTROYED,
+    data object Destroyed : AppCreationState()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/AppCreationState.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/AppCreationState.kt
@@ -6,9 +6,9 @@ package com.x8bit.bitwarden.data.platform.manager.model
 sealed class AppCreationState {
     /**
      * Denotes that the app is currently created.
-     * @param createdForAutofill Whether the app was created for autofill.
+     * @param isAutoFill Whether the app was created for autofill.
      */
-    data class Created(val createdForAutofill: Boolean) : AppCreationState()
+    data class Created(val isAutoFill: Boolean) : AppCreationState()
 
     /**
      * Denotes that the app is currently destroyed.

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -312,7 +312,7 @@ class VaultLockManagerImpl(
                 when (appCreationState) {
                     is AppCreationState.Created -> {
                         handleOnCreated(
-                            createdForAutofill = appCreationState.createdForAutofill,
+                            createdForAutofill = appCreationState.isAutoFill,
                             isFirstCreated = isFirstCreated,
                         )
                         isFirstCreated = false

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -594,13 +594,26 @@ class VaultLockManagerImpl(
     }
 
     /**
-     * Helper enum that indicates the reason we are checking for timeout.
+     * Helper sealed class which denotes the reason to check the vault timeout.
      */
     private sealed class CheckTimeoutReason {
+        /**
+         * Indicates the app has been backgrounded but is still running.
+         */
         data object AppBackgrounded : CheckTimeoutReason()
+
+        /**
+         * Indicates the app has entered a Created state.
+         * @param firstTimeCreation if this is the first time the process is being created.
+         * @param createdForAutofill if the the creation event is due to an activity being launched
+         * for autofill.
+         */
         data class AppCreated(val firstTimeCreation: Boolean, val createdForAutofill: Boolean) :
             CheckTimeoutReason()
 
+        /**
+         * Indicates that the current user has changed.
+         */
         data object UserChanged : CheckTimeoutReason()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -353,17 +353,17 @@ class VaultLockManagerImpl(
             .launchIn(unconfinedScope)
     }
 
-    private fun handleOnForeground() {
-        val userId = activeUserId ?: return
-        userIdTimerJobMap[userId]?.cancel()
-    }
-
     private fun handleOnBackground() {
         val userId = activeUserId ?: return
         checkForVaultTimeout(
             userId = userId,
             checkTimeoutReason = CheckTimeoutReason.AppBackgrounded,
         )
+    }
+
+    private fun handleOnForeground() {
+        val userId = activeUserId ?: return
+        userIdTimerJobMap[userId]?.cancel()
     }
 
     private fun observeUserSwitchingChanges() {
@@ -496,7 +496,7 @@ class VaultLockManagerImpl(
                 if (checkTimeoutReason is CheckTimeoutReason.AppCreated) {
                     // We need to check the timeout action on the first time creation no matter what
                     // for all subsequent creations we should check if this is for autofill and
-                    // if it is we skip checking the timeout action.
+                    // and if it is we skip checking the timeout action.
                     if (
                         checkTimeoutReason.firstTimeCreation ||
                         !checkTimeoutReason.createdForAutofill
@@ -617,8 +617,10 @@ class VaultLockManagerImpl(
          * @param createdForAutofill if the the creation event is due to an activity being launched
          * for autofill.
          */
-        data class AppCreated(val firstTimeCreation: Boolean, val createdForAutofill: Boolean) :
-            CheckTimeoutReason()
+        data class AppCreated(
+            val firstTimeCreation: Boolean,
+            val createdForAutofill: Boolean,
+        ) : CheckTimeoutReason()
 
         /**
          * Indicates that the current user has changed.

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/AppStateManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/AppStateManagerTest.kt
@@ -72,7 +72,7 @@ class AppStateManagerTest {
                 assertEquals(AppCreationState.Destroyed, awaitItem())
 
                 activityLifecycleCallbacks.captured.onActivityCreated(activity, null)
-                assertEquals(AppCreationState.Created(createdForAutofill = false), awaitItem())
+                assertEquals(AppCreationState.Created(isAutoFill = false), awaitItem())
 
                 activityLifecycleCallbacks.captured.onActivityCreated(activity, null)
                 expectNoEvents()

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/AppStateManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/AppStateManagerTest.kt
@@ -3,14 +3,17 @@ package com.x8bit.bitwarden.data.platform.manager
 import android.app.Activity
 import android.app.Application
 import app.cash.turbine.test
+import com.x8bit.bitwarden.data.autofill.util.createdForAutofill
 import com.x8bit.bitwarden.data.platform.manager.model.AppCreationState
 import com.x8bit.bitwarden.data.platform.manager.model.AppForegroundState
 import com.x8bit.bitwarden.data.util.FakeLifecycleOwner
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -59,15 +62,17 @@ class AppStateManagerTest {
     @Test
     fun `appCreatedStateFlow should emit whenever the underlying activities are all destroyed or a creation event occurs`() =
         runTest {
+            mockkStatic(Activity::createdForAutofill)
             val activity = mockk<Activity> {
                 every { isChangingConfigurations } returns false
+                every { createdForAutofill } returns false
             }
             appStateManager.appCreatedStateFlow.test {
                 // Initial state is DESTROYED
-                assertEquals(AppCreationState.DESTROYED, awaitItem())
+                assertEquals(AppCreationState.Destroyed, awaitItem())
 
                 activityLifecycleCallbacks.captured.onActivityCreated(activity, null)
-                assertEquals(AppCreationState.CREATED, awaitItem())
+                assertEquals(AppCreationState.Created(createdForAutofill = false), awaitItem())
 
                 activityLifecycleCallbacks.captured.onActivityCreated(activity, null)
                 expectNoEvents()
@@ -76,7 +81,8 @@ class AppStateManagerTest {
                 expectNoEvents()
 
                 activityLifecycleCallbacks.captured.onActivityDestroyed(activity)
-                assertEquals(AppCreationState.DESTROYED, awaitItem())
+                assertEquals(AppCreationState.Destroyed, awaitItem())
             }
+            unmockkStatic(Activity::createdForAutofill)
         }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/FakeAppStateManager.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/FakeAppStateManager.kt
@@ -11,7 +11,8 @@ import kotlinx.coroutines.flow.asStateFlow
  * A faked implementation of [AppStateManager]
  */
 class FakeAppStateManager : AppStateManager {
-    private val mutableAppCreationStateFlow = MutableStateFlow(AppCreationState.DESTROYED)
+    private val mutableAppCreationStateFlow =
+        MutableStateFlow<AppCreationState>(AppCreationState.Destroyed)
     private val mutableAppForegroundStateFlow = MutableStateFlow(AppForegroundState.BACKGROUNDED)
 
     override val appCreatedStateFlow: StateFlow<AppCreationState>

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -166,7 +166,7 @@ class VaultLockManagerTest {
         MOCK_TIMEOUTS.forEachIndexed { index, vaultTimeout ->
             resetTest(vaultTimeout = vaultTimeout)
             fakeAppStateManager.appCreationState =
-                AppCreationState.Created(createdForAutofill = false)
+                AppCreationState.Created(isAutoFill = false)
             // On the first time Created any status will see vault locked or for any subsequent
             // Created events only OnAppRestart should be locked.
             when {
@@ -188,7 +188,7 @@ class VaultLockManagerTest {
         MOCK_TIMEOUTS.forEach { vaultTimeout ->
             resetTest(vaultTimeout = vaultTimeout)
             fakeAppStateManager.appCreationState =
-                AppCreationState.Created(createdForAutofill = false)
+                AppCreationState.Created(isAutoFill = false)
             // Only OnAppRestart will be affected here as the first time event already took place.
             when (vaultTimeout) {
                 VaultTimeout.OnAppRestart,
@@ -323,7 +323,7 @@ class VaultLockManagerTest {
         verifyUnlockedVaultBlocking(userId = USER_ID)
         assertTrue(vaultLockManager.isVaultUnlocked(USER_ID))
 
-        fakeAppStateManager.appCreationState = AppCreationState.Created(createdForAutofill = false)
+        fakeAppStateManager.appCreationState = AppCreationState.Created(isAutoFill = false)
 
         assertFalse(vaultLockManager.isVaultUnlocked(USER_ID))
     }
@@ -340,7 +340,7 @@ class VaultLockManagerTest {
         verifyUnlockedVaultBlocking(userId = USER_ID)
         assertTrue(vaultLockManager.isVaultUnlocked(USER_ID))
 
-        fakeAppStateManager.appCreationState = AppCreationState.Created(createdForAutofill = true)
+        fakeAppStateManager.appCreationState = AppCreationState.Created(isAutoFill = true)
 
         assertFalse(vaultLockManager.isVaultUnlocked(USER_ID))
     }
@@ -353,7 +353,7 @@ class VaultLockManagerTest {
         mutableVaultTimeoutActionStateFlow.value = VaultTimeoutAction.LOCK
         mutableVaultTimeoutStateFlow.value = VaultTimeout.ThirtyMinutes
 
-        fakeAppStateManager.appCreationState = AppCreationState.Created(createdForAutofill = false)
+        fakeAppStateManager.appCreationState = AppCreationState.Created(isAutoFill = false)
 
         assertFalse(vaultLockManager.isVaultUnlocked(USER_ID))
     }
@@ -369,7 +369,7 @@ class VaultLockManagerTest {
         verifyUnlockedVaultBlocking(userId = USER_ID)
         assertTrue(vaultLockManager.isVaultUnlocked(USER_ID))
 
-        fakeAppStateManager.appCreationState = AppCreationState.Created(createdForAutofill = false)
+        fakeAppStateManager.appCreationState = AppCreationState.Created(isAutoFill = false)
 
         verify(exactly = 1) { settingsRepository.getVaultTimeoutActionStateFlow(USER_ID) }
     }
@@ -396,7 +396,7 @@ class VaultLockManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
         // We want to skip the first time since that is different from subsequent foregrounds
-        fakeAppStateManager.appCreationState = AppCreationState.Created(createdForAutofill = false)
+        fakeAppStateManager.appCreationState = AppCreationState.Created(isAutoFill = false)
 
         // Will be used within each loop to reset the test to a suitable initial state.
         fun resetTest(vaultTimeout: VaultTimeout) {
@@ -413,7 +413,7 @@ class VaultLockManagerTest {
             resetTest(vaultTimeout = vaultTimeout)
 
             fakeAppStateManager.appCreationState =
-                AppCreationState.Created(createdForAutofill = false)
+                AppCreationState.Created(isAutoFill = false)
             // Advance by 6 minutes. Only actions with a timeout less than this will be triggered.
             testDispatcher.scheduler.advanceTimeBy(delayTimeMillis = 6 * 60 * 1000L)
 
@@ -442,7 +442,7 @@ class VaultLockManagerTest {
             resetTest(vaultTimeout = vaultTimeout)
 
             fakeAppStateManager.appCreationState =
-                AppCreationState.Created(createdForAutofill = false)
+                AppCreationState.Created(isAutoFill = false)
             // Advance by 6 minutes. Only actions with a timeout less than this will be triggered.
             testDispatcher.scheduler.advanceTimeBy(delayTimeMillis = 6 * 60 * 1000L)
 
@@ -475,7 +475,7 @@ class VaultLockManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
 
         // We want to skip the first time since that is different from subsequent foregrounds
-        fakeAppStateManager.appCreationState = AppCreationState.Created(createdForAutofill = false)
+        fakeAppStateManager.appCreationState = AppCreationState.Created(isAutoFill = false)
 
         // Will be used within each loop to reset the test to a suitable initial state.
         fun resetTest(vaultTimeout: VaultTimeout) {
@@ -492,7 +492,7 @@ class VaultLockManagerTest {
             resetTest(vaultTimeout = vaultTimeout)
 
             fakeAppStateManager.appCreationState =
-                AppCreationState.Created(createdForAutofill = true)
+                AppCreationState.Created(isAutoFill = true)
             // Advance by 6 minutes. Only actions with a timeout less than this will be triggered.
             testDispatcher.scheduler.advanceTimeBy(delayTimeMillis = 6 * 60 * 1000L)
 
@@ -506,7 +506,7 @@ class VaultLockManagerTest {
             resetTest(vaultTimeout = vaultTimeout)
 
             fakeAppStateManager.appCreationState =
-                AppCreationState.Created(createdForAutofill = true)
+                AppCreationState.Created(isAutoFill = true)
             // Advance by 6 minutes. Only actions with a timeout less than this will be triggered.
             testDispatcher.scheduler.advanceTimeBy(delayTimeMillis = 6 * 60 * 1000L)
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -219,6 +219,7 @@ class VaultLockManagerTest {
 
         // Start in a foregrounded state
         fakeAppStateManager.appForegroundState = AppForegroundState.FOREGROUNDED
+        fakeAppStateManager.appCreationState = AppCreationState.Created(isAutoFill = false)
 
         // Will be used within each loop to reset the test to a suitable initial state.
         fun resetTest(vaultTimeout: VaultTimeout) {


### PR DESCRIPTION
## 🎟️ Tracking
[PM-16062](https://bitwarden.atlassian.net/browse/PM-16062)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- When the app was being opened by the AutoFill/Accessibility services from a cold start, the user would need to unlock the vault, and once completing the AutoFill request the vault was being locked based on the state being send to the `VaultLockManager`. 
- This was especially called out for logins that have a (2 page) flow, where the user was being asked to unlock the vault again to grab the password on the second page.
- This change changes the `VaultLockManager` to check the timeout action instead on events of the activity being created for the first time with the added context of if was created for Autofill purposes.

## 📸 Screenshots

https://github.com/user-attachments/assets/982edd38-2aea-4e76-94c9-1f73d70f1277


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16062]: https://bitwarden.atlassian.net/browse/PM-16062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ