### PR TITLE
Remove the language change dialog

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -14,10 +14,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
@@ -30,7 +27,6 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
-import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
@@ -128,7 +124,6 @@ private fun LanguageSelectionRow(
     modifier: Modifier = Modifier,
     resources: Resources = LocalContext.current.resources,
 ) {
-    var languageChangedDialogOption: String? by rememberSaveable { mutableStateOf(value = null) }
     BitwardenMultiSelectButton(
         label = stringResource(id = R.string.language),
         options = AppLanguage.entries.map { it.text() }.toImmutableList(),
@@ -137,19 +132,10 @@ private fun LanguageSelectionRow(
             onLanguageSelection(
                 AppLanguage.entries.first { selectedLanguage == it.text.toString(resources) },
             )
-            languageChangedDialogOption = selectedLanguage
         },
         cardStyle = CardStyle.Full,
         modifier = modifier,
     )
-
-    languageChangedDialogOption?.let {
-        BitwardenBasicDialog(
-            title = stringResource(id = R.string.language),
-            message = stringResource(id = R.string.language_change_x_description, it),
-            onDismissRequest = { languageChangedDialogOption = null },
-        )
-    }
 }
 
 @Composable

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
@@ -64,7 +64,7 @@ class AppearanceScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `on language selection dialog item click should send LanguageChange and show dialog`() {
+    fun `on language selection dialog item click should send LanguageChange`() {
         // Clicking the Language row shows the language selection dialog
         composeTestRule
             .onNodeWithContentDescription(label = "Default (System). Language")
@@ -79,17 +79,6 @@ class AppearanceScreenTest : BaseComposeTest() {
             .onAllNodesWithText("Afrikaans")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsNotDisplayed()
-
-        // Should show confirmation dialog
-        composeTestRule
-            .onAllNodesWithText("Ok")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .assertIsDisplayed()
-        // Clicking "Ok" should dismiss confirmation dialog
-        composeTestRule.onAllNodesWithText("Ok")
-            .filterToOne(hasAnyAncestor(isDialog()))
-            .performClick()
-        composeTestRule.assertNoDialogExists()
 
         verify {
             viewModel.trySendAction(


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the language change dialog that informs users that they need to restart the app. This is not true, the app does not need to restart.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
