### PR TITLE
PM-17378: Update remember me text

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
@@ -260,8 +260,8 @@ private fun LandingScreenContent(
         Spacer(modifier = Modifier.height(height = 8.dp))
 
         BitwardenSwitch(
-            label = stringResource(id = R.string.remember_me),
-            isChecked = state.isRememberMeEnabled,
+            label = stringResource(id = R.string.remember_email),
+            isChecked = state.isRememberEmailEnabled,
             onCheckedChange = onRememberMeToggle,
             cardStyle = CardStyle.Full,
             modifier = Modifier

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -43,7 +43,7 @@ class LandingViewModel @Inject constructor(
         ?: LandingState(
             emailInput = authRepository.rememberedEmailAddress.orEmpty(),
             isContinueButtonEnabled = authRepository.rememberedEmailAddress != null,
-            isRememberMeEnabled = authRepository.rememberedEmailAddress != null,
+            isRememberEmailEnabled = authRepository.rememberedEmailAddress != null,
             selectedEnvironmentType = environmentRepository.environment.type,
             selectedEnvironmentLabel = environmentRepository.environment.label,
             dialog = null,
@@ -185,7 +185,7 @@ class LandingViewModel @Inject constructor(
         }
 
         val email = state.emailInput
-        val isRememberMeEnabled = state.isRememberMeEnabled
+        val isRememberMeEnabled = state.isRememberEmailEnabled
 
         // Update the remembered email address
         authRepository.rememberedEmailAddress = email.takeUnless { !isRememberMeEnabled }
@@ -210,7 +210,7 @@ class LandingViewModel @Inject constructor(
     }
 
     private fun handleRememberMeToggled(action: LandingAction.RememberMeToggle) {
-        mutableStateFlow.update { it.copy(isRememberMeEnabled = action.isChecked) }
+        mutableStateFlow.update { it.copy(isRememberEmailEnabled = action.isChecked) }
     }
 
     private fun handleEnvironmentTypeSelect(action: LandingAction.EnvironmentTypeSelect) {
@@ -261,7 +261,7 @@ class LandingViewModel @Inject constructor(
 data class LandingState(
     val emailInput: String,
     val isContinueButtonEnabled: Boolean,
-    val isRememberMeEnabled: Boolean,
+    val isRememberEmailEnabled: Boolean,
     val selectedEnvironmentType: Environment.Type,
     val selectedEnvironmentLabel: String,
     val dialog: DialogState?,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
@@ -269,8 +269,8 @@ private fun TwoFactorLoginScreenContent(
         }
 
         BitwardenSwitch(
-            label = stringResource(id = R.string.remember_me),
-            isChecked = state.isRememberMeEnabled,
+            label = stringResource(id = R.string.remember),
+            isChecked = state.isRememberEnabled,
             onCheckedChange = onRememberMeToggle,
             cardStyle = CardStyle.Full,
             modifier = Modifier
@@ -317,7 +317,7 @@ private fun TwoFactorLoginScreenContentPreview() {
                 dialogState = null,
                 displayEmail = "email@dot.com",
                 isContinueButtonEnabled = true,
-                isRememberMeEnabled = true,
+                isRememberEnabled = true,
                 captchaToken = null,
                 email = "",
                 password = "",

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -68,7 +68,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                     .twoFactorResponse
                     .preferredAuthMethod
                     .isContinueButtonEnabled,
-                isRememberMeEnabled = false,
+                isRememberEnabled = false,
                 captchaToken = null,
                 email = args.emailAddress,
                 password = args.password,
@@ -445,7 +445,7 @@ class TwoFactorLoginViewModel @Inject constructor(
     private fun handleRememberMeToggle(action: TwoFactorLoginAction.RememberMeToggle) {
         mutableStateFlow.update {
             it.copy(
-                isRememberMeEnabled = action.isChecked,
+                isRememberEnabled = action.isChecked,
             )
         }
     }
@@ -561,7 +561,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                 twoFactorData = TwoFactorDataModel(
                     code = code,
                     method = state.authMethod.value.toString(),
-                    remember = state.isRememberMeEnabled,
+                    remember = state.isRememberEnabled,
                 ),
                 captchaToken = state.captchaToken,
                 orgIdentifier = state.orgIdentifier,
@@ -586,7 +586,7 @@ data class TwoFactorLoginState(
     val dialogState: DialogState?,
     val displayEmail: String,
     val isContinueButtonEnabled: Boolean,
-    val isRememberMeEnabled: Boolean,
+    val isRememberEnabled: Boolean,
     // Internal
     val captchaToken: String?,
     val email: String,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,7 +225,8 @@
   <string name="login_unavailable">Login unavailable</string>
   <string name="no_two_step_available">This account has two-step login set up, however, none of the configured two-step providers are supported on this device. Please use a supported device and/or add additional providers that are better supported across devices (such as an authenticator app).</string>
   <string name="recovery_code_title">Recovery code</string>
-  <string name="remember_me">Remember me</string>
+  <string name="remember">Remember</string>
+  <string name="remember_email">Remember email</string>
   <string name="send_verification_code_again">Send verification code email again</string>
   <string name="two_step_login_options">Two-step login options</string>
   <string name="use_another_two_step_method">Use another two-step login method</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
@@ -245,17 +245,17 @@ class LandingScreenTest : BaseComposeTest() {
 
     @Test
     fun `remember me should be toggled on or off according to the state`() {
-        composeTestRule.onNodeWithText("Remember me").assertIsOff()
+        composeTestRule.onNodeWithText("Remember email").assertIsOff()
 
-        mutableStateFlow.update { it.copy(isRememberMeEnabled = true) }
+        mutableStateFlow.update { it.copy(isRememberEmailEnabled = true) }
 
-        composeTestRule.onNodeWithText("Remember me").assertIsOn()
+        composeTestRule.onNodeWithText("Remember email").assertIsOn()
     }
 
     @Test
     fun `remember me click should send RememberMeToggle action`() {
         composeTestRule
-            .onNodeWithText("Remember me")
+            .onNodeWithText("Remember email")
             .performClick()
         verify {
             viewModel.trySendAction(LandingAction.RememberMeToggle(true))
@@ -473,7 +473,7 @@ private val ACTIVE_ACCOUNT_SUMMARY = AccountSummary(
 private val DEFAULT_STATE = LandingState(
     emailInput = "",
     isContinueButtonEnabled = true,
-    isRememberMeEnabled = false,
+    isRememberEmailEnabled = false,
     selectedEnvironmentType = Environment.Type.US,
     selectedEnvironmentLabel = Environment.Us.label,
     dialog = null,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
@@ -60,7 +60,7 @@ class LandingViewModelTest : BaseViewModelTest() {
                 DEFAULT_STATE.copy(
                     emailInput = rememberedEmail,
                     isContinueButtonEnabled = true,
-                    isRememberMeEnabled = true,
+                    isRememberEmailEnabled = true,
                 ),
                 awaitItem(),
             )
@@ -107,7 +107,7 @@ class LandingViewModelTest : BaseViewModelTest() {
         val expectedState = DEFAULT_STATE.copy(
             emailInput = "test",
             isContinueButtonEnabled = false,
-            isRememberMeEnabled = true,
+            isRememberEmailEnabled = true,
         )
         val handle = SavedStateHandle(mapOf("state" to expectedState))
         val viewModel = createViewModel(savedStateHandle = handle)
@@ -242,7 +242,7 @@ class LandingViewModelTest : BaseViewModelTest() {
         val initialState = DEFAULT_STATE.copy(
             emailInput = rememberedEmail,
             isContinueButtonEnabled = true,
-            isRememberMeEnabled = true,
+            isRememberEmailEnabled = true,
             accountSummaries = accountSummaries,
         )
         assertEquals(
@@ -298,7 +298,7 @@ class LandingViewModelTest : BaseViewModelTest() {
             val initialState = DEFAULT_STATE.copy(
                 emailInput = rememberedEmail,
                 isContinueButtonEnabled = true,
-                isRememberMeEnabled = true,
+                isRememberEmailEnabled = true,
                 accountSummaries = accountSummaries,
             )
             assertEquals(
@@ -359,7 +359,7 @@ class LandingViewModelTest : BaseViewModelTest() {
             val initialState = DEFAULT_STATE.copy(
                 emailInput = rememberedEmail,
                 isContinueButtonEnabled = true,
-                isRememberMeEnabled = true,
+                isRememberEmailEnabled = true,
                 accountSummaries = accountSummaries,
             )
             assertEquals(
@@ -434,7 +434,7 @@ class LandingViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(LandingAction.RememberMeToggle(true))
             assertEquals(
                 viewModel.stateFlow.value,
-                DEFAULT_STATE.copy(isRememberMeEnabled = true),
+                DEFAULT_STATE.copy(isRememberEmailEnabled = true),
             )
         }
     }
@@ -599,7 +599,7 @@ class LandingViewModelTest : BaseViewModelTest() {
         private val DEFAULT_STATE = LandingState(
             emailInput = "",
             isContinueButtonEnabled = false,
-            isRememberMeEnabled = false,
+            isRememberEmailEnabled = false,
             selectedEnvironmentType = Environment.Type.US,
             selectedEnvironmentLabel = Environment.Us.label,
             dialog = null,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
@@ -155,7 +155,7 @@ class TwoFactorLoginScreenTest : BaseComposeTest() {
 
     @Test
     fun `remember me click should send RememberMeToggle action`() {
-        composeTestRule.onNodeWithText("Remember me").performClick()
+        composeTestRule.onNodeWithText("Remember").performClick()
         verify {
             viewModel.trySendAction(TwoFactorLoginAction.RememberMeToggle(true))
         }
@@ -163,11 +163,11 @@ class TwoFactorLoginScreenTest : BaseComposeTest() {
 
     @Test
     fun `remember me should be toggled on or off according to the state`() {
-        composeTestRule.onNodeWithText("Remember me").assertIsOff()
+        composeTestRule.onNodeWithText("Remember").assertIsOff()
 
-        mutableStateFlow.update { it.copy(isRememberMeEnabled = true) }
+        mutableStateFlow.update { it.copy(isRememberEnabled = true) }
 
-        composeTestRule.onNodeWithText("Remember me").assertIsOn()
+        composeTestRule.onNodeWithText("Remember").assertIsOn()
     }
 
     @Test
@@ -290,7 +290,7 @@ private val DEFAULT_STATE = TwoFactorLoginState(
     displayEmail = "ex***@email.com",
     dialogState = null,
     isContinueButtonEnabled = false,
-    isRememberMeEnabled = false,
+    isRememberEnabled = false,
     captchaToken = null,
     email = "example@email.com",
     password = "password123",

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -118,7 +118,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                 twoFactorData = TwoFactorDataModel(
                     code = token,
                     method = TwoFactorAuthMethod.YUBI_KEY.value.toString(),
-                    remember = DEFAULT_STATE.isRememberMeEnabled,
+                    remember = DEFAULT_STATE.isRememberEnabled,
                 ),
                 captchaToken = DEFAULT_STATE.captchaToken,
                 orgIdentifier = DEFAULT_STATE.orgIdentifier,
@@ -786,7 +786,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(TwoFactorLoginAction.RememberMeToggle(true))
         assertEquals(
             DEFAULT_STATE.copy(
-                isRememberMeEnabled = true,
+                isRememberEnabled = true,
             ),
             viewModel.stateFlow.value,
         )
@@ -1045,7 +1045,7 @@ private val DEFAULT_STATE = TwoFactorLoginState(
     displayEmail = "ex***@email.com",
     dialogState = null,
     isContinueButtonEnabled = false,
-    isRememberMeEnabled = false,
+    isRememberEnabled = false,
     captchaToken = null,
     email = DEFAULT_EMAIL_ADDRESS,
     password = DEFAULT_PASSWORD,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17378](https://bitwarden.atlassian.net/browse/PM-17378)

## 📔 Objective

This PR updates the remember text to match the latest designs.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/507b256b-6ceb-4457-8d57-c76679cd1092" width="300" /> | <img src="https://github.com/user-attachments/assets/5165f101-bf3e-42a4-8f76-b7e5ba558190" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17378]: https://bitwarden.atlassian.net/browse/PM-17378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ