### PR TITLE
[PM-16870] Add support for IronFox

### DIFF
--- a/app/src/main/assets/fido2_privileged_community.json
+++ b/app/src/main/assets/fido2_privileged_community.json
@@ -39,6 +39,18 @@
     {
       "type": "android",
       "info": {
+        "package_name": "org.ironfoxoss.ironfox",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "C5:E2:91:B5:A5:71:F9:C8:CD:9A:97:99:C2:C9:4E:02:EC:97:03:94:88:93:F2:CA:75:6D:67:B9:42:04:F9:04"
+          }
+        ]
+      }
+    },
+    {
+      "type": "android",
+      "info": {
         "package_name": "org.mozilla.fenix",
         "signatures": [
           {

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/BrowserUtil.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/BrowserUtil.kt
@@ -128,6 +128,11 @@ private val ACCESSIBILITY_SUPPORTED_BROWSERS = listOf(
         // 2nd = Anticipation
         possibleUrlFieldIds = listOf("url_bar_title", "mozac_browser_toolbar_url_view"),
     ),
+    Browser(
+        packageName = "org.ironfoxoss.ironfox",
+        // 2nd = Legacy
+        possibleUrlFieldIds = listOf("mozac_browser_toolbar_url_view", "url_bar_title"),
+    ),
     Browser(packageName = "org.mozilla.fenix", urlFieldId = "mozac_browser_toolbar_url_view"),
     // [DEPRECATED ENTRY]
     Browser(

--- a/app/src/main/res/xml/autofill_service_configuration.xml
+++ b/app/src/main/res/xml/autofill_service_configuration.xml
@@ -239,6 +239,9 @@
         android:name="org.gnu.icecat"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package
+        android:name="org.ironfoxoss.ironfox"
+        android:maxLongVersionCode="10000000000" />
+    <compatibility-package
         android:name="org.mozilla.fenix"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package


### PR DESCRIPTION
## 🎟️ Tracking

This issue was brought to our attention via a user from our Discord Server.

## 📔 Objective

IronFox is a new privacy and security-oriented web browser for Android, based on Firefox. It's forked from the recently discontinued [Mull Browser](https://divestos.org/pages/our_apps#mull).

Autofilling log-in info from Bitwarden in IronFox is currently broken; this fixes it by adding our app ID.

Please let me know if there's any questions or concerns :)
