### PR TITLE
Pm 18050/remove pin policy

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/PolicyTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/PolicyTypeJson.kt
@@ -83,6 +83,12 @@ enum class PolicyTypeJson {
     ACTIVATE_AUTOFILL,
 
     /**
+     * Hides the setting to "Unlock with Pin".
+     */
+    @SerialName("14")
+    REMOVE_UNLOCK_WITH_PIN,
+
+    /**
      * Represents an unknown policy type.
      *
      * This is used for forward compatibility to handle new policy types that the client doesn't yet

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -258,19 +258,21 @@ fun AccountSecurityScreen(
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
             )
-            Spacer(modifier = Modifier.height(height = 8.dp))
-            BitwardenUnlockWithPinSwitch(
-                isUnlockWithPasswordEnabled = state.isUnlockWithPasswordEnabled,
-                isUnlockWithPinEnabled = state.isUnlockWithPinEnabled,
-                onUnlockWithPinToggleAction = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle(it)) }
-                },
-                cardStyle = CardStyle.Full,
-                modifier = Modifier
-                    .testTag("UnlockWithPinSwitch")
-                    .fillMaxWidth()
-                    .standardHorizontalMargin(),
-            )
+            if (!state.removeUnlockWithPinPolicyEnabled || state.isUnlockWithPinEnabled) {
+                Spacer(modifier = Modifier.height(height = 8.dp))
+                BitwardenUnlockWithPinSwitch(
+                    isUnlockWithPasswordEnabled = state.isUnlockWithPasswordEnabled,
+                    isUnlockWithPinEnabled = state.isUnlockWithPinEnabled,
+                    onUnlockWithPinToggleAction = remember(viewModel) {
+                        { viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle(it)) }
+                    },
+                    cardStyle = CardStyle.Full,
+                    modifier = Modifier
+                        .testTag("UnlockWithPinSwitch")
+                        .fillMaxWidth()
+                        .standardHorizontalMargin(),
+                )
+            }
             Spacer(Modifier.height(16.dp))
             if (state.shouldShowEnableAuthenticatorSync) {
                 SyncWithAuthenticatorRow(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -114,9 +114,9 @@ class AccountSecurityViewModel @Inject constructor(
 
         policyManager
             .getActivePoliciesFlow(type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN)
-            .map { _ ->
+            .map { policies ->
                 AccountSecurityAction.Internal.RemovePinPolicyUpdateReceive(
-                    removeUnlockWithPinPolicyEnabled = true,
+                    removeUnlockWithPinPolicyEnabled = policies.isNotEmpty(),
                 )
             }
             .onEach(::sendAction)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -82,6 +82,7 @@ class AccountSecurityViewModel @Inject constructor(
             vaultTimeoutPolicyMinutes = null,
             vaultTimeoutPolicyAction = null,
             shouldShowUnlockActionCard = false,
+            removeUnlockWithPinPolicyEnabled = false,
         )
     },
 ) {
@@ -106,6 +107,16 @@ class AccountSecurityViewModel @Inject constructor(
                     vaultTimeoutPolicies = policies.mapNotNull {
                         it.policyInformation as? PolicyInformation.VaultTimeout
                     },
+                )
+            }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        policyManager
+            .getActivePoliciesFlow(type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN)
+            .map { _ ->
+                AccountSecurityAction.Internal.RemovePinPolicyUpdateReceive(
+                    removeUnlockWithPinPolicyEnabled = true,
                 )
             }
             .onEach(::sendAction)
@@ -390,6 +401,20 @@ class AccountSecurityViewModel @Inject constructor(
             is AccountSecurityAction.Internal.PinProtectedLockUpdate -> {
                 handlePinProtectedLockUpdate(action)
             }
+
+            is AccountSecurityAction.Internal.RemovePinPolicyUpdateReceive -> {
+                handleRemovePinPolicyUpdate(action)
+            }
+        }
+    }
+
+    private fun handleRemovePinPolicyUpdate(
+        action: AccountSecurityAction.Internal.RemovePinPolicyUpdateReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(
+                removeUnlockWithPinPolicyEnabled = action.removeUnlockWithPinPolicyEnabled,
+            )
         }
     }
 
@@ -524,6 +549,7 @@ data class AccountSecurityState(
     val vaultTimeoutPolicyMinutes: Int?,
     val vaultTimeoutPolicyAction: String?,
     val shouldShowUnlockActionCard: Boolean,
+    val removeUnlockWithPinPolicyEnabled: Boolean,
 ) : Parcelable {
     /**
      * Indicates that there is a mechanism for unlocking your vault in place.
@@ -785,6 +811,13 @@ sealed class AccountSecurityAction {
          */
         data class PolicyUpdateReceive(
             val vaultTimeoutPolicies: List<PolicyInformation.VaultTimeout>?,
+        ) : Internal()
+
+        /**
+         * A remove pin policy update has been received.
+         */
+        data class RemovePinPolicyUpdateReceive(
+            val removeUnlockWithPinPolicyEnabled: Boolean,
         ) : Internal()
 
         /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -242,6 +242,28 @@ class AccountSecurityScreenTest : BaseComposeTest() {
     }
 
     @Test
+    fun `unlock with pin toggle should be displayed according to state`() {
+        val toggleText = "Unlock with PIN code"
+        composeTestRule.onNodeWithText(toggleText).performScrollTo().assertIsDisplayed()
+
+        mutableStateFlow.update {
+            DEFAULT_STATE.copy(
+                removeUnlockWithPinPolicyEnabled = true,
+                isUnlockWithPinEnabled = true,
+            )
+        }
+        composeTestRule.onNodeWithText(toggleText).performScrollTo().assertIsDisplayed()
+
+        mutableStateFlow.update {
+            DEFAULT_STATE.copy(
+                removeUnlockWithPinPolicyEnabled = true,
+                isUnlockWithPinEnabled = false,
+            )
+        }
+        composeTestRule.onNodeWithText(toggleText).assertDoesNotExist()
+    }
+
+    @Test
     fun `on unlock with pin toggle when enabled should send UnlockWithPinToggle Disabled`() {
         mutableStateFlow.update {
             it.copy(isUnlockWithPinEnabled = true)
@@ -1541,4 +1563,5 @@ private val DEFAULT_STATE = AccountSecurityState(
     vaultTimeoutPolicyMinutes = null,
     vaultTimeoutPolicyAction = null,
     shouldShowUnlockActionCard = false,
+    removeUnlockWithPinPolicyEnabled = false,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -25,7 +25,7 @@ import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentReposito
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
-import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
+import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson.Policy
 import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockPolicy
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
@@ -81,7 +81,8 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         every { firstTimeStateFlow } returns mutableFirstTimeStateFlow
         every { storeShowUnlockSettingBadge(any()) } just runs
     }
-    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Policy>>()
+    private val mutableActivePolicyFlow = bufferedMutableSharedFlow<List<Policy>>()
+    private val mutableRemovePinPolicyFlow = bufferedMutableSharedFlow<List<Policy>>()
     private val biometricsEncryptionManager: BiometricsEncryptionManager = mockk {
         every { createCipherOrNull(DEFAULT_USER_STATE.activeUserId) } returns CIPHER
         every { getOrCreateCipher(DEFAULT_USER_STATE.activeUserId) } returns CIPHER
@@ -96,6 +97,9 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         every {
             getActivePoliciesFlow(type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT)
         } returns mutableActivePolicyFlow
+        every {
+            getActivePoliciesFlow(type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN)
+        } returns mutableRemovePinPolicyFlow
     }
     private val featureFlagManager: FeatureFlagManager = mockk(relaxed = true) {
         every { getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
@@ -158,6 +162,29 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                 DEFAULT_STATE.copy(
                     vaultTimeoutPolicyMinutes = 10,
                     vaultTimeoutPolicyAction = "lock",
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `state updates when remove pin policies change`() = runTest {
+        val viewModel = createViewModel()
+
+        mutableRemovePinPolicyFlow.emit(
+            listOf(
+                createMockPolicy(
+                    isEnabled = true,
+                    type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN,
+                ),
+            ),
+        )
+
+        viewModel.stateFlow.test {
+            assertEquals(
+                DEFAULT_STATE.copy(
+                    removeUnlockWithPinPolicyEnabled = true,
                 ),
                 awaitItem(),
             )
@@ -907,4 +934,5 @@ private val DEFAULT_STATE: AccountSecurityState = AccountSecurityState(
     vaultTimeoutPolicyAction = null,
     shouldShowEnableAuthenticatorSync = false,
     shouldShowUnlockActionCard = false,
+    removeUnlockWithPinPolicyEnabled = false,
 )


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18050

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Remove remove unlock with pin policy logic:

- If policy enabled
    - unlock with pin is ON, then show unlock with pin feature
      - if user toggles it OFF, then hide unlock with pin feature
    - unlock with pin is OFF, then hide unlock with pin feature
    - user logs out, then clear pin values so when logging back in the feature is hidden


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Hidden PIN:
<img width="230" alt="image" src="https://github.com/user-attachments/assets/9d41baae-356f-410e-b086-61d39b842d1f" />

When policy is enabled and the user turns off PIN, the field is hidden:
https://github.com/user-attachments/assets/991e1cea-ce04-481f-82cf-d90ac796a887


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
