### PR TITLE
PM-17851: Update manual code entry screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -690,6 +690,7 @@ Scanning will happen automatically.</string>
   <string name="verification_codes">Verification codes</string>
   <string name="premium_subscription_required">Premium subscription required</string>
   <string name="cannot_add_authenticator_key">Cannot add authenticator key?</string>
+  <string name="cannot_add_authenticator_key_scan_qr_code">Cannot add authenticator key? <annotation link="scanQrCode">Scan QR Code</annotation></string>
   <string name="scan_qr_code">Scan QR Code</string>
   <string name="cannot_scan_qr_code">Cannot scan QR Code?</string>
   <string name="authenticator_key_scanner">Authenticator key</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreenTests.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreenTests.kt
@@ -22,6 +22,7 @@ import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.FakePermissionManager
 import com.x8bit.bitwarden.ui.util.assertNoDialogExists
+import com.x8bit.bitwarden.ui.util.performCustomAccessibilityAction
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -102,8 +103,8 @@ class ManualCodeEntryScreenTests : BaseComposeTest() {
         fakePermissionManager.checkPermissionResult = true
 
         composeTestRule
-            .onNodeWithText("Scan QR Code")
-            .performClick()
+            .onNodeWithText(text = "Cannot add authenticator key? Scan QR Code")
+            .performCustomAccessibilityAction(label = "Scan QR Code")
 
         verify {
             viewModel.trySendAction(ManualCodeEntryAction.ScanQrCodeTextClick)
@@ -115,8 +116,8 @@ class ManualCodeEntryScreenTests : BaseComposeTest() {
         fakePermissionManager.checkPermissionResult = false
 
         composeTestRule
-            .onNodeWithText("Scan QR Code")
-            .performClick()
+            .onNodeWithText(text = "Cannot add authenticator key? Scan QR Code")
+            .performCustomAccessibilityAction(label = "Scan QR Code")
 
         composeTestRule
             .onAllNodesWithText("Enable camera permission to use the scanner")
@@ -191,8 +192,8 @@ class ManualCodeEntryScreenTests : BaseComposeTest() {
         fakePermissionManager.checkPermissionResult = false
 
         composeTestRule
-            .onNodeWithText("Scan QR Code")
-            .performClick()
+            .onNodeWithText(text = "Cannot add authenticator key? Scan QR Code")
+            .performCustomAccessibilityAction(label = "Scan QR Code")
 
         composeTestRule
             .onAllNodesWithText("Enable camera permission to use the scanner")


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17851](https://bitwarden.atlassian.net/browse/PM-17851)

## 📔 Objective

This PR updates the UI for the `ManualCodeEntryScreen` to match the v3 designs.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/7101500c-cf17-488c-a3ca-24033d450499" width="300" /> | <img src="https://github.com/user-attachments/assets/55a1254d-f4e4-4cc1-a9f3-2db4332c9e78" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17851]: https://bitwarden.atlassian.net/browse/PM-17851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ