### PR TITLE
Update SingleTapPasskeyAuthentication and SingleTapPassskeyCreation to be remote flags

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -189,7 +189,7 @@ sealed class FlagKey<out T : Any> {
     data object SingleTapPasskeyCreation : FlagKey<Boolean>() {
         override val keyName: String = "single-tap-passkey-creation"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
+        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -198,7 +198,7 @@ sealed class FlagKey<out T : Any> {
     data object SingleTapPasskeyAuthentication : FlagKey<Boolean>() {
         override val keyName: String = "single-tap-passkey-authentication"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
+        override val isRemotelyConfigured: Boolean = true
     }
 
     //region Dummy keys for testing


### PR DESCRIPTION
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
