### PR TITLE
[PM-17354] feat: allow using non-numeric characters within PIN

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithPinSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenUnlockWithPinSwitch.kt
@@ -83,7 +83,6 @@ fun BitwardenUnlockWithPinSwitch(
                     onUnlockWithPinToggleAction(UnlockWithPinState.Disabled)
                     pin = ""
                 },
-                isPinCreation = true,
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
@@ -44,9 +44,6 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * @param onCancelClick A callback for when the "Cancel" button is clicked.
  * @param onSubmitClick A callback for when the "Submit" button is clicked.
  * @param onDismissRequest A callback for when the dialog is requesting to be dismissed.
- * @param isPinCreation A flag for determining if the dialog is being used for PIN creation. We
- * want to restrict PINs to numeric values but also support any existing PINs with non-numeric
- * characters.
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Suppress("LongMethod")
@@ -55,7 +52,6 @@ fun PinInputDialog(
     onCancelClick: () -> Unit,
     onSubmitClick: (String) -> Unit,
     onDismissRequest: () -> Unit,
-    isPinCreation: Boolean = false,
 ) {
     var pin by remember { mutableStateOf(value = "") }
     Dialog(
@@ -112,10 +108,8 @@ fun PinInputDialog(
                     label = stringResource(id = R.string.pin),
                     value = pin,
                     autoFocus = true,
-                    onValueChange = { newValue ->
-                        pin = newValue.filter { it.isDigit() || !isPinCreation }
-                    },
-                    keyboardType = KeyboardType.Number,
+                    onValueChange = { },
+                    keyboardType = KeyboardType.Password,
                     textFieldTestTag = "AlertInputField",
                     cardStyle = CardStyle.Full,
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Relates to https://community.bitwarden.com/t/mobile-support-for-alphanumeric-pin-codes/27671

## 🎟️ Tracking

https://community.bitwarden.com/t/mobile-support-for-alphanumeric-pin-codes/27671

## 📔 Objective

As there are quite some feature requests to allow using non-numeric characters within the PIN, I thought I give it a shot and propose my desired change as a PR. Please bear with me if this violates one of your processes - I'm happy to learn and adapt 🙂

## 📸 Screenshots

It's just the same, just with the keyboard offering all characters.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
