### PR TITLE
Fix vault favorites spacing

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -118,6 +118,8 @@ fun VaultContent(
                         .testTag("CipherCell")
                         .standardHorizontalMargin(),
                 )
+            }
+            item {
                 Spacer(modifier = Modifier.height(height = 16.dp))
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes a spacing issue between card items in the vault screen favorites.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/2273b1b4-86d0-4fa1-bad9-3d069ba1be4b" width="300" /> | <img src="https://github.com/user-attachments/assets/6359dd30-3865-45a1-8b7b-24ae2f72ba90" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
