### PR TITLE
PM-17384 PM-17386 - Create Account Design Audit

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
@@ -185,7 +185,6 @@ fun LandingScreen(
             onCreateAccountClick = remember(viewModel) {
                 { viewModel.trySendAction(LandingAction.CreateAccountClick) }
             },
-            modifier = Modifier.fillMaxSize(),
         )
     }
 }
@@ -204,6 +203,7 @@ private fun LandingScreenContent(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
+            .fillMaxSize()
             .imePadding()
             .verticalScroll(rememberScrollState())
             .statusBarsPadding(),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -25,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -157,30 +157,21 @@ fun StartRegistrationScreen(
             BitwardenTopAppBar(
                 title = stringResource(id = R.string.create_account),
                 scrollBehavior = scrollBehavior,
-                navigationIcon = rememberVectorPainter(id = R.drawable.ic_back),
+                navigationIcon = rememberVectorPainter(id = R.drawable.ic_close),
                 navigationIconContentDescription = stringResource(id = R.string.back),
                 onNavigationIconClick = handler.onBackClick,
             )
         },
     ) {
-        Column(
-            modifier = Modifier
-                .imePadding()
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState()),
-        ) {
-            StartRegistrationContent(
-                emailInput = state.emailInput,
-                selectedEnvironmentType = state.selectedEnvironmentType,
-                nameInput = state.nameInput,
-                isReceiveMarketingEmailsToggled = state.isReceiveMarketingEmailsToggled,
-                isContinueButtonEnabled = state.isContinueButtonEnabled,
-                isNewOnboardingUiEnabled = state.showNewOnboardingUi,
-                handler = handler,
-            )
-            Spacer(modifier = Modifier.height(height = 16.dp))
-            Spacer(modifier = Modifier.navigationBarsPadding())
-        }
+        StartRegistrationContent(
+            emailInput = state.emailInput,
+            selectedEnvironmentType = state.selectedEnvironmentType,
+            nameInput = state.nameInput,
+            isReceiveMarketingEmailsToggled = state.isReceiveMarketingEmailsToggled,
+            isContinueButtonEnabled = state.isContinueButtonEnabled,
+            isNewOnboardingUiEnabled = state.showNewOnboardingUi,
+            handler = handler,
+        )
     }
 }
 
@@ -196,31 +187,31 @@ private fun StartRegistrationContent(
     isNewOnboardingUiEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
+            .verticalScroll(rememberScrollState()),
+    ) {
         Spacer(modifier = Modifier.height(height = 12.dp))
+
         if (isNewOnboardingUiEnabled) {
+            Spacer(modifier = Modifier.weight(1f))
             Image(
-                painter = rememberVectorPainter(id = R.drawable.vault),
+                painter = rememberVectorPainter(id = R.drawable.bitwarden_logo),
+                colorFilter = ColorFilter.tint(BitwardenTheme.colorScheme.icon.secondary),
                 contentDescription = null,
                 modifier = Modifier
-                    .size(132.dp)
-                    .align(Alignment.CenterHorizontally),
+                    .standardHorizontalMargin()
+                    .fillMaxWidth(),
             )
-            Spacer(modifier = Modifier.height(48.dp))
+            Spacer(modifier = Modifier.weight(1f))
         }
+        Spacer(modifier = Modifier.height(12.dp))
+
         BitwardenTextField(
-            label = stringResource(id = R.string.name),
-            value = nameInput,
-            onValueChange = handler.onNameInputChange,
-            textFieldTestTag = "NameEntry",
-            cardStyle = CardStyle.Top(dividerPadding = 0.dp),
-            modifier = Modifier
-                .fillMaxWidth()
-                .standardHorizontalMargin(),
-        )
-        BitwardenTextField(
-            label = stringResource(id = R.string.email_address),
-            placeholder = stringResource(R.string.email_address_required),
+            label = stringResource(id = R.string.email_address_required),
             value = emailInput,
             onValueChange = handler.onEmailInputChange,
             keyboardType = KeyboardType.Email,
@@ -252,14 +243,27 @@ private fun StartRegistrationContent(
                     }
                 }
             },
-            cardStyle = CardStyle.Bottom,
+            cardStyle = CardStyle.Full,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
         )
-        Spacer(modifier = Modifier.height(24.dp))
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        BitwardenTextField(
+            label = stringResource(id = R.string.name),
+            value = nameInput,
+            onValueChange = handler.onNameInputChange,
+            textFieldTestTag = "NameEntry",
+            cardStyle = CardStyle.Full,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
 
         if (selectedEnvironmentType != Environment.Type.SELF_HOSTED) {
+            Spacer(modifier = Modifier.height(8.dp))
             ReceiveMarketingEmailsSwitch(
                 isChecked = isReceiveMarketingEmailsToggled,
                 onCheckedChange = handler.onReceiveMarketingEmailsToggle,
@@ -268,8 +272,9 @@ private fun StartRegistrationContent(
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
             )
-            Spacer(modifier = Modifier.height(24.dp))
         }
+
+        Spacer(modifier = Modifier.height(24.dp))
 
         BitwardenFilledButton(
             label = stringResource(id = R.string.continue_text),
@@ -280,13 +285,17 @@ private fun StartRegistrationContent(
                 .standardHorizontalMargin()
                 .fillMaxWidth(),
         )
-        Spacer(modifier = Modifier.height(16.dp))
+
+        Spacer(modifier = Modifier.height(12.dp))
+
         TermsAndPrivacyText(
             onTermsClick = handler.onTermsClick,
             onPrivacyPolicyClick = handler.onPrivacyPolicyClick,
             modifier = Modifier.standardHorizontalMargin(),
         )
-        Spacer(modifier = Modifier.height(4.dp))
+
+        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.navigationBarsPadding())
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -158,7 +158,7 @@ fun StartRegistrationScreen(
                 title = stringResource(id = R.string.create_account),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = R.drawable.ic_close),
-                navigationIconContentDescription = stringResource(id = R.string.back),
+                navigationIconContentDescription = stringResource(id = R.string.close),
                 onNavigationIconClick = handler.onBackClick,
             )
         },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -159,7 +159,7 @@ fun StartRegistrationScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = R.drawable.ic_close),
                 navigationIconContentDescription = stringResource(id = R.string.close),
-                onNavigationIconClick = handler.onBackClick,
+                onNavigationIconClick = handler.onCloseButtonClick,
             )
         },
     ) {
@@ -404,7 +404,7 @@ private fun StartRegistrationContentFilledOut_preview() {
                 onReceiveMarketingEmailsToggle = {},
                 onUnsubscribeMarketingEmailsClick = {},
                 onServerGeologyHelpClick = {},
-                onBackClick = {},
+                onCloseButtonClick = {},
             ),
         )
     }
@@ -431,7 +431,7 @@ private fun StartRegistrationContentEmpty_preview() {
                 onReceiveMarketingEmailsToggle = {},
                 onUnsubscribeMarketingEmailsClick = {},
                 onServerGeologyHelpClick = {},
-                onBackClick = {},
+                onCloseButtonClick = {},
             ),
         )
     }
@@ -458,7 +458,7 @@ private fun StartRegistrationContentNewOnboardingUi_preview() {
                 onReceiveMarketingEmailsToggle = {},
                 onUnsubscribeMarketingEmailsClick = {},
                 onServerGeologyHelpClick = {},
-                onBackClick = {},
+                onCloseButtonClick = {},
             ),
         )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -159,7 +159,7 @@ fun StartRegistrationScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = R.drawable.ic_close),
                 navigationIconContentDescription = stringResource(id = R.string.close),
-                onNavigationIconClick = handler.onCloseButtonClick,
+                onNavigationIconClick = handler.onCloseClick,
             )
         },
     ) {
@@ -404,7 +404,7 @@ private fun StartRegistrationContentFilledOut_preview() {
                 onReceiveMarketingEmailsToggle = {},
                 onUnsubscribeMarketingEmailsClick = {},
                 onServerGeologyHelpClick = {},
-                onCloseButtonClick = {},
+                onCloseClick = {},
             ),
         )
     }
@@ -431,7 +431,7 @@ private fun StartRegistrationContentEmpty_preview() {
                 onReceiveMarketingEmailsToggle = {},
                 onUnsubscribeMarketingEmailsClick = {},
                 onServerGeologyHelpClick = {},
-                onCloseButtonClick = {},
+                onCloseClick = {},
             ),
         )
     }
@@ -458,7 +458,7 @@ private fun StartRegistrationContentNewOnboardingUi_preview() {
                 onReceiveMarketingEmailsToggle = {},
                 onUnsubscribeMarketingEmailsClick = {},
                 onServerGeologyHelpClick = {},
-                onCloseButtonClick = {},
+                onCloseClick = {},
             ),
         )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
@@ -12,7 +12,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.model.Environment.Type
-import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseButtonClick
+import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.ContinueClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EmailInputChange
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EnvironmentTypeSelect
@@ -94,7 +94,7 @@ class StartRegistrationViewModel @Inject constructor(
             is ContinueClick -> handleContinueClick()
             is EmailInputChange -> handleEmailInputChanged(action)
             is NameInputChange -> handleNameInputChanged(action)
-            is CloseButtonClick -> handleCloseClick()
+            is CloseClick -> handleCloseClick()
             is ErrorDialogDismiss -> handleDialogDismiss()
             is ReceiveMarketingEmailsToggle -> handleReceiveMarketingEmailsToggle(
                 action,
@@ -385,7 +385,7 @@ sealed class StartRegistrationAction {
     /**
      * Indicates that the top-bar close button was clicked.
      */
-    data object CloseButtonClick : StartRegistrationAction()
+    data object CloseClick : StartRegistrationAction()
 
     /**
      * Email input changed.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
@@ -12,7 +12,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.model.Environment.Type
-import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.BackClick
+import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseButtonClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.ContinueClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EmailInputChange
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EnvironmentTypeSelect
@@ -94,7 +94,7 @@ class StartRegistrationViewModel @Inject constructor(
             is ContinueClick -> handleContinueClick()
             is EmailInputChange -> handleEmailInputChanged(action)
             is NameInputChange -> handleNameInputChanged(action)
-            is BackClick -> handleBackClick()
+            is CloseButtonClick -> handleCloseClick()
             is ErrorDialogDismiss -> handleDialogDismiss()
             is ReceiveMarketingEmailsToggle -> handleReceiveMarketingEmailsToggle(
                 action,
@@ -173,7 +173,7 @@ class StartRegistrationViewModel @Inject constructor(
         }
     }
 
-    private fun handleBackClick() {
+    private fun handleCloseClick() {
         sendEvent(StartRegistrationEvent.NavigateBack)
     }
 
@@ -383,9 +383,9 @@ sealed class StartRegistrationAction {
     data object ContinueClick : StartRegistrationAction()
 
     /**
-     * User clicked back.
+     * Indicates that the top-bar close button was clicked.
      */
-    data object BackClick : StartRegistrationAction()
+    data object CloseButtonClick : StartRegistrationAction()
 
     /**
      * Email input changed.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/handlers/StartRegistrationHandler.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/handlers/StartRegistrationHandler.kt
@@ -20,7 +20,7 @@ data class StartRegistrationHandler(
     val onReceiveMarketingEmailsToggle: (Boolean) -> Unit,
     val onUnsubscribeMarketingEmailsClick: () -> Unit,
     val onServerGeologyHelpClick: () -> Unit,
-    val onCloseButtonClick: () -> Unit,
+    val onCloseClick: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -71,8 +71,8 @@ data class StartRegistrationHandler(
                 onServerGeologyHelpClick = {
                     viewModel.trySendAction(StartRegistrationAction.ServerGeologyHelpClick)
                 },
-                onCloseButtonClick = {
-                    viewModel.trySendAction(StartRegistrationAction.CloseButtonClick)
+                onCloseClick = {
+                    viewModel.trySendAction(StartRegistrationAction.CloseClick)
                 },
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/handlers/StartRegistrationHandler.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/handlers/StartRegistrationHandler.kt
@@ -20,7 +20,7 @@ data class StartRegistrationHandler(
     val onReceiveMarketingEmailsToggle: (Boolean) -> Unit,
     val onUnsubscribeMarketingEmailsClick: () -> Unit,
     val onServerGeologyHelpClick: () -> Unit,
-    val onBackClick: () -> Unit,
+    val onCloseButtonClick: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -71,7 +71,9 @@ data class StartRegistrationHandler(
                 onServerGeologyHelpClick = {
                     viewModel.trySendAction(StartRegistrationAction.ServerGeologyHelpClick)
                 },
-                onBackClick = { viewModel.trySendAction(StartRegistrationAction.BackClick) },
+                onCloseButtonClick = {
+                    viewModel.trySendAction(StartRegistrationAction.CloseButtonClick)
+                },
             )
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -2,10 +2,8 @@ package com.x8bit.bitwarden.ui.platform.components.field
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -173,18 +171,18 @@ fun BitwardenPasswordField(
                     .fillMaxWidth(),
             )
             supportingTextContent?.let {
-                Spacer(modifier = Modifier.height(height = 8.dp))
+                // Spacer(modifier = Modifier.height(height = 8.dp))
                 BitwardenHorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 16.dp),
                 )
-                Spacer(modifier = Modifier.height(height = 12.dp))
+                // Spacer(modifier = Modifier.height(height = 12.dp))
                 Column(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     content = it,
                 )
-                Spacer(modifier = Modifier.height(height = 6.dp))
+                // Spacer(modifier = Modifier.height(height = 6.dp))
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -2,8 +2,10 @@ package com.x8bit.bitwarden.ui.platform.components.field
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -171,18 +173,18 @@ fun BitwardenPasswordField(
                     .fillMaxWidth(),
             )
             supportingTextContent?.let {
-                // Spacer(modifier = Modifier.height(height = 8.dp))
+                Spacer(modifier = Modifier.height(height = 8.dp))
                 BitwardenHorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 16.dp),
                 )
-                // Spacer(modifier = Modifier.height(height = 12.dp))
+                Spacer(modifier = Modifier.height(height = 12.dp))
                 Column(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     content = it,
                 )
-                // Spacer(modifier = Modifier.height(height = 6.dp))
+                Spacer(modifier = Modifier.height(height = 6.dp))
             }
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
@@ -133,7 +133,7 @@ class StartRegistrationScreenTest : BaseComposeTest() {
 
     @Test
     fun `email input change should send EmailInputChange action`() {
-        composeTestRule.onNodeWithText("Email address").performTextInput(TEST_INPUT)
+        composeTestRule.onNodeWithText("Email address (required)").performTextInput(TEST_INPUT)
         verify { viewModel.trySendAction(EmailInputChange(TEST_INPUT)) }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.core.net.toUri
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
-import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.BackClick
+import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseButtonClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EmailInputChange
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
@@ -69,9 +69,9 @@ class StartRegistrationScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `close click should send BackClick action`() {
-        composeTestRule.onNodeWithContentDescription("Back").performClick()
-        verify { viewModel.trySendAction(BackClick) }
+    fun `close click should send CloseClick action`() {
+        composeTestRule.onNodeWithContentDescription("Close").performClick()
+        verify { viewModel.trySendAction(CloseButtonClick) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.core.net.toUri
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
-import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseButtonClick
+import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EmailInputChange
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
@@ -71,7 +71,7 @@ class StartRegistrationScreenTest : BaseComposeTest() {
     @Test
     fun `close click should send CloseClick action`() {
         composeTestRule.onNodeWithContentDescription("Close").performClick()
-        verify { viewModel.trySendAction(CloseButtonClick) }
+        verify { viewModel.trySendAction(CloseClick) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
@@ -11,7 +11,7 @@ import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
-import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseButtonClick
+import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.ContinueClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EmailInputChange
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EnvironmentTypeSelect
@@ -308,7 +308,7 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
             featureFlagManager = featureFlagManager,
         )
         viewModel.eventFlow.test {
-            viewModel.trySendAction(CloseButtonClick)
+            viewModel.trySendAction(CloseClick)
             assertEquals(NavigateBack, awaitItem())
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
@@ -11,7 +11,7 @@ import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
-import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.BackClick
+import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.CloseButtonClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.ContinueClick
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EmailInputChange
 import com.x8bit.bitwarden.ui.auth.feature.startregistration.StartRegistrationAction.EnvironmentTypeSelect
@@ -308,7 +308,7 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
             featureFlagManager = featureFlagManager,
         )
         viewModel.eventFlow.test {
-            viewModel.trySendAction(BackClick)
+            viewModel.trySendAction(CloseButtonClick)
             assertEquals(NavigateBack, awaitItem())
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17384](https://bitwarden.atlassian.net/browse/PM-17384)
[PM-17386](https://bitwarden.atlassian.net/browse/PM-17386)

## 📔 Objective

- Change color of non-link text to Text-Secondary
- Remove Vault illustration in favor of the Bitwarden logo and align spacing
- Reverse order of the name and email fields
- Update back button icon to be a “X” close button
- Update the email address placeholder to `Email address (required)`

## 📸 Screenshots
### With new boarding flag on 
![Screenshot_1738179826](https://github.com/user-attachments/assets/840ff120-4c75-419e-8208-e5e665412e09)

### With new onboarding flag on (Self hosted)
![Screenshot_1738179567](https://github.com/user-attachments/assets/9d3f36f5-7dd7-4bb2-a109-fc15641e166b)

### With new boarding flag off
![Screenshot_1738179834](https://github.com/user-attachments/assets/cf20fb8f-0284-4f7e-942a-f070c90dadd4)

### With new onboarding flag off (Self hosted)
![Screenshot_1738179583](https://github.com/user-attachments/assets/60843fa7-8498-49e0-9064-6bfa89ba4802)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17384]: https://bitwarden.atlassian.net/browse/PM-17384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-17386]: https://bitwarden.atlassian.net/browse/PM-17386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ