### PR TITLE
[PM-9439] Use passkey icon for items with FIDO2 credentials in search results

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
@@ -11,6 +11,7 @@ import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.CollectionView
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
 import com.x8bit.bitwarden.data.platform.util.SpecialCharWithPrecedenceComparator
 import com.x8bit.bitwarden.data.platform.util.subtitle
 import com.x8bit.bitwarden.ui.platform.base.util.asText
@@ -247,7 +248,7 @@ private fun CipherView.toIconData(
             login?.uris.toLoginIconData(
                 baseIconUrl = baseIconUrl,
                 isIconLoadingDisabled = isIconLoadingDisabled,
-                usePasskeyDefaultIcon = false,
+                usePasskeyDefaultIcon = this.isActiveWithFido2Credentials,
             )
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
@@ -9,6 +9,7 @@ import com.bitwarden.vault.CollectionView
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFido2CredentialList
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSendView
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.feature.search.SearchState
@@ -453,6 +454,43 @@ class SearchTypeDataExtensionsTest {
         assertEquals(
             SearchState.ViewState.Empty(
                 message = R.string.there_are_no_items_that_match_the_search.asText(),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `CipherViews toViewState should usePasskeyDefaultIcon based on cipher fido2 credentials`() {
+        mockkStatic(Uri::parse)
+        every { Uri.parse(any()) } returns mockk {
+            every { host } returns "www.mockuri.com"
+        }
+        val result = listOf(
+            createMockCipherView(
+                number = 1,
+                fido2Credentials = createMockSdkFido2CredentialList(number = 1),
+            ),
+            createMockCipherView(number = 2),
+        ).toViewState(
+            searchTerm = "mock",
+            baseIconUrl = "https://vault.bitwarden.com/icons",
+            isIconLoadingDisabled = false,
+            hasMasterPassword = true,
+            isAutofill = false,
+            isPremiumUser = true,
+            isTotp = false,
+            organizationPremiumStatusMap = emptyMap(),
+        )
+
+        assertEquals(
+            SearchState.ViewState.Content(
+                displayItems = listOf(
+                    createMockDisplayItemForCipher(
+                        number = 1,
+                        fallbackIconRes = R.drawable.ic_bw_passkey,
+                    ),
+                    createMockDisplayItemForCipher(number = 2),
+                ),
             ),
             result,
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.feature.search.util
 
+import androidx.annotation.DrawableRes
 import com.bitwarden.send.SendType
 import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
@@ -16,6 +17,7 @@ fun createMockDisplayItemForCipher(
     number: Int,
     cipherType: CipherType = CipherType.LOGIN,
     isTotp: Boolean = false,
+    @DrawableRes fallbackIconRes: Int = R.drawable.ic_globe,
 ): SearchState.DisplayItem =
     when (cipherType) {
         CipherType.LOGIN -> {
@@ -27,7 +29,7 @@ fun createMockDisplayItemForCipher(
                 subtitleTestTag = "CipherSubTitleLabel",
                 iconData = IconData.Network(
                     uri = "https://vault.bitwarden.com/icons/www.mockuri.com/icon.png",
-                    fallbackIconRes = R.drawable.ic_globe,
+                    fallbackIconRes = fallbackIconRes,
                 ),
                 extraIconList = listOf(
                     IconRes(


### PR DESCRIPTION
## 🎟️ Tracking

PM-9439

## 📔 Objective

Display the passkey icon for search results that contain FIDO2 credentials when the web icon is unavailable.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="378" alt="image" src="https://github.com/user-attachments/assets/c6982651-bbad-4ff1-a754-af84524393f6" /> | <img width="378" alt="image" src="https://github.com/user-attachments/assets/c9b434f0-f50f-4843-bfff-94d434cbcf62" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
