### PR TITLE
PM-18370: Update space between label and tooltip

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -308,7 +308,7 @@ fun BitwardenTextField(
                                         targetValue = targetSize,
                                         label = "${it.contentDescription}_animation",
                                     )
-                                    Spacer(modifier = Modifier.width(16.dp))
+                                    Spacer(modifier = Modifier.width(width = 8.dp))
                                     BitwardenStandardIconButton(
                                         vectorIconRes = R.drawable.ic_question_circle_small,
                                         contentDescription = it.contentDescription,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18370](https://bitwarden.atlassian.net/browse/PM-18275)

## 📔 Objective

This PR updates the space between the label and the tooltip to be consistent with the latest designs.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/fa48d367-8250-43c8-80c4-8e051e49c2f2" width="300" /> | <img src="https://github.com/user-attachments/assets/2a4501d6-09a6-4252-9394-6696adf643b6" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18370]: https://bitwarden.atlassian.net/browse/PM-18370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ