### PR TITLE
[PM-16670] Force app to sync after 2FA notice

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1350,6 +1350,7 @@ class AuthRepositoryImpl(
     }
 
     override fun checkUserNeedsNewDeviceTwoFactorNotice(): Boolean {
+        vaultRepository.syncIfNecessary()
         return activeUserId?.let { userId ->
             val temporaryFlag = featureFlagManager.getFeatureFlag(FlagKey.NewDeviceTemporaryDismiss)
             val permanentFlag = featureFlagManager.getFeatureFlag(FlagKey.NewDevicePermanentDismiss)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModel.kt
@@ -8,6 +8,7 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.util.baseWebVaultUrlOrDefault
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.ChangeAccountEmailClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.ContinueDialogClick
@@ -32,6 +33,7 @@ class NewDeviceNoticeTwoFactorViewModel @Inject constructor(
     val authRepository: AuthRepository,
     val environmentRepository: EnvironmentRepository,
     val featureFlagManager: FeatureFlagManager,
+    val settingsRepository: SettingsRepository,
 ) : BaseViewModel<
     NewDeviceNoticeTwoFactorState,
     NewDeviceNoticeTwoFactorEvent,
@@ -88,6 +90,8 @@ class NewDeviceNoticeTwoFactorViewModel @Inject constructor(
     private fun handleContinueDialog() {
         when (state.dialogState) {
             is ChangeAccountEmailDialog -> {
+                // when the user leaves the app set sync date to null to force a sync on next unlock
+                settingsRepository.vaultLastSync = null
                 sendEvent(
                     NewDeviceNoticeTwoFactorEvent.NavigateToChangeAccountEmail(url = webAccountUrl),
                 )
@@ -95,6 +99,8 @@ class NewDeviceNoticeTwoFactorViewModel @Inject constructor(
             }
 
             is TurnOnTwoFactorDialog -> {
+                // when the user leaves the app set sync date to null to force a sync on next unlock
+                settingsRepository.vaultLastSync = null
                 sendEvent(
                     NewDeviceNoticeTwoFactorEvent.NavigateToTurnOnTwoFactor(url = webTwoFactorUrl),
                 )

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -170,6 +170,7 @@ class AuthRepositoryTest {
     private val vaultRepository: VaultRepository = mockk {
         every { vaultUnlockDataStateFlow } returns mutableVaultUnlockDataStateFlow
         every { deleteVaultData(any()) } just runs
+        every { syncIfNecessary() } just runs
     }
     private val fakeAuthDiskSource = FakeAuthDiskSource()
     private val fakeEnvironmentRepository =

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -6543,6 +6543,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertTrue(shouldShowNewDeviceNotice)
         }
 
@@ -6565,6 +6568,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertFalse(shouldShowNewDeviceNotice)
         }
 
@@ -6586,6 +6592,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertTrue(shouldShowNewDeviceNotice)
         }
 
@@ -6604,6 +6613,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertFalse(shouldShowNewDeviceNotice)
         }
 
@@ -6624,6 +6636,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertFalse(shouldShowNewDeviceNotice)
         }
 
@@ -6639,6 +6654,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertFalse(shouldShowNewDeviceNotice)
         }
 
@@ -6664,6 +6682,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertFalse(shouldShowNewDeviceNotice)
         }
 
@@ -6687,6 +6708,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertFalse(shouldShowNewDeviceNotice)
         }
 
@@ -6710,6 +6734,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertTrue(shouldShowNewDeviceNotice)
         }
 
@@ -6733,6 +6760,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertTrue(shouldShowNewDeviceNotice)
         }
 
@@ -6756,6 +6786,9 @@ class AuthRepositoryTest {
 
             val shouldShowNewDeviceNotice = repository.checkUserNeedsNewDeviceTwoFactorNotice()
 
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
             assertFalse(shouldShowNewDeviceNotice)
         }
 
@@ -6784,6 +6817,9 @@ class AuthRepositoryTest {
             } returns false
 
             assertFalse(repository.checkUserNeedsNewDeviceTwoFactorNotice())
+            verify(exactly = 2) {
+                vaultRepository.syncIfNecessary()
+            }
         }
 
     @Test
@@ -6797,6 +6833,9 @@ class AuthRepositoryTest {
             fakeAuthDiskSource.userState = null
 
             assertFalse(repository.checkUserNeedsNewDeviceTwoFactorNotice())
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
         }
 
     @Test
@@ -6817,8 +6856,11 @@ class AuthRepositoryTest {
                     ),
                 ),
             )
-
             assertFalse(repository.checkUserNeedsNewDeviceTwoFactorNotice())
+
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
         }
 
     @Test
@@ -6842,6 +6884,9 @@ class AuthRepositoryTest {
             )
 
             assertTrue(repository.checkUserNeedsNewDeviceTwoFactorNotice())
+            verify(exactly = 1) {
+                vaultRepository.syncIfNecessary()
+            }
         }
 
     companion object {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModelTest.kt
@@ -6,6 +6,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.NewDeviceNoticeState
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorDialogState.ChangeAccountEmailDialog
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorDialogState.TurnOnTwoFactorDialog
@@ -14,6 +15,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -32,6 +34,8 @@ class NewDeviceNoticeTwoFactorViewModelTest : BaseViewModelTest() {
         every { getFeatureFlag(FlagKey.NewDevicePermanentDismiss) } returns false
         every { getFeatureFlag(FlagKey.NewDeviceTemporaryDismiss) } returns true
     }
+
+    private val settingsRepository = mockk<SettingsRepository>(relaxed = true)
 
     @Test
     fun `initial state should be correct with NewDevicePermanentDismiss flag false`() = runTest {
@@ -130,6 +134,9 @@ class NewDeviceNoticeTwoFactorViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE,
                     viewModel.stateFlow.value,
                 )
+                verify(exactly = 1) {
+                    settingsRepository.vaultLastSync = null
+                }
             }
         }
 
@@ -151,6 +158,9 @@ class NewDeviceNoticeTwoFactorViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE,
                     viewModel.stateFlow.value,
                 )
+                verify(exactly = 1) {
+                    settingsRepository.vaultLastSync = null
+                }
             }
         }
 
@@ -172,7 +182,7 @@ class NewDeviceNoticeTwoFactorViewModelTest : BaseViewModelTest() {
             authRepository = authRepository,
             environmentRepository = environmentRepository,
             featureFlagManager = featureFlagManager,
-            settingsRepository = mockk(relaxed = true),
+            settingsRepository = settingsRepository,
         )
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModelTest.kt
@@ -172,6 +172,7 @@ class NewDeviceNoticeTwoFactorViewModelTest : BaseViewModelTest() {
             authRepository = authRepository,
             environmentRepository = environmentRepository,
             featureFlagManager = featureFlagManager,
+            settingsRepository = mockk(relaxed = true),
         )
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16670

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
We need the app to sync when the user leaves the app to setup a two factor method and comes back. This will void the grace period of 30 mins between vault syncs. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
