### PR TITLE
[PM-18140] Handle unknown SecureNoteTypeJson values

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SecureNoteTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SecureNoteTypeJson.kt
@@ -21,4 +21,6 @@ enum class SecureNoteTypeJson {
 private class SecureNoteTypeSerializer : BaseEnumeratedIntSerializer<SecureNoteTypeJson>(
     className = "SecureNoteTypeJson",
     values = SecureNoteTypeJson.entries.toTypedArray(),
+    // Because GENERIC is the only valid value we default to it if an unknown value is received.
+    default = SecureNoteTypeJson.GENERIC,
 )


### PR DESCRIPTION
## 🎟️ Tracking

PM-18140

## 📔 Objective

The `SecureNoteTypeJson` serializer now defaults to `GENERIC` if an unknown value is received, as `GENERIC` is the only valid value.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
