### PR TITLE
[PM-17368] After cut, update text and clear selection.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.res.stringResource
@@ -123,6 +124,7 @@ fun BitwardenPasswordField(
             onValueChange = onValueChange,
             defaultTextToolbar = LocalTextToolbar.current,
             clipboardManager = LocalClipboardManager.current.nativeClipboard,
+            focusManager = LocalFocusManager.current,
         )
 
         TextToolbarType.NONE -> BitwardenEmptyTextToolbar

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.text.TextStyle
@@ -237,6 +238,7 @@ fun BitwardenTextField(
             onValueChange = onValueChange,
             defaultTextToolbar = LocalTextToolbar.current,
             clipboardManager = LocalClipboardManager.current.nativeClipboard,
+            focusManager = LocalFocusManager.current,
         )
 
         TextToolbarType.NONE -> BitwardenEmptyTextToolbar

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/toolbar/BitwardenCutCopyTextToolbar.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/toolbar/BitwardenCutCopyTextToolbar.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.components.field.toolbar
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.platform.TextToolbarStatus
@@ -19,6 +20,7 @@ class BitwardenCutCopyTextToolbar(
     private val onValueChange: (String) -> Unit,
     private val defaultTextToolbar: TextToolbar,
     private val clipboardManager: ClipboardManager,
+    private val focusManager: FocusManager,
 ) : TextToolbar {
     override val status: TextToolbarStatus get() = defaultTextToolbar.status
 
@@ -58,7 +60,16 @@ class BitwardenCutCopyTextToolbar(
                                 )
                             },
                     )
-                    onValueChange("")
+                    // Clear selection
+                    focusManager.clearFocus(force = true)
+                    // Add correct text without selection
+                    onValueChange(
+                        value.text.replaceRange(
+                            minOf(value.selection.start, value.selection.end),
+                            maxOf(value.selection.start, value.selection.end),
+                            "",
+                        ),
+                    )
                 }
             },
             onSelectAllRequested = onSelectAllRequested,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-17368](https://bitwarden.atlassian.net/browse/PM-17368)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix bug where when a user used cut on a TextField it would clear it.
Update text without the selection and clear selection afterwards

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/fcea2b94-418f-4237-a600-3668796db345



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17368]: https://bitwarden.atlassian.net/browse/PM-17368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ