### PR TITLE
[PM-15906] Implement single tap passkey flows

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
@@ -13,6 +13,8 @@ import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2OriginManagerImpl
 import com.x8bit.bitwarden.data.autofill.fido2.processor.Fido2ProviderProcessor
 import com.x8bit.bitwarden.data.autofill.fido2.processor.Fido2ProviderProcessorImpl
 import com.x8bit.bitwarden.data.platform.manager.AssetManager
+import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
@@ -44,6 +46,8 @@ object Fido2ProviderModule {
         fido2CredentialManager: Fido2CredentialManager,
         dispatcherManager: DispatcherManager,
         intentManager: IntentManager,
+        biometricsEncryptionManager: BiometricsEncryptionManager,
+        featureFlagManager: FeatureFlagManager,
         clock: Clock,
     ): Fido2ProviderProcessor =
         Fido2ProviderProcessorImpl(
@@ -54,6 +58,8 @@ object Fido2ProviderModule {
             fido2CredentialManager,
             intentManager,
             clock,
+            biometricsEncryptionManager,
+            featureFlagManager,
             dispatcherManager,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CreateCredentialRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CreateCredentialRequest.kt
@@ -20,6 +20,7 @@ data class Fido2CreateCredentialRequest(
     val packageName: String,
     val signingInfo: SigningInfo,
     val origin: String?,
+    val isUserVerified: Boolean?,
 ) : Parcelable {
     val callingAppInfo: CallingAppInfo
         get() = CallingAppInfo(

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequest.kt
@@ -18,6 +18,7 @@ data class Fido2CredentialAssertionRequest(
     val packageName: String,
     val signingInfo: SigningInfo,
     val origin: String?,
+    val isUserVerified: Boolean?,
 ) : Parcelable {
     val callingAppInfo: CallingAppInfo
         get() = CallingAppInfo(packageName, signingInfo, origin)

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
@@ -18,7 +18,7 @@ import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_USER_ID
  * Checks if this [Intent] contains a [Fido2CreateCredentialRequest] related to an ongoing FIDO 2
  * credential creation process.
  */
-fun Intent.getFido2CredentialRequestOrNull(): Fido2CreateCredentialRequest? {
+fun Intent.getFido2CreateCredentialRequestOrNull(): Fido2CreateCredentialRequest? {
     if (isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) return null
 
     val systemRequest = PendingIntentHandler
@@ -39,6 +39,7 @@ fun Intent.getFido2CredentialRequestOrNull(): Fido2CreateCredentialRequest? {
         packageName = systemRequest.callingAppInfo.packageName,
         signingInfo = systemRequest.callingAppInfo.signingInfo,
         origin = systemRequest.callingAppInfo.origin,
+        isUserVerified = systemRequest.biometricPromptResult?.isSuccessful ?: false,
     )
 }
 
@@ -67,6 +68,9 @@ fun Intent.getFido2AssertionRequestOrNull(): Fido2CredentialAssertionRequest? {
     val userId: String = getStringExtra(EXTRA_KEY_USER_ID)
         ?: return null
 
+    val isUserVerified = systemRequest.biometricPromptResult?.isSuccessful
+        ?: false
+
     return Fido2CredentialAssertionRequest(
         userId = userId,
         cipherId = cipherId,
@@ -76,6 +80,7 @@ fun Intent.getFido2AssertionRequestOrNull(): Fido2CredentialAssertionRequest? {
         packageName = systemRequest.callingAppInfo.packageName,
         signingInfo = systemRequest.callingAppInfo.signingInfo,
         origin = systemRequest.callingAppInfo.origin,
+        isUserVerified = isUserVerified,
     )
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -40,6 +40,8 @@ sealed class FlagKey<out T : Any> {
                 NewDeviceTemporaryDismiss,
                 IgnoreEnvironmentCheck,
                 MutualTls,
+                SingleTapPasskeyCreation,
+                SingleTapPasskeyAuthentication,
             )
         }
     }
@@ -177,6 +179,24 @@ sealed class FlagKey<out T : Any> {
      */
     data object MutualTls : FlagKey<Boolean>() {
         override val keyName: String = "mutual-tls"
+        override val defaultValue: Boolean = false
+        override val isRemotelyConfigured: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key to enable single tap passkey creation.
+     */
+    data object SingleTapPasskeyCreation : FlagKey<Boolean>() {
+        override val keyName: String = "single-tap-passkey-creation"
+        override val defaultValue: Boolean = false
+        override val isRemotelyConfigured: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key to enable single tap passkey authentication.
+     */
+    data object SingleTapPasskeyAuthentication : FlagKey<Boolean>() {
+        override val keyName: String = "single-tap-passkey-authentication"
         override val defaultValue: Boolean = false
         override val isRemotelyConfigured: Boolean = false
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -39,6 +39,8 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.NewDeviceTemporaryDismiss,
     FlagKey.IgnoreEnvironmentCheck,
     FlagKey.MutualTls,
+    FlagKey.SingleTapPasskeyCreation,
+    FlagKey.SingleTapPasskeyAuthentication,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
         key = flagKey as FlagKey<Boolean>,
@@ -92,4 +94,7 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.NewDeviceTemporaryDismiss -> stringResource(R.string.new_device_temporary_dismiss)
     FlagKey.IgnoreEnvironmentCheck -> stringResource(R.string.ignore_environment_check)
     FlagKey.MutualTls -> stringResource(R.string.mutual_tls)
+    FlagKey.SingleTapPasskeyCreation -> stringResource(R.string.single_tap_passkey_creation)
+    FlagKey.SingleTapPasskeyAuthentication ->
+        stringResource(R.string.single_tap_passkey_authentication)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1114,11 +1114,13 @@ Do you want to switch to this account?</string>
   <string name="you_can_change_your_account_email_on_the_bitwarden_web_app">You can change your account email on the Bitwarden web app.</string>
   <string name="login_credentials">Login Credentials</string>
   <string name="autofill_options">Autofill Options</string>
-    <string name="use_this_button_to_generate_a_new_unique_password">Use this button to generate a new unique password.</string>
+  <string name="use_this_button_to_generate_a_new_unique_password">Use this button to generate a new unique password.</string>
   <string name="coachmark_1_of_3">1 of 3</string>
   <string name="coachmark_2_of_3">2 of 3</string>
   <string name="you_ll_only_need_to_set_up_authenticator_key">You’ll only need to set up Authenticator Key for logins that require two-factor authentication with a code. The key will continuously generate six-digit codes you can use to log in.</string>
   <string name="coachmark_3_of_3">3 of 3</string>
   <string name="you_must_add_a_web_address_to_use_autofill_to_access_this_account">You must add a web address to use autofill to access this account.</string>
   <string name="mutual_tls">Mutual TLS</string>
+  <string name="single_tap_passkey_creation">Single tap passkey creation</string>
+  <string name="single_tap_passkey_authentication">Single tap passkey sign-on</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -22,10 +22,10 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionReq
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.fido2.util.getFido2AssertionRequestOrNull
-import com.x8bit.bitwarden.data.autofill.fido2.util.getFido2CredentialRequestOrNull
+import com.x8bit.bitwarden.data.autofill.fido2.util.getFido2CreateCredentialRequestOrNull
 import com.x8bit.bitwarden.data.autofill.fido2.util.getFido2GetCredentialsRequestOrNull
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl
@@ -136,7 +136,7 @@ class MainViewModelTest : BaseViewModelTest() {
             Intent::getAutofillSelectionDataOrNull,
             Intent::getCompleteRegistrationDataIntentOrNull,
             Intent::getFido2AssertionRequestOrNull,
-            Intent::getFido2CredentialRequestOrNull,
+            Intent::getFido2CreateCredentialRequestOrNull,
             Intent::getFido2GetCredentialsRequestOrNull,
             Intent::isAddTotpLoginItemFromAuthenticator,
         )
@@ -156,7 +156,7 @@ class MainViewModelTest : BaseViewModelTest() {
             Intent::getAutofillSelectionDataOrNull,
             Intent::getCompleteRegistrationDataIntentOrNull,
             Intent::getFido2AssertionRequestOrNull,
-            Intent::getFido2CredentialRequestOrNull,
+            Intent::getFido2CreateCredentialRequestOrNull,
             Intent::getFido2GetCredentialsRequestOrNull,
             Intent::isAddTotpLoginItemFromAuthenticator,
         )
@@ -612,6 +612,7 @@ class MainViewModelTest : BaseViewModelTest() {
             packageName = "com.x8bit.bitwarden",
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
+            isUserVerified = true,
         )
         val fido2Intent = createMockIntent(
             mockFido2CreateCredentialRequest = fido2CreateCredentialRequest,
@@ -638,11 +639,13 @@ class MainViewModelTest : BaseViewModelTest() {
         )
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `on ReceiveFirstIntent with fido2 request data should set the user to unverified`() {
+    fun `on ReceiveFirstIntent with fido2 create request data should set the user verification based on request`() {
         val viewModel = createViewModel()
+        val createCredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
         val fido2Intent = createMockIntent(
-            mockFido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+            mockFido2CreateCredentialRequest = createCredentialRequest,
         )
 
         viewModel.trySendAction(
@@ -652,7 +655,7 @@ class MainViewModelTest : BaseViewModelTest() {
         )
 
         verify {
-            fido2CredentialManager.isUserVerified = false
+            fido2CredentialManager.isUserVerified = createCredentialRequest.isUserVerified ?: false
         }
     }
 
@@ -667,6 +670,7 @@ class MainViewModelTest : BaseViewModelTest() {
             packageName = "com.x8bit.bitwarden",
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
+            isUserVerified = true,
         )
         val mockIntent = createMockIntent(
             mockFido2CreateCredentialRequest = fido2CreateCredentialRequest,
@@ -697,6 +701,7 @@ class MainViewModelTest : BaseViewModelTest() {
             packageName = "com.x8bit.bitwarden",
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
+            isUserVerified = true,
         )
         val mockIntent = createMockIntent(
             mockFido2CreateCredentialRequest = fido2CreateCredentialRequest,
@@ -1101,7 +1106,7 @@ private fun createMockIntent(
     every { getAutofillSelectionDataOrNull() } returns mockAutofillSelectionData
     every { getCompleteRegistrationDataIntentOrNull() } returns mockCompleteRegistrationData
     every { getFido2AssertionRequestOrNull() } returns mockFido2CredentialAssertionRequest
-    every { getFido2CredentialRequestOrNull() } returns mockFido2CreateCredentialRequest
+    every { getFido2CreateCredentialRequestOrNull() } returns mockFido2CreateCredentialRequest
     every { getFido2GetCredentialsRequestOrNull() } returns mockFido2GetCredentialsRequest
     every { isMyVaultShortcut } returns mockIsMyVaultShortcut
     every { isPasswordGeneratorShortcut } returns mockIsPasswordGeneratorShortcut

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
@@ -16,7 +16,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResu
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
-import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.platform.util.asSuccess
 import com.x8bit.bitwarden.data.platform.util.decodeFromStringOrNull
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
@@ -170,7 +170,7 @@ class Fido2CredentialManagerTest {
     @Test
     fun `registerFido2Credential should construct ClientData DefaultWithCustomHash when callingAppInfo origin is populated`() =
         runTest {
-            val mockFido2CreateCredentialRequest = createMockFido2CredentialRequest(
+            val mockFido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(
                 number = 1,
                 origin = "origin",
                 signingInfo = mockSigningInfo,
@@ -210,7 +210,7 @@ class Fido2CredentialManagerTest {
                 every { apkContentsSigners } returns arrayOf(Signature(DEFAULT_APP_SIGNATURE))
                 every { hasMultipleSigners() } returns false
             }
-            val mockFido2Request = createMockFido2CredentialRequest(
+            val mockFido2Request = createMockFido2CreateCredentialRequest(
                 number = 1,
                 signingInfo = mockSigningInfo,
             )
@@ -243,7 +243,7 @@ class Fido2CredentialManagerTest {
                 every { apkContentsSigners } returns arrayOf(Signature(DEFAULT_APP_SIGNATURE))
                 every { hasMultipleSigners() } returns false
             }
-            val mockFido2CreateCredentialRequest = createMockFido2CredentialRequest(
+            val mockFido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(
                 number = 1,
                 origin = "origin",
                 signingInfo = mockSigningInfo,
@@ -283,7 +283,7 @@ class Fido2CredentialManagerTest {
                 every { apkContentsSigners } returns arrayOf(Signature(DEFAULT_APP_SIGNATURE))
                 every { hasMultipleSigners() } returns false
             }
-            val mockFido2CreateCredentialRequest = createMockFido2CredentialRequest(
+            val mockFido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(
                 number = 1,
                 origin = "origin",
                 signingInfo = mockSigningInfo,
@@ -328,7 +328,7 @@ class Fido2CredentialManagerTest {
             val mockSigningInfo = mockk<SigningInfo> {
                 every { hasMultipleSigners() } returns true
             }
-            val mockFido2CredentialRequest = createMockFido2CredentialRequest(
+            val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(
                 number = 1,
                 origin = "origin",
                 signingInfo = mockSigningInfo,
@@ -353,7 +353,7 @@ class Fido2CredentialManagerTest {
             val mockSigningInfo = mockk<SigningInfo> {
                 every { hasMultipleSigners() } returns true
             }
-            val mockFido2CredentialRequest = createMockFido2CredentialRequest(
+            val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(
                 number = 1,
                 signingInfo = mockSigningInfo,
             )
@@ -377,7 +377,7 @@ class Fido2CredentialManagerTest {
                 every { apkContentsSigners } returns arrayOf(Signature(DEFAULT_APP_SIGNATURE))
                 every { hasMultipleSigners() } returns false
             }
-            val mockFido2CredentialRequest = createMockFido2CredentialRequest(
+            val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(
                 number = 1,
                 origin = "illegal empty spaces",
                 signingInfo = mockSigningInfo,
@@ -402,7 +402,7 @@ class Fido2CredentialManagerTest {
                 every { apkContentsSigners } returns arrayOf(Signature(DEFAULT_APP_SIGNATURE))
                 every { hasMultipleSigners() } returns false
             }
-            val mockFido2CredentialRequest = createMockFido2CredentialRequest(
+            val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(
                 number = 1,
                 origin = "origin",
                 signingInfo = mockSigningInfo,
@@ -440,7 +440,7 @@ class Fido2CredentialManagerTest {
 
     @Test
     fun `registerFido2Credential should return Error when origin is null`() = runTest {
-        val mockAssertionRequest = createMockFido2CredentialRequest(
+        val mockAssertionRequest = createMockFido2CreateCredentialRequest(
             number = 1,
             origin = null,
             signingInfo = mockSigningInfo,

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequestUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequestUtil.kt
@@ -5,6 +5,7 @@ import android.content.pm.SigningInfo
 fun createMockFido2CredentialAssertionRequest(
     number: Int = 1,
     userId: String = "mockUserId-$number",
+    isUserVerified: Boolean = false,
 ): Fido2CredentialAssertionRequest =
     Fido2CredentialAssertionRequest(
         userId = userId,
@@ -15,4 +16,5 @@ fun createMockFido2CredentialAssertionRequest(
         packageName = "mockPackageName-$number",
         signingInfo = SigningInfo(),
         origin = "mockOrigin-$number",
+        isUserVerified = isUserVerified,
     )

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialRequestUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialRequestUtil.kt
@@ -5,7 +5,7 @@ import android.content.pm.SigningInfo
 /**
  * Creates a mock [Fido2CreateCredentialRequest] with a given [number].
  */
-fun createMockFido2CredentialRequest(
+fun createMockFido2CreateCredentialRequest(
     number: Int,
     origin: String? = null,
     signingInfo: SigningInfo = SigningInfo(),
@@ -16,4 +16,5 @@ fun createMockFido2CredentialRequest(
         packageName = "com.x8bit.bitwarden",
         signingInfo = signingInfo,
         origin = origin,
+        isUserVerified = true,
     )

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtilsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtilsTest.kt
@@ -75,7 +75,7 @@ class Fido2IntentUtilsTest {
             PendingIntentHandler.retrieveProviderCreateCredentialRequest(intent)
         } returns mockProviderRequest
 
-        val createRequest = intent.getFido2CredentialRequestOrNull()
+        val createRequest = intent.getFido2CreateCredentialRequestOrNull()
         assertEquals(
             Fido2CreateCredentialRequest(
                 userId = "mockUserId",
@@ -83,6 +83,7 @@ class Fido2IntentUtilsTest {
                 packageName = mockCallingAppInfo.packageName,
                 signingInfo = mockCallingAppInfo.signingInfo,
                 origin = mockCallingAppInfo.origin,
+                isUserVerified = false,
             ),
             createRequest,
         )
@@ -94,7 +95,7 @@ class Fido2IntentUtilsTest {
 
         every { isBuildVersionBelow(34) } returns true
 
-        assertNull(intent.getFido2CredentialRequestOrNull())
+        assertNull(intent.getFido2CreateCredentialRequestOrNull())
     }
 
     @Suppress("MaxLineLength")
@@ -106,7 +107,7 @@ class Fido2IntentUtilsTest {
             PendingIntentHandler.retrieveProviderCreateCredentialRequest(intent)
         } returns null
 
-        assertNull(intent.getFido2CredentialRequestOrNull())
+        assertNull(intent.getFido2CreateCredentialRequestOrNull())
     }
 
     @Suppress("MaxLineLength")
@@ -127,7 +128,7 @@ class Fido2IntentUtilsTest {
             PendingIntentHandler.retrieveProviderCreateCredentialRequest(intent)
         } returns mockProviderRequest
 
-        assertNull(intent.getFido2CredentialRequestOrNull())
+        assertNull(intent.getFido2CreateCredentialRequestOrNull())
     }
 
     @Suppress("MaxLineLength")
@@ -157,7 +158,7 @@ class Fido2IntentUtilsTest {
             PendingIntentHandler.retrieveProviderCreateCredentialRequest(intent)
         } returns mockProviderRequest
 
-        assertNull(intent.getFido2CredentialRequestOrNull())
+        assertNull(intent.getFido2CreateCredentialRequestOrNull())
     }
 
     @Test
@@ -199,6 +200,7 @@ class Fido2IntentUtilsTest {
                 packageName = mockCallingAppInfo.packageName,
                 signingInfo = mockCallingAppInfo.signingInfo,
                 origin = mockCallingAppInfo.origin,
+                isUserVerified = false,
             ),
             assertionRequest,
         )

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
@@ -152,6 +152,7 @@ class SpecialCircumstanceExtensionsTest {
             packageName = "mockPackageName",
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
+            isUserVerified = true,
         )
         assertEquals(
             fido2CreateCredentialRequest,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -121,6 +121,8 @@ private val DEFAULT_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.NewDevicePermanentDismiss to true,
     FlagKey.IgnoreEnvironmentCheck to true,
     FlagKey.MutualTls to true,
+    FlagKey.SingleTapPasskeyCreation to true,
+    FlagKey.SingleTapPasskeyAuthentication to true,
 )
 
 private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
@@ -138,6 +140,8 @@ private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.NewDevicePermanentDismiss to false,
     FlagKey.IgnoreEnvironmentCheck to false,
     FlagKey.MutualTls to false,
+    FlagKey.SingleTapPasskeyCreation to false,
+    FlagKey.SingleTapPasskeyAuthentication to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -670,6 +670,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
             packageName = "com.x8bit.bitwarden",
             signingInfo = SigningInfo(),
             origin = "mockOrigin",
+            isUserVerified = true,
         )
         specialCircumstanceManager.specialCircumstance =
             SpecialCircumstance.Fido2Save(fido2CreateCredentialRequest)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -21,7 +21,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
-import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
@@ -359,6 +359,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             packageName = "mockPackageName-1",
             signingInfo = SigningInfo(),
             origin = null,
+            isUserVerified = true,
         )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
             fido2CreateCredentialRequest = fido2CreateCredentialRequest,
@@ -781,6 +782,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 packageName = "mockPackageName",
                 signingInfo = mockk<SigningInfo>(),
                 origin = null,
+                isUserVerified = true,
             )
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
@@ -860,6 +862,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 packageName = "mockPackageName",
                 signingInfo = mockk<SigningInfo>(),
                 origin = null,
+                isUserVerified = false,
             )
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
@@ -940,7 +943,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2, SaveClick should skip user verification when user is verified`() =
         runTest {
-            val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val fido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = fido2CredentialRequest,
@@ -992,7 +995,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2, SaveClick should show fido2 error dialog when create options are null`() =
         runTest {
-            val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val fido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = fido2CredentialRequest,
@@ -1036,7 +1039,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2, SaveClick should emit fido user verification as optional when verification is PREFERRED`() =
         runTest {
-            val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val fido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = fido2CredentialRequest,
@@ -1081,7 +1084,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `in add mode during fido2, SaveClick should emit fido user verification as required when request user verification option is REQUIRED`() =
         runTest {
-            val fido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val fido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = fido2CredentialRequest,
@@ -1789,7 +1792,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     ),
                 ),
             )
-            val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = mockFido2CredentialRequest,
@@ -1840,7 +1843,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 notes = "mockNotes-1",
             ),
         )
-        val mockFidoRequest = createMockFido2CredentialRequest(number = 1)
+        val mockFidoRequest = createMockFido2CreateCredentialRequest(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
             fido2CreateCredentialRequest = mockFidoRequest,
         )
@@ -1911,7 +1914,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     notes = "mockNotes-1",
                 ),
             )
-            val mockFidoRequest = createMockFido2CredentialRequest(number = 1)
+            val mockFidoRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = mockFidoRequest,
             )
@@ -4083,7 +4086,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         fun `UserVerificationSuccess should display Fido2ErrorDialog when activeUserId is null`() {
             every { authRepository.activeUserId } returns null
             specialCircumstanceManager.specialCircumstance =
-                SpecialCircumstance.Fido2Save(createMockFido2CredentialRequest(number = 1))
+                SpecialCircumstance.Fido2Save(createMockFido2CreateCredentialRequest(number = 1))
 
             viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationSuccess)
 
@@ -4100,7 +4103,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `UserVerificationSuccess should set isUserVerified to true, and register FIDO 2 credential`() =
             runTest {
-                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Success(
                     registrationResponse = "mockResponse",
                 )
@@ -4144,7 +4147,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `Fido2RegisterCredentialResult Error should show toast and emit CompleteFido2Registration result`() =
             runTest {
-                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Error
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = mockRequest,
@@ -4181,7 +4184,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `Fido2RegisterCredentialResult Success should show toast and emit CompleteFido2Registration result`() =
             runTest {
-                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Success(
                     registrationResponse = "mockResponse",
                 )
@@ -4220,7 +4223,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `Fido2RegisterCredentialResult Cancelled should emit CompleteFido2Registration result`() =
             runTest {
-                val mockRequest = createMockFido2CredentialRequest(number = 1)
+                val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
                 val mockResult = Fido2RegisterCredentialResult.Cancelled
                 specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                     fido2CreateCredentialRequest = mockRequest,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensionsTest.kt
@@ -53,6 +53,7 @@ class Fido2CredentialRequestExtensionsTest {
                 packageName = "mockPackageName-1",
                 signingInfo = SigningInfo(),
                 origin = null,
+                isUserVerified = true,
             )
                 .toDefaultAddTypeContent(
                     attestationOptions = createMockPasskeyAttestationOptions(1),
@@ -89,6 +90,7 @@ class Fido2CredentialRequestExtensionsTest {
                 packageName = "mockPackageName-1",
                 signingInfo = SigningInfo(),
                 origin = "www.test.com",
+                isUserVerified = true,
             )
                 .toDefaultAddTypeContent(
                     attestationOptions = createMockPasskeyAttestationOptions(number = 1),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -26,7 +26,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResu
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
-import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
@@ -204,6 +204,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             "com.x8bit.bitwarden",
             SigningInfo(),
             origin = null,
+            isUserVerified = true,
         )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
             fido2CreateCredentialRequest = fido2CreateCredentialRequest,
@@ -452,7 +453,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `ItemClick for vault item during FIDO 2 registration should show FIDO 2 error dialog when cipherView is null`() {
         val cipherView = createMockCipherView(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+            fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
         )
         mutableVaultDataStateFlow.value = DataState.Loaded(
             data = VaultData(
@@ -481,7 +482,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         setupMockUri()
         val cipherView = createMockCipherView(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-            fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+            fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
         )
         mutableVaultDataStateFlow.value = DataState.Loaded(
             data = VaultData(
@@ -516,7 +517,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 fido2Credentials = createMockSdkFido2CredentialList(number = 1),
             )
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -559,7 +560,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1, fido2Credentials = null)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -607,7 +608,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1)
-            val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+            val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = mockFido2CredentialRequest,
             )
@@ -650,7 +651,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `ItemClick for vault item during FIDO 2 registration should skip user verification when user is verified`() {
         setupMockUri()
         val cipherView = createMockCipherView(number = 1)
-        val mockFido2CredentialRequest = createMockFido2CredentialRequest(number = 1)
+        val mockFido2CredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
             fido2CreateCredentialRequest = mockFido2CredentialRequest,
         )
@@ -1576,6 +1577,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 packageName = "com.x8bit.bitwarden",
                 signingInfo = SigningInfo(),
                 origin = "mockOrigin",
+                isUserVerified = true,
             )
 
             specialCircumstanceManager.specialCircumstance =
@@ -2158,6 +2160,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             "com.x8bit.bitwarden",
             SigningInfo(),
             origin = "com.x8bit.bitwarden",
+            isUserVerified = true,
         )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
             fido2CreateCredentialRequest,
@@ -2208,6 +2211,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 packageName = "com.x8bit.bitwarden",
                 signingInfo = SigningInfo(),
                 origin = null,
+                isUserVerified = true,
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -2239,6 +2243,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 packageName = "com.x8bit.bitwarden",
                 signingInfo = SigningInfo(),
                 origin = null,
+                isUserVerified = true,
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -2270,6 +2275,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 packageName = "com.x8bit.bitwarden",
                 signingInfo = SigningInfo(),
                 origin = null,
+                isUserVerified = true,
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -2301,6 +2307,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 packageName = "com.x8bit.bitwarden",
                 signingInfo = SigningInfo(),
                 origin = null,
+                isUserVerified = true,
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -2332,6 +2339,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 packageName = "com.x8bit.bitwarden",
                 signingInfo = SigningInfo(),
                 origin = null,
+                isUserVerified = true,
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -2363,6 +2371,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 packageName = "com.x8bit.bitwarden",
                 signingInfo = SigningInfo(),
                 origin = null,
+                isUserVerified = true,
             )
 
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -2464,7 +2473,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `DismissFido2ErrorDialogClick should clear the dialog state then complete FIDO 2 registration based on state`() =
         runTest {
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                createMockFido2CredentialRequest(number = 1),
+                createMockFido2CreateCredentialRequest(number = 1),
             )
             val viewModel = createVaultItemListingViewModel()
             viewModel.trySendAction(VaultItemListingsAction.DismissFido2ErrorDialogClick)
@@ -3367,7 +3376,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `UserVerificationSuccess should display Fido2ErrorDialog when activeUserId is null`() {
         every { authRepository.activeUserId } returns null
         specialCircumstanceManager.specialCircumstance =
-            SpecialCircumstance.Fido2Save(createMockFido2CredentialRequest(number = 1))
+            SpecialCircumstance.Fido2Save(createMockFido2CreateCredentialRequest(number = 1))
 
         val viewModel = createVaultItemListingViewModel()
         viewModel.trySendAction(
@@ -3390,7 +3399,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `UserVerificationSuccess should set isUserVerified to true, and register FIDO 2 credential when verification result is received`() =
         runTest {
-            val mockRequest = createMockFido2CredentialRequest(number = 1)
+            val mockRequest = createMockFido2CreateCredentialRequest(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
                 fido2CreateCredentialRequest = mockRequest,
             )
@@ -4050,7 +4059,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
@@ -4084,7 +4093,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val cipherView = createMockCipherView(number = 1)
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
-                fido2CreateCredentialRequest = createMockFido2CredentialRequest(number = 1),
+                fido2CreateCredentialRequest = createMockFido2CreateCredentialRequest(number = 1),
             )
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
@@ -828,6 +828,7 @@ class VaultItemListingDataExtensionsTest {
                     packageName = "",
                     signingInfo = SigningInfo(),
                     origin = "https://www.test.com",
+                    isUserVerified = true,
                 ),
                 fido2CredentialAutofillViews = null,
                 totpData = null,


### PR DESCRIPTION
## 🎟️ Tracking

PM-15906
PM-12511
Resolves https://github.com/bitwarden/android/issues/3953

## 📔 Objective

Add a biometric prompt to the passkey registration and authentication flows.

The biometric prompt will be shown when creating or authenticating with a passkey if the user has supported device biometrics enabled.

This change also adds an `isUserVerified` flag to the Fido2 requests to determine if the user has verified their identity using the single tap flow.

> [!NOTE]
> When vault timeout is set to immediate, users must unlock multiple times. This is intentional since the application is set to lock immediately after backgrounding and the passkey flow requires backgrounding the application after initial unlock and credential discovery.

## 📸 Screenshots

### Device biometrics enabled

#### Vault timeout **not** `immediate`
| Case   | Before | After  |
|--------|--------|--------|
| Create | <video src="https://github.com/user-attachments/assets/5adc9e33-daeb-4fdb-bfba-205c1f862a08"/> | <video src="https://github.com/user-attachments/assets/825c10e0-a3b2-46c9-b346-dce6786761fe"/> |
| Auth | <video src="https://github.com/user-attachments/assets/1c0ea461-d586-4b50-9e1d-8e4b242b70ca"/> | <video src="https://github.com/user-attachments/assets/c6d743bb-3e4f-4cc1-ad93-f5b1f95a9f91"/> |

#### Vault timeout set to `immediate`
| Case   | Before | After |
|--------|--------|--------|
| Create | <video src=""/> | <video src="https://github.com/user-attachments/assets/45dadedf-4286-40d3-ab6b-7b7ead1bd416"/> |
| Auth | <video src=""/> | <video src="https://github.com/user-attachments/assets/675932e8-55d3-418e-8047-ae080e4ea928"/> |


### Device biometrics disabled

#### Vault timeout **not** `immediate`
| Case   | Before | After |
|--------|--------|--------|
| Create | <video src=""/> | <video src="https://github.com/user-attachments/assets/dd63c01e-0497-4164-9d5d-70f2da9178e0"/> | 
| Auth | <video src=""/> | <video src="https://github.com/user-attachments/assets/bf529772-1865-4174-88f6-0cd1d229ffb3"/> |

#### Vault timeout set to `immediate`
| Case   | Before | After |
|--------|--------|--------|
| Create | <video src=""/> | <video src="https://github.com/user-attachments/assets/516e7e2b-255e-4389-8cea-b47efe1ace41"/> | 
| Auth | <video src=""/> | <video src="https://github.com/user-attachments/assets/348b0e2c-a9e7-43cd-be88-ab9f0245d511"/> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
