### PR TITLE
PM-16621 add explore generator card to be able to trigger coach marks

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
@@ -97,7 +97,7 @@ class MainActivity : AppCompatActivity() {
                 }
             }
             updateScreenCapture(isScreenCaptureAllowed = state.isScreenCaptureAllowed)
-            LocalManagerProvider {
+             LocalManagerProvider {
                 BitwardenTheme(theme = state.theme) {
                     RootNavScreen(
                         onSplashScreenRemoved = { shouldShowSplashScreen = false },

--- a/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
@@ -97,7 +97,7 @@ class MainActivity : AppCompatActivity() {
                 }
             }
             updateScreenCapture(isScreenCaptureAllowed = state.isScreenCaptureAllowed)
-             LocalManagerProvider {
+            LocalManagerProvider {
                 BitwardenTheme(theme = state.theme) {
                     RootNavScreen(
                         onSplashScreenRemoved = { shouldShowSplashScreen = false },

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -356,4 +356,19 @@ interface SettingsDiskSource {
      * Stores the given [count] completed create send actions for the device.
      */
     fun storeCreateSendActionCount(count: Int?)
+
+    /**
+     * Gets the Boolean value of if the Generator CoachMark tour has been interacted with.
+     */
+    fun getHasSeenGeneratorCoachMark(): Boolean?
+
+    /**
+     * Stores a value for if the Generator CoachMark tour has been interacted with
+     */
+    fun storeHasSeenGeneratorCoachMark(hasSeen: Boolean?)
+
+    /**
+     * Returns an [Flow] to observe updates to the "HasSeenGeneratorCoachMark" value.
+     */
+    fun getHasSeenGeneratorCoachMarkFlow(): Flow<Boolean?>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -10,7 +10,6 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppThem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.onSubscription
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.Instant
 
@@ -40,6 +39,7 @@ private const val IS_VAULT_REGISTERED_FOR_EXPORT = "isVaultRegisteredForExport"
 private const val ADD_ACTION_COUNT = "addActionCount"
 private const val COPY_ACTION_COUNT = "copyActionCount"
 private const val CREATE_ACTION_COUNT = "createActionCount"
+private const val HAS_SEEN_GENERATOR_COACH_MARK = "hasSeenGeneratorCoachMark"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -77,6 +77,8 @@ class SettingsDiskSourceImpl(
     private val mutableIsCrashLoggingEnabledFlow = bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableHasUserLoggedInOrCreatedAccountFlow = bufferedMutableSharedFlow<Boolean?>()
+
+    private val mutableHasSeenGeneratorCoachMarkFlow = bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableScreenCaptureAllowedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -181,6 +183,7 @@ class SettingsDiskSourceImpl(
         // - screen capture allowed
         // - show autofill setting badge
         // - show unlock setting badge
+        // - has seen generator coach mark
     }
 
     override fun getAccountBiometricIntegrityValidity(
@@ -481,6 +484,22 @@ class SettingsDiskSourceImpl(
             value = count,
         )
     }
+
+    override fun getHasSeenGeneratorCoachMark(): Boolean? =
+        getBoolean(key = HAS_SEEN_GENERATOR_COACH_MARK)
+
+    override fun storeHasSeenGeneratorCoachMark(hasSeen: Boolean?) {
+        putBoolean(
+            key = HAS_SEEN_GENERATOR_COACH_MARK,
+            value = hasSeen,
+        )
+        mutableHasSeenGeneratorCoachMarkFlow.tryEmit(hasSeen)
+    }
+
+    override fun getHasSeenGeneratorCoachMarkFlow(): Flow<Boolean?> =
+        mutableHasSeenGeneratorCoachMarkFlow.onSubscription {
+            emit(getHasSeenGeneratorCoachMark())
+        }
 
     private fun getMutableLastSyncFlow(
         userId: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManager.kt
@@ -40,6 +40,12 @@ interface FirstTimeActionManager {
     val firstTimeStateFlow: Flow<FirstTimeState>
 
     /**
+     * Returns observable flow of if a user on the device has seen the Generator screen
+     * coach mark tour.
+     */
+    val hasSeenGeneratorCoachMarkFlow: Flow<Boolean>
+
+    /**
      * Get the current [FirstTimeState] of the active user if available, otherwise return
      * a default configuration.
      */
@@ -66,4 +72,9 @@ interface FirstTimeActionManager {
      * Update the value of the showImportLoginsSettingsBadge status for the active user.
      */
     fun storeShowImportLoginsSettingsBadge(showBadge: Boolean)
+
+    /**
+     * Can be called to indicate that a user has seen the Generator coach mark tour.
+     */
+    fun hasSeenGeneratorCoachMarkTour()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -154,6 +154,12 @@ class FirstTimeActionManagerImpl @Inject constructor(
             }
             .distinctUntilChanged()
 
+    override val hasSeenGeneratorCoachMarkFlow: Flow<Boolean>
+        get() = settingsDiskSource
+            .getHasSeenGeneratorCoachMarkFlow()
+            .map { it ?: false }
+            .distinctUntilChanged()
+
     /**
      * Get the current [FirstTimeState] of the active user if available, otherwise return
      * a default configuration.
@@ -209,6 +215,10 @@ class FirstTimeActionManagerImpl @Inject constructor(
             userId = activeUserId,
             showBadge = showBadge,
         )
+    }
+
+    override fun hasSeenGeneratorCoachMarkTour() {
+        settingsDiskSource.storeHasSeenGeneratorCoachMark(hasSeen = true)
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -158,6 +158,11 @@ class FirstTimeActionManagerImpl @Inject constructor(
         get() = settingsDiskSource
             .getHasSeenGeneratorCoachMarkFlow()
             .map { it ?: false }
+            .combine(
+                featureFlagManager.getFeatureFlagFlow(FlagKey.OnboardingFlow),
+            ) { hasSeenTour, featureFlagEnabled ->
+                hasSeenTour || !featureFlagEnabled
+            }
             .distinctUntilChanged()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -44,6 +44,7 @@ import com.x8bit.bitwarden.ui.platform.components.appbar.action.OverflowMenuItem
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
+import com.x8bit.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordField
@@ -317,6 +318,20 @@ private fun ScrollContent(
             )
 
             Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        if (state.shouldShowExploreGeneratorCard) {
+            BitwardenActionCard(
+                cardTitle = stringResource(R.string.explore_the_generator),
+                cardSubtitle = stringResource(
+                    R.string.learn_more_about_generating_secure_login_credentials_with_guided_tour,
+                ),
+                actionText = stringResource(R.string.get_started),
+                onActionClick = passwordHandlers.onGeneratorActionCardClicked,
+                onDismissClick = passwordHandlers.onGeneratorActionCardDismissed,
+                modifier = Modifier.standardHorizontalMargin(),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
         }
 
         GeneratedStringItem(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -329,7 +329,9 @@ private fun ScrollContent(
                 actionText = stringResource(R.string.get_started),
                 onActionClick = passwordHandlers.onGeneratorActionCardClicked,
                 onDismissClick = passwordHandlers.onGeneratorActionCardDismissed,
-                modifier = Modifier.standardHorizontalMargin(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
             )
             Spacer(modifier = Modifier.height(24.dp))
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/handlers/PasswordHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/handlers/PasswordHandlers.kt
@@ -20,6 +20,8 @@ data class PasswordHandlers(
     val onPasswordMinNumbersCounterChange: (Int) -> Unit,
     val onPasswordMinSpecialCharactersChange: (Int) -> Unit,
     val onPasswordToggleAvoidAmbiguousCharsChange: (Boolean) -> Unit,
+    val onGeneratorActionCardClicked: () -> Unit,
+    val onGeneratorActionCardDismissed: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -27,6 +29,7 @@ data class PasswordHandlers(
          * Creates an instance of [PasswordHandlers] by binding actions to the provided
          * [GeneratorViewModel].
          */
+        @Suppress("LongMethod")
         fun create(
             viewModel: GeneratorViewModel,
         ): PasswordHandlers = PasswordHandlers(
@@ -85,6 +88,16 @@ data class PasswordHandlers(
                     GeneratorAction.MainType.Password.ToggleAvoidAmbiguousCharactersChange(
                         avoidAmbiguousChars = shouldAvoidAmbiguousChars,
                     ),
+                )
+            },
+            onGeneratorActionCardDismissed = {
+                viewModel.trySendAction(
+                    GeneratorAction.ExploreGeneratorCardDismissed,
+                )
+            },
+            onGeneratorActionCardClicked = {
+                viewModel.trySendAction(
+                    GeneratorAction.StartExploreGeneratorTour,
                 )
             },
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1114,11 +1114,13 @@ Do you want to switch to this account?</string>
   <string name="you_can_change_your_account_email_on_the_bitwarden_web_app">You can change your account email on the Bitwarden web app.</string>
   <string name="login_credentials">Login Credentials</string>
   <string name="autofill_options">Autofill Options</string>
-    <string name="use_this_button_to_generate_a_new_unique_password">Use this button to generate a new unique password.</string>
+  <string name="use_this_button_to_generate_a_new_unique_password">Use this button to generate a new unique password.</string>
   <string name="coachmark_1_of_3">1 of 3</string>
   <string name="coachmark_2_of_3">2 of 3</string>
   <string name="you_ll_only_need_to_set_up_authenticator_key">You’ll only need to set up Authenticator Key for logins that require two-factor authentication with a code. The key will continuously generate six-digit codes you can use to log in.</string>
   <string name="coachmark_3_of_3">3 of 3</string>
   <string name="you_must_add_a_web_address_to_use_autofill_to_access_this_account">You must add a web address to use autofill to access this account.</string>
   <string name="mutual_tls">Mutual TLS</string>
+  <string name="explore_the_generator">Explore the generator</string>
+  <string name="learn_more_about_generating_secure_login_credentials_with_guided_tour">Learn more about generating secure login credentials with a guided tour.</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1239,4 +1239,34 @@ class SettingsDiskSourceTest {
         settingsDiskSource.storeCreateSendActionCount(count = 1)
         assertEquals(1, fakeSharedPreferences.getInt(createActionCountKey, 0))
     }
+
+    @Test
+    fun `getHasSeenGeneratorCoachMark should pull value from SharedPreferences`() {
+        val hasSeenGeneratorCoachMarkKey = "bwPreferencesStorage:hasSeenGeneratorCoachMark"
+        fakeSharedPreferences.edit { putBoolean(hasSeenGeneratorCoachMarkKey, true) }
+        assertTrue(settingsDiskSource.getHasSeenGeneratorCoachMark() == true)
+    }
+
+    @Test
+    fun `storeHasSeenGeneratorCoachMark should update SharedPreferences`() {
+        val hasSeenGeneratorCoachMarkKey = "bwPreferencesStorage:hasSeenGeneratorCoachMark"
+        settingsDiskSource.storeHasSeenGeneratorCoachMark(hasSeen = true)
+        assertTrue(
+            fakeSharedPreferences.getBoolean(
+                key = hasSeenGeneratorCoachMarkKey,
+                defaultValue = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `getHasSeenGeneratorCoachMarkFlow emits changes to stored value`() = runTest {
+        settingsDiskSource.getHasSeenGeneratorCoachMarkFlow().test {
+            assertNull(awaitItem())
+            settingsDiskSource.storeHasSeenGeneratorCoachMark(hasSeen = false)
+            assertFalse(awaitItem() ?: true)
+            settingsDiskSource.storeHasSeenGeneratorCoachMark(hasSeen = true)
+            assertTrue(awaitItem() ?: false)
+        }
+    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -42,6 +42,8 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val mutableScreenCaptureAllowedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
+    private val mutableHasSeenGeneratorCoachMarkFlow = bufferedMutableSharedFlow<Boolean?>()
+
     private var storedAppTheme: AppTheme = AppTheme.DEFAULT
     private val storedLastSyncTime = mutableMapOf<String, Instant?>()
     private val storedVaultTimeoutActions = mutableMapOf<String, VaultTimeoutAction?>()
@@ -68,6 +70,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private var addCipherActionCount: Int? = null
     private var generatedActionCount: Int? = null
     private var createSendActionCount: Int? = null
+    private var hasSeenGeneratorCoachMark: Boolean? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -379,6 +382,19 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     override fun storeCreateSendActionCount(count: Int?) {
         createSendActionCount = count
     }
+
+    override fun getHasSeenGeneratorCoachMark(): Boolean? =
+        hasSeenGeneratorCoachMark
+
+    override fun storeHasSeenGeneratorCoachMark(hasSeen: Boolean?) {
+        hasSeenGeneratorCoachMark = hasSeen
+        mutableHasSeenGeneratorCoachMarkFlow.tryEmit(hasSeen)
+    }
+
+    override fun getHasSeenGeneratorCoachMarkFlow(): Flow<Boolean?> =
+        mutableHasSeenGeneratorCoachMarkFlow.onSubscription {
+            emit(hasSeenGeneratorCoachMark)
+        }
 
     //region Private helper functions
     private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
@@ -295,6 +296,23 @@ class FirstTimeActionManagerTest {
                 awaitItem(),
             )
         }
+    }
+
+    @Test
+    fun `hasSeenGeneratorCoachMarkFlow updates when disk source updates`() = runTest {
+        firstTimeActionManager.hasSeenGeneratorCoachMarkFlow.test {
+            // null will be mapped to false
+            assertFalse(awaitItem())
+            fakeSettingsDiskSource.storeHasSeenGeneratorCoachMark(hasSeen = true)
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `hasSeenGeneratorCoachMarkTour sets the value to true in the disk source`() {
+        assertNull(fakeSettingsDiskSource.getHasSeenGeneratorCoachMark())
+        firstTimeActionManager.hasSeenGeneratorCoachMarkTour()
+        assertTrue(fakeSettingsDiskSource.getHasSeenGeneratorCoachMark() == true)
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -10,9 +10,11 @@ import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasAnySibling
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasProgressBarRangeInfo
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onChildren
@@ -1521,6 +1523,89 @@ class GeneratorScreenTest : BaseComposeTest() {
         verify { viewModel.trySendAction(GeneratorAction.LifecycleResume) }
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Explore generator card shows when default mode and hasSeenExploreGeneratorCard is false`() {
+        updateState(
+            state = DEFAULT_STATE.copy(hasSeenExploreGeneratorCard = false),
+        )
+        composeTestRule
+            .onNodeWithText("Explore the generator")
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Explore generator card does not show when default mode and hasSeenExploreGeneratorCard is true`() {
+        updateState(
+            state = DEFAULT_STATE.copy(hasSeenExploreGeneratorCard = true),
+        )
+        composeTestRule
+            .onNodeWithText("Explore the generator")
+            .assertDoesNotExist()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Explore generator card does not show when modal mode and hasSeenExploreGeneratorCard is false`() {
+        updateState(
+            state = DEFAULT_STATE.copy(
+                hasSeenExploreGeneratorCard = true,
+                generatorMode = GeneratorMode.Modal.Password,
+            ),
+        )
+        composeTestRule
+            .onNodeWithText("Explore the generator")
+            .assertDoesNotExist()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Explore generator card does not when default mode, hasSeenExploreGeneratorCard is false, and main type is not password`() {
+        updateState(
+            state = DEFAULT_STATE.copy(
+                hasSeenExploreGeneratorCard = true,
+                generatorMode = GeneratorMode.Modal.Password,
+                selectedType = GeneratorState.MainType.Username(),
+            ),
+        )
+        composeTestRule
+            .onNodeWithText("Explore the generator")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `Clicking close button on generator card send ExploreGeneratorCardDismissed action`() {
+        updateState(
+            state = DEFAULT_STATE.copy(hasSeenExploreGeneratorCard = false),
+        )
+        composeTestRule
+            .onNode(
+                hasContentDescription("Close")
+                    and hasAnySibling(hasText("Explore the generator")),
+            )
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(GeneratorAction.ExploreGeneratorCardDismissed)
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Clicking call to action button on generator card send StartExploreGeneratorTour action`() {
+        updateState(
+            state = DEFAULT_STATE.copy(hasSeenExploreGeneratorCard = false),
+        )
+        composeTestRule
+            .onNodeWithText("Get started")
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(GeneratorAction.StartExploreGeneratorTour)
+        }
+    }
+
     //endregion Random Word Tests
 
     private fun updateState(state: GeneratorState) {
@@ -1532,4 +1617,5 @@ private val DEFAULT_STATE = GeneratorState(
     generatedText = "",
     selectedType = GeneratorState.MainType.Password(),
     currentEmailAddress = "currentEmail",
+    hasSeenExploreGeneratorCard = true,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -8,13 +8,11 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratedCatchAllUsernameResult
@@ -121,13 +119,6 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         every { hasSeenGeneratorCoachMarkFlow } returns mutableHasSeenGeneratorCoachMarkFlow
     }
 
-    private val mutableOnboardFlowFeatureFlagFlow = MutableStateFlow(false)
-    private val featureFlagManager: FeatureFlagManager = mockk {
-        every {
-            getFeatureFlagFlow(FlagKey.OnboardingFlow)
-        } returns mutableOnboardFlowFeatureFlagFlow
-    }
-
     @Test
     fun `initial state should be correct when there is no saved state`() {
         val viewModel = createViewModel(state = null)
@@ -158,7 +149,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
             currentEmailAddress = "currentEmail",
             isUnderPolicy = false,
             website = "",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
         val viewModel = createViewModel(
@@ -194,7 +185,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
             currentEmailAddress = "currentEmail",
             isUnderPolicy = false,
             website = null,
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
         val viewModel = createViewModel(
@@ -2182,20 +2173,9 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         assertEquals(10, password.computedMinimumLength)
     }
 
-    @Test
-    fun `when OnboardFlow feature flag is off, shouldShowExploreGeneratorCard should be false`() {
-        mutableOnboardFlowFeatureFlagFlow.update { true }
-        val viewModel = createViewModel()
-        assertTrue(viewModel.stateFlow.value.shouldShowExploreGeneratorCard)
-
-        mutableOnboardFlowFeatureFlagFlow.update { false }
-        assertFalse(viewModel.stateFlow.value.shouldShowExploreGeneratorCard)
-    }
-
     @Suppress("MaxLineLength")
     @Test
     fun `when first time action manager has seen generator tour value updates to true shouldShowExploreGeneratorCard should update to false`() {
-        mutableOnboardFlowFeatureFlagFlow.update { true }
         val viewModel = createViewModel()
         assertTrue(viewModel.stateFlow.value.shouldShowExploreGeneratorCard)
         mutableHasSeenGeneratorCoachMarkFlow.update { true }
@@ -2205,7 +2185,6 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `shouldShowExploreGeneratorCard value should be false if generator screen is in modal mode`() {
-        mutableOnboardFlowFeatureFlagFlow.update { true }
         mutableHasSeenGeneratorCoachMarkFlow.update { false }
         val viewModel = createViewModel(
             savedStateHandle = createSavedStateHandleWithState(
@@ -2222,7 +2201,6 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `shouldShowExploreGeneratorCard value should be false if generator screen selected type is not password`() {
-        mutableOnboardFlowFeatureFlagFlow.update { true }
         mutableHasSeenGeneratorCoachMarkFlow.update { false }
         val viewModel = createViewModel(
             savedStateHandle = createSavedStateHandleWithState(
@@ -2278,7 +2256,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 avoidAmbiguousChars = avoidAmbiguousChars,
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createPassphraseState(
@@ -2297,7 +2275,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 includeNumber = includeNumber,
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createUsernameModeState(
@@ -2313,7 +2291,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createForwardedEmailAliasState(
@@ -2329,7 +2307,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createAddyIoState(
@@ -2344,7 +2322,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createDuckDuckGoState(
@@ -2359,7 +2337,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createFastMailState(
@@ -2374,7 +2352,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createFirefoxRelayState(
@@ -2389,7 +2367,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createForwardEmailState(
@@ -2404,7 +2382,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createSimpleLoginState(
@@ -2419,7 +2397,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createPlusAddressedEmailState(
@@ -2434,7 +2412,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createCatchAllEmailState(
@@ -2449,7 +2427,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createRandomWordState(
@@ -2466,7 +2444,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
                 ),
             ),
             currentEmailAddress = "currentEmail",
-            hasSeenExploreGeneratorCard = true,
+            hasSeenExploreGeneratorCard = false,
         )
 
     private fun createSavedStateHandleWithState(state: GeneratorState) =
@@ -2484,7 +2462,6 @@ class GeneratorViewModelTest : BaseViewModelTest() {
         policyManager = policyManager,
         reviewPromptManager = reviewPromptManager,
         firstTimeActionManager = firstTimeActionManager,
-        featureFlagManager = featureFlagManager,
     )
 
     private fun createViewModel(


### PR DESCRIPTION
## 🎟️ Tracking
[PM-16621](https://bitwarden.atlassian.net/browse/PM-16621)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Show the action card when necessary
- Once card has been interacted with store that value and don't show the card anymore.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/a141736f-83a0-4a02-b600-9b438cd7f8fb


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16621]: https://bitwarden.atlassian.net/browse/PM-16621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ