### PR TITLE
PM-17680: Overwrite the expiration date to the deletion date

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/util/AddSendStateExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/util/AddSendStateExtensions.kt
@@ -31,7 +31,11 @@ fun AddSendState.ViewState.Content.toSendView(
         hideEmail = common.isHideEmailChecked,
         revisionDate = clock.instant(),
         deletionDate = common.deletionDate.toInstant(),
-        expirationDate = common.expirationDate?.toInstant(),
+        expirationDate = common.expirationDate?.let {
+            // We no longer support expiration dates but is a send has one already,
+            // we just update it to match the deletion date.
+            common.deletionDate.toInstant()
+        },
     )
 
 private fun AddSendState.ViewState.Content.SendType.toSendType(): SendType =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/util/AddSendStateExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/util/AddSendStateExtensionsTest.kt
@@ -58,6 +58,31 @@ class AddSendStateExtensionsTest {
 
         assertEquals(sendView, result)
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toSendView should create an appropriate SendView with expiration date set to deletion date`() {
+        val sendView = createMockSendView(number = 1, type = SendType.TEXT).copy(
+            id = null,
+            accessId = null,
+            key = null,
+            accessCount = 0U,
+            hasPassword = false,
+            deletionDate = ZonedDateTime.parse("2030-10-27T12:00:00Z").toInstant(),
+            expirationDate = ZonedDateTime.parse("2030-10-27T12:00:00Z").toInstant(),
+        )
+
+        val result = DEFAULT_VIEW_STATE
+            .copy(
+                common = DEFAULT_COMMON_STATE.copy(
+                    deletionDate = ZonedDateTime.parse("2030-10-27T12:00:00Z"),
+                    expirationDate = ZonedDateTime.parse("2026-10-27T12:00:00Z"),
+                ),
+            )
+            .toSendView(FIXED_CLOCK)
+
+        assertEquals(sendView, result)
+    }
 }
 
 private val FIXED_CLOCK: Clock = Clock.fixed(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17680](https://bitwarden.atlassian.net/browse/PM-17680)

## 📔 Objective

This PR will set the expiration date on sends to the deletion date whenever you update a send that already have an expiration date set.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17680]: https://bitwarden.atlassian.net/browse/PM-17680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ