### PR TITLE
[QA-968] Adding missing testTag for MP hint email field

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreen.kt
@@ -117,6 +117,7 @@ fun MasterPasswordHintScreen(
                 },
                 label = stringResource(id = R.string.email_address),
                 keyboardType = KeyboardType.Email,
+                textFieldTestTag = "MasterPasswordHintEmailField"
             )
 
             Text(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreen.kt
@@ -117,7 +117,7 @@ fun MasterPasswordHintScreen(
                 },
                 label = stringResource(id = R.string.email_address),
                 keyboardType = KeyboardType.Email,
-                textFieldTestTag = "MasterPasswordHintEmailField"
+                textFieldTestTag = "MasterPasswordHintEmailField",
             )
 
             Text(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[QA-947]: https://bitwarden.atlassian.net/browse/QA-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ