### PR TITLE
PM-18410: Remove cipher type dropdown from add item screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -42,8 +42,6 @@ import kotlinx.collections.immutable.toImmutableList
 fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
     state: VaultAddEditState.ViewState.Content,
     isAddItemMode: Boolean,
-    typeOptions: List<VaultAddEditState.ItemTypeOption>,
-    onTypeOptionClicked: (VaultAddEditState.ItemTypeOption) -> Unit,
     commonTypeHandlers: VaultAddEditCommonHandlers,
     loginItemTypeHandlers: VaultAddEditLoginTypeHandlers,
     identityItemTypeHandlers: VaultAddEditIdentityTypeHandlers,
@@ -115,18 +113,6 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-
-            item {
-                TypeOptionsItem(
-                    entries = typeOptions,
-                    itemType = state.type,
-                    onTypeOptionClicked = onTypeOptionClicked,
-                    modifier = Modifier
-                        .testTag("ItemTypePicker")
-                        .standardHorizontalMargin(),
                 )
             }
         }
@@ -280,31 +266,6 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
             Spacer(modifier = Modifier.navigationBarsPadding())
         }
     }
-}
-
-@Composable
-private fun TypeOptionsItem(
-    entries: List<VaultAddEditState.ItemTypeOption>,
-    itemType: VaultAddEditState.ViewState.Content.ItemType,
-    onTypeOptionClicked: (VaultAddEditState.ItemTypeOption) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val optionsWithStrings = entries.associateWith { stringResource(id = it.labelRes) }
-
-    BitwardenMultiSelectButton(
-        label = stringResource(id = R.string.type),
-        options = optionsWithStrings.values.toImmutableList(),
-        selectedOption = stringResource(id = itemType.itemTypeOption.labelRes),
-        onOptionSelected = { selectedOption ->
-            val selectedOptionId = optionsWithStrings
-                .entries
-                .first { it.value == selectedOption }
-                .key
-            onTypeOptionClicked(selectedOptionId)
-        },
-        cardStyle = CardStyle.Full,
-        modifier = modifier,
-    )
 }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -368,14 +368,6 @@ fun VaultAddEditScreen(
                     VaultAddEditContent(
                         state = viewState,
                         isAddItemMode = state.isAddItemMode,
-                        typeOptions = state.supportedItemTypes,
-                        onTypeOptionClicked = remember(viewModel) {
-                            {
-                                viewModel.trySendAction(
-                                    VaultAddEditAction.Common.TypeOptionSelect(it),
-                                )
-                            }
-                        },
                         loginItemTypeHandlers = loginItemTypeHandlers,
                         commonTypeHandlers = commonTypeHandlers,
                         permissionsManager = permissionsManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -623,55 +623,13 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `clicking a Type Option should send TypeOptionSelect action`() {
-        // Opens the menu
-        composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "Login. Type")
-            .performClick()
-
-        // Choose the option from the menu
-        composeTestRule
-            .onAllNodesWithText(text = "Login")
-            .onLast()
-            .performScrollTo()
-            .performClick()
-
-        verify {
-            viewModel.trySendAction(
-                VaultAddEditAction.Common.TypeOptionSelect(VaultAddEditState.ItemTypeOption.LOGIN),
-            )
-        }
-    }
-
-    @Test
-    fun `the Type Option field should display the text of the selected item type`() {
-        composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "Login. Type")
-            .assertIsDisplayed()
-
-        mutableStateFlow.update {
-            it.copy(
-                viewState = VaultAddEditState.ViewState.Content(
-                    common = VaultAddEditState.ViewState.Content.Common(),
-                    type = VaultAddEditState.ViewState.Content.ItemType.Card(),
-                    isIndividualVaultDisabled = false,
-                ),
-            )
-        }
-
-        composeTestRule
-            .onNodeWithContentDescriptionAfterScroll(label = "Card. Type")
-            .assertIsDisplayed()
-    }
-
-    @Test
     fun `in ItemType_Login state the password should change according to state`() {
         composeTestRule
             .onNodeWithTextAfterScroll("Password")
             .assertTextEquals("Password", "")
             .assertIsEnabled()
         composeTestRule
-            .onNodeWithText("Check password for data breaches")
+            .onNodeWithTextAfterScroll("Check password for data breaches")
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Generate password")
@@ -3926,7 +3884,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
             ),
             dialog = VaultAddEditState.DialogState.Generic(message = "test".asText()),
             vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
-            supportedItemTypes = VaultAddEditState.ItemTypeOption.entries,
             shouldShowCoachMarkTour = false,
         )
 
@@ -3938,7 +3895,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
                 isIndividualVaultDisabled = false,
             ),
             dialog = null,
-            supportedItemTypes = VaultAddEditState.ItemTypeOption.entries,
             shouldShowCoachMarkTour = false,
         )
 
@@ -3950,7 +3906,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
                 isIndividualVaultDisabled = false,
             ),
             dialog = null,
-            supportedItemTypes = VaultAddEditState.ItemTypeOption.entries,
             shouldShowCoachMarkTour = false,
         )
 
@@ -3962,11 +3917,9 @@ class VaultAddEditScreenTest : BaseComposeTest() {
                 isIndividualVaultDisabled = false,
             ),
             dialog = null,
-            supportedItemTypes = VaultAddEditState.ItemTypeOption.entries,
             shouldShowCoachMarkTour = false,
         )
 
-        @Suppress("MaxLineLength")
         private val DEFAULT_STATE_SECURE_NOTES_CUSTOM_FIELDS = VaultAddEditState(
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(
@@ -3985,7 +3938,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
             ),
             dialog = null,
             vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.SECURE_NOTE),
-            supportedItemTypes = VaultAddEditState.ItemTypeOption.entries,
             shouldShowCoachMarkTour = false,
         )
 
@@ -3997,7 +3949,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
                 isIndividualVaultDisabled = false,
             ),
             dialog = null,
-            supportedItemTypes = VaultAddEditState.ItemTypeOption.entries,
             shouldShowCoachMarkTour = false,
         )
 
@@ -4009,7 +3960,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
                 isIndividualVaultDisabled = false,
             ),
             dialog = null,
-            supportedItemTypes = VaultAddEditState.ItemTypeOption.entries,
             shouldShowCoachMarkTour = false,
         )
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -203,8 +203,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             totpData = null,
             shouldShowCloseButton = true,
             shouldExitOnSave = false,
-            supportedItemTypes = VaultAddEditState.ItemTypeOption.entries
-                .filter { it != VaultAddEditState.ItemTypeOption.SSH_KEYS },
             shouldShowCoachMarkTour = false,
         )
         val viewModel = createAddVaultItemViewModel(
@@ -286,8 +284,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     type = VaultAddEditState.ViewState.Content.ItemType.Login(),
                 ),
                 dialog = null,
-                supportedItemTypes = VaultAddEditState.ItemTypeOption.entries
-                    .filter { it != VaultAddEditState.ItemTypeOption.SSH_KEYS },
                 shouldShowCoachMarkTour = false,
             ),
             viewModel.stateFlow.value,
@@ -2121,156 +2117,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             }
         }
 
-    @Test
-    fun `TypeOptionSelect LOGIN should switch to LoginItem`() = runTest {
-        mutableVaultDataFlow.value = DataState.Loaded(
-            createVaultData(cipherView = createMockCipherView(1)),
-        )
-        val viewModel = createAddVaultItemViewModel()
-        val action = VaultAddEditAction.Common.TypeOptionSelect(
-            VaultAddEditState.ItemTypeOption.LOGIN,
-        )
-
-        viewModel.trySendAction(action)
-
-        val expectedState = loginInitialState.copy(
-            viewState = VaultAddEditState.ViewState.Content(
-                common = createCommonContentViewState(),
-                isIndividualVaultDisabled = false,
-                type = createLoginTypeContentViewState(),
-                previousItemTypes = mapOf(
-                    VaultAddEditState.ItemTypeOption.LOGIN
-                        to VaultAddEditState.ViewState.Content.ItemType.Login(),
-                ),
-            ),
-        )
-
-        assertEquals(
-            expectedState,
-            viewModel.stateFlow.value,
-        )
-    }
-
-    @Test
-    fun `TypeOptionSelect CARD should switch to CardItem`() = runTest {
-        mutableVaultDataFlow.value = DataState.Loaded(
-            createVaultData(cipherView = createMockCipherView(1)),
-        )
-        val viewModel = createAddVaultItemViewModel()
-        val action = VaultAddEditAction.Common.TypeOptionSelect(
-            VaultAddEditState.ItemTypeOption.CARD,
-        )
-
-        viewModel.trySendAction(action)
-
-        val expectedState = loginInitialState.copy(
-            viewState = VaultAddEditState.ViewState.Content(
-                common = createCommonContentViewState(),
-                isIndividualVaultDisabled = false,
-                type = VaultAddEditState.ViewState.Content.ItemType.Card(),
-                previousItemTypes = mapOf(
-                    VaultAddEditState.ItemTypeOption.LOGIN
-                        to VaultAddEditState.ViewState.Content.ItemType.Login(),
-                ),
-            ),
-        )
-
-        assertEquals(
-            expectedState,
-            viewModel.stateFlow.value,
-        )
-    }
-
-    @Test
-    fun `TypeOptionSelect IDENTITY should switch to IdentityItem`() = runTest {
-        mutableVaultDataFlow.value = DataState.Loaded(
-            createVaultData(cipherView = createMockCipherView(1)),
-        )
-        val viewModel = createAddVaultItemViewModel()
-        val action = VaultAddEditAction.Common.TypeOptionSelect(
-            VaultAddEditState.ItemTypeOption.IDENTITY,
-        )
-
-        viewModel.trySendAction(action)
-
-        val expectedState = loginInitialState.copy(
-            viewState = VaultAddEditState.ViewState.Content(
-                common = createCommonContentViewState(),
-                isIndividualVaultDisabled = false,
-                type = VaultAddEditState.ViewState.Content.ItemType.Identity(),
-                previousItemTypes = mapOf(
-                    VaultAddEditState.ItemTypeOption.LOGIN
-                        to VaultAddEditState.ViewState.Content.ItemType.Login(),
-                ),
-            ),
-        )
-
-        assertEquals(
-            expectedState,
-            viewModel.stateFlow.value,
-        )
-    }
-
-    @Test
-    fun `TypeOptionSelect SECURE_NOTES should switch to SecureNotesItem`() = runTest {
-        mutableVaultDataFlow.value = DataState.Loaded(
-            createVaultData(cipherView = createMockCipherView(1)),
-        )
-        val viewModel = createAddVaultItemViewModel()
-        val action = VaultAddEditAction.Common.TypeOptionSelect(
-            VaultAddEditState.ItemTypeOption.SECURE_NOTES,
-        )
-
-        viewModel.trySendAction(action)
-
-        val expectedState = loginInitialState.copy(
-            viewState = VaultAddEditState.ViewState.Content(
-                common = createCommonContentViewState(),
-                isIndividualVaultDisabled = false,
-                type = VaultAddEditState.ViewState.Content.ItemType.SecureNotes,
-                previousItemTypes = mapOf(
-                    VaultAddEditState.ItemTypeOption.LOGIN
-                        to VaultAddEditState.ViewState.Content.ItemType.Login(),
-                ),
-            ),
-        )
-
-        assertEquals(
-            expectedState,
-            viewModel.stateFlow.value,
-        )
-    }
-
-    @Test
-    fun `TypeOptionSelect SSH_KEYS should switch to SshKeysItem`() = runTest {
-        mutableVaultDataFlow.value = DataState.Loaded(
-            createVaultData(cipherView = createMockCipherView(1)),
-        )
-        val viewModel = createAddVaultItemViewModel()
-        val action = VaultAddEditAction.Common.TypeOptionSelect(
-            VaultAddEditState.ItemTypeOption.SSH_KEYS,
-        )
-
-        viewModel.trySendAction(action)
-
-        val expectedState = loginInitialState.copy(
-            viewState = VaultAddEditState.ViewState.Content(
-                common = createCommonContentViewState(),
-                isIndividualVaultDisabled = false,
-                type = VaultAddEditState.ViewState.Content.ItemType.SshKey(),
-                previousItemTypes = mapOf(
-                    VaultAddEditState.ItemTypeOption.LOGIN
-                        to VaultAddEditState.ViewState.Content.ItemType.Login(),
-                ),
-            ),
-        )
-
-        assertEquals(
-            expectedState,
-            viewModel.stateFlow.value,
-        )
-    }
-
     @Nested
     inner class VaultAddEditLoginTypeItemActions {
         private lateinit var viewModel: VaultAddEditViewModel
@@ -2709,29 +2555,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         )
         assertTrue(viewModel.stateFlow.value.shouldShowLearnAboutNewLogins)
         mutableShouldShowAddLoginCoachMarkFlow.update { false }
-        assertFalse(viewModel.stateFlow.value.shouldShowLearnAboutNewLogins)
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `when first time action manager value is true, but type content is not login shouldShowLearnAboutNewLogins should be false`() {
-        mutableShouldShowAddLoginCoachMarkFlow.update { true }
-        val viewModel = createAddVaultItemViewModel(
-            savedStateHandle = createSavedStateHandleWithState(
-                state = createVaultAddItemState(
-                    typeContentViewState = createLoginTypeContentViewState(),
-                ),
-                vaultAddEditType = VaultAddEditType.AddItem(
-                    vaultItemCipherType = VaultItemCipherType.LOGIN,
-                ),
-            ),
-        )
-        assertTrue(viewModel.stateFlow.value.shouldShowLearnAboutNewLogins)
-        viewModel.trySendAction(
-            VaultAddEditAction.Common.TypeOptionSelect(
-                VaultAddEditState.ItemTypeOption.SSH_KEYS,
-            ),
-        )
         assertFalse(viewModel.stateFlow.value.shouldShowLearnAboutNewLogins)
     }
 
@@ -4440,7 +4263,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         typeContentViewState: VaultAddEditState.ViewState.Content.ItemType = createLoginTypeContentViewState(),
         dialogState: VaultAddEditState.DialogState? = null,
         totpData: TotpData? = null,
-        supportedItemTypes: List<VaultAddEditState.ItemTypeOption> = VaultAddEditState.ItemTypeOption.entries,
         shouldClearSpecialCircumstance: Boolean = true,
     ): VaultAddEditState =
         VaultAddEditState(
@@ -4453,7 +4275,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             dialog = dialogState,
             shouldExitOnSave = shouldExitOnSave,
             totpData = totpData,
-            supportedItemTypes = supportedItemTypes,
             shouldShowCoachMarkTour = false,
             shouldClearSpecialCircumstance = shouldClearSpecialCircumstance,
         )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18410](https://bitwarden.atlassian.net/browse/PM-18410)

## 📔 Objective

This PR removes the cipher type selector from from the add item UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18410]: https://bitwarden.atlassian.net/browse/PM-18410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ