### PR TITLE
PM-17765 & PM-17767 Adjust spacing in vault screen and adjust account switcher icon size and minimum row height

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/account/BitwardenAccountSwitcher.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/account/BitwardenAccountSwitcher.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
@@ -286,6 +287,7 @@ private fun AccountSummaryItem(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .testTag("AccountCell")
+            .requiredHeightIn(min = 60.dp)
             .combinedClickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(
@@ -304,14 +306,14 @@ private fun AccountSummaryItem(
                 painter = rememberVectorPainter(id = R.drawable.ic_account_initials_container),
                 contentDescription = null,
                 tint = accountSummary.avatarColor,
-                modifier = Modifier.size(40.dp),
+                modifier = Modifier.size(24.dp),
             )
 
             Text(
                 text = accountSummary.initials,
                 style = BitwardenTheme.typography.titleMedium
                     // Do not allow scaling
-                    .copy(fontSize = 16.dp.toUnscaledTextUnit()),
+                    .copy(fontSize = 12.dp.toUnscaledTextUnit()),
                 color = accountSummary.avatarColor.toSafeOverlayColor(),
                 modifier = Modifier.clearAndSetSemantics { },
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -72,12 +72,12 @@ fun VaultContent(
                         .testTag("VerificationCodesFilter")
                         .standardHorizontalMargin(),
                 )
+                Spacer(modifier = Modifier.height(height = 16.dp))
             }
         }
 
         if (state.favoriteItems.isNotEmpty()) {
             item {
-                Spacer(modifier = Modifier.height(height = 16.dp))
                 BitwardenListHeaderText(
                     label = stringResource(id = R.string.favorites),
                     supportingLabel = state.favoriteItems.count().toString(),
@@ -118,11 +118,11 @@ fun VaultContent(
                         .testTag("CipherCell")
                         .standardHorizontalMargin(),
                 )
+                Spacer(modifier = Modifier.height(height = 16.dp))
             }
         }
 
         item {
-            Spacer(modifier = Modifier.height(height = 16.dp))
             BitwardenListHeaderText(
                 label = stringResource(id = R.string.types),
                 supportingLabel = state.itemTypesCount.toString(),
@@ -220,9 +220,12 @@ fun VaultContent(
             }
         }
 
+        item {
+            Spacer(modifier = Modifier.height(height = 16.dp))
+        }
+
         if (state.folderItems.isNotEmpty()) {
             item {
-                Spacer(modifier = Modifier.height(height = 16.dp))
                 BitwardenListHeaderText(
                     label = stringResource(id = R.string.folders),
                     supportingLabel = state.folderItems.count().toString(),
@@ -250,11 +253,13 @@ fun VaultContent(
                         .standardHorizontalMargin(),
                 )
             }
+            item {
+                Spacer(modifier = Modifier.height(height = 16.dp))
+            }
         }
 
         if (state.noFolderItems.isNotEmpty()) {
             item {
-                Spacer(modifier = Modifier.height(height = 16.dp))
                 BitwardenListHeaderText(
                     label = stringResource(id = R.string.folder_none),
                     supportingLabel = state.noFolderItems.count().toString(),
@@ -295,11 +300,13 @@ fun VaultContent(
                         .standardHorizontalMargin(),
                 )
             }
+            item {
+                Spacer(modifier = Modifier.height(height = 16.dp))
+            }
         }
 
         if (state.collectionItems.isNotEmpty()) {
             item {
-                Spacer(modifier = Modifier.height(height = 16.dp))
                 BitwardenListHeaderText(
                     label = stringResource(id = R.string.collections),
                     supportingLabel = state.collectionItems.count().toString(),
@@ -327,10 +334,12 @@ fun VaultContent(
                         .standardHorizontalMargin(),
                 )
             }
+            item {
+                Spacer(modifier = Modifier.height(height = 16.dp))
+            }
         }
 
         item {
-            Spacer(modifier = Modifier.height(height = 16.dp))
             BitwardenListHeaderText(
                 label = stringResource(id = R.string.trash),
                 supportingLabel = TRASH_TYPES_COUNT.toString(),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17765](https://bitwarden.atlassian.net/browse/PM-17765)
[PM-17767](https://bitwarden.atlassian.net/browse/PM-17767)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Fix the spacing in the vault screen between the start of the content and the items, move the 16.dp padding between items to the end of "each" section so for conditional content it will only be applied if needed.
- Change icon size in account switcher drop down and set a minimum row height for each option per the desing.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
OLD | NEW
![image](https://github.com/user-attachments/assets/906fb77f-5e6b-4fc1-aa38-4aa55eac64b6)

![image](https://github.com/user-attachments/assets/33261458-b261-4189-9450-f9a24fcb7bb6)

![image](https://github.com/user-attachments/assets/538169da-8694-4d7d-9d56-6ed013246f87)



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17765]: https://bitwarden.atlassian.net/browse/PM-17765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-17767]: https://bitwarden.atlassian.net/browse/PM-17767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ