### PR TITLE
PM-17205: Check accessibility service status on start up

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManagerImpl.kt
@@ -11,7 +11,9 @@ import kotlinx.coroutines.flow.asStateFlow
 class AccessibilityEnabledManagerImpl(
     accessibilityManager: AccessibilityManager,
 ) : AccessibilityEnabledManager {
-    private val mutableIsAccessibilityEnabledStateFlow = MutableStateFlow(value = false)
+    private val mutableIsAccessibilityEnabledStateFlow = MutableStateFlow(
+        value = accessibilityManager.isEnabled,
+    )
 
     init {
         accessibilityManager.addAccessibilityStateChangeListener(

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/manager/AccessibilityEnabledManagerTest.kt
@@ -15,6 +15,7 @@ class AccessibilityEnabledManagerTest {
     private val accessibilityStateChangeListener =
         slot<AccessibilityManager.AccessibilityStateChangeListener>()
     private val accessibilityManager = mockk<AccessibilityManager> {
+        every { isEnabled } returns false
         every {
             addAccessibilityStateChangeListener(capture(accessibilityStateChangeListener))
         } returns true


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17205](https://bitwarden.atlassian.net/browse/PM-17205)

## 📔 Objective

This PR updates the `AccessibilityEnabledManager` to check the status of the accessibility service on start up to avoid default values of false.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17205]: https://bitwarden.atlassian.net/browse/PM-17205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ