### PR TITLE
[DRAFT] PM-16631 - CoachMark tour of adding log in item.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkContainer.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkContainer.kt
@@ -1,0 +1,230 @@
+package com.x8bit.bitwarden.ui.platform.components.coachmark
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.graphics.ClipOp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
+import com.x8bit.bitwarden.ui.platform.components.text.BitwardenClickableText
+import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+import kotlinx.coroutines.launch
+
+private const val ROUNDED_RECT_RADIUS = 8f
+
+/**
+ * A composable container that manages and displays coach mark highlights.
+ *
+ * This composable provides a full-screen overlay that can highlight specific
+ * areas of the UI and display tooltips to guide the user through a sequence
+ * of steps or features.
+ *
+ * @param T The type of the enum used to represent the unique keys for each coach mark highlight.
+ * @param state The [CoachMarkState] that manages the sequence and state of the coach marks.
+ * @param modifier The modifier to be applied to the container.
+ * @param content The composable content that defines the coach mark highlights within the
+ * [CoachMarkScope].
+ */
+@Composable
+@Suppress("LongMethod")
+fun <T : Enum<T>> CoachMarkContainer(
+    state: CoachMarkState<T>,
+    modifier: Modifier = Modifier,
+    content: @Composable CoachMarkScope<T>.() -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    Box(modifier = Modifier
+        .pointerInput(Unit) {
+            detectTapGestures(
+                onTap = {
+                    if (state.isVisible.value) {
+                        scope.launch {
+                            state.showCoachMark()
+                        }
+                    }
+                },
+            )
+        }
+        .fillMaxSize()
+        .then(modifier),
+    ) {
+        CoachMarkScopeInstance(coachMarkState = state).content()
+        val boundedRectangle by state.currentHighlightBounds
+        if (
+            boundedRectangle != Rect.Zero && state.isVisible.value
+        ) {
+            val highlightArea = Rect(
+                topLeft = boundedRectangle.topLeft,
+                bottomRight = boundedRectangle.bottomRight,
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .drawBehind {
+                        clipPath(
+                            path = Path().apply {
+                                when (state.currentHighlightShape.value) {
+                                    CoachMarkHighlightShape.SQUARE -> addRoundRect(
+                                        RoundRect(
+                                            rect = highlightArea,
+                                            cornerRadius = CornerRadius(
+                                                x = ROUNDED_RECT_RADIUS,
+                                            ),
+                                        ),
+                                    )
+
+                                    CoachMarkHighlightShape.OVAL -> addOval(highlightArea)
+                                }
+                            },
+                            clipOp = ClipOp.Difference,
+                            block = {
+                                drawRect(
+                                    color = Color.Black,
+                                    alpha = 0.5f,
+                                )
+                            },
+                        )
+                    },
+            )
+        }
+    }
+    LaunchedEffect(Unit) {
+        if (state.isVisible.value && (state.currentHighlight.value != null)) {
+            state.showCoachMark()
+        }
+    }
+}
+
+@Preview
+@Composable
+@Suppress("LongMethod")
+private fun BitwardenCoachMarkContainer_preview() {
+    BitwardenTheme {
+        val state = rememberCoachMarkState(Foo.entries)
+        val scope = rememberCoroutineScope()
+        CoachMarkContainer(
+            state = state,
+        ) {
+            Column(
+                modifier = Modifier
+                    .background(BitwardenTheme.colorScheme.background.primary)
+                    .padding(top = 100.dp)
+                    .padding(horizontal = 16.dp)
+                    .fillMaxSize(),
+            ) {
+
+                BitwardenClickableText(
+                    label = "Start Coach Mark Flow",
+                    onClick = {
+                        scope.launch {
+                            state.showCoachMark()
+                        }
+                    },
+                    style = BitwardenTheme.typography.labelLarge,
+                    modifier = Modifier
+                        .padding(bottom = 16.dp)
+                        .align(Alignment.CenterHorizontally),
+                )
+                Spacer(Modifier.height(24.dp))
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .fillMaxWidth(),
+                ) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    CoachMarkHighlight(
+                        key = Foo.Bar,
+                        title = "1 of 3",
+                        description = "Use this button to generate a new unique password.",
+                        rightAction = {
+                            BitwardenClickableText(
+                                label = "Next",
+                                onClick = {
+                                    scope.launch {
+                                        state.showNextCoachMark()
+                                    }
+                                },
+                                style = BitwardenTheme.typography.labelLarge,
+                            )
+                        },
+                        shape = CoachMarkHighlightShape.OVAL,
+                    ) {
+                        BitwardenStandardIconButton(
+                            painter = rememberVectorPainter(R.drawable.ic_puzzle),
+                            contentDescription = stringResource(R.string.close),
+                            onClick = {},
+                        )
+                    }
+                }
+                Spacer(Modifier.height(24.dp))
+                CoachMarkHighlight(
+                    key = Foo.Baz,
+                    title = "Foo",
+                    description = "Baz",
+                    leftAction = {
+                        BitwardenClickableText(
+                            label = "Back",
+                            onClick = {
+                                scope.launch {
+                                    state.showPreviousCoachMark()
+                                }
+                            },
+                            style = BitwardenTheme.typography.labelLarge,
+                        )
+                    },
+                    rightAction = {
+                        BitwardenClickableText(
+                            label = "Done",
+                            onClick = {
+                                scope.launch {
+                                    state.coachingComplete()
+                                }
+                            },
+                            style = BitwardenTheme.typography.labelLarge,
+                        )
+                    },
+                ) {
+                    Text(text = "Foo Baz")
+                }
+
+                Spacer(Modifier.size(100.dp))
+            }
+        }
+    }
+}
+
+/**
+ * Example enum for demonstration purposes.
+ */
+private enum class Foo {
+    Bar,
+    Baz,
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkContainer.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkContainer.kt
@@ -61,17 +61,6 @@ fun <T : Enum<T>> CoachMarkContainer(
 ) {
     val scope = rememberCoroutineScope()
     Box(modifier = Modifier
-        .pointerInput(Unit) {
-            detectTapGestures(
-                onTap = {
-                    if (state.isVisible.value) {
-                        scope.launch {
-                            state.showCoachMark()
-                        }
-                    }
-                },
-            )
-        }
         .fillMaxSize()
         .then(modifier),
     ) {
@@ -87,6 +76,17 @@ fun <T : Enum<T>> CoachMarkContainer(
 
             Box(
                 modifier = Modifier
+                    .pointerInput(Unit) {
+                        detectTapGestures(
+                            onTap = {
+                                if (state.isVisible.value) {
+                                    scope.launch {
+                                        state.showCoachMark()
+                                    }
+                                }
+                            },
+                        )
+                    }
                     .fillMaxSize()
                     .drawBehind {
                         clipPath(
@@ -145,7 +145,7 @@ private fun BitwardenCoachMarkContainer_preview() {
                     label = "Start Coach Mark Flow",
                     onClick = {
                         scope.launch {
-                            state.showCoachMark()
+                            state.showCoachMark(Foo.Bar)
                         }
                     },
                     style = BitwardenTheme.typography.labelLarge,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkScope.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkScope.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Text
@@ -76,6 +78,18 @@ interface CoachMarkScope<T : Enum<T>> {
         rightAction: (@Composable RowScope.() -> Unit)? = null,
         anchorContent: @Composable () -> Unit,
     )
+
+    fun LazyListScope.coachMarkHighlight(
+        key: T,
+        title: String,
+        description: String,
+        shape: CoachMarkHighlightShape = CoachMarkHighlightShape.SQUARE,
+        onDismiss: (() -> Unit)? = null,
+        leftAction: (@Composable RowScope.() -> Unit)? = null,
+        rightAction: (@Composable RowScope.() -> Unit)? = null,
+        lazyListKey: Any = key,
+        anchorContent: @Composable () -> Unit,
+    )
 }
 
 /**
@@ -138,6 +152,32 @@ class CoachMarkScopeInstance<T : Enum<T>>(
             }
         }
     }
+
+    override fun LazyListScope.coachMarkHighlight(
+        key: T,
+        title: String,
+        description: String,
+        shape: CoachMarkHighlightShape,
+        onDismiss: (() -> Unit)?,
+        leftAction: @Composable() (RowScope.() -> Unit)?,
+        rightAction: @Composable() (RowScope.() -> Unit)?,
+        lazyListKey: Any,
+        anchorContent: @Composable () -> Unit,
+    ) {
+        item(lazyListKey) {
+            this@CoachMarkScopeInstance.CoachMarkHighlight(
+                key = key,
+                title = title,
+                description = description,
+                shape = shape,
+                onDismiss = onDismiss,
+                leftAction = leftAction,
+                rightAction = rightAction,
+                anchorContent = anchorContent,
+            )
+        }
+    }
+
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkScope.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkScope.kt
@@ -1,0 +1,191 @@
+package com.x8bit.bitwarden.ui.platform.components.coachmark
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.RichTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.TooltipScope
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
+import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+
+/**
+ * Defines the scope for creating coach mark highlights within a user interface.
+ *
+ * This interface provides a way to define and display a highlight that guides the user's
+ * attention to a specific part of the UI, often accompanied by a tooltip with
+ * explanatory text and actions.
+ *
+ * @param T The type of the enum used to represent the unique keys for each coach mark highlight.
+ */
+interface CoachMarkScope<T : Enum<T>> {
+
+    /**
+     * Creates a highlight for a specific coach mark.
+     *
+     * This function defines a region of the UI to be highlighted, along with an
+     * associated tooltip that can display a title, description, and actions.
+     *
+     * @param key The unique key identifying this highlight. This key is used to
+     * manage the state and order of the coach mark sequence.
+     * @param title The title of the coach mark, displayed in the tooltip.
+     * @param description The description of the coach mark, providing more context
+     * to the user. Displayed in the tooltip.
+     * @param shape The shape of the highlight. Defaults to [CoachMarkHighlightShape.SQUARE].
+     * Use [CoachMarkHighlightShape.OVAL] for a circular highlight.
+     * @param onDismiss An optional callback that is invoked when the coach mark is dismissed
+     * (e.g., by clicking the close button). If provided, this function
+     * will be executed after the coach mark is dismissed. If not provided,
+     * no action is taken on dismissal.
+     * @param leftAction An optional composable to be displayed on the left side of the
+     * action row in the tooltip. This can be used to provide
+     * additional actions or controls.
+     * @param rightAction An optional composable to be displayed on the right side of the
+     * action row in the tooltip. This can be used to provide
+     * primary actions or navigation.
+     * @param anchorContent The composable content to be highlighted. This is the UI element
+     * that will be visually emphasized by the coach mark.
+     */
+    @Composable
+    fun CoachMarkHighlight(
+        key: T,
+        title: String,
+        description: String,
+        shape: CoachMarkHighlightShape = CoachMarkHighlightShape.SQUARE,
+        onDismiss: (() -> Unit)? = null,
+        leftAction: (@Composable RowScope.() -> Unit)? = null,
+        rightAction: (@Composable RowScope.() -> Unit)? = null,
+        anchorContent: @Composable () -> Unit,
+    )
+}
+
+/**
+ * Creates an instance of [CoachMarkScope] for a given [CoachMarkState].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+class CoachMarkScopeInstance<T : Enum<T>>(
+    private val coachMarkState: CoachMarkState<T>,
+) : CoachMarkScope<T> {
+
+    @Composable
+    override fun CoachMarkHighlight(
+        key: T,
+        title: String,
+        description: String,
+        shape: CoachMarkHighlightShape,
+        onDismiss: (() -> Unit)?,
+        leftAction: @Composable() (RowScope.() -> Unit)?,
+        rightAction: @Composable() (RowScope.() -> Unit)?,
+        anchorContent: @Composable () -> Unit,
+    ) {
+        val anchorBounds = remember { mutableStateOf<Rect?>(null) }
+        val toolTipState = rememberTooltipState(
+            initialIsVisible = false,
+            isPersistent = true,
+        )
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(
+                spacingBetweenTooltipAndAnchor = 10.dp,
+            ),
+            tooltip = {
+                CoachMarkToolTip(
+                    title = title,
+                    description = description,
+                    onDismiss = {
+                        coachMarkState.coachingComplete()
+                        onDismiss?.invoke()
+                    },
+                    leftAction = leftAction,
+                    rightAction = rightAction,
+                )
+            },
+            enableUserInput = false,
+            focusable = false,
+            state = toolTipState,
+            modifier = Modifier.onGloballyPositioned {
+                anchorBounds.value = it.boundsInRoot()
+            },
+        ) {
+            anchorContent()
+        }
+        LaunchedEffect(anchorBounds) {
+            anchorBounds.value?.let {
+                coachMarkState.updateHighlight(
+                    key = key,
+                    bounds = it,
+                    toolTipState = toolTipState,
+                    shape = shape,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TooltipScope.CoachMarkToolTip(
+    title: String,
+    description: String,
+    onDismiss: (() -> Unit),
+    leftAction: (@Composable RowScope.() -> Unit)?,
+    rightAction: (@Composable RowScope.() -> Unit)?,
+) {
+    RichTooltip(
+        caretSize = DpSize(width = 24.dp, height = 16.dp),
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = title,
+                    style = BitwardenTheme.typography.eyebrowMedium,
+                    color = BitwardenTheme.colorScheme.text.secondary,
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                BitwardenStandardIconButton(
+                    painter = rememberVectorPainter(R.drawable.ic_close),
+                    contentDescription = stringResource(R.string.close),
+                    onClick = onDismiss,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        },
+        action = {
+            Row(
+                Modifier.fillMaxWidth(),
+            ) {
+                leftAction?.invoke(this)
+                Spacer(modifier = Modifier.weight(1f))
+                rightAction?.invoke(this)
+            }
+        },
+        colors = TooltipDefaults.richTooltipColors(
+            containerColor = BitwardenTheme.colorScheme.background.primary,
+        ),
+    ) {
+        Text(
+            text = description,
+            style = BitwardenTheme.typography.bodyMedium,
+            color = BitwardenTheme.colorScheme.text.primary,
+        )
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkState.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkState.kt
@@ -1,0 +1,251 @@
+package com.x8bit.bitwarden.ui.platform.components.coachmark
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.geometry.Rect
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Manages the state of a coach mark sequence, guiding users through a series of highlights.
+ *
+ * This class handles the ordered list of highlights, the currently active highlight,
+ * and the overall visibility of the coach mark overlay. It uses a mutex to ensure
+ * thread-safe access to the shared state.
+ *
+ * @param T The type of the enum used to represent the coach mark keys.
+ * @property orderedList The ordered list of coach mark keys that define the sequence.
+ * @param initialCoachMarkHighlight The initial coach mark to be highlighted, or null if
+ * none should be highlighted at start.
+ * @param isCoachMarkVisible is any coach mark currently visible.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+class CoachMarkState<T : Enum<T>>(
+    val orderedList: List<T>,
+    initialCoachMarkHighlight: T? = null,
+    isCoachMarkVisible: Boolean = false,
+) {
+    private val mutex = Mutex()
+    private val highlights: MutableMap<T, CoachMarkHighlight<T>?> = mutableMapOf()
+    private val _currentHighlight = mutableStateOf(initialCoachMarkHighlight)
+    val currentHighlight: State<T?> = _currentHighlight
+    private val _currentHighlightBounds = mutableStateOf(Rect.Zero)
+    val currentHighlightBounds: State<Rect> = _currentHighlightBounds
+    private val _currentHighlightShape = mutableStateOf(CoachMarkHighlightShape.SQUARE)
+    val currentHighlightShape: State<CoachMarkHighlightShape> = _currentHighlightShape
+
+    private val _isVisible = mutableStateOf(isCoachMarkVisible)
+    val isVisible: State<Boolean> = _isVisible
+
+    /**
+     * Updates the highlight information for a given key. If the key matches the current shown
+     * [key] then we also update the public state for the highlight bounds and shape.
+     *
+     * @param key The key of the highlight to update.
+     * @param bounds The rectangular bounds of the area to highlight. If null, defaults to
+     * Rect.Zero.
+     * @param toolTipState The state of the tooltip associated with this highlight.
+     * @param shape The shape of the highlight (e.g., square, oval). Defaults to
+     * [CoachMarkHighlightShape.SQUARE].
+     */
+    suspend fun updateHighlight(
+        key: T,
+        bounds: Rect?,
+        toolTipState: TooltipState,
+        shape: CoachMarkHighlightShape = CoachMarkHighlightShape.SQUARE,
+    ) {
+        mutex.withLock {
+            highlights[key] = CoachMarkHighlight(
+                key = key,
+                highlightBounds = bounds ?: Rect.Zero,
+                toolTipState = toolTipState,
+                shape = shape,
+            ).also {
+                if (key == currentHighlight.value) {
+                    updateCoachMarkStateInternal(it)
+                }
+            }
+        }
+    }
+
+    /**
+     * Shows the current coach mark, if it exists. If there is no current highlighted
+     * coach mark, attempt to show the "next" available coach mark.
+     */
+    suspend fun showCoachMark() {
+        val highlightToShow = mutex.withLock {
+            getCurrentHighlight()
+        }
+        if (highlightToShow != null) {
+            _isVisible.value = true
+            highlightToShow.toolTipState.show()
+        } else {
+            showNextCoachMark()
+        }
+    }
+
+    /**
+     * Shows the next highlight in the sequence.
+     * If there is no previous highlight, it will show the first highlight.
+     * If the previous highlight is the last in the list, nothing will happen.
+     */
+    suspend fun showNextCoachMark() {
+        val highlightToShow = mutex.withLock {
+            val previousHighlight = getCurrentHighlight()
+            previousHighlight?.toolTipState?.cleanUp()
+            val index = orderedList.indexOf(previousHighlight?.key)
+            if (index < 0 && previousHighlight != null) return
+            _currentHighlight.value = orderedList.getOrNull(index + 1)
+            _isVisible.value = currentHighlight.value != null
+            getCurrentHighlight()
+        }
+        updateCoachMarkStateInternal(highlightToShow)
+        highlightToShow?.toolTipState?.show()
+    }
+
+    /**
+     * Shows the previous coach mark in the sequence.
+     *  If the current highlighted coach mark is the first in the list, the coach mark will
+     * be hidden.
+     */
+    suspend fun showPreviousCoachMark() {
+        val highlightToShow = mutex.withLock {
+            val currentHighlight = getCurrentHighlight()
+            currentHighlight?.toolTipState?.cleanUp() ?: return
+            val index = orderedList.indexOf(currentHighlight.key)
+            if (index == 0) {
+                _currentHighlight.value = null
+                _isVisible.value = false
+                return
+            }
+            _currentHighlight.value = orderedList.getOrNull(index - 1)
+            _isVisible.value = this.currentHighlight.value != null
+            getCurrentHighlight()
+        }
+        updateCoachMarkStateInternal(highlightToShow)
+        highlightToShow?.toolTipState?.show()
+    }
+
+    /**
+     * Completes the coaching sequence, clearing all highlights and resetting the state.
+     */
+    fun coachingComplete() {
+        getCurrentHighlight()?.toolTipState?.cleanUp()
+        _currentHighlight.value = null
+        _currentHighlightBounds.value = Rect.Zero
+        _currentHighlightShape.value = CoachMarkHighlightShape.SQUARE
+        _isVisible.value = false
+    }
+
+    /**
+     * Gets the current highlight information.
+     *
+     * @return The current [CoachMarkHighlight] or null if no highlight is active.
+     */
+    private fun getCurrentHighlight(): CoachMarkHighlight<T>? {
+        return highlights[currentHighlight.value]
+    }
+
+    private fun updateCoachMarkStateInternal(highlight: CoachMarkHighlight<T>?) {
+        _currentHighlightShape.value = highlight?.shape ?: CoachMarkHighlightShape.SQUARE
+        _currentHighlightBounds.value = highlight?.highlightBounds ?: Rect.Zero
+    }
+
+    /**
+     * Cleans up the tooltip state by dismissing it if visible and calling onDispose.
+     */
+    private fun TooltipState.cleanUp() {
+        if (isVisible) {
+            dismiss()
+        }
+        onDispose()
+    }
+
+    @Suppress("UndocumentedPublicClass")
+    companion object {
+        /**
+         * Creates a [Saver] for [CoachMarkState] to enable saving and restoring its state.
+         *
+         * @return A [Saver] that can save and restore [CoachMarkState].
+         */
+        inline fun <reified T : Enum<T>> saver(): Saver<CoachMarkState<T>, Any> =
+            listSaver(
+                save = { coachMarkState ->
+                    listOf(
+                        coachMarkState.orderedList.map { it.name },
+                        coachMarkState.currentHighlight.value?.name,
+                        coachMarkState.isVisible.value,
+                    )
+                },
+                restore = { restoredList ->
+                    val enumList = restoredList[0] as List<String>
+                    val currentHighlightName = restoredList[1] as String?
+                    val enumValues = enumValues<T>()
+                    val list = enumList.mapNotNull { name ->
+                        enumValues.find { it.name == name }
+                    }
+                    val currentHighlight = currentHighlightName?.let { name ->
+                        enumValues.find { it.name == name }
+                    }
+                    val isVisible = restoredList[2] as Boolean
+                    CoachMarkState(
+                        orderedList = list,
+                        initialCoachMarkHighlight = currentHighlight,
+                        isCoachMarkVisible = isVisible,
+                    )
+                },
+            )
+    }
+}
+
+/**
+ * Remembers and saves the state of a [CoachMarkState].
+ *
+ * @param T The type of the enum used to represent the coach mark keys.
+ * @param orderedList The ordered list of coach mark keys.
+ * @return A [CoachMarkState] instance.
+ */
+@Composable
+inline fun <reified T : Enum<T>> rememberCoachMarkState(orderedList: List<T>): CoachMarkState<T> {
+    return rememberSaveable(saver = CoachMarkState.saver<T>()) {
+        CoachMarkState(orderedList)
+    }
+}
+
+/**
+ * Represents a highlight within a coach mark sequence.
+ *
+ * @param T The type of the enum key used to identify the highlight.
+ * @property key The unique key identifying this highlight.
+ * @property highlightBounds The rectangular bounds of the area to highlight.
+ * @property toolTipState The state of the tooltip associated with this highlight.
+ * @property shape The shape of the highlight (e.g., square, oval).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+data class CoachMarkHighlight<T : Enum<T>>(
+    val key: T,
+    val highlightBounds: Rect,
+    val toolTipState: TooltipState,
+    val shape: CoachMarkHighlightShape,
+)
+
+/**
+ * Defines the available shapes for a coach mark highlight.
+ */
+enum class CoachMarkHighlightShape {
+    /**
+     * A square-shaped highlight.
+     */
+    SQUARE,
+
+    /**
+     * An oval-shaped highlight.
+     */
+    OVAL,
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
+import com.x8bit.bitwarden.ui.platform.components.coachmark.CoachMarkScope
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
@@ -29,7 +30,7 @@ import kotlinx.collections.immutable.toImmutableList
  */
 @Composable
 @Suppress("LongMethod", "CyclomaticComplexMethod")
-fun VaultAddEditContent(
+fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
     state: VaultAddEditState.ViewState.Content,
     isAddItemMode: Boolean,
     typeOptions: List<VaultAddEditState.ItemTypeOption>,
@@ -41,6 +42,9 @@ fun VaultAddEditContent(
     sshKeyItemTypeHandlers: VaultAddEditSshKeyTypeHandlers,
     modifier: Modifier = Modifier,
     permissionsManager: PermissionsManager,
+    onNextCoachMark: () -> Unit,
+    onPreviousCoachMark: () -> Unit,
+    onCoachMarkTourComplete: () -> Unit,
 ) {
     val launcher = permissionsManager.getLauncher(
         onResult = { isGranted ->
@@ -106,6 +110,12 @@ fun VaultAddEditContent(
                             launcher.launch(Manifest.permission.CAMERA)
                         }
                     },
+                    coachMarkScope = this@VaultAddEditContent,
+                    onGenerateCoachMarkNextClick = onNextCoachMark,
+                    onAuthenticatorKeyCoachMarkBackClick = onPreviousCoachMark,
+                    onAuthenticatorKeyCoachMarkNextClick = onNextCoachMark,
+                    onWebsiteURICoachMarkBackClick = onPreviousCoachMark,
+                    onWebsiteURICoachMarkDoneClick = onCoachMarkTourComplete,
                 )
             }
 
@@ -175,4 +185,10 @@ private fun TypeOptionsItem(
         },
         modifier = modifier,
     )
+}
+
+enum class AddEditItemCoachMark {
+    GENERATE_PASSWORD,
+    TOTP,
+    URI,
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -3,13 +3,16 @@ package com.x8bit.bitwarden.ui.vault.feature.addedit
 import android.widget.Toast
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -28,6 +31,8 @@ import com.x8bit.bitwarden.ui.platform.components.appbar.NavigationIcon
 import com.x8bit.bitwarden.ui.platform.components.appbar.action.BitwardenOverflowActionItem
 import com.x8bit.bitwarden.ui.platform.components.appbar.action.OverflowMenuItemData
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
+import com.x8bit.bitwarden.ui.platform.components.coachmark.CoachMarkContainer
+import com.x8bit.bitwarden.ui.platform.components.coachmark.rememberCoachMarkState
 import com.x8bit.bitwarden.ui.platform.components.content.BitwardenErrorContent
 import com.x8bit.bitwarden.ui.platform.components.content.BitwardenLoadingContent
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
@@ -56,6 +61,8 @@ import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditIdentit
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditLoginTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditSshKeyTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditUserVerificationHandlers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Top level composable for the vault add item screen.
@@ -247,112 +254,137 @@ fun VaultAddEditScreen(
     }
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
-    BitwardenScaffold(
-        modifier = Modifier
-            .fillMaxSize()
-            .nestedScroll(scrollBehavior.nestedScrollConnection),
-        topBar = {
-            BitwardenTopAppBar(
-                title = state.screenDisplayName(),
-                navigationIcon = NavigationIcon(
-                    navigationIcon = rememberVectorPainter(id = R.drawable.ic_close),
-                    navigationIconContentDescription = stringResource(id = R.string.close),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(VaultAddEditAction.Common.CloseClick) }
-                    },
-                )
-                    .takeIf { state.shouldShowCloseButton },
-                scrollBehavior = scrollBehavior,
-                actions = {
-                    BitwardenTextButton(
-                        label = stringResource(id = R.string.save),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(VaultAddEditAction.Common.SaveClick) }
-                        },
-                        modifier = Modifier.testTag("SaveButton"),
-                    )
-                    BitwardenOverflowActionItem(
-                        menuItemDataList = persistentListOfNotNull(
-                            OverflowMenuItemData(
-                                text = stringResource(id = R.string.attachments),
-                                onClick = remember(viewModel) {
-                                    {
-                                        viewModel.trySendAction(
-                                            VaultAddEditAction.Common.AttachmentsClick,
-                                        )
-                                    }
-                                },
-                            )
-                                .takeUnless { state.isAddItemMode },
-                            OverflowMenuItemData(
-                                text = stringResource(id = R.string.move_to_organization),
-                                onClick = remember(viewModel) {
-                                    {
-                                        viewModel.trySendAction(
-                                            VaultAddEditAction.Common.MoveToOrganizationClick,
-                                        )
-                                    }
-                                },
-                            )
-                                .takeUnless { state.isAddItemMode || state.isCipherInCollection },
-                            OverflowMenuItemData(
-                                text = stringResource(id = R.string.collections),
-                                onClick = remember(viewModel) {
-                                    {
-                                        viewModel.trySendAction(
-                                            VaultAddEditAction.Common.CollectionsClick,
-                                        )
-                                    }
-                                },
-                            )
-                                .takeUnless {
-                                    state.isAddItemMode ||
-                                        !state.isCipherInCollection ||
-                                        !state.canAssociateToCollections
-                                },
-                            OverflowMenuItemData(
-                                text = stringResource(id = R.string.delete),
-                                onClick = { pendingDeleteCipher = true },
-                            )
-                                .takeUnless { state.isAddItemMode || !state.canDelete },
-                        ),
-                    )
-                },
-            )
-        },
+    val coachMarkState = rememberCoachMarkState(
+        orderedList = AddEditItemCoachMark.entries,
+    )
+    val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(Unit) {
+        delay(3000L)
+        coachMarkState.showCoachMark()
+    }
+    CoachMarkContainer(
+        state = coachMarkState,
     ) {
-        when (val viewState = state.viewState) {
-            is VaultAddEditState.ViewState.Content -> {
-                VaultAddEditContent(
-                    state = viewState,
-                    isAddItemMode = state.isAddItemMode,
-                    typeOptions = state.supportedItemTypes,
-                    onTypeOptionClicked = remember(viewModel) {
-                        { viewModel.trySendAction(VaultAddEditAction.Common.TypeOptionSelect(it)) }
+        BitwardenScaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .nestedScroll(scrollBehavior.nestedScrollConnection),
+            topBar = {
+                BitwardenTopAppBar(
+                    title = state.screenDisplayName(),
+                    navigationIcon = NavigationIcon(
+                        navigationIcon = rememberVectorPainter(id = R.drawable.ic_close),
+                        navigationIconContentDescription = stringResource(id = R.string.close),
+                        onNavigationIconClick = remember(viewModel) {
+                            { viewModel.trySendAction(VaultAddEditAction.Common.CloseClick) }
+                        },
+                    )
+                        .takeIf { state.shouldShowCloseButton },
+                    scrollBehavior = scrollBehavior,
+                    actions = {
+                        BitwardenTextButton(
+                            label = stringResource(id = R.string.save),
+                            onClick = remember(viewModel) {
+                                { viewModel.trySendAction(VaultAddEditAction.Common.SaveClick) }
+                            },
+                            modifier = Modifier.testTag("SaveButton"),
+                        )
+                        BitwardenOverflowActionItem(
+                            menuItemDataList = persistentListOfNotNull(
+                                OverflowMenuItemData(
+                                    text = stringResource(id = R.string.attachments),
+                                    onClick = remember(viewModel) {
+                                        {
+                                            viewModel.trySendAction(
+                                                VaultAddEditAction.Common.AttachmentsClick,
+                                            )
+                                        }
+                                    },
+                                )
+                                    .takeUnless { state.isAddItemMode },
+                                OverflowMenuItemData(
+                                    text = stringResource(id = R.string.move_to_organization),
+                                    onClick = remember(viewModel) {
+                                        {
+                                            viewModel.trySendAction(
+                                                VaultAddEditAction.Common.MoveToOrganizationClick,
+                                            )
+                                        }
+                                    },
+                                )
+                                    .takeUnless { state.isAddItemMode || state.isCipherInCollection },
+                                OverflowMenuItemData(
+                                    text = stringResource(id = R.string.collections),
+                                    onClick = remember(viewModel) {
+                                        {
+                                            viewModel.trySendAction(
+                                                VaultAddEditAction.Common.CollectionsClick,
+                                            )
+                                        }
+                                    },
+                                )
+                                    .takeUnless {
+                                        state.isAddItemMode ||
+                                            !state.isCipherInCollection ||
+                                            !state.canAssociateToCollections
+                                    },
+                                OverflowMenuItemData(
+                                    text = stringResource(id = R.string.delete),
+                                    onClick = { pendingDeleteCipher = true },
+                                )
+                                    .takeUnless { state.isAddItemMode || !state.canDelete },
+                            ),
+                        )
                     },
-                    loginItemTypeHandlers = loginItemTypeHandlers,
-                    commonTypeHandlers = commonTypeHandlers,
-                    permissionsManager = permissionsManager,
-                    identityItemTypeHandlers = identityItemTypeHandlers,
-                    cardItemTypeHandlers = cardItemTypeHandlers,
-                    sshKeyItemTypeHandlers = sshKeyItemTypeHandlers,
-                    modifier = Modifier
-                        .imePadding()
-                        .fillMaxSize(),
                 )
-            }
+            },
+        ) {
+            when (val viewState = state.viewState) {
+                is VaultAddEditState.ViewState.Content -> {
+                    VaultAddEditContent(
+                        state = viewState,
+                        isAddItemMode = state.isAddItemMode,
+                        typeOptions = state.supportedItemTypes,
+                        onTypeOptionClicked = remember(viewModel) {
+                            { viewModel.trySendAction(VaultAddEditAction.Common.TypeOptionSelect(it)) }
+                        },
+                        loginItemTypeHandlers = loginItemTypeHandlers,
+                        commonTypeHandlers = commonTypeHandlers,
+                        permissionsManager = permissionsManager,
+                        identityItemTypeHandlers = identityItemTypeHandlers,
+                        cardItemTypeHandlers = cardItemTypeHandlers,
+                        sshKeyItemTypeHandlers = sshKeyItemTypeHandlers,
+                        modifier = Modifier
+                            .imePadding()
+                            .fillMaxSize(),
+                        onPreviousCoachMark = {
+                            coroutineScope.launch {
+                                coachMarkState.showPreviousCoachMark()
+                            }
+                        },
+                        onNextCoachMark = {
+                            coroutineScope.launch {
+                                coachMarkState.showNextCoachMark()
+                            }
+                        },
+                        onCoachMarkTourComplete = {
+                            coachMarkState.coachingComplete()
+                        }
+                    )
+                }
 
-            is VaultAddEditState.ViewState.Error -> {
-                BitwardenErrorContent(
-                    message = viewState.message(),
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
+                is VaultAddEditState.ViewState.Error -> {
+                    BitwardenErrorContent(
+                        message = viewState.message(),
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
 
-            VaultAddEditState.ViewState.Loading -> {
-                BitwardenLoadingContent(
-                    modifier = Modifier.fillMaxSize(),
-                )
+                VaultAddEditState.ViewState.Loading -> {
+                    BitwardenLoadingContent(
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-16631](https://bitwarden.atlassian.net/browse/PM-16631)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- To build a reusable piece of code that can be used for the various coach mark "tours" for first time users.
- To apply this to the required UI in the `VaultAddEditContent` content.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
**What works nicely:**
Static content: 
[progress.webm](https://github.com/user-attachments/assets/2227245c-515e-4bab-9c18-1a3645989cb6)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16631]: https://bitwarden.atlassian.net/browse/PM-16631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ