### PR TITLE
Add spacer between type and name when creating a login cipher

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
@@ -54,6 +54,7 @@ fun LazyListScope.vaultAddEditLoginItems(
     onTotpSetupClick: () -> Unit,
 ) {
     item {
+        Spacer(modifier = Modifier.height(height = 8.dp))
         BitwardenTextField(
             label = stringResource(id = R.string.name),
             value = commonState.name,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR addresses a bug when creating a new login cipher where the type card and the name card are too close together.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/20167c99-7d78-44d1-a94a-b8d36fc7a086" width="300" /> | <img src="https://github.com/user-attachments/assets/ace2ced9-5957-4d91-91f2-f27d1ec6340f" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
