### PR TITLE
PM-16630 Add action card to start add login coachmarks

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -361,4 +361,19 @@ interface SettingsDiskSource {
      * Stores the given [count] completed create send actions for the device.
      */
     fun storeCreateSendActionCount(count: Int?)
+
+    /**
+     * Gets the Boolean value of if the Add Login CoachMark tour has been interacted with.
+     */
+    fun getHasSeenAddLoginCoachMark(): Boolean?
+
+    /**
+     * Stores a value for if the Add Login CoachMark tour has been interacted with
+     */
+    fun storeHasSeenAddLoginCoachMark(hasSeen: Boolean?)
+
+    /**
+     * Returns an [Flow] to observe updates to the "HasSeenAddLoginCoachMark" value.
+     */
+    fun getHasSeenAddLoginCoachMarkFlow(): Flow<Boolean?>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -39,6 +39,7 @@ private const val IS_VAULT_REGISTERED_FOR_EXPORT = "isVaultRegisteredForExport"
 private const val ADD_ACTION_COUNT = "addActionCount"
 private const val COPY_ACTION_COUNT = "copyActionCount"
 private const val CREATE_ACTION_COUNT = "createActionCount"
+private const val HAS_SEEN_ADD_LOGIN_COACH_MARK = "hasSeenAddLoginCoachMark"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -77,6 +78,8 @@ class SettingsDiskSourceImpl(
     private val mutableIsCrashLoggingEnabledFlow = bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableHasUserLoggedInOrCreatedAccountFlow = bufferedMutableSharedFlow<Boolean?>()
+
+    private val mutableHasSeenAddLoginCoachMarkFlow = bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableScreenCaptureAllowedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -185,6 +188,7 @@ class SettingsDiskSourceImpl(
         // - screen capture allowed
         // - show autofill setting badge
         // - show unlock setting badge
+        // - has seen add login coach mark
     }
 
     override fun getAccountBiometricIntegrityValidity(
@@ -485,6 +489,22 @@ class SettingsDiskSourceImpl(
             value = count,
         )
     }
+
+    override fun getHasSeenAddLoginCoachMark(): Boolean? =
+        getBoolean(key = HAS_SEEN_ADD_LOGIN_COACH_MARK)
+
+    override fun storeHasSeenAddLoginCoachMark(hasSeen: Boolean?) {
+        putBoolean(
+            key = HAS_SEEN_ADD_LOGIN_COACH_MARK,
+            value = hasSeen,
+        )
+        mutableHasSeenAddLoginCoachMarkFlow.tryEmit(hasSeen)
+    }
+
+    override fun getHasSeenAddLoginCoachMarkFlow(): Flow<Boolean?> =
+        mutableHasSeenAddLoginCoachMarkFlow.onSubscription {
+            emit(getBoolean(key = HAS_SEEN_ADD_LOGIN_COACH_MARK))
+        }
 
     private fun getMutableLastSyncFlow(
         userId: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManager.kt
@@ -40,6 +40,11 @@ interface FirstTimeActionManager {
     val firstTimeStateFlow: Flow<FirstTimeState>
 
     /**
+     * Returns observable flow of if a user on the device has seen the Add Login coach mark tour.
+     */
+    val hasSeenAddLoginCoachMarkFlow: Flow<Boolean>
+
+    /**
      * Get the current [FirstTimeState] of the active user if available, otherwise return
      * a default configuration.
      */
@@ -66,4 +71,9 @@ interface FirstTimeActionManager {
      * Update the value of the showImportLoginsSettingsBadge status for the active user.
      */
     fun storeShowImportLoginsSettingsBadge(showBadge: Boolean)
+
+    /**
+     * Can be called to indicate that a user has seen the AddLogin coach mark tour.
+     */
+    fun hasSeenAddLoginCoachMarkTour()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -159,6 +159,13 @@ class FirstTimeActionManagerImpl @Inject constructor(
             .getHasSeenAddLoginCoachMarkFlow()
             // default value of false.
             .map { it ?: false }
+            .combine(
+                featureFlagManager.getFeatureFlagFlow(FlagKey.OnboardingFlow),
+            ) { hasSeenTour, featureIsEnabled ->
+                // If the feature flag is off always return true so observers know
+                // the card has not been shown.
+                hasSeenTour || !featureIsEnabled
+            }
             .distinctUntilChanged()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -154,6 +154,13 @@ class FirstTimeActionManagerImpl @Inject constructor(
             }
             .distinctUntilChanged()
 
+    override val hasSeenAddLoginCoachMarkFlow: Flow<Boolean>
+        get() = settingsDiskSource
+            .getHasSeenAddLoginCoachMarkFlow()
+            // default value of false.
+            .map { it ?: false }
+            .distinctUntilChanged()
+
     /**
      * Get the current [FirstTimeState] of the active user if available, otherwise return
      * a default configuration.
@@ -209,6 +216,10 @@ class FirstTimeActionManagerImpl @Inject constructor(
             userId = activeUserId,
             showBadge = showBadge,
         )
+    }
+
+    override fun hasSeenAddLoginCoachMarkTour() {
+        settingsDiskSource.storeHasSeenAddLoginCoachMark(hasSeen = true)
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -92,7 +92,9 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
                     actionText = stringResource(R.string.get_started),
                     onActionClick = loginItemTypeHandlers.onStartLoginCoachMarkTour,
                     onDismissClick = loginItemTypeHandlers.onDismissLearnAboutLoginsCard,
-                    modifier = Modifier.standardHorizontalMargin(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .standardHorizontalMargin(),
                 )
             }
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.x8bit.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.x8bit.bitwarden.ui.platform.components.coachmark.CoachMarkScope
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
@@ -50,6 +51,7 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
     onPreviousCoachMark: () -> Unit,
     onCoachMarkTourComplete: () -> Unit,
     onCoachMarkDismissed: () -> Unit,
+    shouldShowLearnAboutLoginsCard: Boolean,
 ) {
     val launcher = permissionsManager.getLauncher(
         onResult = { isGranted ->
@@ -79,6 +81,21 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
             }
         }
 
+        if (shouldShowLearnAboutLoginsCard) {
+            item {
+                Spacer(modifier = Modifier.height(height = 12.dp))
+                BitwardenActionCard(
+                    cardTitle = stringResource(R.string.learn_about_new_logins),
+                    cardSubtitle = stringResource(
+                        R.string.we_ll_walk_you_through_the_key_features_to_add_a_new_login,
+                    ),
+                    actionText = stringResource(R.string.get_started),
+                    onActionClick = loginItemTypeHandlers.onStartLoginCoachMarkTour,
+                    onDismissClick = loginItemTypeHandlers.onDismissLearnAboutLoginsCard,
+                    modifier = Modifier.standardHorizontalMargin(),
+                )
+            }
+        }
         item {
             Spacer(modifier = Modifier.height(height = 12.dp))
             BitwardenListHeaderText(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -384,6 +384,7 @@ fun VaultAddEditScreen(
                             coachMarkState.coachingComplete(onComplete = scrollBackToTop)
                         },
                         onCoachMarkDismissed = scrollBackToTop,
+                        shouldShowLearnAboutLoginsCard = state.shouldShowLearnAboutNewLogins,
                         modifier = Modifier
                             .imePadding()
                             .fillMaxSize(),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditLoginTypeHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditLoginTypeHandlers.kt
@@ -42,6 +42,8 @@ data class VaultAddEditLoginTypeHandlers(
     val onAddNewUriClick: () -> Unit,
     val onPasswordVisibilityChange: (Boolean) -> Unit,
     val onClearFido2CredentialClick: () -> Unit,
+    val onStartLoginCoachMarkTour: () -> Unit,
+    val onDismissLearnAboutLoginsCard: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -121,6 +123,16 @@ data class VaultAddEditLoginTypeHandlers(
                 onClearFido2CredentialClick = {
                     viewModel.trySendAction(
                         VaultAddEditAction.ItemType.LoginType.ClearFido2CredentialClick,
+                    )
+                },
+                onStartLoginCoachMarkTour = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.LoginType.StartLearnAboutLogins,
+                    )
+                },
+                onDismissLearnAboutLoginsCard = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.LoginType.LearnAboutLoginsDismissed,
                     )
                 },
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1121,4 +1121,6 @@ Do you want to switch to this account?</string>
   <string name="mutual_tls">Mutual TLS</string>
   <string name="single_tap_passkey_creation">Single tap passkey creation</string>
   <string name="single_tap_passkey_authentication">Single tap passkey sign-on</string>
+  <string name="learn_about_new_logins">Learn about new logins</string>
+  <string name="we_ll_walk_you_through_the_key_features_to_add_a_new_login">We\'ll walk you through the key features to add a new login.</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1253,4 +1253,34 @@ class SettingsDiskSourceTest {
         settingsDiskSource.storeCreateSendActionCount(count = 1)
         assertEquals(1, fakeSharedPreferences.getInt(createActionCountKey, 0))
     }
+
+    @Test
+    fun `getHasSeenAddLoginCoachMark should pull value from SharedPreferences`() {
+        val hasSeenAddLoginCoachMarkKey = "bwPreferencesStorage:hasSeenAddLoginCoachMark"
+        fakeSharedPreferences.edit { putBoolean(hasSeenAddLoginCoachMarkKey, true) }
+        assertTrue(settingsDiskSource.getHasSeenAddLoginCoachMark() == true)
+    }
+
+    @Test
+    fun `storeHasSeenAddLoginCoachMark should update SharedPreferences`() {
+        val hasSeenAddLoginCoachMarkKey = "bwPreferencesStorage:hasSeenAddLoginCoachMark"
+        settingsDiskSource.storeHasSeenAddLoginCoachMark(hasSeen = true)
+        assertTrue(
+            fakeSharedPreferences.getBoolean(
+                key = hasSeenAddLoginCoachMarkKey,
+                defaultValue = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `getHasSeenAddLoginCoachMarkFlow emits changes to stored value`() = runTest {
+        settingsDiskSource.getHasSeenAddLoginCoachMarkFlow().test {
+            assertNull(awaitItem())
+            settingsDiskSource.storeHasSeenAddLoginCoachMark(hasSeen = false)
+            assertFalse(awaitItem() ?: true)
+            settingsDiskSource.storeHasSeenAddLoginCoachMark(hasSeen = true)
+            assertTrue(awaitItem() ?: false)
+        }
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -40,6 +40,8 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val mutableHasUserLoggedInOrCreatedAccount =
         bufferedMutableSharedFlow<Boolean?>()
 
+    private val mutableHasSeenAddLoginCoachMarkFlow = bufferedMutableSharedFlow<Boolean?>()
+
     private val mutableScreenCaptureAllowedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
@@ -70,6 +72,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private var addCipherActionCount: Int? = null
     private var generatedActionCount: Int? = null
     private var createSendActionCount: Int? = null
+    private var hasSeenAddLoginCoachMark: Boolean? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -389,6 +392,20 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     override fun storeCreateSendActionCount(count: Int?) {
         createSendActionCount = count
     }
+
+    override fun getHasSeenAddLoginCoachMark(): Boolean? {
+        return hasSeenAddLoginCoachMark
+    }
+
+    override fun storeHasSeenAddLoginCoachMark(hasSeen: Boolean?) {
+        hasSeenAddLoginCoachMark = hasSeen
+        mutableHasSeenAddLoginCoachMarkFlow.tryEmit(hasSeen)
+    }
+
+    override fun getHasSeenAddLoginCoachMarkFlow(): Flow<Boolean?> =
+        mutableHasSeenAddLoginCoachMarkFlow.onSubscription {
+            emit(getHasSeenAddLoginCoachMark())
+        }
 
     //region Private helper functions
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
@@ -295,6 +296,23 @@ class FirstTimeActionManagerTest {
                 awaitItem(),
             )
         }
+    }
+
+    @Test
+    fun `hasSeenAddLoginCoachMarkFlow updates when disk source updates`() = runTest {
+        firstTimeActionManager.hasSeenAddLoginCoachMarkFlow.test {
+            // null will be mapped to false
+            assertFalse(awaitItem())
+            fakeSettingsDiskSource.storeHasSeenAddLoginCoachMark(hasSeen = true)
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `hasSeenAddLoginCoachMarkTour sets the value to true in the disk source`() {
+        assertNull(fakeSettingsDiskSource.getHasSeenAddLoginCoachMark())
+        firstTimeActionManager.hasSeenAddLoginCoachMarkTour()
+        assertTrue(fakeSettingsDiskSource.getHasSeenAddLoginCoachMark() == true)
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -25,7 +25,6 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCreden
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
@@ -33,7 +32,6 @@ import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
@@ -173,14 +171,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     private val firstTimeActionManager = mockk<FirstTimeActionManager> {
         every { hasSeenAddLoginCoachMarkTour() } just runs
         every { hasSeenAddLoginCoachMarkFlow } returns mutableHasSeenAddLoginCoachMarkFlow
-    }
-
-    // Feature flag default to be enabled.
-    private val mutableOnboardingFeatureFlagFlow = MutableStateFlow(true)
-    private val featureFlagManager = mockk<FeatureFlagManager> {
-        every {
-            getFeatureFlagFlow(FlagKey.OnboardingFlow)
-        } returns mutableOnboardingFeatureFlagFlow
     }
 
     @BeforeEach
@@ -2623,25 +2613,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         }
     }
 
-    @Test
-    fun `when OnboardFlow feature flag is off, shouldShowLearnAboutNewLogins should be false`() {
-        mutableOnboardingFeatureFlagFlow.update { true }
-        val viewModel = createAddVaultItemViewModel(
-            savedStateHandle = createSavedStateHandleWithState(
-                state = createVaultAddItemState(
-                    typeContentViewState = createLoginTypeContentViewState(),
-                ),
-                vaultAddEditType = VaultAddEditType.AddItem(
-                    vaultItemCipherType = VaultItemCipherType.LOGIN,
-                ),
-            ),
-        )
-        assertTrue(viewModel.stateFlow.value.shouldShowLearnAboutNewLogins)
-
-        mutableOnboardingFeatureFlagFlow.update { false }
-        assertFalse(viewModel.stateFlow.value.shouldShowLearnAboutNewLogins)
-    }
-
     @Suppress("MaxLineLength")
     @Test
     fun `when first time action manager has seen logins tour value updates to true shouldShowLearnAboutNewLogins should update to false`() {
@@ -2710,7 +2681,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `LearnAboutLoginsDismissed action calls first time action manager hasSeenAddLoginCoachMarkTour called and show coach mark event sent`() =
+    fun `StartLearnAboutLogins action calls first time action manager hasSeenAddLoginCoachMarkTour called and show coach mark event sent`() =
         runTest {
             val viewModel = createAddVaultItemViewModel()
             viewModel.eventFlow.test {
@@ -3246,7 +3217,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 organizationEventManager = organizationEventManager,
                 networkConnectionManager = networkConnectionManager,
                 firstTimeActionManager = firstTimeActionManager,
-                featureFlagManager = featureFlagManager,
             )
         }
 
@@ -4508,7 +4478,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             organizationEventManager = organizationEventManager,
             networkConnectionManager = networkConnectionManager,
             firstTimeActionManager = firstTimeActionManager,
-            featureFlagManager = featureFlagManager,
         )
 
     private fun createVaultData(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16630](https://bitwarden.atlassian.net/browse/PM-16630)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

- If the user has not seen the tour in the current install/storage instance, the "Onboarding flow" feature flag is on, they are in "add item" mode, and adding a "LoginType" item: we show the action card. 
- The card is dismissed when the user interacts with it.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/15ae9abf-0871-4e03-813e-cec73b7339f6


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16630]: https://bitwarden.atlassian.net/browse/PM-16630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ