### PR TITLE
[PM-17882] Cannot select autofill after creating new login

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -2062,7 +2062,7 @@ data class VaultAddEditState(
     val supportedItemTypes: List<ItemTypeOption>,
     // Internal
     val shouldExitOnSave: Boolean = false,
-    val shouldClearSpecialCircumstance: Boolean = false,
+    val shouldClearSpecialCircumstance: Boolean = true,
     val totpData: TotpData? = null,
     private val shouldShowCoachMarkTour: Boolean,
 ) : Parcelable {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -176,6 +176,7 @@ class VaultAddEditViewModel @Inject constructor(
                 shouldExitOnSave = shouldExitOnSave,
                 supportedItemTypes = getSupportedItemTypeOptions(),
                 shouldShowCoachMarkTour = false,
+                shouldClearSpecialCircumstance = autofillSelectionData == null,
             )
         },
 ) {
@@ -1523,7 +1524,9 @@ class VaultAddEditViewModel @Inject constructor(
             }
 
             is CreateCipherResult.Success -> {
-                specialCircumstanceManager.specialCircumstance = null
+                if (state.shouldClearSpecialCircumstance) {
+                    specialCircumstanceManager.specialCircumstance = null
+                }
                 if (state.shouldExitOnSave) {
                     sendEvent(event = VaultAddEditEvent.ExitApp)
                 } else {
@@ -2059,6 +2062,7 @@ data class VaultAddEditState(
     val supportedItemTypes: List<ItemTypeOption>,
     // Internal
     val shouldExitOnSave: Boolean = false,
+    val shouldClearSpecialCircumstance: Boolean = false,
     val totpData: TotpData? = null,
     private val shouldShowCoachMarkTour: Boolean,
 ) : Parcelable {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-17882

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix bug:
When the user created a new cipher using the autofill selection, it would clear the special circumstance and immediately close the `VaultItemListingScreen`, showing the vault instead. 

Added condition to not clear the special circumstance on cipher create if it is a `AutofillSelectionData`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/878a10d5-1a83-4d3e-83c0-42e05c41f678


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
