### PR TITLE
[PM-17939] Restrict test.yml coverage upload to On Push and Pull Request triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    if: success()
+    if: success() && (github.event_name == 'push' || github.event_name == 'pull_request')
 
     steps:
       - name: Download test artifacts


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17939

## 📔 Objective

While troubleshooting Codecov issues I noticed the default branch wasn't correctly set and that Pull Requests are being compared with Merge Queue branches, due to Codecov not supporting the same commit existing in multiple branches ([ref](https://github.com/codecov/feedback/issues/216#issuecomment-1883055575)). By restricting coverage upload to On Push and Pull Request triggers I'm expecting Codecov to start comparing Pull Requests to `main`, improving how incremental changes are handled.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
