### PR TITLE
[PM-16961] Fix opening vault item URLs with no scheme

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -150,7 +150,17 @@ class IntentManagerImpl(
             }
         } else {
             val newUri = if (uri.scheme == null) {
-                uri.buildUpon().scheme("https").build()
+                // Host can be mistaken as path if scheme is not set and URI does not start with "//".
+                if (uri.authority == null && uri.path != null) {
+                    uri
+                        .buildUpon()
+                        .scheme("https")
+                        .authority(uri.pathSegments[0])
+                        .path(uri.path!!.removePrefix(uri.pathSegments[0]))
+                        .build()
+                } else {
+                    uri.buildUpon().scheme("https").build()
+                }
             } else {
                 uri.normalizeScheme()
             }


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/android/issues/4552

## 📔 Objective

This PR fixes an issue where vault item URLs entered without a scheme and not starting with `//` (e.g. `github.com`) may not open properly on some browsers. Technically this is not a bug but is due to the way URIs are parsed per the [RFC](https://www.rfc-editor.org/rfc/rfc2396), which treats the above example as a path instead of a host name. So the URL that's actually sent in the intent becomes `https:/github.com`.

The proposed solution should work well with all the different ways of typing a URL: `https://github.com`, `//github.com`, and `github.com`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
