### PR TITLE
[PM-17694] Only update FIDO2 user verification status during single-tap sign-in

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -339,9 +339,8 @@ class MainViewModel @Inject constructor(
                 // Set the user's verification status when a new FIDO 2 request is received to force
                 // explicit verification if the user's vault is unlocked when the request is
                 // received.
-                fido2CredentialManager.isUserVerified =
-                    fido2CreateCredentialRequestData.isUserVerified
-                        ?: fido2CredentialManager.isUserVerified
+                fido2CreateCredentialRequestData.isUserVerified
+                    ?.let { isVerified -> fido2CredentialManager.isUserVerified = isVerified }
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.Fido2Save(
                         fido2CreateCredentialRequest = fido2CreateCredentialRequestData,
@@ -356,9 +355,11 @@ class MainViewModel @Inject constructor(
             }
 
             fido2CredentialAssertionRequest != null -> {
-                fido2CredentialManager.isUserVerified =
-                    fido2CredentialAssertionRequest.isUserVerified
-                        ?: false
+                // If device biometric verification was performed as part of single-tap
+                // authentication, set the user's verification state to the device result.
+                // Otherwise, retain the verification state as-is.
+                fido2CredentialAssertionRequest.isUserVerified
+                    ?.let { isVerified -> fido2CredentialManager.isUserVerified = isVerified }
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.Fido2Assertion(
                         fido2AssertionRequest = fido2CredentialAssertionRequest,

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequest.kt
@@ -7,6 +7,19 @@ import kotlinx.parcelize.Parcelize
 
 /**
  * Models a FIDO 2 credential authentication request parsed from the launching intent.
+ *
+ * @param userId The ID of the Bitwarden user to authenticate.
+ * @param cipherId The ID of the cipher that contains the passkey to authenticate.
+ * @param credentialId The ID of the credential to authenticate.
+ * @param requestJson The JSON representation of the FIDO 2 request.
+ * @param clientDataHash The hash of the client data.
+ * @param packageName The package name of the calling app.
+ * @param signingInfo The signing info of the calling app.
+ * @param origin The origin of the calling app. Only populated if the calling application is a
+ * privileged application. I.e., a web browser.
+ * @param isUserVerified Whether the user has been verified prior to receiving this request. Only
+ * populated if device biometric verification was performed. If null, the application is responsible
+ * for prompting user verification when it is deemed necessary.
  */
 @Parcelize
 data class Fido2CredentialAssertionRequest(

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
@@ -39,7 +39,7 @@ fun Intent.getFido2CreateCredentialRequestOrNull(): Fido2CreateCredentialRequest
         packageName = systemRequest.callingAppInfo.packageName,
         signingInfo = systemRequest.callingAppInfo.signingInfo,
         origin = systemRequest.callingAppInfo.origin,
-        isUserVerified = systemRequest.biometricPromptResult?.isSuccessful ?: false,
+        isUserVerified = systemRequest.biometricPromptResult?.isSuccessful,
     )
 }
 
@@ -69,7 +69,6 @@ fun Intent.getFido2AssertionRequestOrNull(): Fido2CredentialAssertionRequest? {
         ?: return null
 
     val isUserVerified = systemRequest.biometricPromptResult?.isSuccessful
-        ?: false
 
     return Fido2CredentialAssertionRequest(
         userId = userId,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17694

## 📔 Objective

Update the FIDO2 authentication flow to ignore user verification results when single-tap sign-on is not used. This prevents redundant user verification from being performed if the user unlocked their vault to retrieve matching credentials.

## 📸 Screenshots


https://github.com/user-attachments/assets/eb1792c9-b1be-449c-a782-a31cc5f42c0f


https://github.com/user-attachments/assets/79ebafc9-2827-42c6-8bd4-c7a179fa4f6a



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
