### PR TITLE
[PM-17405] Add mutual TLS feature flag

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -39,6 +39,7 @@ sealed class FlagKey<out T : Any> {
                 NewDevicePermanentDismiss,
                 NewDeviceTemporaryDismiss,
                 IgnoreEnvironmentCheck,
+                MutualTls,
             )
         }
     }
@@ -167,6 +168,15 @@ sealed class FlagKey<out T : Any> {
      */
     data object IgnoreEnvironmentCheck : FlagKey<Boolean>() {
         override val keyName: String = "ignore-environment-check"
+        override val defaultValue: Boolean = false
+        override val isRemotelyConfigured: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for the Mutual TLS feature.
+     */
+    data object MutualTls : FlagKey<Boolean>() {
+        override val keyName: String = "mutual-tls"
         override val defaultValue: Boolean = false
         override val isRemotelyConfigured: Boolean = false
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -38,6 +38,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.NewDevicePermanentDismiss,
     FlagKey.NewDeviceTemporaryDismiss,
     FlagKey.IgnoreEnvironmentCheck,
+    FlagKey.MutualTls,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
         key = flagKey as FlagKey<Boolean>,
@@ -90,4 +91,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.NewDevicePermanentDismiss -> stringResource(R.string.new_device_permanent_dismiss)
     FlagKey.NewDeviceTemporaryDismiss -> stringResource(R.string.new_device_temporary_dismiss)
     FlagKey.IgnoreEnvironmentCheck -> stringResource(R.string.ignore_environment_check)
+    FlagKey.MutualTls -> stringResource(R.string.mutual_tls)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1120,4 +1120,5 @@ Do you want to switch to this account?</string>
   <string name="you_ll_only_need_to_set_up_authenticator_key">You’ll only need to set up Authenticator Key for logins that require two-factor authentication with a code. The key will continuously generate six-digit codes you can use to log in.</string>
   <string name="coachmark_3_of_3">3 of 3</string>
   <string name="you_must_add_a_web_address_to_use_autofill_to_access_this_account">You must add a web address to use autofill to access this account.</string>
+  <string name="mutual_tls">Mutual TLS</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -120,6 +120,7 @@ private val DEFAULT_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.NewDeviceTemporaryDismiss to true,
     FlagKey.NewDevicePermanentDismiss to true,
     FlagKey.IgnoreEnvironmentCheck to true,
+    FlagKey.MutualTls to true,
 )
 
 private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
@@ -136,6 +137,7 @@ private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.NewDeviceTemporaryDismiss to false,
     FlagKey.NewDevicePermanentDismiss to false,
     FlagKey.IgnoreEnvironmentCheck to false,
+    FlagKey.MutualTls to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17405

## 📔 Objective

Adds a new feature flag for mutual TLS.

This commit introduces a new feature flag named `mutual-tls` that can be used to enable or disable mutual TLS authentication. It also includes necessary UI elements to interact with the flag in the debug menu.

## 📸 Screenshots

<img width="377" alt="image" src="https://github.com/user-attachments/assets/c298d325-d1f5-410d-9532-0a389d9bce37" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
