### PR TITLE
[PM-13351] Prevent editing of TOTP key in 'can edit except passwords' collection

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
@@ -114,55 +114,16 @@ fun LazyListScope.vaultAddEditLoginItems(
         Spacer(modifier = Modifier.height(height = 8.dp))
     }
 
-    if (loginState.totp != null) {
-        item {
-            BitwardenTextFieldWithActions(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin(),
-                label = stringResource(id = R.string.totp),
-                value = loginState.totp,
-                trailingIconContent = {
-                    BitwardenStandardIconButton(
-                        vectorIconRes = R.drawable.ic_clear,
-                        contentDescription = stringResource(id = R.string.delete),
-                        onClick = loginItemTypeHandlers.onClearTotpKeyClick,
-                    )
-                },
-                onValueChange = {},
-                readOnly = true,
-                singleLine = true,
-                actions = {
-                    BitwardenStandardIconButton(
-                        vectorIconRes = R.drawable.ic_copy,
-                        contentDescription = stringResource(id = R.string.copy_totp),
-                        onClick = {
-                            loginItemTypeHandlers.onCopyTotpKeyClick(loginState.totp)
-                        },
-                    )
-                    BitwardenStandardIconButton(
-                        vectorIconRes = R.drawable.ic_camera,
-                        contentDescription = stringResource(id = R.string.camera),
-                        onClick = onTotpSetupClick,
-                    )
-                },
-                textFieldTestTag = "LoginTotpEntry",
-                cardStyle = CardStyle.Full,
-            )
-        }
-    } else {
-        item {
-            Spacer(modifier = Modifier.height(16.dp))
-            BitwardenOutlinedButton(
-                label = stringResource(id = R.string.setup_totp),
-                icon = rememberVectorPainter(id = R.drawable.ic_light_bulb),
-                onClick = onTotpSetupClick,
-                modifier = Modifier
-                    .testTag("SetupTotpButton")
-                    .fillMaxWidth()
-                    .standardHorizontalMargin(),
-            )
-        }
+    item {
+        TotpRow(
+            totpKey = loginState.totp,
+            canViewTotp = loginState.canViewPassword,
+            loginItemTypeHandlers = loginItemTypeHandlers,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+            onTotpSetupClick = onTotpSetupClick,
+        )
     }
 
     item {
@@ -517,6 +478,77 @@ private fun PasswordRow(
             value = password,
             cardStyle = CardStyle.Bottom,
             modifier = modifier.testTag("LoginPasswordEntry"),
+        )
+    }
+}
+
+@Suppress("LongMethod")
+@Composable
+private fun TotpRow(
+    totpKey: String?,
+    canViewTotp: Boolean,
+    loginItemTypeHandlers: VaultAddEditLoginTypeHandlers,
+    modifier: Modifier = Modifier,
+    onTotpSetupClick: () -> Unit,
+) {
+    if (totpKey != null) {
+        if (canViewTotp) {
+            BitwardenTextFieldWithActions(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+                label = stringResource(id = R.string.totp),
+                value = totpKey,
+                trailingIconContent = {
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_clear,
+                        contentDescription = stringResource(id = R.string.delete),
+                        onClick = loginItemTypeHandlers.onClearTotpKeyClick,
+                    )
+                },
+                onValueChange = {},
+                readOnly = true,
+                singleLine = true,
+                actions = {
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_copy,
+                        contentDescription = stringResource(id = R.string.copy_totp),
+                        onClick = {
+                            loginItemTypeHandlers.onCopyTotpKeyClick(totpKey)
+                        },
+                    )
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_camera,
+                        contentDescription = stringResource(id = R.string.camera),
+                        onClick = onTotpSetupClick,
+                    )
+                },
+                textFieldTestTag = "LoginTotpEntry",
+                cardStyle = CardStyle.Full,
+            )
+        } else {
+            BitwardenTextField(
+                label = stringResource(id = R.string.totp),
+                value = totpKey,
+                cardStyle = CardStyle.Bottom,
+                modifier = modifier.testTag("LoginTotpEntry"),
+                onValueChange = {},
+                readOnly = true,
+                enabled = false,
+                singleLine = true,
+            )
+        }
+    } else {
+        Spacer(modifier = Modifier.height(16.dp))
+        BitwardenOutlinedButton(
+            label = stringResource(id = R.string.setup_totp),
+            icon = rememberVectorPainter(id = R.drawable.ic_light_bulb),
+            onClick = onTotpSetupClick,
+            modifier = Modifier
+                .testTag("SetupTotpButton")
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+            isEnabled = canViewTotp,
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13351

## 📔 Objective

This disables the ability to edit the TOTP key if the item is part of a collection with `Can Edit, Except Passwords` permission

## 📸 Screenshots

Item with existing TOTP key:

![android_can-edit-except-pw-item-with-totp](https://github.com/user-attachments/assets/2105781c-d7b3-4fff-8fbc-76b8bb6b3438)

Item without existing TOTP key:

![android_can-edit-except-pw-item-without-totp](https://github.com/user-attachments/assets/6378696a-5919-4711-aab6-43cab131a062)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
