### PR TITLE
[PM-17531] Add dialog for client certificate import

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenClientCertificateInfoDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenClientCertificateInfoDialog.kt
@@ -1,0 +1,124 @@
+package com.x8bit.bitwarden.ui.platform.components.dialog
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
+import androidx.compose.ui.unit.dp
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
+import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordField
+import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
+import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+
+/**
+ * Represents a Bitwarden-styled dialog for entering client certificate password and alias.
+ *
+ * @param onConfirmClick called when the confirm button is clicked and emits the input values.
+ * @param onDismissRequest called when the user attempts to dismiss the dialog (for example by
+ * tapping outside of it).
+ */
+@Suppress("LongMethod")
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun BitwardenClientCertificateDialog(
+    onConfirmClick: (alias: String, password: String) -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var alias by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        dismissButton = {
+            BitwardenTextButton(
+                label = stringResource(id = R.string.cancel),
+                onClick = onDismissRequest,
+                modifier = Modifier.testTag("DismissAlertButton"),
+            )
+        },
+        confirmButton = {
+            BitwardenTextButton(
+                label = stringResource(id = R.string.submit),
+                isEnabled = password.isNotEmpty(),
+                onClick = { onConfirmClick(alias, password) },
+                modifier = Modifier.testTag("AcceptAlertButton"),
+            )
+        },
+        title = {
+            Text(
+                text = stringResource(R.string.import_client_certificate),
+                style = BitwardenTheme.typography.headlineSmall,
+                modifier = Modifier.testTag("AlertTitleText"),
+            )
+        },
+        text = {
+            Column {
+                Text(
+                    text = stringResource(R.string.enter_the_client_certificate_password_and_alias),
+                    style = BitwardenTheme.typography.bodyMedium,
+                    modifier = Modifier.testTag("AlertContentText"),
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                BitwardenTextField(
+                    label = stringResource(R.string.alias),
+                    value = alias,
+                    onValueChange = { alias = it },
+                    autoFocus = true,
+                    cardStyle = CardStyle.Top(dividerPadding = 0.dp),
+                    textFieldTestTag = "AlertClientCertificateAliasInputField",
+                    modifier = Modifier.imePadding(),
+                )
+
+                BitwardenPasswordField(
+                    label = stringResource(R.string.password),
+                    value = password,
+                    onValueChange = { password = it },
+                    cardStyle = CardStyle.Bottom,
+                    textFieldTestTag = "AlertClientCertificatePasswordInputField",
+                    modifier = Modifier.imePadding(),
+                )
+            }
+        },
+        shape = BitwardenTheme.shapes.dialog,
+        containerColor = BitwardenTheme.colorScheme.background.primary,
+        iconContentColor = BitwardenTheme.colorScheme.icon.secondary,
+        titleContentColor = BitwardenTheme.colorScheme.text.primary,
+        textContentColor = BitwardenTheme.colorScheme.text.primary,
+        modifier = modifier.semantics {
+            testTagsAsResourceId = true
+            testTag = "AlertPopup"
+        },
+    )
+}
+
+@Preview(showBackground = true)
+@PreviewScreenSizes
+@Composable
+private fun BitwardenClientCertificateDialogPreview() {
+    BitwardenTheme {
+        BitwardenClientCertificateDialog(
+            onConfirmClick = { alias, password -> },
+            onDismissRequest = {},
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1125,4 +1125,7 @@ Do you want to switch to this account?</string>
   <string name="we_ll_walk_you_through_the_key_features_to_add_a_new_login">We\'ll walk you through the key features to add a new login.</string>
   <string name="explore_the_generator">Explore the generator</string>
   <string name="learn_more_about_generating_secure_login_credentials_with_guided_tour">Learn more about generating secure login credentials with a guided tour.</string>
+  <string name="import_client_certificate">Import client certificate</string>
+  <string name="enter_the_client_certificate_password_and_alias">Enter the client certificate password and the desired alias for this certificate.</string>
+  <string name="alias">Alias</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

PM-17531
Relates to #4486 

## 📔 Objective

This commit introduces a new dialog for importing client certificates. The dialog prompts the user to enter the certificate password and alias.

## 📸 Screenshots

<img width="320" alt="image" src="https://github.com/user-attachments/assets/6b331a85-92c3-44df-9a3a-4575a942ee43" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
