### PR TITLE
[PM-9535] Show toast when copying values prior to Android 13

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerImpl.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardMan
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
+import com.x8bit.bitwarden.ui.platform.base.util.asText
 import java.time.Clock
 
 /**
@@ -34,7 +35,10 @@ class AutofillTotpManagerImpl(
         )
 
         if (totpResult is GenerateTotpResult.Success) {
-            clipboardManager.setText(text = totpResult.code)
+            clipboardManager.setText(
+                text = totpResult.code,
+                toastDescriptorOverride = R.string.verification_code_totp.asText(),
+            )
             Toast
                 .makeText(
                     context.applicationContext,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManager.kt
@@ -35,6 +35,15 @@ interface BitwardenClipboardManager {
      * See [setText] for more details.
      */
     fun setText(
+        text: String,
+        isSensitive: Boolean = true,
+        toastDescriptorOverride: Text,
+    )
+
+    /**
+     * See [setText] for more details.
+     */
+    fun setText(
         text: Text,
         isSensitive: Boolean = true,
         toastDescriptorOverride: String? = null,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
@@ -48,7 +48,10 @@ class BitwardenClipboardManagerImpl(
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
             val descriptor = toastDescriptorOverride
                 ?.let { context.resources.getString(R.string.value_has_been_copied, it) }
-                ?: context.resources.getString(R.string.copied_to_clipboard)
+                ?: context.resources.getString(
+                    R.string.value_has_been_copied,
+                    context.resources.getString(R.string.value),
+                )
             Toast.makeText(context, descriptor, Toast.LENGTH_SHORT).show()
         }
 
@@ -68,6 +71,14 @@ class BitwardenClipboardManagerImpl(
 
     override fun setText(text: String, isSensitive: Boolean, toastDescriptorOverride: String?) {
         setText(text.toAnnotatedString(), isSensitive, toastDescriptorOverride)
+    }
+
+    override fun setText(text: String, isSensitive: Boolean, toastDescriptorOverride: Text) {
+        setText(
+            text.toAnnotatedString(),
+            isSensitive,
+            toastDescriptorOverride.toString(context.resources),
+        )
     }
 
     override fun setText(text: Text, isSensitive: Boolean, toastDescriptorOverride: String?) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -303,7 +303,10 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun handleCopyUrlClick(action: ListingItemOverflowAction.SendAction.CopyUrlClick) {
-        clipboardManager.setText(action.sendUrl)
+        clipboardManager.setText(
+            text = action.sendUrl,
+            toastDescriptorOverride = R.string.link.asText(),
+        )
     }
 
     private fun handleDeleteClick(action: ListingItemOverflowAction.SendAction.DeleteClick) {
@@ -350,19 +353,28 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun handleCopyNoteClick(action: ListingItemOverflowAction.VaultAction.CopyNoteClick) {
-        clipboardManager.setText(action.notes)
+        clipboardManager.setText(
+            text = action.notes,
+            toastDescriptorOverride = R.string.notes.asText(),
+        )
     }
 
     private fun handleCopyNumberClick(
         action: ListingItemOverflowAction.VaultAction.CopyNumberClick,
     ) {
-        clipboardManager.setText(action.number)
+        clipboardManager.setText(
+            text = action.number,
+            toastDescriptorOverride = R.string.number.asText(),
+        )
     }
 
     private fun handleCopyPasswordClick(
         action: ListingItemOverflowAction.VaultAction.CopyPasswordClick,
     ) {
-        clipboardManager.setText(action.password)
+        clipboardManager.setText(
+            text = action.password,
+            toastDescriptorOverride = R.string.password.asText(),
+        )
         organizationEventManager.trackEvent(
             event = OrganizationEvent.CipherClientCopiedPassword(cipherId = action.cipherId),
         )
@@ -371,7 +383,10 @@ class SearchViewModel @Inject constructor(
     private fun handleCopySecurityCodeClick(
         action: ListingItemOverflowAction.VaultAction.CopySecurityCodeClick,
     ) {
-        clipboardManager.setText(action.securityCode)
+        clipboardManager.setText(
+            text = action.securityCode,
+            toastDescriptorOverride = R.string.security_code.asText(),
+        )
         organizationEventManager.trackEvent(
             event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = action.cipherId),
         )
@@ -380,7 +395,10 @@ class SearchViewModel @Inject constructor(
     private fun handleCopyUsernameClick(
         action: ListingItemOverflowAction.VaultAction.CopyUsernameClick,
     ) {
-        clipboardManager.setText(action.username)
+        clipboardManager.setText(
+            text = action.username,
+            toastDescriptorOverride = R.string.username.asText(),
+        )
     }
 
     private fun handleEditCipherClick(action: ListingItemOverflowAction.VaultAction.EditClick) {
@@ -462,7 +480,10 @@ class SearchViewModel @Inject constructor(
         when (val result = action.result) {
             is GenerateTotpResult.Error -> Unit
             is GenerateTotpResult.Success -> {
-                clipboardManager.setText(result.code)
+                clipboardManager.setText(
+                    text = result.code,
+                    toastDescriptorOverride = R.string.totp.asText(),
+                )
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModel.kt
@@ -131,7 +131,10 @@ class PasswordHistoryViewModel @Inject constructor(
     }
 
     private fun handleCopyClick(password: GeneratedPassword) {
-        clipboardManager.setText(text = password.password)
+        clipboardManager.setText(
+            text = password.password,
+            toastDescriptorOverride = R.string.password.asText(),
+        )
     }
 
     private fun List<PasswordHistoryView>?.toViewState(): PasswordHistoryState.ViewState {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -257,7 +257,10 @@ class SendViewModel @Inject constructor(
     }
 
     private fun handleCopyClick(action: SendAction.CopyClick) {
-        clipboardManager.setText(text = action.sendItem.shareUrl)
+        clipboardManager.setText(
+            text = action.sendItem.shareUrl,
+            toastDescriptorOverride = R.string.send_link.asText(),
+        )
     }
 
     private fun handleSendClick(action: SendAction.SendClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
@@ -201,7 +201,10 @@ class AddSendViewModel @Inject constructor(
                 mutableStateFlow.update { it.copy(dialogState = null) }
                 if (state.isShared) {
                     navigateBack()
-                    clipboardManager.setText(result.sendView.toSendUrl(state.baseWebSendUrl))
+                    clipboardManager.setText(
+                        result.sendView.toSendUrl(state.baseWebSendUrl),
+                        toastDescriptorOverride = R.string.send_link.asText(),
+                    )
                 } else {
                     navigateBack()
                     sendEvent(
@@ -377,7 +380,12 @@ class AddSendViewModel @Inject constructor(
 
     private fun handleCopyLinkClick() {
         onContent {
-            it.common.sendUrl?.let { sendUrl -> clipboardManager.setText(text = sendUrl) }
+            it.common.sendUrl?.let { sendUrl ->
+                clipboardManager.setText(
+                    text = sendUrl,
+                    toastDescriptorOverride = R.string.send_link.asText(),
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1095,7 +1095,10 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleLoginCopyTotpKeyText(
         action: VaultAddEditAction.ItemType.LoginType.CopyTotpKeyClick,
     ) {
-        clipboardManager.setText(text = action.totpKey)
+        clipboardManager.setText(
+            text = action.totpKey,
+            toastDescriptorOverride = R.string.authenticator_key.asText(),
+        )
     }
 
     private fun handleLoginClearTotpKey() {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -517,7 +517,10 @@ class VaultItemViewModel @Inject constructor(
     private fun handleCopyNotesClick() {
         onContent { content ->
             val notes = content.common.notes.orEmpty()
-            clipboardManager.setText(text = notes)
+            clipboardManager.setText(
+                text = notes,
+                toastDescriptorOverride = R.string.notes.asText(),
+            )
         }
     }
 
@@ -583,7 +586,10 @@ class VaultItemViewModel @Inject constructor(
                 )
                 return@onLoginContent
             }
-            clipboardManager.setText(text = password)
+            clipboardManager.setText(
+                text = password,
+                toastDescriptorOverride = R.string.password.asText(),
+            )
             organizationEventManager.trackEvent(
                 event = OrganizationEvent.CipherClientCopiedPassword(cipherId = state.vaultItemId),
             )
@@ -593,18 +599,27 @@ class VaultItemViewModel @Inject constructor(
     private fun handleCopyTotpClick() {
         onLoginContent { _, login ->
             val code = login.totpCodeItemData?.verificationCode ?: return@onLoginContent
-            clipboardManager.setText(text = code)
+            clipboardManager.setText(
+                text = code,
+                toastDescriptorOverride = R.string.totp.asText(),
+            )
         }
     }
 
     private fun handleCopyUriClick(action: VaultItemAction.ItemType.Login.CopyUriClick) {
-        clipboardManager.setText(text = action.uri)
+        clipboardManager.setText(
+            text = action.uri,
+            toastDescriptorOverride = R.string.uri.asText(),
+        )
     }
 
     private fun handleCopyUsernameClick() {
         onLoginContent { _, login ->
             val username = requireNotNull(login.username)
-            clipboardManager.setText(text = username)
+            clipboardManager.setText(
+                text = username,
+                toastDescriptorOverride = R.string.username.asText(),
+            )
         }
     }
 
@@ -727,7 +742,10 @@ class VaultItemViewModel @Inject constructor(
                 )
                 return@onCardContent
             }
-            clipboardManager.setText(text = number)
+            clipboardManager.setText(
+                text = number,
+                toastDescriptorOverride = R.string.number.asText(),
+            )
         }
     }
 
@@ -742,7 +760,10 @@ class VaultItemViewModel @Inject constructor(
                 )
                 return@onCardContent
             }
-            clipboardManager.setText(text = securityCode)
+            clipboardManager.setText(
+                text = securityCode,
+                toastDescriptorOverride = R.string.security_code.asText(),
+            )
         }
     }
 
@@ -801,7 +822,10 @@ class VaultItemViewModel @Inject constructor(
 
     private fun handleCopyPublicKeyClick() {
         onSshKeyContent { _, sshKey ->
-            clipboardManager.setText(text = sshKey.publicKey)
+            clipboardManager.setText(
+                text = sshKey.publicKey,
+                toastDescriptorOverride = R.string.public_key.asText(),
+            )
         }
     }
 
@@ -839,13 +863,19 @@ class VaultItemViewModel @Inject constructor(
                 )
                 return@onSshKeyContent
             }
-            clipboardManager.setText(text = sshKey.privateKey)
+            clipboardManager.setText(
+                text = sshKey.privateKey,
+                toastDescriptorOverride = R.string.private_key.asText(),
+            )
         }
     }
 
     private fun handleCopyFingerprintClick() {
         onSshKeyContent { _, sshKey ->
-            clipboardManager.setText(text = sshKey.fingerprint)
+            clipboardManager.setText(
+                text = sshKey.fingerprint,
+                toastDescriptorOverride = R.string.fingerprint.asText(),
+            )
         }
     }
 
@@ -882,63 +912,90 @@ class VaultItemViewModel @Inject constructor(
     private fun handleCopyIdentityNameClick() {
         onIdentityContent { _, identity ->
             val identityName = identity.identityName.orEmpty()
-            clipboardManager.setText(text = identityName)
+            clipboardManager.setText(
+                text = identityName,
+                toastDescriptorOverride = R.string.identity_name.asText(),
+            )
         }
     }
 
     private fun handleCopyIdentityUsernameClick() {
         onIdentityContent { _, identity ->
             val username = identity.username.orEmpty()
-            clipboardManager.setText(text = username)
+            clipboardManager.setText(
+                text = username,
+                toastDescriptorOverride = R.string.username.asText(),
+            )
         }
     }
 
     private fun handleCopyCompanyClick() {
         onIdentityContent { _, identity ->
             val company = identity.company.orEmpty()
-            clipboardManager.setText(text = company)
+            clipboardManager.setText(
+                text = company,
+                toastDescriptorOverride = R.string.company.asText(),
+            )
         }
     }
 
     private fun handleCopySsnClick() {
         onIdentityContent { _, identity ->
             val ssn = identity.ssn.orEmpty()
-            clipboardManager.setText(text = ssn)
+            clipboardManager.setText(
+                text = ssn,
+                toastDescriptorOverride = R.string.ssn.asText(),
+            )
         }
     }
 
     private fun handleCopyPassportNumberClick() {
         onIdentityContent { _, identity ->
             val passportNumber = identity.passportNumber.orEmpty()
-            clipboardManager.setText(text = passportNumber)
+            clipboardManager.setText(
+                text = passportNumber,
+                toastDescriptorOverride = R.string.passport_number.asText(),
+            )
         }
     }
 
     private fun handleCopyLicenseNumberClick() {
         onIdentityContent { _, identity ->
             val licenseNumber = identity.licenseNumber.orEmpty()
-            clipboardManager.setText(text = licenseNumber)
+            clipboardManager.setText(
+                text = licenseNumber,
+                toastDescriptorOverride = R.string.license_number.asText(),
+            )
         }
     }
 
     private fun handleCopyEmailClick() {
         onIdentityContent { _, identity ->
             val email = identity.email.orEmpty()
-            clipboardManager.setText(text = email)
+            clipboardManager.setText(
+                text = email,
+                toastDescriptorOverride = R.string.email.asText(),
+            )
         }
     }
 
     private fun handleCopyPhoneClick() {
         onIdentityContent { _, identity ->
             val phone = identity.phone.orEmpty()
-            clipboardManager.setText(text = phone)
+            clipboardManager.setText(
+                text = phone,
+                toastDescriptorOverride = R.string.phone.asText(),
+            )
         }
     }
 
     private fun handleCopyAddressClick() {
         onIdentityContent { _, identity ->
             val address = identity.address.orEmpty()
-            clipboardManager.setText(text = address)
+            clipboardManager.setText(
+                text = address,
+                toastDescriptorOverride = R.string.address.asText(),
+            )
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -487,7 +487,10 @@ class VaultItemListingViewModel @Inject constructor(
     }
 
     private fun handleCopySendUrlClick(action: ListingItemOverflowAction.SendAction.CopyUrlClick) {
-        clipboardManager.setText(text = action.sendUrl)
+        clipboardManager.setText(
+            text = action.sendUrl,
+            toastDescriptorOverride = R.string.send_link.asText(),
+        )
     }
 
     private fun handleDeleteSendClick(action: ListingItemOverflowAction.SendAction.DeleteClick) {
@@ -757,19 +760,28 @@ class VaultItemListingViewModel @Inject constructor(
     }
 
     private fun handleCopyNoteClick(action: ListingItemOverflowAction.VaultAction.CopyNoteClick) {
-        clipboardManager.setText(action.notes)
+        clipboardManager.setText(
+            text = action.notes,
+            toastDescriptorOverride = R.string.notes.asText(),
+        )
     }
 
     private fun handleCopyNumberClick(
         action: ListingItemOverflowAction.VaultAction.CopyNumberClick,
     ) {
-        clipboardManager.setText(action.number)
+        clipboardManager.setText(
+            text = action.number,
+            toastDescriptorOverride = R.string.number.asText(),
+        )
     }
 
     private fun handleCopyPasswordClick(
         action: ListingItemOverflowAction.VaultAction.CopyPasswordClick,
     ) {
-        clipboardManager.setText(action.password)
+        clipboardManager.setText(
+            text = action.password,
+            toastDescriptorOverride = R.string.password.asText(),
+        )
         organizationEventManager.trackEvent(
             event = OrganizationEvent.CipherClientCopiedPassword(cipherId = action.cipherId),
         )
@@ -778,7 +790,10 @@ class VaultItemListingViewModel @Inject constructor(
     private fun handleCopySecurityCodeClick(
         action: ListingItemOverflowAction.VaultAction.CopySecurityCodeClick,
     ) {
-        clipboardManager.setText(action.securityCode)
+        clipboardManager.setText(
+            text = action.securityCode,
+            toastDescriptorOverride = R.string.security_code.asText(),
+        )
         organizationEventManager.trackEvent(
             event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = action.cipherId),
         )
@@ -796,7 +811,10 @@ class VaultItemListingViewModel @Inject constructor(
     private fun handleCopyUsernameClick(
         action: ListingItemOverflowAction.VaultAction.CopyUsernameClick,
     ) {
-        clipboardManager.setText(action.username)
+        clipboardManager.setText(
+            text = action.username,
+            toastDescriptorOverride = R.string.username.asText(),
+        )
     }
 
     private fun handleEditCipherClick(action: ListingItemOverflowAction.VaultAction.EditClick) {
@@ -1064,7 +1082,10 @@ class VaultItemListingViewModel @Inject constructor(
         when (val result = action.result) {
             is GenerateTotpResult.Error -> Unit
             is GenerateTotpResult.Success -> {
-                clipboardManager.setText(result.code)
+                clipboardManager.setText(
+                    text = result.code,
+                    toastDescriptorOverride = R.string.totp.asText(),
+                )
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -447,19 +447,28 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleCopyNoteClick(action: ListingItemOverflowAction.VaultAction.CopyNoteClick) {
-        clipboardManager.setText(action.notes)
+        clipboardManager.setText(
+            text = action.notes,
+            toastDescriptorOverride = R.string.notes.asText(),
+        )
     }
 
     private fun handleCopyNumberClick(
         action: ListingItemOverflowAction.VaultAction.CopyNumberClick,
     ) {
-        clipboardManager.setText(action.number)
+        clipboardManager.setText(
+            text = action.number,
+            toastDescriptorOverride = R.string.number.asText(),
+        )
     }
 
     private fun handleCopyPasswordClick(
         action: ListingItemOverflowAction.VaultAction.CopyPasswordClick,
     ) {
-        clipboardManager.setText(action.password)
+        clipboardManager.setText(
+            text = action.password,
+            toastDescriptorOverride = R.string.password.asText(),
+        )
         organizationEventManager.trackEvent(
             event = OrganizationEvent.CipherClientCopiedPassword(cipherId = action.cipherId),
         )
@@ -468,7 +477,10 @@ class VaultViewModel @Inject constructor(
     private fun handleCopySecurityCodeClick(
         action: ListingItemOverflowAction.VaultAction.CopySecurityCodeClick,
     ) {
-        clipboardManager.setText(action.securityCode)
+        clipboardManager.setText(
+            text = action.securityCode,
+            toastDescriptorOverride = R.string.security_code.asText(),
+        )
         organizationEventManager.trackEvent(
             event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = action.cipherId),
         )
@@ -486,7 +498,10 @@ class VaultViewModel @Inject constructor(
     private fun handleCopyUsernameClick(
         action: ListingItemOverflowAction.VaultAction.CopyUsernameClick,
     ) {
-        clipboardManager.setText(action.username)
+        clipboardManager.setText(
+            text = action.username,
+            toastDescriptorOverride = R.string.username.asText(),
+        )
     }
 
     private fun handleEditClick(action: ListingItemOverflowAction.VaultAction.EditClick) {
@@ -535,7 +550,10 @@ class VaultViewModel @Inject constructor(
         when (val result = action.result) {
             is GenerateTotpResult.Error -> Unit
             is GenerateTotpResult.Success -> {
-                clipboardManager.setText(result.code)
+                clipboardManager.setText(
+                    text = result.code,
+                    toastDescriptorOverride = R.string.totp.asText(),
+                )
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
@@ -106,7 +106,10 @@ class VerificationCodeViewModel @Inject constructor(
     }
 
     private fun handleCopyClick(action: VerificationCodeAction.CopyClick) {
-        clipboardManager.setText(text = action.text)
+        clipboardManager.setText(
+            text = action.text,
+            toastDescriptorOverride = R.string.verification_code_totp.asText(),
+        )
     }
 
     private fun handleItemClick(action: VerificationCodeAction.ItemClick) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1144,4 +1144,5 @@ Do you want to switch to this account?</string>
   <string name="coachmark_6_of_6">6 OF 6</string>
   <string name="use_these_options_to_adjust_your_password_to_your_account_requirements">Use these options to adjust your password to meet your account website\'s requirements.</string>
   <string name="after_you_save_your_new_password_to_bitwarden_don_t_forget_to_update_it_on_your_account_website">"After you save your new password to Bitwarden, don’t forget to update it on your account website. "</string>
+    <string name="link">Link</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerTest.kt
@@ -11,6 +11,8 @@ import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardMan
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
+import com.x8bit.bitwarden.ui.platform.base.util.Text
+import com.x8bit.bitwarden.ui.platform.base.util.asText
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -46,7 +48,7 @@ class AutofillTotpManagerTest {
         every { userStateFlow } returns mutableUserStateFlow
     }
     private val clipboardManager: BitwardenClipboardManager = mockk {
-        every { setText(any<String>()) } just runs
+        every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
     }
     private val settingsRepository: SettingsRepository = mockk()
     private val vaultRepository: VaultRepository = mockk()
@@ -83,7 +85,10 @@ class AutofillTotpManagerTest {
             settingsRepository.isAutoCopyTotpDisabled
         }
         verify(exactly = 0) {
-            clipboardManager.setText(any<String>())
+            clipboardManager.setText(
+                text = any<String>(),
+                toastDescriptorOverride = any<Text>(),
+            )
             toast.show()
         }
     }
@@ -101,7 +106,10 @@ class AutofillTotpManagerTest {
             autofillTotpManager.tryCopyTotpToClipboard(cipherView = cipherView)
 
             verify(exactly = 0) {
-                clipboardManager.setText(any<String>())
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
                 toast.show()
             }
             verify(exactly = 1) {
@@ -123,7 +131,10 @@ class AutofillTotpManagerTest {
             autofillTotpManager.tryCopyTotpToClipboard(cipherView = cipherView)
 
             verify(exactly = 0) {
-                clipboardManager.setText(any<String>())
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
                 toast.show()
             }
             verify(exactly = 1) {
@@ -152,7 +163,10 @@ class AutofillTotpManagerTest {
             autofillTotpManager.tryCopyTotpToClipboard(cipherView = cipherView)
 
             verify(exactly = 1) {
-                clipboardManager.setText(text = TOTP_RESULT_VALUE)
+                clipboardManager.setText(
+                    text = TOTP_RESULT_VALUE,
+                    toastDescriptorOverride = R.string.verification_code_totp.asText(),
+                )
                 settingsRepository.isAutoCopyTotpDisabled
                 toast.show()
             }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -45,6 +45,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.concat
 import com.x8bit.bitwarden.ui.platform.feature.search.util.createMockDisplayItemForCipher
@@ -88,7 +89,7 @@ class SearchViewModelTest : BaseViewModelTest() {
         ZoneOffset.UTC,
     )
     private val clipboardManager: BitwardenClipboardManager = mockk {
-        every { setText(any<String>()) } just runs
+        every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
     }
     private val policyManager: PolicyManager = mockk<PolicyManager> {
         every {
@@ -660,19 +661,22 @@ class SearchViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `OverflowOptionClick Send CopyUrlClick should call setText on clipboardManager`() {
-        val sendUrl = "www.test.com"
-        every { clipboardManager.setText(sendUrl) } just runs
-        val viewModel = createViewModel()
-        viewModel.trySendAction(
-            SearchAction.OverflowOptionClick(
-                ListingItemOverflowAction.SendAction.CopyUrlClick(sendUrl = sendUrl),
-            ),
-        )
-        verify(exactly = 1) {
-            clipboardManager.setText(text = sendUrl)
+    fun `OverflowOptionClick Send CopyUrlClick should call setText on clipboardManager`() =
+        runTest {
+            val sendUrl = "www.test.com"
+            val viewModel = createViewModel()
+            viewModel.trySendAction(
+                SearchAction.OverflowOptionClick(
+                    ListingItemOverflowAction.SendAction.CopyUrlClick(sendUrl = sendUrl),
+                ),
+            )
+            verify(exactly = 1) {
+                clipboardManager.setText(
+                    text = sendUrl,
+                    toastDescriptorOverride = R.string.link.asText(),
+                )
+            }
         }
-    }
 
     @Test
     fun `OverflowOptionClick Send DeleteClick with deleteSend error should display error dialog`() =
@@ -813,7 +817,10 @@ class SearchViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(notes)
+                clipboardManager.setText(
+                    text = notes,
+                    toastDescriptorOverride = R.string.notes.asText(),
+                )
             }
         }
 
@@ -831,7 +838,10 @@ class SearchViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(number)
+                clipboardManager.setText(
+                    text = number,
+                    toastDescriptorOverride = R.string.number.asText(),
+                )
             }
         }
 
@@ -854,7 +864,10 @@ class SearchViewModelTest : BaseViewModelTest() {
             )
 
             verify(exactly = 1) {
-                clipboardManager.setText(code)
+                clipboardManager.setText(
+                    text = code,
+                    toastDescriptorOverride = R.string.totp.asText(),
+                )
             }
         }
 
@@ -876,7 +889,10 @@ class SearchViewModelTest : BaseViewModelTest() {
             )
 
             verify(exactly = 0) {
-                clipboardManager.setText(text = any<String>())
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
             }
         }
 
@@ -897,7 +913,10 @@ class SearchViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(password)
+                clipboardManager.setText(
+                    text = password,
+                    toastDescriptorOverride = R.string.password.asText(),
+                )
                 organizationEventManager.trackEvent(
                     event = OrganizationEvent.CipherClientCopiedPassword(cipherId = cipherId),
                 )
@@ -921,7 +940,10 @@ class SearchViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(securityCode)
+                clipboardManager.setText(
+                    text = securityCode,
+                    toastDescriptorOverride = R.string.security_code.asText(),
+                )
                 organizationEventManager.trackEvent(
                     event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = cipherId),
                 )
@@ -942,7 +964,10 @@ class SearchViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(username)
+                clipboardManager.setText(
+                    text = username,
+                    toastDescriptorOverride = R.string.username.asText(),
+                )
             }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModelTest.kt
@@ -138,7 +138,7 @@ class AboutViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(AboutAction.VersionClick)
 
         verify(exactly = 1) {
-            clipboardManager.setText(expectedText, ofType(Boolean::class), isNull())
+            clipboardManager.setText(expectedText, ofType(Boolean::class), isNull<String>())
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
@@ -16,6 +16,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.tools.feature.send.util.toViewState
 import io.mockk.coEvery
@@ -39,7 +40,9 @@ class SendViewModelTest : BaseViewModelTest() {
     private val mutablePullToRefreshEnabledFlow = MutableStateFlow(false)
     private val mutableSendDataFlow = MutableStateFlow<DataState<SendData>>(DataState.Loading)
 
-    private val clipboardManager: BitwardenClipboardManager = mockk()
+    private val clipboardManager: BitwardenClipboardManager = mockk {
+        every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
+    }
     private val environmentRepo: EnvironmentRepository = mockk {
         every { environment } returns Environment.Us
     }
@@ -238,18 +241,18 @@ class SendViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `CopyClick should call setText on the ClipboardManager`() {
+    fun `CopyClick should call setText on the ClipboardManager`() = runTest {
         val viewModel = createViewModel()
         val testUrl = "www.test.com/"
         val sendItem = mockk<SendState.ViewState.Content.SendItem> {
             every { shareUrl } returns testUrl
         }
-        every { clipboardManager.setText(testUrl) } just runs
-
         viewModel.trySendAction(SendAction.CopyClick(sendItem))
-
         verify(exactly = 1) {
-            clipboardManager.setText(testUrl)
+            clipboardManager.setText(
+                text = testUrl,
+                toastDescriptorOverride = R.string.send_link.asText(),
+            )
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModelTest.kt
@@ -27,6 +27,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateSendResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.model.AddSendType
@@ -64,7 +65,7 @@ class AddSendViewModelTest : BaseViewModelTest() {
         ZoneOffset.UTC,
     )
     private val clipboardManager: BitwardenClipboardManager = mockk {
-        every { setText(any<String>()) } just runs
+        every { setText(any<String>(), toastDescriptorOverride = any<Text>()) } just runs
     }
     private val mutableUserStateFlow = MutableStateFlow<UserState?>(DEFAULT_USER_STATE)
     private val authRepository: AuthRepository = mockk {
@@ -216,7 +217,10 @@ class AddSendViewModelTest : BaseViewModelTest() {
             coVerify(exactly = 1) {
                 vaultRepository.createSend(sendView = mockSendView, fileUri = null)
                 specialCircumstanceManager.specialCircumstance = null
-                clipboardManager.setText(sendUrl)
+                clipboardManager.setText(
+                    text = sendUrl,
+                    toastDescriptorOverride = R.string.send_link.asText(),
+                )
             }
         }
 
@@ -251,7 +255,10 @@ class AddSendViewModelTest : BaseViewModelTest() {
             coVerify(exactly = 1) {
                 vaultRepository.createSend(sendView = mockSendView, fileUri = null)
                 specialCircumstanceManager.specialCircumstance = null
-                clipboardManager.setText(sendUrl)
+                clipboardManager.setText(
+                    text = sendUrl,
+                    toastDescriptorOverride = R.string.send_link.asText(),
+                )
             }
         }
 
@@ -492,7 +499,10 @@ class AddSendViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(AddSendAction.CopyLinkClick)
 
         verify(exactly = 1) {
-            clipboardManager.setText(sendUrl)
+            clipboardManager.setText(
+                text = sendUrl,
+                toastDescriptorOverride = R.string.send_link.asText(),
+            )
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -135,7 +135,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     private val resourceManager: ResourceManager = mockk {
         every { getString(R.string.folder_none) } returns "No Folder"
     }
-    private val clipboardManager: BitwardenClipboardManager = mockk()
+    private val clipboardManager: BitwardenClipboardManager = mockk {
+        every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
+    }
     private val policyManager: PolicyManager = mockk {
         every {
             getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
@@ -2406,16 +2408,16 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         fun `CopyTotpKeyClick should call setText on ClipboardManager`() {
             val viewModel = createAddVaultItemViewModel()
             val testKey = "TestKey"
-            every { clipboardManager.setText(text = testKey) } just runs
-
             viewModel.trySendAction(
                 VaultAddEditAction.ItemType.LoginType.CopyTotpKeyClick(
                     testKey,
                 ),
             )
-
             verify(exactly = 1) {
-                clipboardManager.setText(text = testKey)
+                clipboardManager.setText(
+                    text = testKey,
+                    toastDescriptorOverride = R.string.authenticator_key.asText(),
+                )
             }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -25,8 +25,8 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
-import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
@@ -60,6 +60,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.concat
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
@@ -119,7 +120,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     )
 
     private val clipboardManager: BitwardenClipboardManager = mockk {
-        every { setText(any<String>()) } just runs
+        every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
     }
 
     private val mutableUserStateFlow = MutableStateFlow<UserState?>(DEFAULT_USER_STATE)
@@ -1051,19 +1052,22 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `OverflowOptionClick Send CopyUrlClick should call setText on clipboardManager`() {
-        val sendUrl = "www.test.com"
-        every { clipboardManager.setText(sendUrl) } just runs
-        val viewModel = createVaultItemListingViewModel()
-        viewModel.trySendAction(
-            VaultItemListingsAction.OverflowOptionClick(
-                ListingItemOverflowAction.SendAction.CopyUrlClick(sendUrl = sendUrl),
-            ),
-        )
-        verify(exactly = 1) {
-            clipboardManager.setText(text = sendUrl)
+    fun `OverflowOptionClick Send CopyUrlClick should call setText on clipboardManager`() =
+        runTest {
+            val sendUrl = "www.test.com"
+            val viewModel = createVaultItemListingViewModel()
+            viewModel.trySendAction(
+                VaultItemListingsAction.OverflowOptionClick(
+                    ListingItemOverflowAction.SendAction.CopyUrlClick(sendUrl = sendUrl),
+                ),
+            )
+            verify(exactly = 1) {
+                clipboardManager.setText(
+                    text = sendUrl,
+                    toastDescriptorOverride = R.string.send_link.asText(),
+                )
+            }
         }
-    }
 
     @Test
     fun `OverflowOptionClick Send DeleteClick with deleteSend error should display error dialog`() =
@@ -1204,7 +1208,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(notes)
+                clipboardManager.setText(
+                    text = notes,
+                    toastDescriptorOverride = R.string.notes.asText(),
+                )
             }
         }
 
@@ -1222,7 +1229,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(number)
+                clipboardManager.setText(
+                    text = number,
+                    toastDescriptorOverride = R.string.number.asText(),
+                )
             }
         }
 
@@ -1243,7 +1253,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(password)
+                clipboardManager.setText(
+                    text = password,
+                    toastDescriptorOverride = R.string.password.asText(),
+                )
                 organizationEventManager.trackEvent(
                     event = OrganizationEvent.CipherClientCopiedPassword(cipherId = cipherId),
                 )
@@ -1267,7 +1280,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(securityCode)
+                clipboardManager.setText(
+                    text = securityCode,
+                    toastDescriptorOverride = R.string.security_code.asText(),
+                )
                 organizationEventManager.trackEvent(
                     event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = cipherId),
                 )
@@ -1293,7 +1309,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
 
             verify(exactly = 1) {
-                clipboardManager.setText(code)
+                clipboardManager.setText(
+                    text = code,
+                    toastDescriptorOverride = R.string.totp.asText(),
+                )
             }
         }
 
@@ -1315,7 +1334,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
 
             verify(exactly = 0) {
-                clipboardManager.setText(text = any<String>())
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
             }
         }
 
@@ -1333,7 +1355,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(username)
+                clipboardManager.setText(
+                    text = username,
+                    toastDescriptorOverride = R.string.username.asText(),
+                )
             }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -35,6 +35,7 @@ import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
@@ -78,7 +79,7 @@ class VaultViewModelTest : BaseViewModelTest() {
     }
 
     private val clipboardManager: BitwardenClipboardManager = mockk {
-        every { setText(any<String>()) } just runs
+        every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
     }
     private val policyManager: PolicyManager = mockk {
         every {
@@ -1382,7 +1383,10 @@ class VaultViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(notes)
+                clipboardManager.setText(
+                    text = notes,
+                    toastDescriptorOverride = R.string.notes.asText(),
+                )
             }
         }
 
@@ -1400,7 +1404,10 @@ class VaultViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(number)
+                clipboardManager.setText(
+                    text = number,
+                    toastDescriptorOverride = R.string.number.asText(),
+                )
             }
         }
 
@@ -1421,7 +1428,10 @@ class VaultViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(password)
+                clipboardManager.setText(
+                    text = password,
+                    toastDescriptorOverride = R.string.password.asText(),
+                )
                 organizationEventManager.trackEvent(
                     event = OrganizationEvent.CipherClientCopiedPassword(cipherId = cipherId),
                 )
@@ -1447,7 +1457,10 @@ class VaultViewModelTest : BaseViewModelTest() {
             )
 
             verify(exactly = 1) {
-                clipboardManager.setText(code)
+                clipboardManager.setText(
+                    text = code,
+                    toastDescriptorOverride = R.string.totp.asText(),
+                )
             }
         }
 
@@ -1469,7 +1482,10 @@ class VaultViewModelTest : BaseViewModelTest() {
             )
 
             verify(exactly = 0) {
-                clipboardManager.setText(text = any<String>())
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
             }
         }
 
@@ -1490,7 +1506,10 @@ class VaultViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(securityCode)
+                clipboardManager.setText(
+                    text = securityCode,
+                    toastDescriptorOverride = R.string.security_code.asText(),
+                )
                 organizationEventManager.trackEvent(
                     event = OrganizationEvent.CipherClientCopiedCardCode(cipherId = cipherId),
                 )
@@ -1511,7 +1530,10 @@ class VaultViewModelTest : BaseViewModelTest() {
                 ),
             )
             verify(exactly = 1) {
-                clipboardManager.setText(username)
+                clipboardManager.setText(
+                    text = username,
+                    toastDescriptorOverride = R.string.username.asText(),
+                )
             }
         }
 
@@ -1661,7 +1683,10 @@ class VaultViewModelTest : BaseViewModelTest() {
             )
 
             verify(exactly = 1) {
-                clipboardManager.setText(password)
+                clipboardManager.setText(
+                    text = password,
+                    toastDescriptorOverride = R.string.password.asText(),
+                )
                 organizationEventManager.trackEvent(
                     event = OrganizationEvent.CipherClientCopiedPassword(cipherId = cipherId),
                 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModelTest.kt
@@ -16,6 +16,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
 import com.x8bit.bitwarden.data.vault.manager.model.VerificationCodeItem
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.concat
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
@@ -39,7 +40,9 @@ import org.junit.jupiter.api.Test
 
 class VerificationCodeViewModelTest : BaseViewModelTest() {
 
-    private val clipboardManager: BitwardenClipboardManager = mockk()
+    private val clipboardManager: BitwardenClipboardManager = mockk {
+        every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
+    }
 
     private val mutableAuthCodeFlow =
         MutableStateFlow<DataState<List<VerificationCodeItem>>>(DataState.Loading)
@@ -103,15 +106,17 @@ class VerificationCodeViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `onCopyClick should call setText on the ClipboardManager`() {
+    fun `onCopyClick should call setText on the ClipboardManager`() = runTest {
         val authCode = "123456"
         val viewModel = createViewModel()
-        every { clipboardManager.setText(text = authCode) } just runs
 
         viewModel.trySendAction(VerificationCodeAction.CopyClick(authCode))
 
         verify(exactly = 1) {
-            clipboardManager.setText(text = authCode)
+            clipboardManager.setText(
+                text = authCode,
+                toastDescriptorOverride = R.string.verification_code_totp.asText(),
+            )
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9535](https://bitwarden.atlassian.net/browse/PM-9535)

## 📔 Objective

The clipboard manager now has additional arguments to set custom text. When text is copied to the clipboard a toast is shown to the user with the custom message regardless of the Android version. This way it's clear what was copied.

## 📸 Screenshots

Notes
<img width="369" alt="image" src="https://github.com/user-attachments/assets/1fa47ed9-c148-46e9-8780-5253371c455c" />

Password
<img width="384" alt="image" src="https://github.com/user-attachments/assets/9622e5f9-2fd6-48c1-bdc8-c50faaecf881" />

Username
<img width="394" alt="image" src="https://github.com/user-attachments/assets/012d84f7-2010-4a03-b70f-06cf3d3a1a80" />

URI
<img width="357" alt="image" src="https://github.com/user-attachments/assets/99e13ba2-0166-4507-9012-dae77a830e9c" />

Custom fields
<img width="372" alt="image" src="https://github.com/user-attachments/assets/4e658718-4a25-4d2f-a322-b0445af87e15" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9535]: https://bitwarden.atlassian.net/browse/PM-9535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ