### PR TITLE
Improve the error messaging when an enum is not parsed correctly

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/AuthRequestTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/AuthRequestTypeJson.kt
@@ -21,5 +21,7 @@ enum class AuthRequestTypeJson {
 }
 
 @Keep
-private class AuthRequestTypeSerializer :
-    BaseEnumeratedIntSerializer<AuthRequestTypeJson>(AuthRequestTypeJson.entries.toTypedArray())
+private class AuthRequestTypeSerializer : BaseEnumeratedIntSerializer<AuthRequestTypeJson>(
+    className = "AuthRequestTypeJson",
+    values = AuthRequestTypeJson.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KdfTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KdfTypeJson.kt
@@ -18,5 +18,7 @@ enum class KdfTypeJson {
 }
 
 @Keep
-private class KdfTypeSerializer :
-    BaseEnumeratedIntSerializer<KdfTypeJson>(KdfTypeJson.entries.toTypedArray())
+private class KdfTypeSerializer : BaseEnumeratedIntSerializer<KdfTypeJson>(
+    className = "KdfTypeJson",
+    values = KdfTypeJson.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/TwoFactorAuthMethod.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/TwoFactorAuthMethod.kt
@@ -39,5 +39,7 @@ enum class TwoFactorAuthMethod(val value: UInt) {
 }
 
 @Keep
-private class TwoFactorAuthMethodSerializer :
-    BaseEnumeratedIntSerializer<TwoFactorAuthMethod>(TwoFactorAuthMethod.entries.toTypedArray())
+private class TwoFactorAuthMethodSerializer : BaseEnumeratedIntSerializer<TwoFactorAuthMethod>(
+    className = "TwoFactorAuthMethod",
+    values = TwoFactorAuthMethod.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/serializer/BaseEnumeratedIntSerializer.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/serializer/BaseEnumeratedIntSerializer.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.encoding.Encoder
  */
 @Suppress("UnnecessaryAbstractClass")
 abstract class BaseEnumeratedIntSerializer<T : Enum<T>>(
+    private val className: String,
     private val values: Array<T>,
     private val default: T? = null,
 ) : KSerializer<T> {
@@ -29,7 +30,7 @@ abstract class BaseEnumeratedIntSerializer<T : Enum<T>>(
         val decodedValue = decoder.decodeInt().toString()
         return values.firstOrNull { it.serialNameAnnotation?.value == decodedValue }
             ?: default
-            ?: throw IllegalArgumentException("Unknown value $decodedValue")
+            ?: throw IllegalArgumentException("Unknown value $decodedValue for $className")
     }
 
     override fun serialize(encoder: Encoder, value: T) {

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationType.kt
@@ -63,5 +63,7 @@ enum class NotificationType {
 }
 
 @Keep
-private class NotificationTypeSerializer :
-    BaseEnumeratedIntSerializer<NotificationType>(NotificationType.entries.toTypedArray())
+private class NotificationTypeSerializer : BaseEnumeratedIntSerializer<NotificationType>(
+    className = "NotificationType",
+    values = NotificationType.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEventType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEventType.kt
@@ -130,5 +130,6 @@ enum class OrganizationEventType {
 
 @Keep
 private class OrganizationEventTypeSerializer : BaseEnumeratedIntSerializer<OrganizationEventType>(
+    className = "OrganizationEventType",
     values = OrganizationEventType.entries.toTypedArray(),
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/model/PasscodeGenerationOptions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/model/PasscodeGenerationOptions.kt
@@ -91,5 +91,6 @@ data class PasscodeGenerationOptions(
 @Keep
 private class PasscodeTypeSerializer :
     BaseEnumeratedIntSerializer<PasscodeGenerationOptions.PasscodeType>(
-        PasscodeGenerationOptions.PasscodeType.entries.toTypedArray(),
+        className = "PasscodeGenerationOptions.PasscodeType",
+        values = PasscodeGenerationOptions.PasscodeType.entries.toTypedArray(),
     )

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/model/UsernameGenerationOptions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/model/UsernameGenerationOptions.kt
@@ -122,11 +122,13 @@ data class UsernameGenerationOptions(
 @Keep
 private class UsernameTypeSerializer :
     BaseEnumeratedIntSerializer<UsernameGenerationOptions.UsernameType>(
-        UsernameGenerationOptions.UsernameType.entries.toTypedArray(),
+        className = "UsernameGenerationOptions.UsernameType",
+        values = UsernameGenerationOptions.UsernameType.entries.toTypedArray(),
     )
 
 @Keep
 private class ForwardedEmailServiceTypeSerializer :
     BaseEnumeratedIntSerializer<UsernameGenerationOptions.ForwardedEmailServiceType>(
-        UsernameGenerationOptions.ForwardedEmailServiceType.entries.toTypedArray(),
+        className = "UsernameGenerationOptions.ForwardedEmailServiceType",
+        values = UsernameGenerationOptions.ForwardedEmailServiceType.entries.toTypedArray(),
     )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/CipherRepromptTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/CipherRepromptTypeJson.kt
@@ -25,5 +25,6 @@ enum class CipherRepromptTypeJson {
 
 @Keep
 private class CipherRepromptTypeSerializer : BaseEnumeratedIntSerializer<CipherRepromptTypeJson>(
-    CipherRepromptTypeJson.entries.toTypedArray(),
+    className = "CipherRepromptTypeJson",
+    values = CipherRepromptTypeJson.entries.toTypedArray(),
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/CipherTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/CipherTypeJson.kt
@@ -42,5 +42,7 @@ enum class CipherTypeJson {
 }
 
 @Keep
-private class CipherTypeSerializer :
-    BaseEnumeratedIntSerializer<CipherTypeJson>(CipherTypeJson.entries.toTypedArray())
+private class CipherTypeSerializer : BaseEnumeratedIntSerializer<CipherTypeJson>(
+    className = "CipherTypeJson",
+    values = CipherTypeJson.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/FieldTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/FieldTypeJson.kt
@@ -36,5 +36,7 @@ enum class FieldTypeJson {
 }
 
 @Keep
-private class FieldTypeSerializer :
-    BaseEnumeratedIntSerializer<FieldTypeJson>(FieldTypeJson.entries.toTypedArray())
+private class FieldTypeSerializer : BaseEnumeratedIntSerializer<FieldTypeJson>(
+    className = "FieldTypeJson",
+    values = FieldTypeJson.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/FileUploadType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/FileUploadType.kt
@@ -19,5 +19,6 @@ enum class FileUploadType {
 
 @Keep
 private class FileUploadTypeSerializer : BaseEnumeratedIntSerializer<FileUploadType>(
-    FileUploadType.entries.toTypedArray(),
+    className = "FileUploadType",
+    values = FileUploadType.entries.toTypedArray(),
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/LinkedIdTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/LinkedIdTypeJson.kt
@@ -180,5 +180,7 @@ enum class LinkedIdTypeJson(val value: UInt) {
 }
 
 @Keep
-private class LinkedIdTypeSerializer :
-    BaseEnumeratedIntSerializer<LinkedIdTypeJson>(LinkedIdTypeJson.entries.toTypedArray())
+private class LinkedIdTypeSerializer : BaseEnumeratedIntSerializer<LinkedIdTypeJson>(
+    className = "LinkedIdTypeJson",
+    values = LinkedIdTypeJson.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/OrganizationStatusType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/OrganizationStatusType.kt
@@ -32,5 +32,6 @@ enum class OrganizationStatusType {
 @Keep
 private class OrganizationStatusTypeSerializer :
     BaseEnumeratedIntSerializer<OrganizationStatusType>(
-        OrganizationStatusType.entries.toTypedArray(),
+        className = "OrganizationStatusType",
+        values = OrganizationStatusType.entries.toTypedArray(),
     )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/OrganizationType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/OrganizationType.kt
@@ -43,5 +43,6 @@ enum class OrganizationType {
 
 @Keep
 private class OrganizationTypeSerializer : BaseEnumeratedIntSerializer<OrganizationType>(
-    OrganizationType.entries.toTypedArray(),
+    className = "OrganizationType",
+    values = OrganizationType.entries.toTypedArray(),
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/PolicyTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/PolicyTypeJson.kt
@@ -100,6 +100,7 @@ enum class PolicyTypeJson {
 
 @Keep
 private class PolicyTypeSerializer : BaseEnumeratedIntSerializer<PolicyTypeJson>(
+    className = "PolicyTypeJson",
     values = PolicyTypeJson.entries.toTypedArray(),
     default = PolicyTypeJson.UNKNOWN,
 )

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SecureNoteTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SecureNoteTypeJson.kt
@@ -18,5 +18,7 @@ enum class SecureNoteTypeJson {
 }
 
 @Keep
-private class SecureNoteTypeSerializer :
-    BaseEnumeratedIntSerializer<SecureNoteTypeJson>(SecureNoteTypeJson.entries.toTypedArray())
+private class SecureNoteTypeSerializer : BaseEnumeratedIntSerializer<SecureNoteTypeJson>(
+    className = "SecureNoteTypeJson",
+    values = SecureNoteTypeJson.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SendTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SendTypeJson.kt
@@ -24,5 +24,7 @@ enum class SendTypeJson {
 }
 
 @Keep
-private class SendTypeSerializer :
-    BaseEnumeratedIntSerializer<SendTypeJson>(SendTypeJson.entries.toTypedArray())
+private class SendTypeSerializer : BaseEnumeratedIntSerializer<SendTypeJson>(
+    className = "SendTypeJson",
+    values = SendTypeJson.entries.toTypedArray(),
+)

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/UriMatchTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/UriMatchTypeJson.kt
@@ -48,5 +48,7 @@ enum class UriMatchTypeJson {
 }
 
 @Keep
-private class UriMatchTypeSerializer :
-    BaseEnumeratedIntSerializer<UriMatchTypeJson>(UriMatchTypeJson.entries.toTypedArray())
+private class UriMatchTypeSerializer : BaseEnumeratedIntSerializer<UriMatchTypeJson>(
+    className = "UriMatchTypeJson",
+    values = UriMatchTypeJson.entries.toTypedArray(),
+)

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/serializer/BaseEnumeratedIntSerializerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/serializer/BaseEnumeratedIntSerializerTest.kt
@@ -62,6 +62,7 @@ private enum class TestEnum {
 }
 
 private class TestEnumSerializer : BaseEnumeratedIntSerializer<TestEnum>(
+    className = "TestEnum",
     values = TestEnum.entries.toTypedArray(),
     default = TestEnum.UNKNOWN,
 )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR update failure logging for the `BaseEnumeratedIntSerializer` to indicate the enum it was trying to parse.

This will give us more context about the specific enum being decoded instead of errors like this:
```
Caused by java.lang.IllegalArgumentException: Unknown value 60
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
