### PR TITLE
[PM-16905] Add back button to new device notice

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorNavigation.kt
@@ -24,12 +24,14 @@ fun NavController.navigateToNewDeviceNoticeTwoFactor(
  */
 fun NavGraphBuilder.newDeviceNoticeTwoFactorDestination(
     onNavigateBackToVault: () -> Unit,
+    onNavigateBack: () -> Unit,
 ) {
     composableWithSlideTransitions(
         route = NEW_DEVICE_NOTICE_TWO_FACTOR_ROUTE,
     ) {
         NewDeviceNoticeTwoFactorScreen(
             onNavigateBackToVault = onNavigateBackToVault,
+            onNavigateBack = onNavigateBack,
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
@@ -98,6 +99,8 @@ fun NewDeviceNoticeTwoFactorScreen(
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     BitwardenScaffold(
+        modifier = Modifier
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BitwardenTopAppBar(
                 title = "",

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorScreen.kt
@@ -11,9 +11,12 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -27,6 +30,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.ChangeAccountEmailClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.ContinueDialogClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.DismissDialogClick
+import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.NavigateBackClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.RemindMeLaterClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.TurnOnTwoFactorClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorEvent.NavigateBackToVault
@@ -34,6 +38,8 @@ import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFac
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorEvent.NavigateToTurnOnTwoFactor
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
+import com.x8bit.bitwarden.ui.platform.components.appbar.NavigationIcon
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
@@ -46,9 +52,12 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 /**
  * The top level composable for the new device notice two factor screen.
  */
+@OptIn(ExperimentalMaterial3Api::class)
+@Suppress("LongMethod")
 @Composable
 fun NewDeviceNoticeTwoFactorScreen(
     onNavigateBackToVault: () -> Unit,
+    onNavigateBack: () -> Unit,
     intentManager: IntentManager = LocalIntentManager.current,
     viewModel: NewDeviceNoticeTwoFactorViewModel = hiltViewModel(),
 ) {
@@ -64,6 +73,8 @@ fun NewDeviceNoticeTwoFactorScreen(
             }
 
             NavigateBackToVault -> onNavigateBackToVault()
+
+            NewDeviceNoticeTwoFactorEvent.NavigateBack -> onNavigateBack()
         }
     }
 
@@ -85,7 +96,24 @@ fun NewDeviceNoticeTwoFactorScreen(
         null -> Unit
     }
 
-    BitwardenScaffold {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    BitwardenScaffold(
+        topBar = {
+            BitwardenTopAppBar(
+                title = "",
+                scrollBehavior = scrollBehavior,
+                navigationIcon = NavigationIcon(
+                    navigationIcon = rememberVectorPainter(R.drawable.ic_back),
+                    navigationIconContentDescription = stringResource(id = R.string.back),
+                    onNavigationIconClick = remember(viewModel) {
+                        {
+                            viewModel.trySendAction(NavigateBackClick)
+                        }
+                    },
+                ),
+            )
+        },
+    ) {
         NewDeviceNoticeTwoFactorContent(
             onTurnOnTwoFactorClick = {
                 viewModel.trySendAction(TurnOnTwoFactorClick)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModel.kt
@@ -15,6 +15,7 @@ import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.ChangeAccountEmailClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.ContinueDialogClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.DismissDialogClick
+import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.NavigateBackClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.RemindMeLaterClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorAction.TurnOnTwoFactorClick
 import com.x8bit.bitwarden.ui.auth.feature.newdevicenotice.NewDeviceNoticeTwoFactorDialogState.ChangeAccountEmailDialog
@@ -90,6 +91,8 @@ class NewDeviceNoticeTwoFactorViewModel @Inject constructor(
             DismissDialogClick -> updateDialogState(newState = null)
 
             ContinueDialogClick -> handleContinueDialog()
+
+            NavigateBackClick -> sendEvent(NewDeviceNoticeTwoFactorEvent.NavigateBack)
         }
     }
 
@@ -154,6 +157,11 @@ sealed class NewDeviceNoticeTwoFactorEvent {
      * Navigates back to vault.
      */
     data object NavigateBackToVault : NewDeviceNoticeTwoFactorEvent()
+
+    /**
+     * Navigates back to previous screen.
+     */
+    data object NavigateBack : NewDeviceNoticeTwoFactorEvent()
 }
 
 /**
@@ -184,6 +192,11 @@ sealed class NewDeviceNoticeTwoFactorAction {
      * User tapped the continue dialog button.
      */
     data object ContinueDialogClick : NewDeviceNoticeTwoFactorAction()
+
+    /**
+     * User tapped the back button.
+     */
+    data object NavigateBackClick : NewDeviceNoticeTwoFactorAction()
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -241,6 +241,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         )
         newDeviceNoticeTwoFactorDestination(
             onNavigateBackToVault = { navController.navigateToVaultUnlockedGraph() },
+            onNavigateBack = { navController.popBackStack() },
         )
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorViewModelTest.kt
@@ -127,7 +127,7 @@ class NewDeviceNoticeTwoFactorViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `RemindMeLaterClick should emit NavigateBack`() = runTest {
+    fun `RemindMeLaterClick should emit NavigateBackToVault`() = runTest {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(NewDeviceNoticeTwoFactorAction.RemindMeLaterClick)
@@ -143,6 +143,18 @@ class NewDeviceNoticeTwoFactorViewModelTest : BaseViewModelTest() {
                     ),
                 )
             }
+        }
+    }
+
+    @Test
+    fun `NavigateBackClick should send NavigateBack event`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(NewDeviceNoticeTwoFactorAction.NavigateBackClick)
+        viewModel.eventFlow.test {
+            assertEquals(
+                NewDeviceNoticeTwoFactorEvent.NavigateBack,
+                awaitItem(),
+            )
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-16905

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The second screen of new device notice was missing a back button in its UI. This PR address that issue.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="226" alt="image" src="https://github.com/user-attachments/assets/bb5ab5c8-4e0a-4eae-a7ac-f414292fe9aa" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
