### PR TITLE
Add correct card padding to BitwardenHiddenPasswordField

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenHiddenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenHiddenPasswordField.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.ui.platform.base.util.cardBackground
+import com.x8bit.bitwarden.ui.platform.base.util.cardPadding
 import com.x8bit.bitwarden.ui.platform.components.field.color.bitwardenTextFieldColors
 import com.x8bit.bitwarden.ui.platform.components.field.toolbar.BitwardenEmptyTextToolbar
 import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
@@ -33,7 +35,9 @@ fun BitwardenHiddenPasswordField(
 ) {
     CompositionLocalProvider(value = LocalTextToolbar provides BitwardenEmptyTextToolbar) {
         TextField(
-            modifier = modifier.cardBackground(cardStyle = cardStyle),
+            modifier = modifier
+                .cardBackground(cardStyle = cardStyle)
+                .cardPadding(cardStyle = cardStyle, vertical = 6.dp),
             textStyle = BitwardenTheme.typography.sensitiveInfoSmall,
             label = { Text(text = label) },
             value = value,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

The `BitwardenHiddenPasswordField` was missing card padding. This PR addresses that issue.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/deae238e-8c10-4375-9f5f-8e30f57b499a" width="300" /> | <img src="https://github.com/user-attachments/assets/bfe2dd49-d275-4d89-aba4-08783d9fff7c" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
