### PR TITLE
[PM-17962] Exclude generated Hilt .java files from code coverage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -325,6 +325,7 @@ kover {
                     "*_*Factory\$*",
                     "*.Hilt_*",
                     "*_HiltModules",
+                    "*_HiltModules*",
                     "*_HiltModules\$*",
                     "*_Impl",
                     "*_Impl\$*",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17962

## 📔 Objective

While troubleshooting https://github.com/bitwarden/android/pull/4681 noticed we're including generated .java Hilt files in our code coverage calculation. Confirmed the following change removes "HiltModules" classes from our report file here - https://github.com/bitwarden/android/actions/runs/13140684331

## 📸 Screenshots

Searching for "LazyKeyMap" in our report file before and after this PR fix:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e4656a8e-56ef-4eab-8647-e82aeea4dd83) | ![image](https://github.com/user-attachments/assets/ed3e0791-4247-4eab-a1c1-575be1abca90) |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
