### PR TITLE
[PM-13349] Hide Edit option in cipher list item overflow when editing not permitted

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
@@ -22,7 +22,7 @@ fun CipherView.toOverflowActions(
                     cipherId = cipherId,
                     requiresPasswordReprompt = hasMasterPassword,
                 )
-                    .takeUnless { this.deletedDate != null || !this.edit},
+                    .takeUnless { this.deletedDate != null || !this.edit },
                 this.login?.username?.let {
                     ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = it)
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
@@ -22,7 +22,7 @@ fun CipherView.toOverflowActions(
                     cipherId = cipherId,
                     requiresPasswordReprompt = hasMasterPassword,
                 )
-                    .takeUnless { this.deletedDate != null },
+                    .takeUnless { this.deletedDate != null || !this.edit},
                 this.login?.username?.let {
                     ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = it)
                 },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
@@ -278,6 +278,64 @@ class CipherViewExtensionsTest {
     }
 
     @Test
+    fun `toOverflowActions should not return Edit action when cipher cannot be edited`() {
+        val cipher = createMockCipherView(
+            number = 1,
+            isDeleted = false,
+            cipherType = CipherType.LOGIN,
+        )
+            .copy(
+                id = id,
+                edit = false,
+                login = createMockLoginView(number = 1).copy(
+                    username = null,
+                    password = null,
+                    uris = null,
+                    totp = null,
+                ),
+            )
+
+        val result = cipher.toOverflowActions(hasMasterPassword = true, isPremiumUser = false)
+
+        assertEquals(
+            listOf(ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id)),
+            result,
+        )
+    }
+
+    @Test
+    fun `toOverflowActions should return Edit action when cipher can be edited`() {
+        val cipher = createMockCipherView(
+            number = 1,
+            isDeleted = false,
+            cipherType = CipherType.LOGIN,
+        )
+            .copy(
+                id = id,
+                edit = true,
+                login = createMockLoginView(number = 1).copy(
+                    username = null,
+                    password = null,
+                    uris = null,
+                    totp = null,
+                ),
+            )
+
+        val result = cipher.toOverflowActions(hasMasterPassword = true, isPremiumUser = false)
+
+        assertEquals(
+            listOf(
+                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id),
+                ListingItemOverflowAction.VaultAction.EditClick(
+                    cipherId = id,
+                    requiresPasswordReprompt = true,
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
     fun `toTrailingIcons should return collection icon if collectionId is not empty`() {
         val cipher = createMockCipherView(1).copy(
             organizationId = null,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13349

## 📔 Objective

Hide Edit option in cipher list item overflow when editing not permitted (accompanies #4430)

## 📸 Screenshots

![Screenshot 2025-01-09 at 12 48 02 PM](https://github.com/user-attachments/assets/f139b397-facf-4c69-9ddc-9c2233031d16)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
