### PR TITLE
PM-17968: Create unique secret keys per user and handle decoding error

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1088,6 +1088,7 @@ class AuthRepositoryImpl(
                     }
 
                     is VaultUnlockResult.AuthenticationError,
+                    VaultUnlockResult.BiometricDecodingError,
                     VaultUnlockResult.InvalidStateError,
                     VaultUnlockResult.GenericError,
                         -> {

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensions.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
  */
 fun VaultUnlockError.toLoginErrorResult(): LoginResult.Error = when (this) {
     is VaultUnlockResult.AuthenticationError -> LoginResult.Error(this.message)
+    VaultUnlockResult.BiometricDecodingError,
     VaultUnlockResult.GenericError,
     VaultUnlockResult.InvalidStateError,
         -> LoginResult.Error(errorMessage = null)

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/BiometricsEncryptionManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/BiometricsEncryptionManager.kt
@@ -14,6 +14,11 @@ interface BiometricsEncryptionManager {
     ): Cipher?
 
     /**
+     * Clears the data associated with the users biometrics.
+     */
+    fun clearBiometrics(userId: String)
+
+    /**
      * Gets the [Cipher] built from a keystore, or creates one if it doesn't already exist.
      */
     fun getOrCreateCipher(

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
@@ -71,6 +71,7 @@ class AuthenticatorBridgeRepositoryImpl(
 
                     when (unlockResult) {
                         is VaultUnlockResult.AuthenticationError,
+                        VaultUnlockResult.BiometricDecodingError,
                         VaultUnlockResult.GenericError,
                         VaultUnlockResult.InvalidStateError,
                             -> {

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -232,11 +232,6 @@ interface SettingsRepository {
     fun storePullToRefreshEnabled(isPullToRefreshEnabled: Boolean)
 
     /**
-     * Clears any previously stored encrypted user key used with biometrics for the current user.
-     */
-    fun clearBiometricsKey()
-
-    /**
      * Stores the encrypted user key for biometrics, allowing it to be used to unlock the current
      * user's vault.
      */

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -510,12 +510,6 @@ class SettingsRepositoryImpl(
             )
     }
 
-    override fun clearBiometricsKey() {
-        val userId = activeUserId ?: return
-        authDiskSource.storeUserBiometricInitVector(userId = userId, iv = null)
-        authDiskSource.storeUserBiometricUnlockKey(userId = userId, biometricsKey = null)
-    }
-
     override fun storeUnlockPin(
         pin: String,
         shouldRequireMasterPasswordOnRestart: Boolean,

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -114,6 +114,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
+import java.security.GeneralSecurityException
 import java.time.Clock
 import java.time.temporal.ChronoUnit
 import javax.crypto.Cipher
@@ -555,9 +556,13 @@ class VaultRepositoryImpl(
                 initUserCryptoMethod = InitUserCryptoMethod.DecryptedKey(
                     decryptedUserKey = iv
                         ?.let {
-                            cipher
-                                .doFinal(biometricsKey.toByteArray(Charsets.ISO_8859_1))
-                                .decodeToString()
+                            try {
+                                cipher
+                                    .doFinal(biometricsKey.toByteArray(Charsets.ISO_8859_1))
+                                    .decodeToString()
+                            } catch (_: GeneralSecurityException) {
+                                return VaultUnlockResult.BiometricDecodingError
+                            }
                         }
                         ?: biometricsKey,
                 ),

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/VaultUnlockResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/VaultUnlockResult.kt
@@ -18,6 +18,11 @@ sealed class VaultUnlockResult {
     ) : VaultUnlockResult(), VaultUnlockError
 
     /**
+     * Unable to decode biometrics key.
+     */
+    data object BiometricDecodingError : VaultUnlockResult(), VaultUnlockError
+
+    /**
      * Unable to access user state information.
      */
     data object InvalidStateError : VaultUnlockResult(), VaultUnlockError

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
@@ -132,7 +132,7 @@ class SetupUnlockViewModel @Inject constructor(
     }
 
     private fun handleUnlockWithBiometricToggleDisabled() {
-        settingsRepository.clearBiometricsKey()
+        biometricsEncryptionManager.clearBiometrics(userId = state.userId)
         mutableStateFlow.update { it.copy(isUnlockWithBiometricsEnabled = false) }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -330,6 +330,19 @@ class VaultUnlockViewModel @Inject constructor(
                 }
             }
 
+            VaultUnlockResult.BiometricDecodingError -> {
+                biometricsEncryptionManager.clearBiometrics(userId = state.userId)
+                mutableStateFlow.update {
+                    it.copy(
+                        isBiometricsValid = false,
+                        dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                            title = R.string.biometrics_failed.asText(),
+                            message = R.string.biometrics_decoding_failure.asText(),
+                        ),
+                    )
+                }
+            }
+
             VaultUnlockResult.GenericError,
             VaultUnlockResult.InvalidStateError,
                 -> {
@@ -381,6 +394,7 @@ class VaultUnlockViewModel @Inject constructor(
             val accountSummaries = userState.toAccountSummaries()
             val activeAccountSummary = userState.toActiveAccountSummary()
             it.copy(
+                userId = userState.activeUserId,
                 initials = activeAccountSummary.initials,
                 avatarColorString = activeAccountSummary.avatarColorHex,
                 accountSummaries = accountSummaries,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -318,7 +318,7 @@ class AccountSecurityViewModel @Inject constructor(
     }
 
     private fun handleUnlockWithBiometricToggleDisabled() {
-        settingsRepository.clearBiometricsKey()
+        biometricsEncryptionManager.clearBiometrics(userId = state.userId)
         mutableStateFlow.update { it.copy(isUnlockWithBiometricsEnabled = false) }
         validateVaultTimeoutAction()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,6 +497,8 @@ Scanning will happen automatically.</string>
   <string name="login_expired">Your login session has expired.</string>
   <string name="biometrics_direction">Biometric verification</string>
   <string name="biometrics">Biometrics</string>
+  <string name="biometrics_failed">Biometrics Failed</string>
+  <string name="biometrics_decoding_failure">Log in with your Master Password or PIN then re-enable biometric login in Settings.</string>
   <string name="use_biometrics_to_unlock">Use biometrics to unlock</string>
   <string name="accessibility_overlay_permission_alert">Bitwarden needs attention - See \"Autofill Accessibility Service\" from Bitwarden settings</string>
   <string name="bitwarden_autofill_service_overlay_permission">3. On the Android App Settings screen for Bitwarden, go to the \"Display over other apps\" options (under Advanced) and tap the toggle to allow overlay support.</string>

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensionsTest.kt
@@ -25,9 +25,11 @@ class LoginResultExtensionsTest {
     fun `VaultUnlockResult with no message value are mapped to LoginResult with null error message`() {
         val invalidStateResult = VaultUnlockResult.InvalidStateError.toLoginErrorResult()
         val genericErrorResult = VaultUnlockResult.GenericError.toLoginErrorResult()
+        val biometricErrorResult = VaultUnlockResult.BiometricDecodingError.toLoginErrorResult()
         val expectedResult = LoginResult.Error(errorMessage = null)
 
         assertEquals(expectedResult, invalidStateResult)
         assertEquals(expectedResult, genericErrorResult)
+        assertEquals(expectedResult, biometricErrorResult)
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -807,18 +807,6 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `clearBiometricsKey should remove the stored biometrics key`() {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        fakeAuthDiskSource.storeUserBiometricUnlockKey(userId = USER_ID, "fake key")
-        fakeAuthDiskSource.storeUserBiometricInitVector(userId = USER_ID, byteArrayOf(1))
-
-        settingsRepository.clearBiometricsKey()
-
-        fakeAuthDiskSource.assertBiometricsKey(userId = USER_ID, biometricsKey = null)
-        fakeAuthDiskSource.assertBiometricInitVector(userId = USER_ID, iv = null)
-    }
-
-    @Test
     fun `setupBiometricsKey with missing user state should return BiometricsKeyResult Error`() =
         runTest {
             val cipher = mockk<Cipher>()

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
@@ -153,7 +153,7 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
     fun `on UnlockWithBiometricToggleDisabled should call clearBiometricsKey and update the state`() {
         val initialState = DEFAULT_STATE.copy(isUnlockWithBiometricsEnabled = true)
         every { settingsRepository.isUnlockWithBiometricsEnabled } returns true
-        every { settingsRepository.clearBiometricsKey() } just runs
+        every { biometricsEncryptionManager.clearBiometrics(userId = DEFAULT_USER_ID) } just runs
         val viewModel = createViewModel(initialState)
         assertEquals(initialState, viewModel.stateFlow.value)
 
@@ -164,7 +164,7 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
             viewModel.stateFlow.value,
         )
         verify(exactly = 1) {
-            settingsRepository.clearBiometricsKey()
+            biometricsEncryptionManager.clearBiometrics(userId = DEFAULT_USER_ID)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -1097,6 +1097,37 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `on BiometricsUnlockSuccess should disable biometrics and display error dialog on unlockVaultWithBiometrics BiometricDecodingError`() {
+        val initialState = DEFAULT_STATE.copy(isBiometricEnabled = true)
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(DEFAULT_ACCOUNT.copy(isBiometricsEnabled = true)),
+        )
+        val viewModel = createViewModel(state = initialState)
+        coEvery {
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
+        } returns VaultUnlockResult.BiometricDecodingError
+        every { encryptionManager.clearBiometrics(userId = USER_ID) } just runs
+
+        viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
+
+        assertEquals(
+            initialState.copy(
+                isBiometricsValid = false,
+                dialog = VaultUnlockState.VaultUnlockDialog.Error(
+                    title = R.string.biometrics_failed.asText(),
+                    message = R.string.biometrics_decoding_failure.asText(),
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+        coVerify(exactly = 1) {
+            encryptionManager.clearBiometrics(userId = USER_ID)
+            vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `on BiometricsUnlockSuccess should display error dialog on unlockVaultWithBiometrics InvalidStateError`() {
         val initialState = DEFAULT_STATE.copy(isBiometricEnabled = true)
         mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -432,7 +432,9 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         runTest {
             val initialState = DEFAULT_STATE.copy(isUnlockWithBiometricsEnabled = true)
             every { settingsRepository.isUnlockWithBiometricsEnabled } returns true
-            every { settingsRepository.clearBiometricsKey() } just runs
+            every {
+                biometricsEncryptionManager.clearBiometrics(userId = DEFAULT_USER_ID)
+            } just runs
             val viewModel = createViewModel(initialState)
             assertEquals(initialState, viewModel.stateFlow.value)
 
@@ -443,7 +445,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                 viewModel.stateFlow.value,
             )
             verify(exactly = 1) {
-                settingsRepository.clearBiometricsKey()
+                biometricsEncryptionManager.clearBiometrics(userId = DEFAULT_USER_ID)
             }
         }
 
@@ -456,7 +458,9 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                 isUnlockWithBiometricsEnabled = true,
             )
             every { settingsRepository.isUnlockWithBiometricsEnabled } returns true
-            every { settingsRepository.clearBiometricsKey() } just runs
+            every {
+                biometricsEncryptionManager.clearBiometrics(userId = DEFAULT_USER_ID)
+            } just runs
             every { settingsRepository.vaultTimeoutAction = VaultTimeoutAction.LOGOUT } just runs
             val viewModel = createViewModel(initialState)
             assertEquals(initialState, viewModel.stateFlow.value)
@@ -471,7 +475,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                 viewModel.stateFlow.value,
             )
             verify(exactly = 1) {
-                settingsRepository.clearBiometricsKey()
+                biometricsEncryptionManager.clearBiometrics(userId = DEFAULT_USER_ID)
                 settingsRepository.vaultTimeoutAction = VaultTimeoutAction.LOGOUT
             }
         }
@@ -863,8 +867,9 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 private val CIPHER = mockk<Cipher>()
 private const val FINGERPRINT: String = "fingerprint"
 
+private const val DEFAULT_USER_ID: String = "activeUserId"
 private val DEFAULT_USER_STATE = UserState(
-    activeUserId = "activeUserId",
+    activeUserId = DEFAULT_USER_ID,
     accounts = listOf(
         UserState.Account(
             userId = "activeUserId",
@@ -895,7 +900,7 @@ private val DEFAULT_STATE: AccountSecurityState = AccountSecurityState(
     isUnlockWithBiometricsEnabled = false,
     isUnlockWithPasswordEnabled = true,
     isUnlockWithPinEnabled = false,
-    userId = DEFAULT_USER_STATE.activeUserId,
+    userId = DEFAULT_USER_ID,
     vaultTimeout = VaultTimeout.ThirtyMinutes,
     vaultTimeoutAction = VaultTimeoutAction.LOCK,
     vaultTimeoutPolicyMinutes = null,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17968](https://bitwarden.atlassian.net/browse/PM-17968)
[GitHub Issue](https://github.com/bitwarden/android/issues/4683)

## 📔 Objective

This PR updates the `BiometricsEncryptionManager` to migrate secret keys to be unique per user.

Primary Changes:
- We are going to use user scoped secret keys for all new biometrics
- If a user is already setup with a non-user scoped secret key, then we let them use it
- If it fails to decrypt, then we clear their data and they need to re-setup biometrics (with a user scoped key)

Unfortunately, a user who is already in the failure state is not recoverable and they need to re-setup biometrics.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17968]: https://bitwarden.atlassian.net/browse/PM-17968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ