### PR TITLE
[PM-3553] Add SimpleLogin self-hosted alias feature flag

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -42,6 +42,7 @@ sealed class FlagKey<out T : Any> {
                 MutualTls,
                 SingleTapPasskeyCreation,
                 SingleTapPasskeyAuthentication,
+                SimpleLoginSelfHostAlias,
             )
         }
     }
@@ -197,6 +198,15 @@ sealed class FlagKey<out T : Any> {
      */
     data object SingleTapPasskeyAuthentication : FlagKey<Boolean>() {
         override val keyName: String = "single-tap-passkey-authentication"
+        override val defaultValue: Boolean = false
+        override val isRemotelyConfigured: Boolean = true
+    }
+
+    /**
+     * Data object holding the feature flag key to enable SimpleLogin self-host alias generation.
+     */
+    data object SimpleLoginSelfHostAlias : FlagKey<Boolean>() {
+        override val keyName: String = "simple-login-self-host-alias"
         override val defaultValue: Boolean = false
         override val isRemotelyConfigured: Boolean = true
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -41,6 +41,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.MutualTls,
     FlagKey.SingleTapPasskeyCreation,
     FlagKey.SingleTapPasskeyAuthentication,
+    FlagKey.SimpleLoginSelfHostAlias,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
         key = flagKey as FlagKey<Boolean>,
@@ -97,4 +98,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.SingleTapPasskeyCreation -> stringResource(R.string.single_tap_passkey_creation)
     FlagKey.SingleTapPasskeyAuthentication ->
         stringResource(R.string.single_tap_passkey_authentication)
+    FlagKey.SimpleLoginSelfHostAlias -> stringResource(R.string.simple_login_self_hosted_aliases)
 }

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -21,10 +21,11 @@
     <string name="restart_onboarding_carousel">Show Onboarding Carousel</string>
     <string name="restart_onboarding_carousel_details">This will force the change to app state which will cause the first time carousel to show. The carousel will continue to show for any \"new\" account until a login is completed. May need to exit debug menu manually.</string>
     <string name="app_review_prompt">App Review Prompt</string>
-    <string name="cipher_key_encryption">Cipher Key Encryption</string>">
-    <string name="new_device_permanent_dismiss">New device notice permanent dismiss</string>">
-    <string name="new_device_temporary_dismiss">New device notice temporary dismiss</string>">
+    <string name="cipher_key_encryption">Cipher Key Encryption</string>
+    <string name="new_device_permanent_dismiss">New device notice permanent dismiss</string>
+    <string name="new_device_temporary_dismiss">New device notice temporary dismiss</string>
     <string name="ignore_environment_check">Ignore environment check</string>">
     <string name="reset_coach_mark_tour_status">Reset all coach mark tours</string>
+    <string name="simple_login_self_hosted_aliases">SimpleLogin self-hosted aliases</string>
     <!-- /Debug Menu -->
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -97,6 +97,7 @@ class FlagKeyTest {
                 FlagKey.NewDevicePermanentDismiss,
                 FlagKey.SingleTapPasskeyCreation,
                 FlagKey.SingleTapPasskeyAuthentication,
+                FlagKey.SimpleLoginSelfHostAlias,
             ).all {
                 !it.defaultValue
             },
@@ -125,6 +126,7 @@ class FlagKeyTest {
                 FlagKey.SingleTapPasskeyCreation,
                 FlagKey.SingleTapPasskeyAuthentication,
                 FlagKey.MutualTls,
+                FlagKey.SimpleLoginSelfHostAlias,
             ).all {
                 it.isRemotelyConfigured
             },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -134,6 +134,7 @@ private val DEFAULT_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.MutualTls to true,
     FlagKey.SingleTapPasskeyCreation to true,
     FlagKey.SingleTapPasskeyAuthentication to true,
+    FlagKey.SimpleLoginSelfHostAlias to true,
 )
 
 private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
@@ -153,6 +154,7 @@ private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.MutualTls to false,
     FlagKey.SingleTapPasskeyCreation to false,
     FlagKey.SingleTapPasskeyAuthentication to false,
+    FlagKey.SimpleLoginSelfHostAlias to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-3553

## 📔 Objective

Introduce a new feature flag, `SimpleLoginSelfHostAlias`, to enable the generation of aliases using self-hosted SimpleLogin instances.

## 📸 Screenshots

<img width="401" alt="image" src="https://github.com/user-attachments/assets/98dda9c4-1fc5-4d3c-91be-00c7101a87d1" />



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
