### PR TITLE
PM-14333 fix case of crowdin translation not adding annotations on string with format args

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/util/AutofillIntentUtils.kt
@@ -151,7 +151,7 @@ fun Intent.getTotpCopyIntentOrNull(): AutofillTotpCopyData? =
 
 /**
  * Checks if the given [Activity] was created for Autofill. This is useful to avoid locking the
- * vault if one of the Autofill services starts the only only instance of the [MainActivity].
+ * vault if one of the Autofill services starts the only instance of the [MainActivity].
  */
 val Activity.createdForAutofill: Boolean
     get() = intent.getAutofillSelectionDataOrNull() != null ||

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/StringResExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/StringResExtensions.kt
@@ -61,7 +61,7 @@ fun @receiver:StringRes Int.toAnnotatedString(
         SpannableStringBuilder(resources.getText(this) as SpannedString)
     } catch (e: ClassCastException) {
         // the resource did not contain and valid spans so we just return the raw string.
-        return stringResource(id = this).toAnnotatedString()
+        return stringResource(id = this, *args).toAnnotatedString()
     }
     // Replace any format arguments with the provided arguments.
     spannableBuilder.applyArgAnnotations(args = args)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/util/StringRestExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/util/StringRestExtensionsTest.kt
@@ -100,4 +100,20 @@ class StringRestExtensionsTest : BaseComposeTest() {
             .onNodeWithText("On your computer, open a new browser tab and go to ")
             .assertIsDisplayed()
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `string with no annotations with args should just be handled as normal annotated string`() {
+        composeTestRule.setContent {
+            Text(
+                text = R.string.test_for_string_with_no_annotations_with_format_arg.toAnnotatedString(
+                    args = arrayOf("this"),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText("Nothing special here, except this.")
+            .assertIsDisplayed()
+    }
 }

--- a/app/src/test/res/values/strings_for_tests_only.xml
+++ b/app/src/test/res/values/strings_for_tests_only.xml
@@ -4,6 +4,7 @@
     <string name="test_for_single_link_annotation">Get emails from Bitwarden for announcements, advice, and research opportunities. <annotation link="unsubscribe">Unsubscribe</annotation> at any time.</string>
     <string name="test_for_multi_link_annotation">By continuing, you agree to the <annotation link="termsOfService">Terms of Service</annotation> and <annotation link="privacyPolicy">Privacy Policy</annotation></string>
     <string name="test_for_string_with_no_annotations">Nothing special here.</string>
+    <string name="test_for_string_with_no_annotations_with_format_arg">Nothing special here, except %1$s.</string>
     <string name="test_for_string_with_annotation_and_arg_annotation">On your computer, open a new browser tab and <annotation emphasis="bold">go to <annotation arg="0">%1$s</annotation></annotation></string>
     <!-- /StringResExtensions Test value -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking
PM-14333 - follow up
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Since Crowdin does not add the <annotation> to each translation, need to support the cases where there are format args.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
