### PR TITLE
[PM-8217] Add creationDate and isTwoFactorEnable properties

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/model/AccountJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/disk/model/AccountJson.kt
@@ -2,10 +2,12 @@ package com.x8bit.bitwarden.data.auth.datasource.disk.model
 
 import com.x8bit.bitwarden.data.auth.datasource.network.model.KdfTypeJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.UserDecryptionOptionsJson
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
+import java.time.ZonedDateTime
 
 /**
  * Represents the current account information for a given user.
@@ -35,6 +37,7 @@ data class AccountJson(
      * @property userId The ID of the user.
      * @property email The user's email address.
      * @property isEmailVerified Whether or not the user's email is verified.
+     * @property isTwoFactorEnabled If the profile has two factor authentication enabled.
      * @property name The user's name (if applicable).
      * @property stamp The account's security stamp (if applicable).
      * @property organizationId The ID of the associated organization (if applicable).
@@ -46,6 +49,7 @@ data class AccountJson(
      * @property kdfMemory The amount of memory to use when calculating a password hash (MB).
      * @property kdfParallelism The number of threads to use when calculating a password hash.
      * @property userDecryptionOptions The options available to a user for decryption.
+     * @property creationDate The creation date of the account.
      */
     @OptIn(ExperimentalSerializationApi::class)
     @Serializable
@@ -58,6 +62,9 @@ data class AccountJson(
 
         @SerialName("emailVerified")
         val isEmailVerified: Boolean?,
+
+        @SerialName("isTwoFactorEnabled")
+        val isTwoFactorEnabled: Boolean?,
 
         @SerialName("name")
         val name: String?,
@@ -92,6 +99,10 @@ data class AccountJson(
         @SerialName("userDecryptionOptions")
         @JsonNames("accountDecryptionOptions")
         val userDecryptionOptions: UserDecryptionOptionsJson?,
+
+        @SerialName("creationDate")
+        @Contextual
+        val creationDate: ZonedDateTime?,
     )
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensions.kt
@@ -25,6 +25,7 @@ fun GetTokenResponseJson.Success.toUserState(
             userId = userId,
             email = jwtTokenData.email,
             isEmailVerified = jwtTokenData.isEmailVerified,
+            isTwoFactorEnabled = null,
             name = jwtTokenData.name,
             stamp = null,
             organizationId = null,
@@ -36,6 +37,7 @@ fun GetTokenResponseJson.Success.toUserState(
             kdfMemory = this.kdfMemory,
             kdfParallelism = this.kdfParallelism,
             userDecryptionOptions = this.userDecryptionOptions,
+            creationDate = null,
         ),
         settings = AccountJson.Settings(
             environmentUrlData = environmentUrlData,

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
@@ -59,6 +59,8 @@ fun UserStateJson.toUpdatedUserStateJson(
             avatarColorHex = syncProfile.avatarColor,
             stamp = syncProfile.securityStamp,
             hasPremium = syncProfile.isPremium || syncProfile.isPremiumFromOrganization,
+            isTwoFactorEnabled = syncProfile.isTwoFactorEnabled,
+            creationDate = syncProfile.creationDate,
         )
     val updatedAccount = account.copy(profile = updatedProfile)
     return this

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseJson.kt
@@ -153,6 +153,7 @@ data class SyncResponseJson(
      * @property key The key of the profile (nullable).
      * @property securityStamp The secure stamp of the profile (nullable).
      * @property providers A list of providers associated with the profile (nullable).
+     * @property creationDate The creation date of the account.
      */
     @Serializable
     data class Profile(
@@ -209,6 +210,10 @@ data class SyncResponseJson(
 
         @SerialName("providers")
         val providers: List<Provider>?,
+
+        @SerialName("creationDate")
+        @Contextual
+        val creationDate: ZonedDateTime,
     ) {
         /**
          * Represents an organization in the vault response.

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 
 @Suppress("LargeClass")
 class AuthDiskSourceTest {
@@ -1256,6 +1257,7 @@ private const val USER_STATE_JSON = """
             "userId": "activeUserId",
             "email": "email",
             "emailVerified": true,
+            "isTwoFactorEnabled": false,
             "name": "name",
             "stamp": "stamp",
             "orgIdentifier": "organizationId",
@@ -1278,7 +1280,8 @@ private const val USER_STATE_JSON = """
               "keyConnectorOption": {
                 "keyConnectorUrl": "keyConnectorUrl"
               }
-            }
+            },
+            "creationDate": "2024-09-13T01:00:00.000Z"
           },
           "tokens": {
             "accessToken": "accessToken",
@@ -1318,6 +1321,8 @@ private val USER_STATE = UserStateJson(
                 kdfIterations = 600000,
                 kdfMemory = 16,
                 kdfParallelism = 4,
+                isTwoFactorEnabled = false,
+                creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
                 userDecryptionOptions = UserDecryptionOptionsJson(
                     hasMasterPassword = true,
                     trustedDeviceUserDecryptionOptions = TrustedDeviceUserDecryptionOptionsJson(

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerTest.kt
@@ -1168,6 +1168,8 @@ private val ACCOUNT: AccountJson = AccountJson(
         kdfMemory = 16,
         kdfParallelism = 4,
         userDecryptionOptions = null,
+        isTwoFactorEnabled = false,
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
     ),
     tokens = AccountTokensJson(
         accessToken = ACCESS_TOKEN,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/TrustedDeviceManagerTests.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/TrustedDeviceManagerTests.kt
@@ -297,6 +297,8 @@ private val DEFAULT_ACCOUNT = AccountJson(
         kdfMemory = 16,
         kdfParallelism = 4,
         userDecryptionOptions = DEFAULT_USER_DECRYPTION_OPTIONS,
+        isTwoFactorEnabled = false,
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
     ),
     settings = AccountJson.Settings(
         environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
@@ -319,6 +321,8 @@ private val UPDATED_ACCOUNT = AccountJson(
         kdfMemory = 16,
         kdfParallelism = 4,
         userDecryptionOptions = UPDATED_USER_DECRYPTION_OPTIONS,
+        isTwoFactorEnabled = false,
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
     ),
     settings = AccountJson.Settings(
         environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
@@ -30,6 +30,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.ZonedDateTime
 
 @ExtendWith(MainDispatcherExtension::class)
 class UserLogoutManagerTest {
@@ -256,6 +257,8 @@ private val ACCOUNT_1 = AccountJson(
         kdfMemory = 16,
         kdfParallelism = 4,
         userDecryptionOptions = null,
+        isTwoFactorEnabled = false,
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
     ),
     tokens = AccountTokensJson(
         accessToken = ACCESS_TOKEN,
@@ -281,6 +284,8 @@ private val ACCOUNT_2 = AccountJson(
         kdfMemory = null,
         kdfParallelism = null,
         userDecryptionOptions = null,
+        isTwoFactorEnabled = false,
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
     ),
     tokens = AccountTokensJson(
         accessToken = ACCESS_TOKEN_2,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/util/TrustDeviceResponseExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/util/TrustDeviceResponseExtensionsTest.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.TrustedDeviceUserD
 import com.x8bit.bitwarden.data.auth.datasource.network.model.UserDecryptionOptionsJson
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 
 class TrustDeviceResponseExtensionsTest {
     @Test
@@ -78,6 +79,8 @@ private val DEFAULT_ACCOUNT = AccountJson(
         kdfMemory = 16,
         kdfParallelism = 4,
         userDecryptionOptions = DEFAULT_USER_DECRYPTION_OPTIONS,
+        isTwoFactorEnabled = false,
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
     ),
     settings = AccountJson.Settings(
         environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
@@ -100,6 +103,8 @@ private val UPDATED_ACCOUNT = AccountJson(
         kdfMemory = 16,
         kdfParallelism = 4,
         userDecryptionOptions = UPDATED_USER_DECRYPTION_OPTIONS,
+        isTwoFactorEnabled = false,
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
     ),
     settings = AccountJson.Settings(
         environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -6571,6 +6571,8 @@ class AuthRepositoryTest {
             kdfMemory = 16,
             kdfParallelism = 4,
             userDecryptionOptions = null,
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
         )
         private val ACCOUNT_1 = AccountJson(
             profile = PROFILE_1,
@@ -6594,6 +6596,8 @@ class AuthRepositoryTest {
                 kdfMemory = null,
                 kdfParallelism = null,
                 userDecryptionOptions = null,
+                isTwoFactorEnabled = false,
+                creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
             ),
             settings = AccountJson.Settings(
                 environmentUrlData = null,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/AuthDiskSourceExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/AuthDiskSourceExtensionsTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 
 class AuthDiskSourceExtensionsTest {
     private val authDiskSource: AuthDiskSource = FakeAuthDiskSource()
@@ -531,6 +532,8 @@ private val MOCK_PROFILE = AccountJson.Profile(
     kdfMemory = null,
     kdfParallelism = null,
     userDecryptionOptions = null,
+    isTwoFactorEnabled = false,
+    creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
 )
 
 private val MOCK_ACCOUNT = AccountJson(

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensionsTest.kt
@@ -141,6 +141,8 @@ private val PROFILE_1 = AccountJson.Profile(
     kdfMemory = 16,
     kdfParallelism = 4,
     userDecryptionOptions = null,
+    isTwoFactorEnabled = null,
+    creationDate = null,
 )
 private val ACCOUNT_1 = AccountJson(
     profile = PROFILE_1,
@@ -164,6 +166,8 @@ private val ACCOUNT_2 = AccountJson(
         kdfMemory = null,
         kdfParallelism = null,
         userDecryptionOptions = null,
+        isTwoFactorEnabled = null,
+        creationDate = null,
     ),
     settings = AccountJson.Settings(
         environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
@@ -24,6 +24,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 
 @Suppress("LargeClass")
 class UserStateJsonExtensionsTest {
@@ -59,6 +60,8 @@ class UserStateJsonExtensionsTest {
             kdfMemory = 16,
             kdfParallelism = 4,
             userDecryptionOptions = null,
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
         )
         val originalAccount = AccountJson(
             profile = originalProfile,
@@ -110,6 +113,8 @@ class UserStateJsonExtensionsTest {
                 trustedDeviceUserDecryptionOptions = null,
                 keyConnectorUserDecryptionOptions = null,
             ),
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
         )
         val originalAccount = AccountJson(
             profile = originalProfile,
@@ -178,6 +183,8 @@ class UserStateJsonExtensionsTest {
             kdfMemory = 16,
             kdfParallelism = 4,
             userDecryptionOptions = null,
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
         )
         val originalAccount = AccountJson(
             profile = originalProfile,
@@ -192,6 +199,8 @@ class UserStateJsonExtensionsTest {
                         profile = originalProfile.copy(
                             avatarColorHex = "avatarColor",
                             stamp = "securityStamp",
+                            isTwoFactorEnabled = false,
+                            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
                         ),
                     ),
                 ),
@@ -210,6 +219,9 @@ class UserStateJsonExtensionsTest {
                             every { securityStamp } returns "securityStamp"
                             every { isPremium } returns true
                             every { isPremiumFromOrganization } returns true
+                            every { isTwoFactorEnabled } returns false
+                            every { creationDate } returns ZonedDateTime
+                                .parse("2024-09-13T01:00:00.00Z")
                         }
                     },
                 ),
@@ -235,6 +247,8 @@ class UserStateJsonExtensionsTest {
             kdfMemory = 16,
             kdfParallelism = 4,
             userDecryptionOptions = null,
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
         )
         val originalAccount = AccountJson(
             profile = originalProfile,
@@ -296,6 +310,8 @@ class UserStateJsonExtensionsTest {
                 keyConnectorUserDecryptionOptions = keyConnectorOptionsJson,
                 trustedDeviceUserDecryptionOptions = trustedDeviceOptionsJson,
             ),
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
         )
         val originalAccount = AccountJson(
             profile = originalProfile,

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 
 class FirstTimeActionManagerTest {
     private val fakeAuthDiskSource = FakeAuthDiskSource()
@@ -328,6 +329,8 @@ private val MOCK_PROFILE = AccountJson.Profile(
     kdfMemory = 16,
     kdfParallelism = 4,
     userDecryptionOptions = MOCK_USER_DECRYPTION_OPTIONS,
+    isTwoFactorEnabled = false,
+    creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
 )
 
 private val MOCK_ACCOUNT = AccountJson(

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.time.ZonedDateTime
 
 @Suppress("LargeClass")
 class SettingsRepositoryTest {
@@ -1259,6 +1260,8 @@ private val MOCK_PROFILE = AccountJson.Profile(
     kdfMemory = 16,
     kdfParallelism = 4,
     userDecryptionOptions = MOCK_USER_DECRYPTION_OPTIONS,
+    isTwoFactorEnabled = false,
+    creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
 )
 
 private val MOCK_ACCOUNT = AccountJson(

--- a/app/src/test/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryTest.kt
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 @Suppress("LargeClass")
 class GeneratorRepositoryTest {
@@ -788,6 +789,8 @@ private val USER_STATE = UserStateJson(
                         keyConnectorUrl = "keyConnectorUrl",
                     ),
                 ),
+                isTwoFactorEnabled = false,
+                creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
             ),
             tokens = AccountTokensJson(
                 accessToken = "accessToken",

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseProfileUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseProfileUtil.kt
@@ -25,6 +25,7 @@ fun createMockProfile(number: Int): SyncResponseJson.Profile =
         key = "mockKey-$number",
         securityStamp = "mockSecurityStamp-$number",
         providers = listOf(createMockProvider(number = number)),
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
     )
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceTest.kt
@@ -55,6 +55,7 @@ private const val SYNC_SUCCESS_JSON = """
     "forcePasswordReset": false,
     "usesKeyConnector": false,
     "avatarColor": "mockAvatarColor-1",
+    "creationDate": "2024-09-13T01:00:00.00Z",
     "organizations": [
       {
         "usePolicies": false,

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
@@ -60,6 +60,7 @@ import java.io.File
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 @Suppress("LargeClass")
 class CipherManagerTest {
@@ -2020,6 +2021,8 @@ private val MOCK_PROFILE = AccountJson.Profile(
     kdfMemory = null,
     kdfParallelism = null,
     userDecryptionOptions = null,
+    isTwoFactorEnabled = false,
+    creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
 )
 
 private val MOCK_ACCOUNT = AccountJson(

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("LargeClass")
@@ -1618,6 +1619,8 @@ private val MOCK_PROFILE = AccountJson.Profile(
     kdfMemory = null,
     kdfParallelism = null,
     userDecryptionOptions = null,
+    isTwoFactorEnabled = false,
+    creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
 )
 
 private val MOCK_ACCOUNT = AccountJson(

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -4732,6 +4732,8 @@ private val MOCK_PROFILE = AccountJson.Profile(
     kdfMemory = null,
     kdfParallelism = null,
     userDecryptionOptions = null,
+    isTwoFactorEnabled = false,
+    creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
 )
 
 private val MOCK_ACCOUNT = AccountJson(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-8217

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add creationDate and isTwoFactorEnable properties to user account. Values were already being passed down from api response but were previously ignored.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
