### PR TITLE
[PM-15969] Users with Can Edit access cannot assign collections

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
@@ -110,13 +110,8 @@ fun List<CollectionView>?.hasDeletePermissionInAtLeastOneCollection(
 /**
  * Checks if the user has permission to assign an item to a collection.
  *
- * Assigning to a collection is not allowed when the item is in a collection that the user does not
- * have "manage" permission for and is also in a collection they cannot view the passwords in.
- *
- * E.g., If an item is in A collection with "view except passwords" or "edit except passwords"
- * permission and in another with "manage" permission, the user **cannot** assign the item to other
- * collections. Conversely, if an item is in a collection with "manage" permission and another with
- * "view" or "edit" permission, the user **can** assign the item to other collections.
+ * Assigning to a collection is only allowed when the item is in a collection that the user does
+ * have "manage" or "edit" permission.
  */
 fun List<CollectionView>?.canAssignToCollections(currentCollectionIds: List<String>?): Boolean {
     if (this.isNullOrEmpty()) return true
@@ -126,17 +121,9 @@ fun List<CollectionView>?.canAssignToCollections(currentCollectionIds: List<Stri
     return this
         .any {
             currentCollectionIds.contains(it.id) &&
-                it.permission == CollectionPermission.MANAGE
-        } &&
-
-        // Verify user does not have "edit except password" or "view except passwords"
-        // permission in any collection the item is not in.
-        this
-            .none {
-                currentCollectionIds.contains(it.id) &&
-                    (it.permission == CollectionPermission.EDIT_EXCEPT_PASSWORD ||
-                        it.permission == CollectionPermission.VIEW_EXCEPT_PASSWORDS)
-            }
+                (it.permission == CollectionPermission.MANAGE ||
+                    it.permission == CollectionPermission.EDIT)
+        }
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
@@ -117,7 +117,7 @@ fun List<CollectionView>?.canAssignToCollections(currentCollectionIds: List<Stri
     if (this.isNullOrEmpty()) return true
     if (currentCollectionIds.isNullOrEmpty()) return true
 
-    // Verify user can MANAGE at least one collection the item is in.
+    // Verify user can MANAGE or EDIT at least one collection the item is in.
     return this
         .any {
             currentCollectionIds.contains(it.id) &&

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -1187,7 +1187,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     resourceManager = resourceManager,
                     clock = fixedClock,
                     canDelete = false,
-                    canAssignToCollections = false,
+                    canAssignToCollections = true,
                 )
             } returns stateWithName.viewState
 
@@ -1215,7 +1215,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     resourceManager = resourceManager,
                     clock = fixedClock,
                     canDelete = false,
-                    canAssignToCollections = false,
+                    canAssignToCollections = true,
                 )
             }
         }
@@ -1385,7 +1385,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     resourceManager = resourceManager,
                     clock = fixedClock,
                     canDelete = true,
-                    canAssignToCollections = false,
+                    canAssignToCollections = true,
                 )
             } returns stateWithName.viewState
 
@@ -1414,7 +1414,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     resourceManager = resourceManager,
                     clock = fixedClock,
                     canDelete = true,
-                    canAssignToCollections = false,
+                    canAssignToCollections = true,
                 )
             }
         }
@@ -1440,7 +1440,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     ),
                     notes = "mockNotes-1",
                     canDelete = true,
-                    canAssociateToCollections = false,
+                    canAssociateToCollections = true,
                 ),
             )
 
@@ -1452,7 +1452,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     resourceManager = resourceManager,
                     clock = fixedClock,
                     canDelete = true,
-                    canAssignToCollections = false,
+                    canAssignToCollections = true,
                 )
             } returns stateWithName.viewState
 
@@ -1481,7 +1481,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     resourceManager = resourceManager,
                     clock = fixedClock,
                     canDelete = true,
-                    canAssignToCollections = false,
+                    canAssignToCollections = true,
                 )
             }
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
@@ -155,13 +155,11 @@ class CollectionViewExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `canAssociateToCollections should return false if the user has except password permission at least one collection`() {
+    fun `canAssociateToCollections should return false if the user doesn't have any manage or edit permissions`() {
         val collectionList: List<CollectionView> = listOf(
             createEditExceptPasswordsCollectionView(number = 1),
             createViewCollectionView(number = 2),
             createViewExceptPasswordsCollectionView(number = 3),
-            createManageCollectionView(number = 4),
-            createEditCollectionView(number = 5),
         )
         val collectionIds = collectionList.mapNotNull { it.id }
         assertFalse(collectionList.canAssignToCollections(collectionIds))


### PR DESCRIPTION
`Backport:`https://github.com/bitwarden/android/pull/4512
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15969

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix bug where users with Can Edit permission in one collection could not use "assign to collection".

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/9c9b98de-f5f3-4fdc-a294-f16d27de27ec

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
