### PR TITLE
PM-17797 and PM-17798 set onboarding features to be remotely configurable

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -70,7 +70,7 @@ sealed class FlagKey<out T : Any> {
     data object OnboardingCarousel : FlagKey<Boolean>() {
         override val keyName: String = "native-carousel-flow"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
+        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -79,7 +79,7 @@ sealed class FlagKey<out T : Any> {
     data object OnboardingFlow : FlagKey<Boolean>() {
         override val keyName: String = "native-create-account-flow"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
+        override val isRemotelyConfigured: Boolean = true
     }
 
     /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
@@ -13,7 +13,6 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -127,7 +126,7 @@ class DebugMenuRepositoryTest {
             val mockServerData = mockk<ConfigResponseJson>(relaxed = true) {
                 every { featureStates } returns mapOf(
                     FlagKey.EmailVerification.keyName to JsonPrimitive(true),
-                    FlagKey.OnboardingCarousel.keyName to JsonPrimitive(false),
+                    FlagKey.OnboardingCarousel.keyName to JsonPrimitive(true),
                     FlagKey.OnboardingFlow.keyName to JsonPrimitive(true),
                 )
             }
@@ -144,11 +143,11 @@ class DebugMenuRepositoryTest {
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(FlagKey.EmailVerification, true)
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
                     FlagKey.OnboardingCarousel,
-                    false,
+                    true,
                 )
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
                     FlagKey.OnboardingFlow,
-                    false,
+                    true,
                 )
             }
 
@@ -157,7 +156,6 @@ class DebugMenuRepositoryTest {
                 awaitItem()
                 cancel()
             }
-            unmockkStatic(FlagKey.OnboardingFlow::class)
         }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -140,7 +139,7 @@ class DebugMenuRepositoryTest {
             debugMenuRepository.resetFeatureFlagOverrides()
 
             assertTrue(FlagKey.EmailVerification.isRemotelyConfigured)
-            assertFalse(FlagKey.OnboardingCarousel.isRemotelyConfigured)
+            assertTrue(FlagKey.OnboardingCarousel.isRemotelyConfigured)
             verify(exactly = 1) {
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(FlagKey.EmailVerification, true)
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(


### PR DESCRIPTION
## 🎟️ Tracking
[PM-17797](https://bitwarden.atlassian.net/browse/PM-17797)
[PM-17798](https://bitwarden.atlassian.net/browse/PM-17798)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- set both onboarding flags to be remotely configurable.


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17797]: https://bitwarden.atlassian.net/browse/PM-17797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-17798]: https://bitwarden.atlassian.net/browse/PM-17798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ