### PR TITLE
[PM-8217] Add local feature flag to ignore environment validation

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1388,7 +1388,9 @@ class AuthRepositoryImpl(
      * - Cannot have two-factor authentication enabled.
      */
     private fun newDeviceNoticePreConditionsValid(): Boolean {
-        if (environmentRepository.environment.type == Environment.Type.SELF_HOSTED) {
+        val checkEnvironment = !featureFlagManager.getFeatureFlag(FlagKey.IgnoreEnvironmentCheck)
+        val isSelfHosted = environmentRepository.environment.type == Environment.Type.SELF_HOSTED
+        if (checkEnvironment && isSelfHosted) {
             return false
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -161,6 +161,15 @@ sealed class FlagKey<out T : Any> {
         override val isRemotelyConfigured: Boolean = true
     }
 
+    /**
+     * Data object holding the feature flag key to ignore an environment check.
+     */
+    data object IgnoreEnvironmentCheck : FlagKey<Boolean>() {
+        override val keyName: String = "ignore-environment-check"
+        override val defaultValue: Boolean = false
+        override val isRemotelyConfigured: Boolean = false
+    }
+
     //region Dummy keys for testing
     /**
      * Data object holding the key for a [Boolean] flag to be used in tests.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -38,6 +38,7 @@ sealed class FlagKey<out T : Any> {
                 AppReviewPrompt,
                 NewDevicePermanentDismiss,
                 NewDeviceTemporaryDismiss,
+                IgnoreEnvironmentCheck,
             )
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -35,6 +35,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CipherKeyEncryption,
     FlagKey.NewDevicePermanentDismiss,
     FlagKey.NewDeviceTemporaryDismiss,
+    FlagKey.IgnoreEnvironmentCheck,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
         key = flagKey as FlagKey<Boolean>,
@@ -85,4 +86,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.CipherKeyEncryption -> stringResource(R.string.cipher_key_encryption)
     FlagKey.NewDevicePermanentDismiss -> stringResource(R.string.new_device_permanent_dismiss)
     FlagKey.NewDeviceTemporaryDismiss -> stringResource(R.string.new_device_temporary_dismiss)
+    FlagKey.IgnoreEnvironmentCheck -> stringResource(R.string.ignore_environment_check)
 }

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -24,5 +24,6 @@
     <string name="cipher_key_encryption">Cipher Key Encryption</string>">
     <string name="new_device_permanent_dismiss">New device notice permanent dismiss</string>">
     <string name="new_device_temporary_dismiss">New device notice temporary dismiss</string>">
+    <string name="ignore_environment_check">Ignore environment check</string>">
     <!-- /Debug Menu -->
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -66,4 +66,14 @@ class FlagKeyTest {
     fun `NewDeviceTemporaryDismiss is remotely configured value should be true`() {
         assertTrue(FlagKey.NewDeviceTemporaryDismiss.isRemotelyConfigured)
     }
+
+    @Test
+    fun `IgnoreEnvironmentCheck default value should be false`() {
+        assertFalse(FlagKey.IgnoreEnvironmentCheck.defaultValue)
+    }
+
+    @Test
+    fun `IgnoreEnvironmentCheck is remotely configured value should be false`() {
+        assertFalse(FlagKey.IgnoreEnvironmentCheck.isRemotelyConfigured)
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -119,6 +119,7 @@ private val DEFAULT_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.AppReviewPrompt to true,
     FlagKey.NewDeviceTemporaryDismiss to true,
     FlagKey.NewDevicePermanentDismiss to true,
+    FlagKey.IgnoreEnvironmentCheck to true,
 )
 
 private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
@@ -134,6 +135,7 @@ private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.AppReviewPrompt to false,
     FlagKey.NewDeviceTemporaryDismiss to false,
     FlagKey.NewDevicePermanentDismiss to false,
+    FlagKey.IgnoreEnvironmentCheck to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-8217

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In order for QA to fully test the new device two factor notice feature, we need to bypass the requirement of only showing the notice to Bitwarden Cloud environments. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
