### PR TITLE
[PM-14936] Move `prefixHttpsIfNecessaryOrNull` to `StringExtensions`

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModel.kt
@@ -19,6 +19,7 @@ import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.isValidUri
 import com.x8bit.bitwarden.ui.platform.base.util.orNullIfBlank
+import com.x8bit.bitwarden.ui.platform.base.util.prefixHttpsIfNecessaryOrNull
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.keychain.model.PrivateKeyAliasSelectionResult
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -594,14 +595,3 @@ sealed class EnvironmentAction {
         ) : Internal()
     }
 }
-
-/**
- * If the given [String] is a valid URI, "https://" will be appended if it is not already present.
- * Otherwise `null` will be returned.
- */
-private fun String.prefixHttpsIfNecessaryOrNull(): String? =
-    when {
-        this.isBlank() || !this.isValidUri() -> null
-        "http://" in this || "https://" in this -> this
-        else -> "https://$this"
-    }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensions.kt
@@ -204,3 +204,14 @@ fun String.removeDiacritics(): String =
             Normalizer.normalize(this, Normalizer.Form.NFKD),
             "",
         )
+
+/**
+ * If the given [String] is a valid URI, "https://" will be appended if it is not already present.
+ * Otherwise `null` will be returned.
+ */
+fun String.prefixHttpsIfNecessaryOrNull(): String? =
+    when {
+        this.isBlank() || !this.isValidUri() -> null
+        "http://" in this || "https://" in this -> this
+        else -> "https://$this"
+    }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensionsTest.kt
@@ -141,4 +141,68 @@ class StringExtensionsTest {
         val result = "áéíóů".removeDiacritics()
         assertEquals("aeiou", result)
     }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull should prefix https when URI is valid and no scheme`() {
+        val uri = "example.com"
+        val expected = "https://$uri"
+        val actual = uri.prefixHttpsIfNecessaryOrNull()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull should return null when URI is empty string`() {
+        val uri = ""
+        assertNull(uri.prefixHttpsIfNecessaryOrNull())
+    }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull should return null when URI is whitespace string`() {
+        val uri = " "
+        assertNull(uri.prefixHttpsIfNecessaryOrNull())
+    }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull should return null when URI is invalid`() {
+        val invalidUri = "invalid uri"
+        assertNull(invalidUri.prefixHttpsIfNecessaryOrNull())
+    }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull should return URI unchanged when scheme is http`() {
+        val uri = "http://example.com"
+        val actual = uri.prefixHttpsIfNecessaryOrNull()
+        assertEquals(uri, actual)
+    }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull should return URI unchanged when scheme is https`() {
+        val uri = "https://example.com"
+        val actual = uri.prefixHttpsIfNecessaryOrNull()
+        assertEquals(uri, actual)
+    }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull with long valid URI without scheme`() {
+        val uri = "longexamplewithlots.of.subdomains.com"
+        val expected = "https://$uri"
+        val actual = uri.prefixHttpsIfNecessaryOrNull()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull should return null when uri contains special characters`() {
+        val uri = "example-special!@#$%^&*()_+{}[].com"
+        val actual = uri.prefixHttpsIfNecessaryOrNull()
+        assertNull(actual)
+    }
+
+    @Test
+    fun `prefixHttpsIfNecessaryOrNull should prefix URI when it contains numbers and letters`() {
+        val uri = "example1234567890.com"
+        val expected = "https://$uri"
+        val actual = uri.prefixHttpsIfNecessaryOrNull()
+        assertEquals(expected, actual)
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-3553](https://bitwarden.atlassian.net/browse/PM-3553)
[PM-3503](https://bitwarden.atlassian.net/browse/PM-3503)
[PM-14936](https://bitwarden.atlassian.net/browse/PM-14936)
[PM-7430](https://bitwarden.atlassian.net/browse/PM-7430)

Relates to https://github.com/bitwarden/server/pull/5387
Relates to #3152
Relates to #4708
Relates to #4308

## 📔 Objective

Move `prefixHttpsIfNecessaryOrNull` to `StringExtensions`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14936]: https://bitwarden.atlassian.net/browse/PM-14936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-3503]: https://bitwarden.atlassian.net/browse/PM-3503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-3553]: https://bitwarden.atlassian.net/browse/PM-3553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-7430]: https://bitwarden.atlassian.net/browse/PM-7430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ