### PR TITLE
PM-17410: Update password hint font

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
@@ -243,7 +243,7 @@ private fun LoginScreenContent(
                 BitwardenClickableText(
                     label = stringResource(id = R.string.get_master_passwordword_hint),
                     onClick = onMasterPasswordClick,
-                    style = BitwardenTheme.typography.bodySmall,
+                    style = BitwardenTheme.typography.labelMedium,
                     innerPadding = PaddingValues(
                         top = 8.dp,
                         bottom = 8.dp,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17410](https://bitwarden.atlassian.net/browse/PM-17410)

## 📔 Objective

This PR updates the font on the `Get master password hint` button.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/f17709c9-8270-49b6-8f48-250fce8bec58" width="300" /> | <img src="https://github.com/user-attachments/assets/50c535b6-b746-4c3f-af07-d7bfb8d47321" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17410]: https://bitwarden.atlassian.net/browse/PM-17410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ