### PR TITLE
[PM-17930] Remove default arguments from CoachMarkHighlight

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkContainer.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkContainer.kt
@@ -185,6 +185,8 @@ private fun BitwardenCoachMarkContainer_preview() {
                         key = Foo.Bar,
                         title = "1 of 3",
                         description = "Use this button to generate a new unique password.",
+                        onDismiss = null,
+                        leftAction = null,
                         rightAction = {
                             BitwardenClickableText(
                                 label = "Next",
@@ -211,6 +213,7 @@ private fun BitwardenCoachMarkContainer_preview() {
                     title = "Foo",
                     description = "Baz",
                     shape = CoachMarkHighlightShape.RoundedRectangle(radius = 50f),
+                    onDismiss = null,
                     leftAction = {
                         BitwardenClickableText(
                             label = "Back",

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkScope.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/coachmark/CoachMarkScope.kt
@@ -53,10 +53,10 @@ interface CoachMarkScope<T : Enum<T>> {
         title: String,
         description: String,
         modifier: Modifier = Modifier,
-        shape: CoachMarkHighlightShape = CoachMarkHighlightShape.RoundedRectangle(),
-        onDismiss: (() -> Unit)? = null,
-        leftAction: (@Composable RowScope.() -> Unit)? = null,
-        rightAction: (@Composable RowScope.() -> Unit)? = null,
+        shape: CoachMarkHighlightShape,
+        onDismiss: (() -> Unit)?,
+        leftAction: (@Composable RowScope.() -> Unit)?,
+        rightAction: (@Composable RowScope.() -> Unit)?,
         anchorContent: @Composable () -> Unit,
     )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -656,6 +656,7 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
                         )
                     },
                     shape = CoachMarkHighlightShape.RoundedRectangle(radius = 50f),
+                    leftAction = null,
                 ) {
                     SegmentedButtonOptionContent(option = option)
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLoginItems.kt
@@ -398,6 +398,7 @@ private fun CoachMarkScope<AddEditItemCoachMark>.PasswordRow(
                 ),
                 shape = CoachMarkHighlightShape.Oval,
                 onDismiss = onCoachMarkDismissed,
+                leftAction = null,
                 rightAction = {
                     CoachMarkActionText(
                         actionLabel = stringResource(R.string.next),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17930

## 📔 Objective

Removing the default parameters from CoachMarkHighlight.

Composable functions in an interface do not support default parameters.

Source:
https://issuetracker.google.com/issues/165812010

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
