### PR TITLE
PM-14179: Update generator screen copy button

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -69,10 +69,10 @@ import kotlinx.collections.immutable.toImmutableList
  * @param keyboardType the preferred type of keyboard input.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
  */
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun BitwardenTextField(
-    label: String,
+    label: String?,
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -136,7 +136,7 @@ fun BitwardenTextField(
                     .focusRequester(focusRequester)
                     .fillMaxWidth(),
                 enabled = enabled,
-                label = { Text(text = label) },
+                label = label?.let { { Text(text = it) } },
                 value = textFieldValue,
                 leadingIcon = leadingIconResource?.let { iconResource ->
                     {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextFieldWithActions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextFieldWithActions.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -48,7 +47,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  */
 @Composable
 fun BitwardenTextFieldWithActions(
-    label: String,
+    label: String?,
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -39,6 +39,7 @@ import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenMediumTopAppBa
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.x8bit.bitwarden.ui.platform.components.appbar.action.BitwardenOverflowActionItem
 import com.x8bit.bitwarden.ui.platform.components.appbar.action.OverflowMenuItemData
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTonalIconButton
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
@@ -302,8 +303,8 @@ private fun ScrollContent(
             .fillMaxHeight()
             .verticalScroll(rememberScrollState()),
     ) {
+        Spacer(modifier = Modifier.height(12.dp))
         if (state.isUnderPolicy) {
-            Spacer(modifier = Modifier.height(8.dp))
             BitwardenInfoCalloutCard(
                 text = stringResource(id = R.string.password_generator_policy_in_effect),
                 modifier = Modifier
@@ -312,16 +313,29 @@ private fun ScrollContent(
                     .fillMaxWidth(),
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(12.dp))
         }
 
         GeneratedStringItem(
             generatedText = state.generatedText,
-            onCopyClick = onCopyClick,
             onRegenerateClick = onRegenerateClick,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth(),
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(12.dp))
+
+        BitwardenFilledButton(
+            label = stringResource(id = R.string.copy),
+            onClick = onCopyClick,
+            modifier = Modifier
+                .testTag(tag = "CopyValueButton")
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
 
         BitwardenListHeaderText(
             label = stringResource(id = R.string.options),
@@ -365,22 +379,15 @@ private fun ScrollContent(
 @Composable
 private fun GeneratedStringItem(
     generatedText: String,
-    onCopyClick: () -> Unit,
     onRegenerateClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BitwardenTextFieldWithActions(
-        label = "",
+        label = null,
         textFieldTestTag = "GeneratedPasswordLabel",
         value = generatedText,
         singleLine = false,
         actions = {
-            BitwardenTonalIconButton(
-                vectorIconRes = R.drawable.ic_copy,
-                contentDescription = stringResource(id = R.string.copy),
-                onClick = onCopyClick,
-                modifier = Modifier.testTag("CopyValueButton"),
-            )
             BitwardenTonalIconButton(
                 vectorIconRes = R.drawable.ic_generate,
                 contentDescription = stringResource(id = R.string.generate_password),
@@ -393,7 +400,7 @@ private fun GeneratedStringItem(
         textStyle = BitwardenTheme.typography.sensitiveInfoSmall,
         shouldAddCustomLineBreaks = true,
         visualTransformation = nonLetterColorVisualTransformation(),
-        modifier = modifier.padding(horizontal = 16.dp),
+        modifier = modifier,
         textToolbarType = TextToolbarType.NONE,
     )
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -193,7 +193,7 @@ class GeneratorScreenTest : BaseComposeTest() {
     @Test
     fun `clicking the Copy button should send CopyClick action`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "Copy")
+            .onNodeWithText(text = "Copy")
             .performClick()
 
         verify {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14179](https://bitwarden.atlassian.net/browse/PM-14179)

## 📔 Objective

This PR moves the password copy button down and make it more pronounces as well as updates the `BitwardenTextField` to allow for nullable labels.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/6c22b024-00a9-4d46-9c07-4bcd732ec438" width="300" /> | <img src="https://github.com/user-attachments/assets/d103905c-a41d-4f1d-af5b-ad0449de934a" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14179]: https://bitwarden.atlassian.net/browse/PM-14179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ