### PR TITLE
PM-18294 update add edit screen titles to specify the type

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -2067,10 +2067,17 @@ data class VaultAddEditState(
      * Helper to determine the screen display name.
      */
     val screenDisplayName: Text
-        get() = when (vaultAddEditType) {
-            is VaultAddEditType.AddItem -> R.string.add_item.asText()
-            is VaultAddEditType.EditItem -> R.string.edit_item.asText()
-            is VaultAddEditType.CloneItem -> R.string.add_item.asText()
+        get() {
+            val itemTypeRes = (viewState as? ViewState.Content)
+                ?.type
+                ?.itemTypeOption
+                ?.titleSuffixRes
+                ?: R.string.item
+            return when (vaultAddEditType) {
+                is VaultAddEditType.AddItem -> R.string.new_x.asText(itemTypeRes.asText())
+                is VaultAddEditType.EditItem -> R.string.edit_x.asText(itemTypeRes.asText())
+                is VaultAddEditType.CloneItem -> R.string.new_x.asText(itemTypeRes.asText())
+            }
         }
 
     /**
@@ -2119,12 +2126,12 @@ data class VaultAddEditState(
      *
      * @property labelRes The resource ID of the string that represents the label of each type.
      */
-    enum class ItemTypeOption(val labelRes: Int) {
-        LOGIN(R.string.type_login),
-        CARD(R.string.type_card),
-        IDENTITY(R.string.type_identity),
-        SECURE_NOTES(R.string.type_secure_note),
-        SSH_KEYS(R.string.type_ssh_key),
+    enum class ItemTypeOption(val labelRes: Int, val titleSuffixRes: Int) {
+        LOGIN(R.string.type_login, R.string.login),
+        CARD(R.string.type_card, R.string.card),
+        IDENTITY(R.string.type_identity, R.string.identity),
+        SECURE_NOTES(R.string.type_secure_note, R.string.note),
+        SSH_KEYS(R.string.type_ssh_key, R.string.type_ssh_key),
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
   <string name="add">Add</string>
   <string name="add_folder">Add Folder</string>
   <string name="add_item">Add Item</string>
+  <string name="new_x">New %1$s</string>
+  <string name="item">item</string>
   <string name="an_error_has_occurred">An error has occurred.</string>
   <string name="back">Back</string>
   <string name="bitwarden">Bitwarden</string>
@@ -109,6 +111,7 @@
   <string name="create_an_account">Create an account</string>
   <string name="creating_account">Creating account...</string>
   <string name="edit_item">Edit item</string>
+  <string name="edit_x">Edit %1$s</string>
   <string name="enable_automatic_syncing">Allow automatic syncing</string>
   <string name="enter_email_for_hint">Enter your account email address to receive your master password hint.</string>
   <string name="exntesion_reenable">Reactivate app extension</string>
@@ -306,9 +309,13 @@ Scanning will happen automatically.</string>
   <string name="number">Number</string>
   <string name="security_code">Security code</string>
   <string name="type_card">Card</string>
+  <string name="card">card</string>
   <string name="type_identity">Identity</string>
+  <string name="identity">identity</string>
   <string name="type_login">Login</string>
+  <string name="login">login</string>
   <string name="type_secure_note">Secure note</string>
+  <string name="note">note</string>
   <string name="address1">Address 1</string>
   <string name="address2">Address 2</string>
   <string name="address3">Address 3</string>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-18294](https://bitwarden.atlassian.net/browse/PM-18294)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- For add item screens the screen title should read "New x" (i.e. "New login" for adding a Login).
- For edit item screens the title should now say "Edit x" (i.e. "Edit login when editing an existing Login).
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

https://github.com/user-attachments/assets/82c92bec-589f-45c8-b367-8c79397c7554


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18294]: https://bitwarden.atlassian.net/browse/PM-18294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ