### PR TITLE
PM-14179: Update internal placement of test tags for the BitwardenTextField

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -224,7 +224,6 @@ fun BitwardenTextField(
         Box(modifier = modifier.defaultMinSize(minHeight = 60.dp)) {
             Column(
                 modifier = Modifier
-                    .testTag(textFieldTestTag.orEmpty())
                     .onGloballyPositioned { widthPx = it.size.width }
                     .onFocusEvent { focusState -> hasFocused = focusState.hasFocus }
                     .focusRequester(focusRequester)
@@ -269,7 +268,9 @@ fun BitwardenTextField(
                     keyboardOptions = KeyboardOptions.Default.copy(keyboardType = keyboardType),
                     isError = isError,
                     visualTransformation = visualTransformation,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .run { textFieldTestTag?.let { testTag(tag = it) } ?: this }
+                        .fillMaxWidth(),
                 )
                 supportingTextContent?.let {
                     Spacer(modifier = Modifier.height(height = 8.dp))


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14179](https://bitwarden.atlassian.net/browse/PM-14179)

## 📔 Objective

This PR moves the test tag on the `BitwardenTextField` to the actual `TextField` instead of the wrapping component. THis should fix some issue with automation.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14179]: https://bitwarden.atlassian.net/browse/PM-14179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ