### PR TITLE
QA-1056: Adding testTag to Stepper value text

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -46,7 +46,6 @@ fun BitwardenStepper(
     isIncrementEnabled: Boolean = true,
     isDecrementEnabled: Boolean = true,
     textFieldReadOnly: Boolean = true,
-    stepperActionsTestTag: String? = null,
 ) {
     BitwardenStepper(
         modifier = modifier,
@@ -67,7 +66,6 @@ fun BitwardenStepper(
         isIncrementEnabled = isIncrementEnabled,
         isDecrementEnabled = isDecrementEnabled,
         textFieldReadOnly = textFieldReadOnly,
-        stepperActionsTestTag = stepperActionsTestTag,
         cardStyle = cardStyle,
     )
 }
@@ -104,7 +102,6 @@ fun BitwardenStepper(
     isIncrementEnabled: Boolean = true,
     isDecrementEnabled: Boolean = true,
     textFieldReadOnly: Boolean = true,
-    stepperActionsTestTag: String? = null,
 ) {
     val clampedValue = value?.coerceIn(range)
     if (clampedValue != value && clampedValue != null) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/stepper/BitwardenStepper.kt
@@ -115,7 +115,7 @@ fun BitwardenStepper(
     BitwardenTextField(
         label = label,
         value = clampedValue?.toString().orEmpty(),
-        actionsTestTag = stepperActionsTestTag,
+        textFieldTestTag = "StepperValueLabel",
         actions = {
             BitwardenFilledIconButton(
                 vectorIconRes = R.drawable.ic_minus,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -1011,9 +1011,8 @@ private fun PassphraseNumWordsCounterItem(
         value = numWords.coerceIn(minimumValue = minValue, maximumValue = maxValue),
         range = minValue..maxValue,
         onValueChange = onPassphraseNumWordsCounterChange,
-        stepperActionsTestTag = "NumberOfWordsStepper",
         cardStyle = CardStyle.Full,
-        modifier = modifier.testTag(tag = "NumberOfWordsLabel"),
+        modifier = modifier.testTag(tag = "NumberOfWordsStepper"),
     )
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[QA-947]: https://bitwarden.atlassian.net/browse/QA-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ