### PR TITLE
PM-18083 Ensure segmented buttons on generator fill entire width evenly.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -639,7 +640,7 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
         modifier = modifier
             .fillMaxWidth()
             .testTag(tag = "GeneratorTypePicker"),
-    ) { index, option ->
+    ) { index, weightedWidth, option ->
         when (index) {
             0 -> {
                 CoachMarkHighlight(
@@ -658,7 +659,10 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
                     shape = CoachMarkHighlightShape.RoundedRectangle(radius = 50f),
                     leftAction = null,
                 ) {
-                    SegmentedButtonOptionContent(option = option)
+                    SegmentedButtonOptionContent(
+                        option = option,
+                        modifier = Modifier.width(weightedWidth),
+                    )
                 }
             }
 
@@ -684,7 +688,10 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
                     },
                     shape = CoachMarkHighlightShape.RoundedRectangle(radius = 50f),
                 ) {
-                    SegmentedButtonOptionContent(option = option)
+                    SegmentedButtonOptionContent(
+                        option = option,
+                        modifier = Modifier.width(weightedWidth),
+                    )
                 }
             }
 
@@ -710,12 +717,18 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
                     },
                     shape = CoachMarkHighlightShape.RoundedRectangle(radius = 50f),
                 ) {
-                    SegmentedButtonOptionContent(option = option)
+                    SegmentedButtonOptionContent(
+                        option = option,
+                        modifier = Modifier.width(weightedWidth),
+                    )
                 }
             }
 
             else -> {
-                SegmentedButtonOptionContent(option = option)
+                SegmentedButtonOptionContent(
+                    option = option,
+                    modifier = Modifier.width(weightedWidth),
+                )
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18083](https://bitwarden.atlassian.net/browse/PM-18083)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Fix issue where the segmented buttons were not filling out the full length of the segmented row.
- This is due to the buttons being wrapped in the `CoachMarkHighlights` and confirmed if they are wrapped in any other container it does not respect the `1f` weights applied internally. Instead we are calculating the total width of the row and then splitting it evenly and applying that width to each button.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
**BEFORE**

https://github.com/user-attachments/assets/a9bbf879-548e-4a95-b99f-943460aa045b



**AFTER**

https://github.com/user-attachments/assets/c3d0b5b4-19bd-4b06-b05f-0c10d7247f6c





<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18083]: https://bitwarden.atlassian.net/browse/PM-18083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ