### PR TITLE
PM-17958: Remove language supporting text

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -139,7 +139,6 @@ private fun LanguageSelectionRow(
             )
             languageChangedDialogOption = selectedLanguage
         },
-        supportingText = stringResource(id = R.string.language_description),
         cardStyle = CardStyle.Full,
         modifier = modifier,
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -793,7 +793,6 @@ Do you want to switch to this account?</string>
   <string name="no_pending_requests">No pending requests</string>
   <string name="enable_camer_permission_to_use_the_scanner">Enable camera permission to use the scanner</string>
   <string name="language">Language</string>
-  <string name="language_description">Change the application\'s language</string>
   <string name="language_change_x_description">The language has been changed to %1$s. Please restart the app to see the change</string>
   <string name="language_change_requires_app_restart">Language change requires app restart</string>
   <string name="default_system">Default (System)</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
@@ -54,9 +54,7 @@ class AppearanceScreenTest : BaseComposeTest() {
     @Test
     fun `on language row click should display language selection dialog`() {
         composeTestRule
-            .onNodeWithContentDescription(
-                label = "Default (System). Language. Change the application's language",
-            )
+            .onNodeWithContentDescription(label = "Default (System). Language")
             .performScrollTo()
             .performClick()
         composeTestRule
@@ -69,9 +67,7 @@ class AppearanceScreenTest : BaseComposeTest() {
     fun `on language selection dialog item click should send LanguageChange and show dialog`() {
         // Clicking the Language row shows the language selection dialog
         composeTestRule
-            .onNodeWithContentDescription(
-                label = "Default (System). Language. Change the application's language",
-            )
+            .onNodeWithContentDescription(label = "Default (System). Language")
             .performScrollTo()
             .performClick()
         // Selecting a language dismisses this dialog and displays the confirmation
@@ -107,9 +103,7 @@ class AppearanceScreenTest : BaseComposeTest() {
     @Test
     fun `on language selection dialog cancel click should dismiss dialog`() {
         composeTestRule
-            .onNodeWithContentDescription(
-                label = "Default (System). Language. Change the application's language",
-            )
+            .onNodeWithContentDescription(label = "Default (System). Language")
             .performScrollTo()
             .performClick()
         composeTestRule


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17958](https://bitwarden.atlassian.net/browse/PM-17958)

## 📔 Objective

This PR removes the supporting text from the language selector to match the updated V3 designs.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/b58e28d0-217f-4ca8-8b14-0cd3d957ae56" width="300" /> | <img src="https://github.com/user-attachments/assets/a7fb3bbe-8a0c-44ef-9e57-07ff05c204c6" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17958]: https://bitwarden.atlassian.net/browse/PM-17958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ