### PR TITLE
[PM-18193] Remove scan.yml from Merge Queue status check and update test.yml report job skip

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize]
-  merge_group:
-    types: [checks_requested]
 
 jobs:
   check-run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,17 +90,19 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    if: success() && (github.event_name == 'push' || github.event_name == 'pull_request')
+    if: success()
 
     steps:
       - name: Download test artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         with:
           name: test-reports
 
       - name: Upload to codecov.io
         id: upload-to-codecov
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         continue-on-error: true
         with:
           os: linux
@@ -108,7 +110,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: Comment PR if tests failed
-        if: steps.upload-to-codecov.outcome == 'failure'
+        if: steps.upload-to-codecov.outcome == 'failure' && (github.event_name == 'push' || github.event_name == 'pull_request')
         env:
             PR_NUMBER: ${{ github.event.number }}
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🎟️ Tracking

PM-18193

## 📔 Objective

While troubleshooting why Merge Queue runs were hanging, we concluded we only need scan.yml to run for pull requests. 

The SAST job has been failing occasionally which may have not been properly reported to the merge queue, this change will also serve as a test. Additionally, we're moving the test.yml job restrictions to each individual step, so the report job is marked as Success instead of Skipped, as a test for the merge queue issue.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
