### PR TITLE
[QA-980] Adding missing testTags for Custom fields

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomField.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import com.x8bit.bitwarden.R
@@ -85,7 +86,7 @@ fun VaultAddEditCustomField(
                 value = customField.value,
                 onValueChanged = { onCustomFieldValueChange(customField.copy(value = it)) },
                 onEditValue = { shouldShowChooserDialog = true },
-                modifier = modifier,
+                modifier = modifier.testTag("AddEditCustomBooleanField"),
             )
         }
 
@@ -98,7 +99,7 @@ fun VaultAddEditCustomField(
                 },
                 onVisibilityChanged = onHiddenVisibilityChanged,
                 onEditValue = { shouldShowChooserDialog = true },
-                modifier = modifier,
+                modifier = modifier.testTag("AddEditCustomHiddenField"),
             )
         }
 
@@ -112,7 +113,7 @@ fun VaultAddEditCustomField(
                         onCustomFieldValueChange(customField.copy(vaultLinkedFieldType = it))
                     },
                     onEditValue = { shouldShowChooserDialog = true },
-                    modifier = modifier,
+                    modifier = modifier.testTag("AddEditCustomLinkedField"),
                 )
             }
         }
@@ -123,7 +124,7 @@ fun VaultAddEditCustomField(
                 value = customField.value,
                 onValueChanged = { onCustomFieldValueChange(customField.copy(value = it)) },
                 onEditValue = { shouldShowChooserDialog = true },
-                modifier = modifier,
+                modifier = modifier.testTag("AddEditCustomTextField"),
             )
         }
     }
@@ -159,6 +160,7 @@ private fun CustomFieldBoolean(
                     vectorIconRes = R.drawable.ic_cog,
                     contentDescription = stringResource(id = R.string.edit),
                     onClick = onEditValue,
+                    modifier = Modifier.testTag("CustomFieldSettingsButton"),
                 )
             },
         )
@@ -188,12 +190,15 @@ private fun CustomFieldHiddenField(
             onVisibilityChanged(shouldShowPassword)
         },
         singleLine = true,
+        showPasswordTestTag = "CustomFieldShowPasswordButton",
+        passwordFieldTestTag = "CustomFieldValue",
         modifier = modifier,
         actions = {
             BitwardenTonalIconButton(
                 vectorIconRes = R.drawable.ic_cog,
                 contentDescription = stringResource(id = R.string.edit),
                 onClick = onEditValue,
+                modifier = Modifier.testTag("CustomFieldSettingsButton"),
             )
         },
     )
@@ -215,12 +220,14 @@ private fun CustomFieldTextField(
         value = value,
         onValueChange = onValueChanged,
         singleLine = true,
+        textFieldTestTag = "CustomFieldValue",
         modifier = modifier,
         actions = {
             BitwardenTonalIconButton(
                 vectorIconRes = R.drawable.ic_cog,
                 contentDescription = stringResource(id = R.string.edit),
                 onClick = onEditValue,
+                modifier = Modifier.testTag("CustomFieldSettingsButton"),
             )
         },
     )
@@ -257,7 +264,9 @@ private fun CustomFieldLinkedField(
                     }
                 }
             },
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .testTag("CustomFieldDropdown"),
         )
 
         BitwardenRowOfActions(
@@ -266,6 +275,7 @@ private fun CustomFieldLinkedField(
                     vectorIconRes = R.drawable.ic_cog,
                     contentDescription = stringResource(id = R.string.edit),
                     onClick = onEditValue,
+                    modifier = Modifier.testTag("CustomFieldSettingsButton"),
                 )
             },
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCustomField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCustomField.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.vault.feature.item
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTonalIconButton
@@ -31,7 +32,7 @@ fun CustomField(
                 isChecked = customField.value,
                 readOnly = true,
                 onCheckedChange = { },
-                modifier = modifier,
+                modifier = modifier.testTag("ViewCustomBooleanField"),
             )
         }
 
@@ -44,13 +45,16 @@ fun CustomField(
                 onValueChange = { },
                 readOnly = true,
                 singleLine = false,
-                modifier = modifier,
+                showPasswordTestTag = "CustomFieldShowPasswordButton",
+                passwordFieldTestTag = "CustomFieldValue",
+                modifier = modifier.testTag("ViewCustomHiddenField"),
                 actions = {
                     if (customField.isCopyable) {
                         BitwardenTonalIconButton(
                             vectorIconRes = R.drawable.ic_copy,
                             contentDescription = stringResource(id = R.string.copy),
                             onClick = { onCopyCustomHiddenField(customField.value) },
+                            modifier = Modifier.testTag("CustomFieldCopyValueButton"),
                         )
                     }
                 },
@@ -68,7 +72,8 @@ fun CustomField(
                 onValueChange = { },
                 readOnly = true,
                 singleLine = false,
-                modifier = modifier,
+                modifier = modifier.testTag("ViewCustomLinkedField"),
+                textFieldTestTag = "CustomFieldDropdown"
             )
         }
 
@@ -79,13 +84,15 @@ fun CustomField(
                 onValueChange = { },
                 readOnly = true,
                 singleLine = false,
-                modifier = modifier,
+                textFieldTestTag = "CustomFieldValue",
+                modifier = modifier.testTag("ViewCustomTextField"),
                 actions = {
                     if (customField.isCopyable) {
                         BitwardenTonalIconButton(
                             vectorIconRes = R.drawable.ic_copy,
                             contentDescription = stringResource(id = R.string.copy),
                             onClick = { onCopyCustomTextField(customField.value) },
+                            modifier = Modifier.testTag("CustomFieldCopyValueButton"),
                         )
                     }
                 },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
