### PR TITLE
[PM-10515] fix: Missing build information in About screen version copy

### DIFF
--- a/scripts/update_app_ci_build_info.sh
+++ b/scripts/update_app_ci_build_info.sh
@@ -8,7 +8,7 @@
 
 if [ $# -ne 5 ]; then
     echo "Usage: $0 <repository> <branch> <commit_hash> <ci_run_number> <ci_run_attempt>"
-    echo "E.g: $0 bitwarden/android main abc123 123 1"
+    echo "E.g: ./scripts/$0 bitwarden/android main abc123 123 1"
     exit 1
 fi
 
@@ -20,7 +20,7 @@ commit_hash=$3
 ci_run_number=$4
 ci_run_attempt=$5
 
-ci_build_info_file="../ci.properties"
+ci_build_info_file="ci.properties"
 git_source="${repository}/${branch}@${commit_hash}"
 ci_run_source="${repository}/actions/runs/${ci_run_number}/attempts/${ci_run_attempt}"
 emoji_brick="\\ud83e\\uddf1" # 🧱


### PR DESCRIPTION
## 🎟️ Tracking

PM-10515

## 📔 Objective

https://github.com/bitwarden/android/pull/4456 enhanced the info obtained from the About screen copy, but it was missing build related info. This was due to the `ci.properties` file being created one folder above the repo root folder, because the script is running from the repo root instead of inside the scripts folder.  

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
