### PR TITLE
PM-16474 Adding custom field issues when another text field holds focus

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomFieldsButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomFieldsButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.x8bit.bitwarden.R
@@ -71,10 +72,14 @@ fun VaultAddEditCustomFieldsButton(
             },
         )
     }
-
+    val focusManager = LocalFocusManager.current
     BitwardenOutlinedButton(
         label = stringResource(id = R.string.new_custom_field),
-        onClick = { shouldShowChooserDialog = true },
+        onClick = {
+            // Clear any current focused item such as an unrelated text field.
+            focusManager.clearFocus()
+            shouldShowChooserDialog = true
+        },
         modifier = modifier.testTag("NewCustomFieldButton"),
     )
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-16474
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- When the dialog for naming the custom field is displayed it seems to re-trigger the focus on the outer textfield which causes the list to scroll back to that field in the background consistently and sometimes causes the dialog to dismiss before the user can interact.
- We now clear any other held focus when the user click the button to create the new custom field.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
| Before |
|--------|
|  https://github.com/user-attachments/assets/049cb29f-618b-466e-9ab8-a13903e66367 | 

| After |
|--------|
| https://github.com/user-attachments/assets/709f9d7b-d9ce-4405-966c-fe57f760bda8 | 



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
