### PR TITLE
PM-16830 - Update global loading screen component to new reskinned version

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/indicator/BitwardenCircularProgressIndicator.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/indicator/BitwardenCircularProgressIndicator.kt
@@ -15,5 +15,6 @@ fun BitwardenCircularProgressIndicator(
     CircularProgressIndicator(
         modifier = modifier,
         color = BitwardenTheme.colorScheme.stroke.border,
+        trackColor = BitwardenTheme.colorScheme.background.tertiary,
     )
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16830](https://bitwarden.atlassian.net/browse/PM-16830)

## 📔 Objective

- Update the loading indicator to match the new reskin.  Originally I had read this story wrong and was implementing this app-wide for the full screen loading but after a sync with Dave I realized this ticket is much smaller in size. 
- Using the existing `CircularProgressIndicator` and updated the `trackColor` property to match the new reskin color.  Confirmed with Emily this looks good for this particular ticket. 

## 📸 Screenshots

https://github.com/user-attachments/assets/e450a79f-818d-4978-951b-1f0f093d6809

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16830]: https://bitwarden.atlassian.net/browse/PM-16830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ