### PR TITLE
Update BitwardenPasswordField TestTags

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreen.kt
@@ -255,9 +255,9 @@ private fun CompleteRegistrationContent(
                     modifier = Modifier.fillMaxWidth(),
                 )
             },
+            passwordFieldTestTag = "MasterPasswordEntry",
             cardStyle = CardStyle.Top(dividerPadding = 0.dp),
             modifier = Modifier
-                .testTag("MasterPasswordEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
         )
@@ -272,9 +272,9 @@ private fun CompleteRegistrationContent(
             showPasswordChange = { showPassword = it },
             onValueChange = handler.onConfirmPasswordInputChange,
             showPasswordTestTag = "ConfirmPasswordVisibilityToggle",
+            passwordFieldTestTag = "ConfirmMasterPasswordEntry",
             cardStyle = CardStyle.Middle(dividerPadding = 0.dp),
             modifier = Modifier
-                .testTag("ConfirmMasterPasswordEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
@@ -219,9 +219,9 @@ fun CreateAccountScreen(
                         color = BitwardenTheme.colorScheme.text.secondary,
                     )
                 },
+                passwordFieldTestTag = "MasterPasswordEntry",
                 cardStyle = CardStyle.Top(dividerPadding = 0.dp),
                 modifier = Modifier
-                    .testTag("MasterPasswordEntry")
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
             )
@@ -234,9 +234,9 @@ fun CreateAccountScreen(
                     { viewModel.trySendAction(ConfirmPasswordInputChange(it)) }
                 },
                 showPasswordTestTag = "ConfirmPasswordVisibilityToggle",
+                passwordFieldTestTag = "ConfirmMasterPasswordEntry",
                 cardStyle = CardStyle.Middle(dividerPadding = 0.dp),
                 modifier = Modifier
-                    .testTag("ConfirmMasterPasswordEntry")
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreen.kt
@@ -105,10 +105,10 @@ private fun RemovePasswordScreenContent(
             value = state.input,
             onValueChange = onInputChanged,
             showPasswordTestTag = "PasswordVisibilityToggle",
+            textFieldTestTag = "MasterPasswordEntry",
             autoFocus = true,
             cardStyle = CardStyle.Full,
             modifier = Modifier
-                .testTag(tag = "MasterPasswordEntry")
                 .standardHorizontalMargin()
                 .fillMaxWidth(),
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordScreen.kt
@@ -185,9 +185,9 @@ private fun ResetPasswordScreenContent(
                 label = stringResource(id = R.string.current_master_password),
                 value = state.currentPasswordInput,
                 onValueChange = onCurrentPasswordInputChanged,
+                textFieldTestTag = "MasterPasswordField",
                 cardStyle = CardStyle.Top(dividerPadding = 0.dp),
                 modifier = Modifier
-                    .testTag("MasterPasswordField")
                     .standardHorizontalMargin()
                     .fillMaxWidth(),
             )
@@ -200,6 +200,7 @@ private fun ResetPasswordScreenContent(
             onValueChange = onPasswordInputChanged,
             showPassword = isPasswordVisible,
             showPasswordChange = { isPasswordVisible = it },
+            passwordFieldTestTag = "NewPasswordField",
             cardStyle = if (
                 state.resetReason == ForcePasswordResetReason.WEAK_MASTER_PASSWORD_ON_LOGIN) {
                 CardStyle.Middle(dividerPadding = 0.dp)
@@ -207,7 +208,6 @@ private fun ResetPasswordScreenContent(
                 CardStyle.Top(dividerPadding = 0.dp)
             },
             modifier = Modifier
-                .testTag("NewPasswordField")
                 .standardHorizontalMargin()
                 .fillMaxWidth(),
         )
@@ -218,9 +218,9 @@ private fun ResetPasswordScreenContent(
             onValueChange = onRetypePasswordInputChanged,
             showPassword = isPasswordVisible,
             showPasswordChange = { isPasswordVisible = it },
+            passwordFieldTestTag = "RetypePasswordField",
             cardStyle = CardStyle.Middle(dividerPadding = 0.dp),
             modifier = Modifier
-                .testTag("RetypePasswordField")
                 .standardHorizontalMargin()
                 .fillMaxWidth(),
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreen.kt
@@ -146,9 +146,9 @@ private fun SetPasswordScreenContent(
             showPassword = isPasswordVisible,
             showPasswordChange = { isPasswordVisible = it },
             supportingText = stringResource(id = R.string.master_password_description),
+            passwordFieldTestTag = "NewPasswordField",
             cardStyle = CardStyle.Top(dividerPadding = 0.dp),
             modifier = Modifier
-                .testTag("NewPasswordField")
                 .standardHorizontalMargin()
                 .fillMaxWidth(),
         )
@@ -159,9 +159,9 @@ private fun SetPasswordScreenContent(
             onValueChange = onRetypePasswordInputChanged,
             showPassword = isPasswordVisible,
             showPasswordChange = { isPasswordVisible = it },
+            passwordFieldTestTag = "RetypePasswordField",
             cardStyle = CardStyle.Middle(dividerPadding = 0.dp),
             modifier = Modifier
-                .testTag("RetypePasswordField")
                 .standardHorizontalMargin()
                 .fillMaxWidth(),
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -270,9 +270,9 @@ fun VaultUnlockScreen(
                         },
                     ),
                     supportingText = state.vaultUnlockType.unlockScreenMessage(),
+                    textFieldTestTag = state.vaultUnlockType.unlockScreenInputTestTag,
                     cardStyle = CardStyle.Top(hasDivider = false),
                     modifier = Modifier
-                        .testTag(tag = state.vaultUnlockType.unlockScreenInputTestTag)
                         .standardHorizontalMargin()
                         .fillMaxWidth(),
                 )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenMasterPasswordDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenMasterPasswordDialog.kt
@@ -78,10 +78,9 @@ fun BitwardenMasterPasswordDialog(
                     value = masterPassword,
                     onValueChange = { masterPassword = it },
                     autoFocus = true,
+                    textFieldTestTag = "AlertInputField",
                     cardStyle = CardStyle.Full,
-                    modifier = Modifier
-                        .testTag("AlertInputField")
-                        .imePadding(),
+                    modifier = Modifier.imePadding(),
                 )
             }
         },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenPinDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenPinDialog.kt
@@ -66,9 +66,9 @@ fun BitwardenPinDialog(
                 value = pin,
                 onValueChange = { pin = it },
                 autoFocus = true,
+                textFieldTestTag = "AlertInputField",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
-                    .testTag("AlertInputField")
                     .fillMaxWidth()
                     .imePadding(),
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenHiddenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenHiddenPasswordField.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalTextToolbar
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,6 +25,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * @param label Label for the text field.
  * @param value Current text on the text field.
  * @param modifier Modifier for the composable.
+ * @param passwordFieldTestTag The optional test tag associated with the inner password field.
  * @param cardStyle Indicates the type of card style to be applied.
  */
 @Composable
@@ -31,13 +33,15 @@ fun BitwardenHiddenPasswordField(
     label: String?,
     value: String,
     modifier: Modifier = Modifier,
+    passwordFieldTestTag: String? = null,
     cardStyle: CardStyle? = null,
 ) {
     CompositionLocalProvider(value = LocalTextToolbar provides BitwardenEmptyTextToolbar) {
         TextField(
             modifier = modifier
                 .cardBackground(cardStyle = cardStyle)
-                .cardPadding(cardStyle = cardStyle, vertical = 6.dp),
+                .cardPadding(cardStyle = cardStyle, vertical = 6.dp)
+                .run { passwordFieldTestTag?.let { testTag(tag = it) } ?: this },
             textStyle = BitwardenTheme.typography.sensitiveInfoSmall,
             label = label?.let { { Text(text = it) } },
             value = value,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.TextToolbar
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -74,6 +75,7 @@ import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
  * @param imeAction the preferred IME action for the keyboard to have.
  * @param keyboardActions the callbacks of keyboard actions.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
+ * @param passwordFieldTestTag The optional test tag associated with the inner password field.
  * @param cardStyle Indicates the type of card style to be applied.
  */
 @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -94,6 +96,7 @@ fun BitwardenPasswordField(
     imeAction: ImeAction = ImeAction.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     textToolbarType: TextToolbarType = TextToolbarType.DEFAULT,
+    passwordFieldTestTag: String? = null,
     cardStyle: CardStyle? = null,
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -165,7 +168,9 @@ fun BitwardenPasswordField(
                         onClick = { showPasswordChange.invoke(!showPassword) },
                     )
                 },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .run { passwordFieldTestTag?.let { testTag(tag = it) } ?: this }
+                    .fillMaxWidth(),
             )
             supportingTextContent?.let {
                 Spacer(modifier = Modifier.height(height = 8.dp))
@@ -211,6 +216,7 @@ fun BitwardenPasswordField(
  * @param imeAction the preferred IME action for the keyboard to have.
  * @param keyboardActions the callbacks of keyboard actions.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
+ * @param passwordFieldTestTag The optional test tag associated with the inner password field.
  * @param cardStyle Indicates the type of card style to be applied.
  */
 @Composable
@@ -230,6 +236,7 @@ fun BitwardenPasswordField(
     imeAction: ImeAction = ImeAction.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     textToolbarType: TextToolbarType = TextToolbarType.DEFAULT,
+    passwordFieldTestTag: String? = null,
     cardStyle: CardStyle? = null,
 ) {
     BitwardenPasswordField(
@@ -257,6 +264,7 @@ fun BitwardenPasswordField(
         imeAction = imeAction,
         keyboardActions = keyboardActions,
         textToolbarType = textToolbarType,
+        passwordFieldTestTag = passwordFieldTestTag,
         cardStyle = cardStyle,
     )
 }
@@ -285,6 +293,7 @@ fun BitwardenPasswordField(
  * @param imeAction the preferred IME action for the keyboard to have.
  * @param keyboardActions the callbacks of keyboard actions.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
+ * @param passwordFieldTestTag The optional test tag associated with the inner password field.
  * @param cardStyle Indicates the type of card style to be applied.
  */
 @Composable
@@ -303,6 +312,7 @@ fun BitwardenPasswordField(
     imeAction: ImeAction = ImeAction.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     textToolbarType: TextToolbarType = TextToolbarType.DEFAULT,
+    passwordFieldTestTag: String? = null,
     cardStyle: CardStyle? = null,
 ) {
     var showPassword by rememberSaveable { mutableStateOf(value = initialShowPassword) }
@@ -322,6 +332,7 @@ fun BitwardenPasswordField(
         imeAction = imeAction,
         keyboardActions = keyboardActions,
         textToolbarType = textToolbarType,
+        passwordFieldTestTag = passwordFieldTestTag,
         cardStyle = cardStyle,
     )
 }
@@ -347,6 +358,7 @@ fun BitwardenPasswordField(
  * the password field.
  * @param imeAction the preferred IME action for the keyboard to have.
  * @param keyboardActions the callbacks of keyboard actions.
+ * @param textFieldTestTag The optional test tag associated with the inner text field.
  * @param cardStyle Indicates the type of card style to be applied.
  */
 @Composable
@@ -364,6 +376,7 @@ fun BitwardenPasswordField(
     keyboardType: KeyboardType = KeyboardType.Password,
     imeAction: ImeAction = ImeAction.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
+    textFieldTestTag: String? = null,
     cardStyle: CardStyle? = null,
 ) {
     var showPassword by rememberSaveable { mutableStateOf(initialShowPassword) }
@@ -382,6 +395,7 @@ fun BitwardenPasswordField(
         keyboardType = keyboardType,
         imeAction = imeAction,
         keyboardActions = keyboardActions,
+        passwordFieldTestTag = textFieldTestTag,
         cardStyle = cardStyle,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordFieldWithActions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordFieldWithActions.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.R
@@ -95,10 +94,9 @@ fun BitwardenPasswordFieldWithActions(
                 readOnly = readOnly,
                 singleLine = singleLine,
                 showPasswordTestTag = showPasswordTestTag,
+                passwordFieldTestTag = passwordFieldTestTag,
                 textToolbarType = textToolbarType,
-                modifier = Modifier
-                    .semantics { passwordFieldTestTag?.let { testTag = it } }
-                    .weight(weight = 1f),
+                modifier = Modifier.weight(weight = 1f),
             )
             BitwardenRowOfActions(
                 modifier = Modifier.padding(paddingValues = actionsPadding),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -78,6 +78,7 @@ import kotlinx.collections.immutable.toImmutableList
  * @param visualTransformation Transforms the visual representation of the input [value].
  * @param keyboardType the preferred type of keyboard input.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
+ * @param textFieldTestTag The optional test tag associated with the inner text field.
  * @param cardStyle Indicates the type of card style to be applied.
  */
 @Composable
@@ -161,6 +162,7 @@ fun BitwardenTextField(
  * @param visualTransformation Transforms the visual representation of the input [value].
  * @param keyboardType the preferred type of keyboard input.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
+ * @param textFieldTestTag The optional test tag associated with the inner text field.
  * @param cardStyle Indicates the type of card style to be applied.
  */
 @Suppress("LongMethod", "CyclomaticComplexMethod")

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreen.kt
@@ -249,9 +249,9 @@ private fun ExportVaultScreenContent(
                         modifier = Modifier.fillMaxWidth(),
                     )
                 },
+                showPasswordTestTag = "FilePasswordEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
-                    .testTag("FilePasswordEntry")
                     .standardHorizontalMargin()
                     .fillMaxWidth(),
             )
@@ -264,9 +264,9 @@ private fun ExportVaultScreenContent(
                 onValueChange = onConfirmFilePasswordInputChanged,
                 showPassword = showPassword,
                 showPasswordChange = { showPassword = it },
+                passwordFieldTestTag = "ConfirmFilePasswordEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
-                    .testTag("ConfirmFilePasswordEntry")
                     .standardHorizontalMargin()
                     .fillMaxWidth(),
             )
@@ -321,9 +321,9 @@ private fun ExportVaultScreenContent(
                 value = state.passwordInput,
                 readOnly = state.policyPreventsExport,
                 onValueChange = onPasswordInputChanged,
+                textFieldTestTag = "MasterPasswordEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
-                    .testTag("MasterPasswordEntry")
                     .standardHorizontalMargin()
                     .fillMaxWidth(),
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -910,10 +910,10 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 value = usernameTypeState.selectedServiceType.apiAccessToken,
                 onValueChange = forwardedEmailAliasHandlers.onAddyIoAccessTokenTextChange,
                 showPasswordTestTag = "ShowForwardedEmailApiSecretButton",
+                textFieldTestTag = "ForwardedEmailApiSecretEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .standardHorizontalMargin()
-                    .testTag("ForwardedEmailApiSecretEntry")
                     .fillMaxWidth(),
             )
 
@@ -937,10 +937,10 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 value = usernameTypeState.selectedServiceType.apiKey,
                 onValueChange = forwardedEmailAliasHandlers.onDuckDuckGoApiKeyTextChange,
                 showPasswordTestTag = "ShowForwardedEmailApiSecretButton",
+                textFieldTestTag = "ForwardedEmailApiSecretEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .standardHorizontalMargin()
-                    .testTag("ForwardedEmailApiSecretEntry")
                     .fillMaxWidth(),
             )
         }
@@ -951,10 +951,10 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 value = usernameTypeState.selectedServiceType.apiKey,
                 onValueChange = forwardedEmailAliasHandlers.onFastMailApiKeyTextChange,
                 showPasswordTestTag = "ShowForwardedEmailApiSecretButton",
+                textFieldTestTag = "ForwardedEmailApiSecretEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .standardHorizontalMargin()
-                    .testTag("ForwardedEmailApiSecretEntry")
                     .fillMaxWidth(),
             )
         }
@@ -965,10 +965,10 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 value = usernameTypeState.selectedServiceType.apiAccessToken,
                 onValueChange = forwardedEmailAliasHandlers.onFirefoxRelayAccessTokenTextChange,
                 showPasswordTestTag = "ShowForwardedEmailApiSecretButton",
+                textFieldTestTag = "ForwardedEmailApiSecretEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .standardHorizontalMargin()
-                    .testTag("ForwardedEmailApiSecretEntry")
                     .fillMaxWidth(),
             )
         }
@@ -979,10 +979,10 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 value = usernameTypeState.selectedServiceType.apiKey,
                 onValueChange = forwardedEmailAliasHandlers.onForwardEmailApiKeyTextChange,
                 showPasswordTestTag = "ShowForwardedEmailApiSecretButton",
+                textFieldTestTag = "ForwardedEmailApiSecretEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .standardHorizontalMargin()
-                    .testTag("ForwardedEmailApiSecretEntry")
                     .fillMaxWidth(),
             )
 
@@ -1006,10 +1006,10 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 value = usernameTypeState.selectedServiceType.apiKey,
                 onValueChange = forwardedEmailAliasHandlers.onSimpleLoginApiKeyTextChange,
                 showPasswordTestTag = "ShowForwardedEmailApiSecretButton",
+                textFieldTestTag = "ForwardedEmailApiSecretEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .standardHorizontalMargin()
-                    .testTag("ForwardedEmailApiSecretEntry")
                     .fillMaxWidth(),
             )
         }
@@ -1021,10 +1021,10 @@ private fun ColumnScope.ForwardedEmailAliasTypeContent(
                 value = obfuscatedTextField,
                 onValueChange = { obfuscatedTextField = it },
                 showPasswordTestTag = "ShowForwardedEmailApiSecretButton",
+                textFieldTestTag = "ForwardedEmailApiSecretEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .standardHorizontalMargin()
-                    .testTag("ForwardedEmailApiSecretEntry")
                     .fillMaxWidth(),
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendContent.kt
@@ -420,9 +420,9 @@ private fun AddSendOptions(
                 readOnly = sendRestrictionPolicy,
                 value = state.common.passwordInput,
                 onValueChange = addSendHandlers.onPasswordChange,
+                textFieldTestTag = "SendNewPasswordEntry",
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
-                    .testTag("SendNewPasswordEntry")
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCardItems.kt
@@ -85,9 +85,9 @@ fun LazyListScope.vaultAddEditCardItems(
                 cardHandlers.onNumberVisibilityChange(showNumber)
             },
             showPasswordTestTag = "ShowCardNumberButton",
+            passwordFieldTestTag = "CardNumberEntry",
             cardStyle = CardStyle.Middle(),
             modifier = Modifier
-                .testTag("CardNumberEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
         )
@@ -164,9 +164,9 @@ fun LazyListScope.vaultAddEditCardItems(
             },
             keyboardType = KeyboardType.NumberPassword,
             showPasswordTestTag = "CardShowSecurityCodeButton",
+            passwordFieldTestTag = "CardSecurityCodeEntry",
             cardStyle = CardStyle.Bottom,
             modifier = Modifier
-                .testTag("CardSecurityCodeEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
@@ -578,8 +578,9 @@ private fun CoachMarkScope<AddEditItemCoachMark>.PasswordRow(
         BitwardenHiddenPasswordField(
             label = stringResource(id = R.string.password),
             value = password,
+            passwordFieldTestTag = "LoginPasswordEntry",
             cardStyle = CardStyle.Bottom,
-            modifier = modifier.testTag("LoginPasswordEntry"),
+            modifier = modifier,
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSshKeyItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditSshKeyItems.kt
@@ -77,9 +77,9 @@ fun LazyListScope.vaultAddEditSshKeyItems(
             showPassword = sshKeyState.showPrivateKey,
             showPasswordChange = { sshKeyTypeHandlers.onPrivateKeyVisibilityChange(it) },
             showPasswordTestTag = "ViewPrivateKeyButton",
+            passwordFieldTestTag = "PrivateKeyEntry",
             cardStyle = CardStyle.Middle(),
             modifier = Modifier
-                .testTag("PrivateKeyEntry")
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
@@ -376,9 +376,9 @@ private fun PasswordField(
         BitwardenHiddenPasswordField(
             label = stringResource(id = R.string.password),
             value = passwordData.password,
+            passwordFieldTestTag = "LoginPasswordEntry",
             cardStyle = cardStyle,
-            modifier = modifier
-                .testTag("LoginPasswordEntry"),
+            modifier = modifier,
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes an issue occurring in the UI automation tests where the test tags need to be applied to the actual `TextField` instead of the outer element.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
