### PR TITLE
PM-17409: Allow nullable labels text fields

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreen.kt
@@ -141,7 +141,7 @@ private fun MasterPasswordGeneratorContent(
     ) {
         Spacer(modifier = Modifier.height(height = 12.dp))
         BitwardenTextField(
-            label = "",
+            label = null,
             value = generatedPassword,
             onValueChange = {},
             readOnly = true,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenHiddenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenHiddenPasswordField.kt
@@ -28,7 +28,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  */
 @Composable
 fun BitwardenHiddenPasswordField(
-    label: String,
+    label: String?,
     value: String,
     modifier: Modifier = Modifier,
     cardStyle: CardStyle? = null,
@@ -39,7 +39,7 @@ fun BitwardenHiddenPasswordField(
                 .cardBackground(cardStyle = cardStyle)
                 .cardPadding(cardStyle = cardStyle, vertical = 6.dp),
             textStyle = BitwardenTheme.typography.sensitiveInfoSmall,
-            label = { Text(text = label) },
+            label = label?.let { { Text(text = it) } },
             value = value,
             onValueChange = { },
             visualTransformation = PasswordVisualTransformation(),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -76,10 +76,10 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
  * @param cardStyle Indicates the type of card style to be applied.
  */
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun BitwardenPasswordField(
-    label: String,
+    label: String?,
     value: String,
     showPassword: Boolean,
     showPasswordChange: (Boolean) -> Unit,
@@ -129,7 +129,7 @@ fun BitwardenPasswordField(
             TextField(
                 colors = bitwardenTextFieldColors(),
                 textStyle = BitwardenTheme.typography.sensitiveInfoSmall,
-                label = { Text(text = label) },
+                label = label?.let { { Text(text = it) } },
                 value = textFieldValue,
                 onValueChange = {
                     textFieldValueState = it
@@ -215,7 +215,7 @@ fun BitwardenPasswordField(
  */
 @Composable
 fun BitwardenPasswordField(
-    label: String,
+    label: String?,
     value: String,
     showPassword: Boolean,
     showPasswordChange: (Boolean) -> Unit,
@@ -289,7 +289,7 @@ fun BitwardenPasswordField(
  */
 @Composable
 fun BitwardenPasswordField(
-    label: String,
+    label: String?,
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -351,7 +351,7 @@ fun BitwardenPasswordField(
  */
 @Composable
 fun BitwardenPasswordField(
-    label: String,
+    label: String?,
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordFieldWithActions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordFieldWithActions.kt
@@ -59,7 +59,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  */
 @Composable
 fun BitwardenPasswordFieldWithActions(
-    label: String,
+    label: String?,
     value: String,
     showPassword: Boolean,
     showPasswordChange: (Boolean) -> Unit,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -44,7 +44,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  */
 @Composable
 fun BitwardenStepper(
-    label: String,
+    label: String?,
     value: Int?,
     onValueChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -101,7 +101,7 @@ fun BitwardenStepper(
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun BitwardenStepper(
-    label: String,
+    label: String?,
     value: Int?,
     onValueChange: (Int) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -1017,7 +1017,7 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
         null -> {
             var obfuscatedTextField by remember { mutableStateOf("") }
             BitwardenPasswordField(
-                label = "",
+                label = null,
                 value = obfuscatedTextField,
                 onValueChange = { obfuscatedTextField = it },
                 showPasswordTestTag = "ShowForwardedEmailApiSecretButton",


### PR DESCRIPTION
## 🎟️ Tracking

PM-17409

## 📔 Objective

This PR allows the various text fields to have a null label. When the label is null, the content will be centered more appropriately that when the label is present but empty.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/8ecd86b0-5de2-4604-a337-d4b12b1e503a" width="300" /> | <img src="https://github.com/user-attachments/assets/fe3a1b9a-ab87-43c8-9012-d7e885d3dcf7" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
