### PR TITLE
PM-17382 - Update “Logging in as…” text and link style on log in screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
@@ -307,8 +307,8 @@ private fun LoginScreenContent(
                 state.environmentLabel,
             ),
             textAlign = TextAlign.Center,
-            style = BitwardenTheme.typography.bodyMedium,
-            color = BitwardenTheme.colorScheme.text.primary,
+            style = BitwardenTheme.typography.bodySmall,
+            color = BitwardenTheme.colorScheme.text.secondary,
             modifier = Modifier
                 .testTag("LoggingInAsLabel")
                 .standardHorizontalMargin()
@@ -318,7 +318,7 @@ private fun LoginScreenContent(
         BitwardenClickableText(
             label = stringResource(id = R.string.not_you),
             onClick = onNotYouButtonClick,
-            style = BitwardenTheme.typography.labelLarge,
+            style = BitwardenTheme.typography.labelMedium,
             innerPadding = PaddingValues(vertical = 8.dp, horizontal = 16.dp),
             modifier = Modifier
                 .standardHorizontalMargin()


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17382](https://bitwarden.atlassian.net/browse/PM-17382)

## 📔 Objective

- Update the style/color on text on the `LoginScreen`

## 📸 Screenshots
![Screenshot_1738079234](https://github.com/user-attachments/assets/b550e454-95fd-4750-8a2a-cadeb3f02cf3)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17382]: https://bitwarden.atlassian.net/browse/PM-17382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ