### PR TITLE
PM-16821: remove padding on right side of the vault screen dividers

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -118,7 +118,7 @@ fun VaultContent(
                 BitwardenHorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(all = 16.dp),
+                        .padding(top = 16.dp, start = 16.dp, bottom = 16.dp),
                 )
             }
         }
@@ -219,7 +219,7 @@ fun VaultContent(
                 BitwardenHorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(all = 16.dp),
+                        .padding(top = 16.dp, start = 16.dp, bottom = 16.dp),
                 )
             }
 
@@ -257,7 +257,7 @@ fun VaultContent(
                 BitwardenHorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(all = 16.dp),
+                        .padding(top = 16.dp, start = 16.dp, bottom = 16.dp),
                 )
             }
 
@@ -304,7 +304,7 @@ fun VaultContent(
                 BitwardenHorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(all = 16.dp),
+                        .padding(top = 16.dp, start = 16.dp, bottom = 16.dp),
                 )
             }
 
@@ -337,7 +337,7 @@ fun VaultContent(
             BitwardenHorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(all = 16.dp),
+                    .padding(top = 16.dp, start = 16.dp, bottom = 16.dp),
             )
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16821](https://bitwarden.atlassian.net/browse/PM-16821)

## 📔 Objective

This PR removes the extra padding on the right side of the dividers on the Vault Screen.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/cf586fd1-0942-45f3-9d41-4f3778a32b4a" width="300" /> | <img src="https://github.com/user-attachments/assets/4c8a3c58-04a5-4212-a854-fac15e446842" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16821]: https://bitwarden.atlassian.net/browse/PM-16821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ