### PR TITLE
PM-16861 - Update Behavior When Tapping Same Generator Tab Already Viewing

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -801,6 +801,8 @@ class GeneratorViewModel @Inject constructor(
     //region Main Type Option Handlers
 
     private fun handleMainTypeOptionSelect(action: GeneratorAction.MainTypeOptionSelect) {
+        if (action.mainTypeOption == state.selectedType.mainTypeOption) return
+
         when (action.mainTypeOption) {
             GeneratorState.MainTypeOption.PASSWORD -> {
                 loadPasscodeOptions(selectedType = GeneratorState.MainType.Password())

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -745,7 +745,7 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     fun `MainTypeOptionSelect PASSWORD should switch to Passcode`() = runTest {
         val viewModel = createViewModel()
         viewModel.trySendAction(
-            GeneratorAction.MainTypeOptionSelect(GeneratorState.MainTypeOption.USERNAME)
+            GeneratorAction.MainTypeOptionSelect(GeneratorState.MainTypeOption.USERNAME),
         )
 
         fakeGeneratorRepository.setMockGeneratePasswordResult(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -744,7 +744,9 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     @Test
     fun `MainTypeOptionSelect PASSWORD should switch to Passcode`() = runTest {
         val viewModel = createViewModel()
-        viewModel.trySendAction(GeneratorAction.MainTypeOptionSelect(GeneratorState.MainTypeOption.USERNAME))
+        viewModel.trySendAction(
+            GeneratorAction.MainTypeOptionSelect(GeneratorState.MainTypeOption.USERNAME)
+        )
 
         fakeGeneratorRepository.setMockGeneratePasswordResult(
             GeneratedPasswordResult.Success("updatedText"),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -717,20 +717,47 @@ class GeneratorViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `MainTypeOptionSelect shouldn't update the state if its already selected`() = runTest {
+        val viewModel = createViewModel()
+        fakeGeneratorRepository.setMockGeneratePassphraseResult(
+            GeneratedPassphraseResult.Success("updatedText"),
+        )
+
+        val expectedState = initialPasscodeState.copy(
+            selectedType = GeneratorState.MainType.Passphrase(),
+            generatedText = "updatedText",
+        )
+
+        val action = GeneratorAction.MainTypeOptionSelect(GeneratorState.MainTypeOption.PASSPHRASE)
+
+        viewModel.trySendAction(action)
+        assertEquals(expectedState, viewModel.stateFlow.value)
+
+        fakeGeneratorRepository.setMockGeneratePassphraseResult(
+            GeneratedPassphraseResult.Success("updatedTextAgain"),
+        )
+
+        viewModel.trySendAction(action)
+        assertEquals(expectedState, viewModel.stateFlow.value)
+    }
+
+    @Test
     fun `MainTypeOptionSelect PASSWORD should switch to Passcode`() = runTest {
         val viewModel = createViewModel()
+        viewModel.trySendAction(GeneratorAction.MainTypeOptionSelect(GeneratorState.MainTypeOption.USERNAME))
+
         fakeGeneratorRepository.setMockGeneratePasswordResult(
             GeneratedPasswordResult.Success("updatedText"),
         )
 
         val action = GeneratorAction.MainTypeOptionSelect(GeneratorState.MainTypeOption.PASSWORD)
 
-        viewModel.trySendAction(action)
-
         val expectedState = initialPasscodeState.copy(
             selectedType = GeneratorState.MainType.Password(),
             generatedText = "updatedText",
         )
+
+        viewModel.trySendAction(action)
 
         assertEquals(expectedState, viewModel.stateFlow.value)
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16861](https://bitwarden.atlassian.net/browse/PM-16861)

## 📔 Objective

-  When tapping on the same segmented button selection (Password / Passphrase / Username) a new password/passphrase/username is not generated again.  User can tap the same tab over and over and nothing should change.

## 📸 Screenshots
[untitled.webm](https://github.com/user-attachments/assets/7c724933-8612-4bf3-892f-909f409e6795)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16861]: https://bitwarden.atlassian.net/browse/PM-16861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ