### PR TITLE
PM-17684: Update the cursor color throughout the app

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/color/BitwardenTextFieldColors.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/color/BitwardenTextFieldColors.kt
@@ -48,8 +48,8 @@ fun bitwardenTextFieldColors(
     unfocusedContainerColor = Color.Transparent,
     disabledContainerColor = Color.Transparent,
     errorContainerColor = Color.Transparent,
-    cursorColor = BitwardenTheme.colorScheme.icon.primary,
-    errorCursorColor = BitwardenTheme.colorScheme.icon.primary,
+    cursorColor = BitwardenTheme.colorScheme.text.interaction,
+    errorCursorColor = BitwardenTheme.colorScheme.text.interaction,
     textSelectionColors = TextSelectionColors(
         handleColor = BitwardenTheme.colorScheme.stroke.border,
         backgroundColor = BitwardenTheme.colorScheme.stroke.border.copy(alpha = 0.4f),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17684](https://bitwarden.atlassian.net/browse/PM-17684)

## 📔 Objective

This PR updates the cursor color throughout the app.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d4e5b983-2687-4d79-93f1-4e373e0627f5" width="300" /> | <img src="https://github.com/user-attachments/assets/7d2910b3-80e9-43e2-83a6-59779196c038" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17684]: https://bitwarden.atlassian.net/browse/PM-17684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ