### PR TITLE
PM-18121, PM-18294: Add, Edit, and View cipher screens require cipher type for top app bar title

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -59,6 +59,7 @@ import com.x8bit.bitwarden.ui.platform.theme.NonNullExitTransitionProvider
 import com.x8bit.bitwarden.ui.platform.theme.RootTransitionProviders
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.model.AddSendType
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.navigateToAddSend
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
 import com.x8bit.bitwarden.ui.vault.feature.addedit.navigateToVaultAddEdit
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.navigateToVaultItemListingAsRoot
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
@@ -190,6 +191,7 @@ fun RootNavScreen(
             RootNavState.ResetPassword -> {
                 navController.navigateToResetPasswordScreen(rootNavOptions)
             }
+
             RootNavState.SetPassword -> navController.navigateToSetPassword(rootNavOptions)
             RootNavState.Splash -> navController.navigateToSplash(rootNavOptions)
             RootNavState.TrustedDevice -> navController.navigateToTrustedDeviceGraph(rootNavOptions)
@@ -217,7 +219,8 @@ fun RootNavScreen(
             is RootNavState.VaultUnlockedForAutofillSave -> {
                 navController.navigateToVaultUnlockedGraph(rootNavOptions)
                 navController.navigateToVaultAddEdit(
-                    vaultAddEditType = VaultAddEditType.AddItem(
+                    args = VaultAddEditArgs(
+                        vaultAddEditType = VaultAddEditType.AddItem,
                         vaultItemCipherType = VaultItemCipherType.LOGIN,
                     ),
                     navOptions = rootNavOptions,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.base.util.toListItemCardStyle
@@ -126,7 +127,7 @@ fun SearchContent(
                     } else if (it.autofillSelectionOptions.isNotEmpty()) {
                         autofillSelectionOptionsItem = it
                     } else {
-                        searchHandlers.onItemClick(it.id)
+                        searchHandlers.onItemClick(it.id, it.cipherType)
                     }
                 },
                 trailingLabelIcons = it
@@ -187,7 +188,7 @@ private fun AutofillSelectionDialog(
     displayItem: SearchState.DisplayItem,
     onAutofillItemClick: (cipherId: String) -> Unit,
     onAutofillAndSaveItemClick: (cipherId: String) -> Unit,
-    onViewItemClick: (cipherId: String) -> Unit,
+    onViewItemClick: (cipherId: String, cipherType: CipherType?) -> Unit,
     onMasterPasswordRepromptRequest: (MasterPasswordRepromptData) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -241,7 +242,7 @@ private fun AutofillSelectionDialog(
                     text = stringResource(id = R.string.view),
                     onClick = {
                         onDismissRequest()
-                        onViewItemClick(displayItem.id)
+                        onViewItemClick(displayItem.id, displayItem.cipherType)
                     },
                 )
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
@@ -9,6 +9,8 @@ import androidx.navigation.navArgument
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 
 private const val SEARCH_TYPE: String = "search_type"
 private const val SEARCH_TYPE_SEND_ALL: String = "search_type_sends_all"
@@ -52,8 +54,8 @@ data class SearchArgs(
 fun NavGraphBuilder.searchDestination(
     onNavigateBack: () -> Unit,
     onNavigateToEditSend: (sendId: String) -> Unit,
-    onNavigateToEditCipher: (cipherId: String) -> Unit,
-    onNavigateToViewCipher: (cipherId: String) -> Unit,
+    onNavigateToEditCipher: (args: VaultAddEditArgs) -> Unit,
+    onNavigateToViewCipher: (args: VaultItemArgs) -> Unit,
 ) {
     composableWithSlideTransitions(
         route = SEARCH_ROUTE,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreen.kt
@@ -36,7 +36,10 @@ import com.x8bit.bitwarden.ui.platform.composition.LocalAppResumeStateManager
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
 import com.x8bit.bitwarden.ui.platform.feature.search.handlers.SearchHandlers
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.vault.VaultFilter
+import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import kotlinx.collections.immutable.toImmutableList
 
 /**
@@ -48,8 +51,8 @@ import kotlinx.collections.immutable.toImmutableList
 fun SearchScreen(
     onNavigateBack: () -> Unit,
     onNavigateToEditSend: (sendId: String) -> Unit,
-    onNavigateToEditCipher: (cipherId: String) -> Unit,
-    onNavigateToViewCipher: (cipherId: String) -> Unit,
+    onNavigateToEditCipher: (args: VaultAddEditArgs) -> Unit,
+    onNavigateToViewCipher: (args: VaultItemArgs) -> Unit,
     intentManager: IntentManager = LocalIntentManager.current,
     viewModel: SearchViewModel = hiltViewModel(),
     appResumeStateManager: AppResumeStateManager = LocalAppResumeStateManager.current,
@@ -70,8 +73,24 @@ fun SearchScreen(
         when (event) {
             SearchEvent.NavigateBack -> onNavigateBack()
             is SearchEvent.NavigateToEditSend -> onNavigateToEditSend(event.sendId)
-            is SearchEvent.NavigateToEditCipher -> onNavigateToEditCipher(event.cipherId)
-            is SearchEvent.NavigateToViewCipher -> onNavigateToViewCipher(event.cipherId)
+            is SearchEvent.NavigateToEditCipher -> {
+                onNavigateToEditCipher(
+                    VaultAddEditArgs(
+                        vaultAddEditType = VaultAddEditType.EditItem(vaultItemId = event.cipherId),
+                        vaultItemCipherType = event.cipherType,
+                    ),
+                )
+            }
+
+            is SearchEvent.NavigateToViewCipher -> {
+                onNavigateToViewCipher(
+                    VaultItemArgs(
+                        vaultItemId = event.cipherId,
+                        cipherType = event.cipherType,
+                    ),
+                )
+            }
+
             is SearchEvent.NavigateToUrl -> intentManager.launchUri(event.url.toUri())
             is SearchEvent.ShowShareSheet -> intentManager.shareText(event.content)
             is SearchEvent.ShowToast -> {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.platform.feature.search
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.LoginUriView
 import com.x8bit.bitwarden.R
@@ -50,6 +51,8 @@ import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.toFilteredList
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.toVaultFilterData
 import com.x8bit.bitwarden.ui.vault.model.TotpData
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.util.toVaultItemCipherType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -65,7 +68,7 @@ private const val KEY_STATE = "state"
 /**
  * View model for the search screen.
  */
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -161,9 +164,15 @@ class SearchViewModel @Inject constructor(
         val event = when (state.searchType) {
             is SearchTypeData.Vault -> {
                 if (state.isTotp) {
-                    SearchEvent.NavigateToEditCipher(cipherId = action.itemId)
+                    SearchEvent.NavigateToEditCipher(
+                        cipherId = action.itemId,
+                        cipherType = requireNotNull(action.cipherType).toVaultItemCipherType(),
+                    )
                 } else {
-                    SearchEvent.NavigateToViewCipher(cipherId = action.itemId)
+                    SearchEvent.NavigateToViewCipher(
+                        cipherId = action.itemId,
+                        cipherType = requireNotNull(action.cipherType).toVaultItemCipherType(),
+                    )
                 }
             }
 
@@ -402,7 +411,12 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun handleEditCipherClick(action: ListingItemOverflowAction.VaultAction.EditClick) {
-        sendEvent(SearchEvent.NavigateToEditCipher(action.cipherId))
+        sendEvent(
+            event = SearchEvent.NavigateToEditCipher(
+                cipherId = action.cipherId,
+                cipherType = action.cipherType.toVaultItemCipherType(),
+            ),
+        )
     }
 
     private fun handleLaunchCipherUrlClick(
@@ -412,7 +426,12 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun handleViewCipherClick(action: ListingItemOverflowAction.VaultAction.ViewClick) {
-        sendEvent(SearchEvent.NavigateToViewCipher(action.cipherId))
+        sendEvent(
+            event = SearchEvent.NavigateToViewCipher(
+                cipherId = action.cipherId,
+                cipherType = action.cipherType.toVaultItemCipherType(),
+            ),
+        )
     }
 
     private fun handleInternalAction(action: SearchAction.Internal) {
@@ -601,7 +620,12 @@ class SearchViewModel @Inject constructor(
             }
 
             is MasterPasswordRepromptData.Totp -> {
-                trySendAction(SearchAction.ItemClick(itemId = data.cipherId))
+                trySendAction(
+                    action = SearchAction.ItemClick(
+                        itemId = data.cipherId,
+                        cipherType = CipherType.LOGIN,
+                    ),
+                )
             }
         }
     }
@@ -862,6 +886,7 @@ data class SearchState(
         val autofillSelectionOptions: List<AutofillSelectionOption>,
         val isTotp: Boolean,
         val shouldDisplayMasterPasswordReprompt: Boolean,
+        val cipherType: CipherType?,
     ) : Parcelable
 }
 
@@ -1041,6 +1066,7 @@ sealed class SearchAction {
      */
     data class ItemClick(
         val itemId: String,
+        val cipherType: CipherType?,
     ) : SearchAction()
 
     /**
@@ -1165,6 +1191,7 @@ sealed class SearchEvent {
      */
     data class NavigateToEditCipher(
         val cipherId: String,
+        val cipherType: VaultItemCipherType,
     ) : SearchEvent()
 
     /**
@@ -1172,6 +1199,7 @@ sealed class SearchEvent {
      */
     data class NavigateToViewCipher(
         val cipherId: String,
+        val cipherType: VaultItemCipherType,
     ) : SearchEvent()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/handlers/SearchHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/handlers/SearchHandlers.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.feature.search.handlers
 
+import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.ui.platform.feature.search.MasterPasswordRepromptData
 import com.x8bit.bitwarden.ui.platform.feature.search.SearchAction
 import com.x8bit.bitwarden.ui.platform.feature.search.SearchViewModel
@@ -12,7 +13,7 @@ import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 data class SearchHandlers(
     val onBackClick: () -> Unit,
     val onDismissRequest: () -> Unit,
-    val onItemClick: (String) -> Unit,
+    val onItemClick: (cipherId: String, cipherType: CipherType?) -> Unit,
     val onAutofillItemClick: (String) -> Unit,
     val onAutofillAndSaveItemClick: (String) -> Unit,
     val onMasterPasswordRepromptSubmit: (password: String, MasterPasswordRepromptData) -> Unit,
@@ -30,7 +31,14 @@ data class SearchHandlers(
             SearchHandlers(
                 onBackClick = { viewModel.trySendAction(SearchAction.BackClick) },
                 onDismissRequest = { viewModel.trySendAction(SearchAction.DismissDialogClick) },
-                onItemClick = { viewModel.trySendAction(SearchAction.ItemClick(it)) },
+                onItemClick = { cipherId, cipherType ->
+                    viewModel.trySendAction(
+                        SearchAction.ItemClick(
+                            itemId = cipherId,
+                            cipherType = cipherType,
+                        ),
+                    )
+                },
                 onAutofillItemClick = {
                     viewModel.trySendAction(SearchAction.AutofillItemClick(it))
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
@@ -233,6 +233,7 @@ private fun CipherView.toDisplayItem(
             },
         isTotp = isTotp,
         shouldDisplayMasterPasswordReprompt = reprompt == CipherRepromptType.PASSWORD,
+        cipherType = this.type,
     )
 
 private fun CipherView.toIconData(
@@ -374,6 +375,7 @@ private fun SendView.toDisplayItem(
         autofillSelectionOptions = emptyList(),
         isTotp = false,
         shouldDisplayMasterPasswordReprompt = false,
+        cipherType = null,
     )
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -53,7 +53,6 @@ import com.x8bit.bitwarden.ui.vault.feature.movetoorganization.navigateToVaultMo
 import com.x8bit.bitwarden.ui.vault.feature.movetoorganization.vaultMoveToOrganizationDestination
 import com.x8bit.bitwarden.ui.vault.feature.qrcodescan.navigateToQrCodeScanScreen
 import com.x8bit.bitwarden.ui.vault.feature.qrcodescan.vaultQrCodeScanDestination
-import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 
 const val VAULT_UNLOCKED_GRAPH_ROUTE: String = "vault_unlocked_graph"
 
@@ -77,18 +76,10 @@ fun NavGraphBuilder.vaultUnlockedGraph(
     ) {
         vaultItemListingDestinationAsRoot(
             onNavigateBack = { navController.popBackStack() },
-            onNavigateToVaultItemScreen = { navController.navigateToVaultItem(vaultItemId = it) },
-            onNavigateToVaultAddItemScreen = { cipherType, selectedFolderId, collectionId ->
-                navController.navigateToVaultAddEdit(
-                    VaultAddEditType.AddItem(cipherType),
-                    selectedFolderId,
-                    collectionId,
-                )
-            },
+            onNavigateToVaultItemScreen = { navController.navigateToVaultItem(it) },
+            onNavigateToVaultAddItemScreen = { navController.navigateToVaultAddEdit(it) },
             onNavigateToSearchVault = { navController.navigateToSearch(searchType = it) },
-            onNavigateToVaultEditItemScreen = {
-                navController.navigateToVaultAddEdit(VaultAddEditType.EditItem(it))
-            },
+            onNavigateToVaultEditItemScreen = { navController.navigateToVaultAddEdit(it) },
             onNavigateToAddFolderScreen = {
                 navController.navigateToFolderAddEdit(
                     folderAddEditType = FolderAddEditType.AddItem,
@@ -99,17 +90,9 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         vaultUnlockedNavBarDestination(
             onNavigateToExportVault = { navController.navigateToExportVault() },
             onNavigateToFolders = { navController.navigateToFolders() },
-            onNavigateToVaultAddItem = { cipherType, selectedFolderId, collectionId ->
-                navController.navigateToVaultAddEdit(
-                    VaultAddEditType.AddItem(cipherType),
-                    selectedFolderId,
-                    collectionId,
-                )
-            },
+            onNavigateToVaultAddItem = { navController.navigateToVaultAddEdit(it) },
             onNavigateToVaultItem = { navController.navigateToVaultItem(it) },
-            onNavigateToVaultEditItem = {
-                navController.navigateToVaultAddEdit(VaultAddEditType.EditItem(it))
-            },
+            onNavigateToVaultEditItem = { navController.navigateToVaultAddEdit(it) },
             onNavigateToSearchVault = { navController.navigateToSearch(searchType = it) },
             onNavigateToSearchSend = { navController.navigateToSearch(searchType = it) },
             onNavigateToAddSend = { navController.navigateToAddSend(AddSendType.AddItem) },
@@ -169,15 +152,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         )
         vaultItemDestination(
             onNavigateBack = { navController.popBackStack() },
-            onNavigateToVaultEditItem = { vaultItemId, isClone ->
-                navController.navigateToVaultAddEdit(
-                    if (isClone) {
-                        VaultAddEditType.CloneItem(vaultItemId)
-                    } else {
-                        VaultAddEditType.EditItem(vaultItemId)
-                    },
-                )
-            },
+            onNavigateToVaultEditItem = { navController.navigateToVaultAddEdit(it) },
             onNavigateToMoveToOrganization = { vaultItemId, showOnlyCollections ->
                 navController.navigateToVaultMoveToOrganization(
                     vaultItemId = vaultItemId,
@@ -226,9 +201,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         searchDestination(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToEditSend = { navController.navigateToAddSend(AddSendType.EditItem(it)) },
-            onNavigateToEditCipher = {
-                navController.navigateToVaultAddEdit(VaultAddEditType.EditItem(it))
-            },
+            onNavigateToEditCipher = { navController.navigateToVaultAddEdit(it) },
             onNavigateToViewCipher = { navController.navigateToVaultItem(it) },
         )
         attachmentDestination(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
@@ -6,7 +6,8 @@ import androidx.navigation.NavOptions
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithStayTransitions
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 
 /**
  * The functions below pertain to entry into the [VaultUnlockedNavBarScreen].
@@ -25,9 +26,9 @@ fun NavController.navigateToVaultUnlockedNavBar(navOptions: NavOptions? = null) 
  */
 @Suppress("LongParameterList")
 fun NavGraphBuilder.vaultUnlockedNavBarDestination(
-    onNavigateToVaultAddItem: (VaultItemCipherType, String?, String?) -> Unit,
-    onNavigateToVaultItem: (vaultItemId: String) -> Unit,
-    onNavigateToVaultEditItem: (vaultItemId: String) -> Unit,
+    onNavigateToVaultAddItem: (args: VaultAddEditArgs) -> Unit,
+    onNavigateToVaultItem: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItem: (args: VaultAddEditArgs) -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
     onNavigateToAddSend: () -> Unit,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -50,10 +50,11 @@ import com.x8bit.bitwarden.ui.tools.feature.generator.generatorGraph
 import com.x8bit.bitwarden.ui.tools.feature.generator.navigateToGeneratorGraph
 import com.x8bit.bitwarden.ui.tools.feature.send.navigateToSendGraph
 import com.x8bit.bitwarden.ui.tools.feature.send.sendGraph
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.vault.VAULT_GRAPH_ROUTE
 import com.x8bit.bitwarden.ui.vault.feature.vault.navigateToVaultGraph
 import com.x8bit.bitwarden.ui.vault.feature.vault.vaultGraph
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 
 /**
  * Top level composable for the Vault Unlocked Screen.
@@ -63,9 +64,9 @@ import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 fun VaultUnlockedNavBarScreen(
     viewModel: VaultUnlockedNavBarViewModel = hiltViewModel(),
     navController: NavHostController = rememberNavController(),
-    onNavigateToVaultAddItem: (VaultItemCipherType, String?, String?) -> Unit,
-    onNavigateToVaultItem: (vaultItemId: String) -> Unit,
-    onNavigateToVaultEditItem: (vaultItemId: String) -> Unit,
+    onNavigateToVaultAddItem: (args: VaultAddEditArgs) -> Unit,
+    onNavigateToVaultItem: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItem: (args: VaultAddEditArgs) -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
     onNavigateToAddSend: () -> Unit,
@@ -161,9 +162,9 @@ private fun VaultUnlockedNavBarScaffold(
     sendTabClickedAction: () -> Unit,
     generatorTabClickedAction: () -> Unit,
     settingsTabClickedAction: () -> Unit,
-    navigateToVaultAddItem: (VaultItemCipherType, String?, String?) -> Unit,
-    onNavigateToVaultItem: (vaultItemId: String) -> Unit,
-    onNavigateToVaultEditItem: (vaultItemId: String) -> Unit,
+    navigateToVaultAddItem: (args: VaultAddEditArgs) -> Unit,
+    onNavigateToVaultItem: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItem: (args: VaultAddEditArgs) -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
     navigateToAddSend: () -> Unit,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemNavigation.kt
@@ -8,18 +8,33 @@ import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+
+private const val LOGIN: String = "login"
+private const val CARD: String = "card"
+private const val IDENTITY: String = "identity"
+private const val SECURE_NOTE: String = "secure_note"
+private const val SSH_KEY: String = "ssh_key"
+private const val VAULT_ITEM_CIPHER_TYPE: String = "vault_item_cipher_type"
 
 private const val VAULT_ITEM_PREFIX = "vault_item"
 private const val VAULT_ITEM_ID = "vault_item_id"
-private const val VAULT_ITEM_ROUTE = "$VAULT_ITEM_PREFIX/{$VAULT_ITEM_ID}"
+private const val VAULT_ITEM_ROUTE = "$VAULT_ITEM_PREFIX/{$VAULT_ITEM_ID}" +
+    "?$VAULT_ITEM_CIPHER_TYPE={$VAULT_ITEM_CIPHER_TYPE}"
 
 /**
  * Class to retrieve vault item arguments from the [SavedStateHandle].
  */
 @OmitFromCoverage
-data class VaultItemArgs(val vaultItemId: String) {
+data class VaultItemArgs(
+    val vaultItemId: String,
+    val cipherType: VaultItemCipherType,
+) {
     constructor(savedStateHandle: SavedStateHandle) : this(
-        checkNotNull(savedStateHandle[VAULT_ITEM_ID]) as String,
+        vaultItemId = checkNotNull(savedStateHandle.get<String>(VAULT_ITEM_ID)),
+        cipherType = requireNotNull(savedStateHandle.get<String>(VAULT_ITEM_CIPHER_TYPE))
+            .toVaultItemCipherType(),
     )
 }
 
@@ -28,7 +43,7 @@ data class VaultItemArgs(val vaultItemId: String) {
  */
 fun NavGraphBuilder.vaultItemDestination(
     onNavigateBack: () -> Unit,
-    onNavigateToVaultEditItem: (vaultItemId: String, isClone: Boolean) -> Unit,
+    onNavigateToVaultEditItem: (args: VaultAddEditArgs) -> Unit,
     onNavigateToMoveToOrganization: (vaultItemId: String, showOnlyCollections: Boolean) -> Unit,
     onNavigateToAttachments: (vaultItemId: String) -> Unit,
     onNavigateToPasswordHistory: (vaultItemId: String) -> Unit,
@@ -37,6 +52,7 @@ fun NavGraphBuilder.vaultItemDestination(
         route = VAULT_ITEM_ROUTE,
         arguments = listOf(
             navArgument(VAULT_ITEM_ID) { type = NavType.StringType },
+            navArgument(VAULT_ITEM_CIPHER_TYPE) { type = NavType.StringType },
         ),
     ) {
         VaultItemScreen(
@@ -53,8 +69,33 @@ fun NavGraphBuilder.vaultItemDestination(
  * Navigate to the vault item screen.
  */
 fun NavController.navigateToVaultItem(
-    vaultItemId: String,
+    args: VaultItemArgs,
     navOptions: NavOptions? = null,
 ) {
-    navigate("$VAULT_ITEM_PREFIX/$vaultItemId", navOptions)
+    navigate(
+        route = "$VAULT_ITEM_PREFIX/${args.vaultItemId}" +
+            "?$VAULT_ITEM_CIPHER_TYPE=${args.cipherType.toTypeString()}",
+        navOptions = navOptions,
+    )
 }
+
+private fun VaultItemCipherType.toTypeString(): String =
+    when (this) {
+        VaultItemCipherType.LOGIN -> LOGIN
+        VaultItemCipherType.CARD -> CARD
+        VaultItemCipherType.IDENTITY -> IDENTITY
+        VaultItemCipherType.SECURE_NOTE -> SECURE_NOTE
+        VaultItemCipherType.SSH_KEY -> SSH_KEY
+    }
+
+private fun String.toVaultItemCipherType(): VaultItemCipherType =
+    when (this) {
+        LOGIN -> VaultItemCipherType.LOGIN
+        CARD -> VaultItemCipherType.CARD
+        IDENTITY -> VaultItemCipherType.IDENTITY
+        SECURE_NOTE -> VaultItemCipherType.SECURE_NOTE
+        SSH_KEY -> VaultItemCipherType.SSH_KEY
+        else -> throw IllegalStateException(
+            "Edit Item string arguments for VaultAddEditNavigation must match!",
+        )
+    }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -32,6 +32,7 @@ import com.x8bit.bitwarden.ui.vault.feature.item.util.toViewState
 import com.x8bit.bitwarden.ui.vault.feature.util.canAssignToCollections
 import com.x8bit.bitwarden.ui.vault.feature.util.hasDeletePermissionInAtLeastOneCollection
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
@@ -61,11 +62,15 @@ class VaultItemViewModel @Inject constructor(
     private val organizationEventManager: OrganizationEventManager,
 ) : BaseViewModel<VaultItemState, VaultItemEvent, VaultItemAction>(
     // We load the state from the savedStateHandle for testing purposes.
-    initialState = savedStateHandle[KEY_STATE] ?: VaultItemState(
-        vaultItemId = VaultItemArgs(savedStateHandle).vaultItemId,
-        viewState = VaultItemState.ViewState.Loading,
-        dialog = null,
-    ),
+    initialState = savedStateHandle[KEY_STATE] ?: run {
+        val args = VaultItemArgs(savedStateHandle)
+        VaultItemState(
+            vaultItemId = args.vaultItemId,
+            cipherType = args.cipherType,
+            viewState = VaultItemState.ViewState.Loading,
+            dialog = null,
+        )
+    },
 ) {
     /**
      * Reference to a temporary attachment saved in cache.
@@ -1358,9 +1363,22 @@ class VaultItemViewModel @Inject constructor(
 @Parcelize
 data class VaultItemState(
     val vaultItemId: String,
+    val cipherType: VaultItemCipherType,
     val viewState: ViewState,
     val dialog: DialogState?,
 ) : Parcelable {
+
+    /**
+     * The displayable title for the top app bar.
+     */
+    val title: Text
+        get() = when (cipherType) {
+            VaultItemCipherType.LOGIN -> R.string.view_login.asText()
+            VaultItemCipherType.CARD -> R.string.view_card.asText()
+            VaultItemCipherType.IDENTITY -> R.string.view_identity.asText()
+            VaultItemCipherType.SECURE_NOTE -> R.string.view_note.asText()
+            VaultItemCipherType.SSH_KEY -> R.string.view_passkey.asText()
+        }
 
     /**
      * Whether or not the cipher has been deleted.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.base.util.toListItemCardStyle
@@ -42,7 +43,7 @@ fun VaultItemListingContent(
     showAddTotpBanner: Boolean,
     collectionClick: (id: String) -> Unit,
     folderClick: (id: String) -> Unit,
-    vaultItemClick: (id: String) -> Unit,
+    vaultItemClick: (id: String, cipherType: CipherType?) -> Unit,
     masterPasswordRepromptSubmit: (password: String, data: MasterPasswordRepromptData) -> Unit,
     onOverflowItemClick: (action: ListingItemOverflowAction) -> Unit,
     modifier: Modifier = Modifier,
@@ -222,7 +223,7 @@ fun VaultItemListingContent(
                                 cipherId = it.id,
                             )
                         } else {
-                            vaultItemClick(it.id)
+                            vaultItemClick(it.id, it.type)
                         }
                     },
                     trailingLabelIcons = it

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
@@ -10,7 +10,8 @@ import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithStayTransitions
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
 
 private const val CARD: String = "card"
@@ -61,14 +62,10 @@ data class VaultItemListingArgs(
 @Suppress("LongParameterList")
 fun NavGraphBuilder.vaultItemListingDestination(
     onNavigateBack: () -> Unit,
-    onNavigateToVaultItemScreen: (id: String) -> Unit,
-    onNavigateToVaultEditItemScreen: (cipherId: String) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToVaultItemListing: (vaultItemListingType: VaultItemListingType) -> Unit,
-    onNavigateToVaultAddItemScreen: (
-        cipherType: VaultItemCipherType,
-        selectedFolderId: String?,
-        selectedCollectionId: String?,
-    ) -> Unit,
+    onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
 ) {
@@ -92,13 +89,9 @@ fun NavGraphBuilder.vaultItemListingDestination(
 @Suppress("LongParameterList")
 fun NavGraphBuilder.vaultItemListingDestinationAsRoot(
     onNavigateBack: () -> Unit,
-    onNavigateToVaultItemScreen: (id: String) -> Unit,
-    onNavigateToVaultEditItemScreen: (cipherId: String) -> Unit,
-    onNavigateToVaultAddItemScreen: (
-        cipherType: VaultItemCipherType,
-        selectedFolderId: String?,
-        selectedCollectionId: String?,
-    ) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItemScreen: (args: VaultAddEditArgs) -> Unit,
+    onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
 ) {
@@ -115,7 +108,7 @@ fun NavGraphBuilder.vaultItemListingDestinationAsRoot(
     ) {
         VaultItemListingScreen(
             onNavigateBack = onNavigateBack,
-            onNavigateToVaultItem = onNavigateToVaultItemScreen,
+            onNavigateToVaultItemScreen = onNavigateToVaultItemScreen,
             onNavigateToVaultEditItemScreen = onNavigateToVaultEditItemScreen,
             onNavigateToVaultAddItemScreen = onNavigateToVaultAddItemScreen,
             onNavigateToSearch = { onNavigateToSearchVault(it as SearchType.Vault) },
@@ -141,7 +134,7 @@ fun NavGraphBuilder.sendItemListingDestination(
         onNavigateBack = onNavigateBack,
         onNavigateToAddSendItem = onNavigateToAddSendItem,
         onNavigateToEditSendItem = onNavigateToEditSendItem,
-        onNavigateToVaultAddItemScreen = { _, _, _ -> },
+        onNavigateToVaultAddItemScreen = { },
         onNavigateToAddFolderScreen = { _ -> },
         onNavigateToVaultItemScreen = { },
         onNavigateToVaultEditItemScreen = { },
@@ -157,14 +150,10 @@ fun NavGraphBuilder.sendItemListingDestination(
 private fun NavGraphBuilder.internalVaultItemListingDestination(
     route: String,
     onNavigateBack: () -> Unit,
-    onNavigateToVaultItemScreen: (id: String) -> Unit,
-    onNavigateToVaultEditItemScreen: (cipherId: String) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToVaultItemListing: (vaultItemListingType: VaultItemListingType) -> Unit,
-    onNavigateToVaultAddItemScreen: (
-        cipherType: VaultItemCipherType,
-        selectedFolderId: String?,
-        selectedCollectionId: String?,
-    ) -> Unit,
+    onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToAddSendItem: () -> Unit,
     onNavigateToEditSendItem: (sendId: String) -> Unit,
@@ -190,7 +179,7 @@ private fun NavGraphBuilder.internalVaultItemListingDestination(
     ) {
         VaultItemListingScreen(
             onNavigateBack = onNavigateBack,
-            onNavigateToVaultItem = onNavigateToVaultItemScreen,
+            onNavigateToVaultItemScreen = onNavigateToVaultItemScreen,
             onNavigateToVaultEditItemScreen = onNavigateToVaultEditItemScreen,
             onNavigateToVaultAddItemScreen = onNavigateToVaultAddItemScreen,
             onNavigateToAddSendItem = onNavigateToAddSendItem,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -54,10 +54,12 @@ import com.x8bit.bitwarden.ui.platform.manager.exit.ExitManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.vault.components.VaultItemSelectionDialog
 import com.x8bit.bitwarden.ui.vault.components.model.CreateVaultItemType
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.handlers.VaultItemListingHandlers
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.handlers.VaultItemListingUserVerificationHandlers
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.initials
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -69,14 +71,10 @@ import kotlinx.collections.immutable.toImmutableList
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 fun VaultItemListingScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToVaultItem: (id: String) -> Unit,
-    onNavigateToVaultEditItemScreen: (cipherVaultId: String) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToVaultItemListing: (vaultItemListingType: VaultItemListingType) -> Unit,
-    onNavigateToVaultAddItemScreen: (
-        vaultItemCipherType: VaultItemCipherType,
-        selectedFolderId: String?,
-        selectedCollectionId: String?,
-    ) -> Unit,
+    onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToAddFolder: (selectedFolderId: String?) -> Unit,
     onNavigateToAddSendItem: () -> Unit,
     onNavigateToEditSendItem: (sendId: String) -> Unit,
@@ -106,7 +104,7 @@ fun VaultItemListingScreen(
             is VaultItemListingEvent.NavigateBack -> onNavigateBack()
 
             is VaultItemListingEvent.NavigateToVaultItem -> {
-                onNavigateToVaultItem(event.id)
+                onNavigateToVaultItemScreen(VaultItemArgs(event.id, event.type))
             }
 
             is VaultItemListingEvent.ShowShareSheet -> {
@@ -119,14 +117,22 @@ fun VaultItemListingScreen(
 
             is VaultItemListingEvent.NavigateToAddVaultItem -> {
                 onNavigateToVaultAddItemScreen(
-                    event.vaultItemCipherType,
-                    event.selectedFolderId,
-                    event.selectedCollectionId,
+                    VaultAddEditArgs(
+                        vaultAddEditType = VaultAddEditType.AddItem,
+                        vaultItemCipherType = event.vaultItemCipherType,
+                        selectedFolderId = event.selectedFolderId,
+                        selectedCollectionId = event.selectedCollectionId,
+                    ),
                 )
             }
 
             is VaultItemListingEvent.NavigateToEditCipher -> {
-                onNavigateToVaultEditItemScreen(event.cipherId)
+                onNavigateToVaultEditItemScreen(
+                    VaultAddEditArgs(
+                        vaultAddEditType = VaultAddEditType.EditItem(vaultItemId = event.cipherId),
+                        vaultItemCipherType = event.cipherType,
+                    ),
+                )
             }
 
             is VaultItemListingEvent.NavigateToUrl -> {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.vault.CipherRepromptType
+import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -79,6 +80,7 @@ import com.x8bit.bitwarden.ui.vault.feature.vault.util.toActiveAccountSummary
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.toFilteredList
 import com.x8bit.bitwarden.ui.vault.model.TotpData
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.util.toVaultItemCipherType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.launchIn
@@ -653,7 +655,12 @@ class VaultItemListingViewModel @Inject constructor(
             return
         }
         state.totpData?.let {
-            sendEvent(VaultItemListingEvent.NavigateToEditCipher(cipherId = action.id))
+            sendEvent(
+                event = VaultItemListingEvent.NavigateToEditCipher(
+                    cipherId = action.id,
+                    cipherType = requireNotNull(action.cipherType).toVaultItemCipherType(),
+                ),
+            )
             return
         }
 
@@ -664,7 +671,10 @@ class VaultItemListingViewModel @Inject constructor(
 
         val event = when (state.itemListingType) {
             is VaultItemListingState.ItemListingType.Vault -> {
-                VaultItemListingEvent.NavigateToVaultItem(id = action.id)
+                VaultItemListingEvent.NavigateToVaultItem(
+                    id = action.id,
+                    type = requireNotNull(action.cipherType).toVaultItemCipherType(),
+                )
             }
 
             is VaultItemListingState.ItemListingType.Send -> {
@@ -903,7 +913,18 @@ class VaultItemListingViewModel @Inject constructor(
     }
 
     private fun handleEditCipherClick(action: ListingItemOverflowAction.VaultAction.EditClick) {
-        sendEvent(VaultItemListingEvent.NavigateToEditCipher(action.cipherId))
+        sendEvent(
+            event = VaultItemListingEvent.NavigateToEditCipher(
+                cipherId = action.cipherId,
+                cipherType = when (action.cipherType) {
+                    CipherType.LOGIN -> VaultItemCipherType.LOGIN
+                    CipherType.SECURE_NOTE -> VaultItemCipherType.SECURE_NOTE
+                    CipherType.CARD -> VaultItemCipherType.CARD
+                    CipherType.IDENTITY -> VaultItemCipherType.IDENTITY
+                    CipherType.SSH_KEY -> VaultItemCipherType.SSH_KEY
+                },
+            ),
+        )
     }
 
     private fun handleLaunchCipherUrlClick(
@@ -913,7 +934,18 @@ class VaultItemListingViewModel @Inject constructor(
     }
 
     private fun handleViewCipherClick(action: ListingItemOverflowAction.VaultAction.ViewClick) {
-        sendEvent(VaultItemListingEvent.NavigateToVaultItem(action.cipherId))
+        sendEvent(
+            event = VaultItemListingEvent.NavigateToVaultItem(
+                id = action.cipherId,
+                type = when (action.cipherType) {
+                    CipherType.LOGIN -> VaultItemCipherType.LOGIN
+                    CipherType.SECURE_NOTE -> VaultItemCipherType.SECURE_NOTE
+                    CipherType.CARD -> VaultItemCipherType.CARD
+                    CipherType.IDENTITY -> VaultItemCipherType.IDENTITY
+                    CipherType.SSH_KEY -> VaultItemCipherType.SSH_KEY
+                },
+            ),
+        )
     }
 
     private fun handleDismissDialogClick() {
@@ -1285,7 +1317,12 @@ class VaultItemListingViewModel @Inject constructor(
             }
 
             is MasterPasswordRepromptData.Totp -> {
-                sendEvent(VaultItemListingEvent.NavigateToEditCipher(data.cipherId))
+                sendEvent(
+                    VaultItemListingEvent.NavigateToEditCipher(
+                        cipherId = data.cipherId,
+                        cipherType = VaultItemCipherType.LOGIN,
+                    ),
+                )
             }
         }
     }
@@ -2079,9 +2116,6 @@ data class VaultItemListingState(
             val displayCollectionList: List<CollectionDisplayItem>,
         ) : ViewState() {
             override val isPullToRefreshEnabled: Boolean get() = true
-            val shouldShowDivider: Boolean
-                get() = displayItemList.isNotEmpty() &&
-                    (displayFolderList.isNotEmpty() || displayCollectionList.isNotEmpty())
         }
 
         /**
@@ -2114,6 +2148,7 @@ data class VaultItemListingState(
      * @property isFido2Creation whether or not this screen is part of fido2 creation flow.
      * @property shouldShowMasterPasswordReprompt whether or not a master password reprompt is
      * required for various secure actions.
+     * @property type Indicates the type of cipher this is or null if it is not a cipher.
      */
     data class DisplayItem(
         val id: String,
@@ -2132,6 +2167,7 @@ data class VaultItemListingState(
         val isFido2Creation: Boolean,
         val isTotp: Boolean,
         val shouldShowMasterPasswordReprompt: Boolean,
+        val type: CipherType?,
     )
 
     /**
@@ -2343,13 +2379,17 @@ sealed class VaultItemListingEvent {
      *
      * @property id the id of the item to navigate to.
      */
-    data class NavigateToVaultItem(val id: String) : VaultItemListingEvent()
+    data class NavigateToVaultItem(
+        val id: String,
+        val type: VaultItemCipherType,
+    ) : VaultItemListingEvent()
 
     /**
      * Navigates to view a cipher.
      */
     data class NavigateToEditCipher(
         val cipherId: String,
+        val cipherType: VaultItemCipherType,
     ) : VaultItemListingEvent()
 
     /**
@@ -2546,7 +2586,10 @@ sealed class VaultItemListingsAction {
      *
      * @property id the id of the item that has been clicked.
      */
-    data class ItemClick(val id: String) : VaultItemListingsAction()
+    data class ItemClick(
+        val id: String,
+        val cipherType: CipherType?,
+    ) : VaultItemListingsAction()
 
     /**
      * Click on the collection.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/handlers/VaultItemListingHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/handlers/VaultItemListingHandlers.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.vault.feature.itemlisting.handlers
 
+import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.MasterPasswordRepromptData
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.VaultItemListingViewModel
@@ -17,7 +18,7 @@ data class VaultItemListingHandlers(
     val backClick: () -> Unit,
     val searchIconClick: () -> Unit,
     val addVaultItemClick: () -> Unit,
-    val itemClick: (id: String) -> Unit,
+    val itemClick: (id: String, cipherType: CipherType?) -> Unit,
     val folderClick: (id: String) -> Unit,
     val collectionClick: (id: String) -> Unit,
     val masterPasswordRepromptSubmit: (password: String, MasterPasswordRepromptData) -> Unit,
@@ -55,7 +56,11 @@ data class VaultItemListingHandlers(
                 collectionClick = {
                     viewModel.trySendAction(VaultItemListingsAction.CollectionClick(it))
                 },
-                itemClick = { viewModel.trySendAction(VaultItemListingsAction.ItemClick(it)) },
+                itemClick = { cipherId, cipherType ->
+                    viewModel.trySendAction(
+                        VaultItemListingsAction.ItemClick(id = cipherId, cipherType = cipherType),
+                    )
+                },
                 folderClick = { viewModel.trySendAction(VaultItemListingsAction.FolderClick(it)) },
                 masterPasswordRepromptSubmit = { password, data ->
                     viewModel.trySendAction(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.itemlisting.model
 
 import android.os.Parcelable
+import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
@@ -75,7 +76,10 @@ sealed class ListingItemOverflowAction : Parcelable {
          * Click on the view cipher overflow option.
          */
         @Parcelize
-        data class ViewClick(val cipherId: String) : VaultAction() {
+        data class ViewClick(
+            val cipherId: String,
+            val cipherType: CipherType,
+        ) : VaultAction() {
             override val title: Text get() = R.string.view.asText()
             override val requiresPasswordReprompt: Boolean get() = false
         }
@@ -86,6 +90,7 @@ sealed class ListingItemOverflowAction : Parcelable {
         @Parcelize
         data class EditClick(
             val cipherId: String,
+            val cipherType: CipherType,
             override val requiresPasswordReprompt: Boolean,
         ) : VaultAction() {
             override val title: Text get() = R.string.edit.asText()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -410,6 +410,7 @@ private fun CipherView.toDisplayItem(
         isTotp = isTotp,
         shouldShowMasterPasswordReprompt = (reprompt == CipherRepromptType.PASSWORD) &&
             hasMasterPassword,
+        type = this.type,
     )
 
 private fun CipherView.toSecondSubtitle(fido2CredentialRpId: String?): String? =
@@ -481,6 +482,7 @@ private fun SendView.toDisplayItem(
         shouldShowMasterPasswordReprompt = false,
         isFido2Creation = false,
         isTotp = false,
+        type = null,
     )
 
 @get:DrawableRes

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
@@ -17,9 +17,13 @@ fun CipherView.toOverflowActions(
         .id
         ?.let { cipherId ->
             listOfNotNull(
-                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = cipherId),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = cipherId,
+                    cipherType = this.type,
+                ),
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = cipherId,
+                    cipherType = this.type,
                     requiresPasswordReprompt = hasMasterPassword,
                 )
                     .takeUnless { this.deletedDate != null || !this.edit },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultGraphNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultGraphNavigation.kt
@@ -6,11 +6,12 @@ import androidx.navigation.NavOptions
 import androidx.navigation.navigation
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.navigateToVaultItemListing
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.vaultItemListingDestination
 import com.x8bit.bitwarden.ui.vault.feature.verificationcode.navigateToVerificationCodeScreen
 import com.x8bit.bitwarden.ui.vault.feature.verificationcode.vaultVerificationCodeDestination
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 
 const val VAULT_GRAPH_ROUTE: String = "vault_graph"
 
@@ -20,13 +21,9 @@ const val VAULT_GRAPH_ROUTE: String = "vault_graph"
 @Suppress("LongParameterList")
 fun NavGraphBuilder.vaultGraph(
     navController: NavController,
-    onNavigateToVaultAddItemScreen: (
-        vaultItemCipherType: VaultItemCipherType,
-        selectedFolderId: String?,
-        selectedCollectionId: String?,
-    ) -> Unit,
-    onNavigateToVaultItemScreen: (vaultItemId: String) -> Unit,
-    onNavigateToVaultEditItemScreen: (vaultItemId: String) -> Unit,
+    onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
     onDimBottomNavBarRequest: (shouldDim: Boolean) -> Unit,
     onNavigateToImportLogins: (SnackbarRelay) -> Unit,
@@ -37,9 +34,7 @@ fun NavGraphBuilder.vaultGraph(
         startDestination = VAULT_ROUTE,
     ) {
         vaultDestination(
-            onNavigateToVaultAddItemScreen = {
-                onNavigateToVaultAddItemScreen(it, null, null)
-            },
+            onNavigateToVaultAddItemScreen = { onNavigateToVaultAddItemScreen(it) },
             onNavigateToVaultItemScreen = onNavigateToVaultItemScreen,
             onNavigateToVaultEditItemScreen = onNavigateToVaultEditItemScreen,
             onNavigateToVaultItemListingScreen = { navController.navigateToVaultItemListing(it) },
@@ -57,9 +52,7 @@ fun NavGraphBuilder.vaultGraph(
             onNavigateToVaultAddItemScreen = onNavigateToVaultAddItemScreen,
             onNavigateToSearchVault = onNavigateToSearchVault,
             onNavigateToVaultEditItemScreen = onNavigateToVaultEditItemScreen,
-            onNavigateToVaultItemListing = {
-                navController.navigateToVaultItemListing(it)
-            },
+            onNavigateToVaultItemListing = { navController.navigateToVaultItemListing(it) },
             onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultNavigation.kt
@@ -6,7 +6,8 @@ import androidx.navigation.NavOptions
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithRootPushTransitions
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
 
 const val VAULT_ROUTE: String = "vault"
@@ -16,10 +17,10 @@ const val VAULT_ROUTE: String = "vault"
  */
 @Suppress("LongParameterList")
 fun NavGraphBuilder.vaultDestination(
-    onNavigateToVaultAddItemScreen: (VaultItemCipherType) -> Unit,
+    onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToVerificationCodeScreen: () -> Unit,
-    onNavigateToVaultItemScreen: (vaultItemId: String) -> Unit,
-    onNavigateToVaultEditItemScreen: (vaultItemId: String) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToVaultItemListingScreen: (vaultItemType: VaultItemListingType) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
     onDimBottomNavBarRequest: (shouldDim: Boolean) -> Unit,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -65,9 +65,11 @@ import com.x8bit.bitwarden.ui.platform.manager.review.AppReviewManager
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
 import com.x8bit.bitwarden.ui.vault.components.VaultItemSelectionDialog
 import com.x8bit.bitwarden.ui.vault.components.model.CreateVaultItemType
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
 import com.x8bit.bitwarden.ui.vault.feature.vault.handlers.VaultHandlers
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -83,11 +85,9 @@ private const val APP_REVIEW_DELAY = 3000L
 @Composable
 fun VaultScreen(
     viewModel: VaultViewModel = hiltViewModel(),
-    onNavigateToVaultAddItemScreen: (
-        vaultItemCipherType: VaultItemCipherType,
-    ) -> Unit,
-    onNavigateToVaultItemScreen: (vaultItemId: String) -> Unit,
-    onNavigateToVaultEditItemScreen: (vaultItemId: String) -> Unit,
+    onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
+    onNavigateToVaultEditItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToVerificationCodeScreen: () -> Unit,
     onNavigateToVaultItemListingScreen: (vaultItemType: VaultItemListingType) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
@@ -129,7 +129,12 @@ fun VaultScreen(
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             is VaultEvent.NavigateToAddItemScreen -> {
-                onNavigateToVaultAddItemScreen(event.type)
+                onNavigateToVaultAddItemScreen(
+                    VaultAddEditArgs(
+                        vaultAddEditType = VaultAddEditType.AddItem,
+                        vaultItemCipherType = event.type,
+                    ),
+                )
             }
 
             VaultEvent.NavigateToVaultSearchScreen -> onNavigateToSearchVault(SearchType.Vault.All)
@@ -138,9 +143,18 @@ fun VaultScreen(
                 onNavigateToVerificationCodeScreen()
             }
 
-            is VaultEvent.NavigateToVaultItem -> onNavigateToVaultItemScreen(event.itemId)
+            is VaultEvent.NavigateToVaultItem -> {
+                onNavigateToVaultItemScreen(VaultItemArgs(event.itemId, event.type))
+            }
 
-            is VaultEvent.NavigateToEditVaultItem -> onNavigateToVaultEditItemScreen(event.itemId)
+            is VaultEvent.NavigateToEditVaultItem -> {
+                onNavigateToVaultEditItemScreen(
+                    VaultAddEditArgs(
+                        vaultAddEditType = VaultAddEditType.EditItem(vaultItemId = event.itemId),
+                        vaultItemCipherType = event.type,
+                    ),
+                )
+            }
 
             is VaultEvent.NavigateToItemListing -> {
                 onNavigateToVaultItemListingScreen(event.itemListingType)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -53,6 +53,7 @@ import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
 import com.x8bit.bitwarden.ui.vault.util.shortName
+import com.x8bit.bitwarden.ui.vault.util.toVaultItemCipherType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -407,7 +408,12 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleVaultItemClick(action: VaultAction.VaultItemClick) {
-        sendEvent(VaultEvent.NavigateToVaultItem(action.vaultItem.id))
+        sendEvent(
+            event = VaultEvent.NavigateToVaultItem(
+                itemId = action.vaultItem.id,
+                type = action.vaultItem.type,
+            ),
+        )
     }
 
     private fun handleTryAgainClick() {
@@ -540,7 +546,12 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleEditClick(action: ListingItemOverflowAction.VaultAction.EditClick) {
-        sendEvent(VaultEvent.NavigateToEditVaultItem(action.cipherId))
+        sendEvent(
+            event = VaultEvent.NavigateToEditVaultItem(
+                itemId = action.cipherId,
+                type = action.cipherType.toVaultItemCipherType(),
+            ),
+        )
     }
 
     private fun handleLaunchClick(action: ListingItemOverflowAction.VaultAction.LaunchClick) {
@@ -548,7 +559,12 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleViewClick(action: ListingItemOverflowAction.VaultAction.ViewClick) {
-        sendEvent(VaultEvent.NavigateToVaultItem(action.cipherId))
+        sendEvent(
+            event = VaultEvent.NavigateToVaultItem(
+                itemId = action.cipherId,
+                type = action.cipherType.toVaultItemCipherType(),
+            ),
+        )
     }
 
     private fun handleInternalAction(action: VaultAction.Internal) {
@@ -988,6 +1004,11 @@ data class VaultState(
             abstract val shouldShowMasterPasswordReprompt: Boolean
 
             /**
+             * The [VaultItemCipherType] this item represents.
+             */
+            abstract val type: VaultItemCipherType
+
+            /**
              * Represents a login item within the vault.
              *
              * @property username The username associated with this login item.
@@ -1004,6 +1025,7 @@ data class VaultState(
                 val username: Text?,
             ) : VaultItem() {
                 override val supportingLabel: Text? get() = username
+                override val type: VaultItemCipherType get() = VaultItemCipherType.LOGIN
             }
 
             /**
@@ -1033,6 +1055,8 @@ data class VaultState(
                         lastFourDigits != null -> "*".asText().concat(lastFourDigits)
                         else -> null
                     }
+
+                override val type: VaultItemCipherType get() = VaultItemCipherType.CARD
             }
 
             /**
@@ -1054,6 +1078,7 @@ data class VaultState(
                 val fullName: Text?,
             ) : VaultItem() {
                 override val supportingLabel: Text? get() = fullName
+                override val type: VaultItemCipherType get() = VaultItemCipherType.IDENTITY
             }
 
             /**
@@ -1071,6 +1096,7 @@ data class VaultState(
                 override val shouldShowMasterPasswordReprompt: Boolean,
             ) : VaultItem() {
                 override val supportingLabel: Text? get() = null
+                override val type: VaultItemCipherType get() = VaultItemCipherType.SECURE_NOTE
             }
 
             /**
@@ -1094,6 +1120,7 @@ data class VaultState(
                 val fingerprint: Text,
             ) : VaultItem() {
                 override val supportingLabel: Text? get() = null
+                override val type: VaultItemCipherType get() = VaultItemCipherType.SSH_KEY
             }
         }
     }
@@ -1147,6 +1174,7 @@ sealed class VaultEvent {
      */
     data class NavigateToVaultItem(
         val itemId: String,
+        val type: VaultItemCipherType,
     ) : VaultEvent()
 
     /**
@@ -1154,6 +1182,7 @@ sealed class VaultEvent {
      */
     data class NavigateToEditVaultItem(
         val itemId: String,
+        val type: VaultItemCipherType,
     ) : VaultEvent()
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeNavigation.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 
 private const val VERIFICATION_CODE_ROUTE: String = "verification_code"
 
@@ -13,7 +14,7 @@ private const val VERIFICATION_CODE_ROUTE: String = "verification_code"
 fun NavGraphBuilder.vaultVerificationCodeDestination(
     onNavigateBack: () -> Unit,
     onNavigateToSearchVault: () -> Unit,
-    onNavigateToVaultItemScreen: (String) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
 ) {
     composableWithPushTransitions(
         route = VERIFICATION_CODE_ROUTE,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreen.kt
@@ -39,7 +39,9 @@ import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.scaffold.rememberBitwardenPullToRefreshState
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.composition.LocalAppResumeStateManager
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.verificationcode.handlers.VerificationCodeHandlers
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -54,7 +56,7 @@ fun VerificationCodeScreen(
     viewModel: VerificationCodeViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit,
     onNavigateToSearch: () -> Unit,
-    onNavigateToVaultItemScreen: (String) -> Unit,
+    onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
     appResumeStateManager: AppResumeStateManager = LocalAppResumeStateManager.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
@@ -79,7 +81,10 @@ fun VerificationCodeScreen(
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             is VerificationCodeEvent.NavigateBack -> onNavigateBack()
-            is VerificationCodeEvent.NavigateToVaultItem -> onNavigateToVaultItemScreen(event.id)
+            is VerificationCodeEvent.NavigateToVaultItem -> {
+                onNavigateToVaultItemScreen(VaultItemArgs(event.id, VaultItemCipherType.LOGIN))
+            }
+
             is VerificationCodeEvent.NavigateToVaultSearchScreen -> {
                 onNavigateToSearch()
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/model/VaultAddEditType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/model/VaultAddEditType.kt
@@ -9,21 +9,16 @@ import kotlinx.parcelize.Parcelize
 sealed class VaultAddEditType : Parcelable {
 
     /**
-     *  The ID of the vault item (nullable).
+     * The ID of the vault item (nullable).
      */
     abstract val vaultItemId: String?
 
     /**
      * Indicates that we want to create a completely new vault item.
-     *
-     * @property vaultItemCipherType The specified [VaultItemCipherType].
      */
     @Parcelize
-    data class AddItem(
-        val vaultItemCipherType: VaultItemCipherType,
-    ) : VaultAddEditType() {
-        override val vaultItemId: String?
-            get() = null
+    data object AddItem : VaultAddEditType() {
+        override val vaultItemId: String? get() = null
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/util/CipherTypeExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/util/CipherTypeExtensions.kt
@@ -1,0 +1,16 @@
+package com.x8bit.bitwarden.ui.vault.util
+
+import com.bitwarden.vault.CipherType
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+
+/**
+ * Converts the [CipherType] to its corresponding [VaultItemCipherType].
+ */
+fun CipherType.toVaultItemCipherType(): VaultItemCipherType =
+    when (this) {
+        CipherType.LOGIN -> VaultItemCipherType.LOGIN
+        CipherType.SECURE_NOTE -> VaultItemCipherType.SECURE_NOTE
+        CipherType.CARD -> VaultItemCipherType.CARD
+        CipherType.IDENTITY -> VaultItemCipherType.IDENTITY
+        CipherType.SSH_KEY -> VaultItemCipherType.SSH_KEY
+    }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,11 @@
   <string name="create_an_account">Create an account</string>
   <string name="creating_account">Creating account...</string>
   <string name="edit_item">Edit item</string>
+  <string name="edit_login">Edit login</string>
+  <string name="edit_card">Edit card</string>
+  <string name="edit_identity">Edit identity</string>
+  <string name="edit_note">Edit note</string>
+  <string name="edit_passkey">Edit passkey</string>
   <string name="enable_automatic_syncing">Allow automatic syncing</string>
   <string name="enter_email_for_hint">Enter your account email address to receive your master password hint.</string>
   <string name="exntesion_reenable">Reactivate app extension</string>
@@ -164,6 +169,7 @@
   <string name="new_identity">New identity</string>
   <string name="no_notes">There are no notes in your vault.</string>
   <string name="new_note">New note</string>
+  <string name="new_passkey">New passkey</string>
   <string name="new_item">New item</string>
   <string name="new_ssh_key">New SSH key</string>
   <string name="no_text_sends">There are no text Sends in your vault.</string>
@@ -209,6 +215,11 @@
   <string name="validating">Validating</string>
   <string name="verification_code">Verification code</string>
   <string name="view_item">View item</string>
+  <string name="view_login">View login</string>
+  <string name="view_card">View card</string>
+  <string name="view_identity">View identity</string>
+  <string name="view_note">View note</string>
+  <string name="view_passkey">View passkey</string>
   <string name="web_vault">Bitwarden web vault</string>
   <string name="lost_2fa_app">Lost authenticator app?</string>
   <string name="items">Items</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
+import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.LoginUriView
 import com.x8bit.bitwarden.R
@@ -54,6 +55,7 @@ import com.x8bit.bitwarden.ui.platform.feature.search.util.toViewState
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.toFilteredList
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import io.mockk.awaits
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -196,8 +198,19 @@ class SearchViewModelTest : BaseViewModelTest() {
     fun `ItemClick for vault item without totp should emit NavigateToViewCipher`() = runTest {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
-            viewModel.trySendAction(SearchAction.ItemClick(itemId = "mock"))
-            assertEquals(SearchEvent.NavigateToViewCipher(cipherId = "mock"), awaitItem())
+            viewModel.trySendAction(
+                SearchAction.ItemClick(
+                    itemId = "mock",
+                    cipherType = CipherType.LOGIN,
+                ),
+            )
+            assertEquals(
+                SearchEvent.NavigateToViewCipher(
+                    cipherId = "mock",
+                    cipherType = VaultItemCipherType.LOGIN,
+                ),
+                awaitItem(),
+            )
         }
     }
 
@@ -207,8 +220,16 @@ class SearchViewModelTest : BaseViewModelTest() {
             SpecialCircumstance.AddTotpLoginItem(mockk())
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
-            viewModel.trySendAction(SearchAction.ItemClick(itemId = "mock"))
-            assertEquals(SearchEvent.NavigateToEditCipher(cipherId = "mock"), awaitItem())
+            viewModel.trySendAction(
+                SearchAction.ItemClick(itemId = "mock", cipherType = CipherType.LOGIN),
+            )
+            assertEquals(
+                SearchEvent.NavigateToEditCipher(
+                    cipherId = "mock",
+                    cipherType = VaultItemCipherType.LOGIN,
+                ),
+                awaitItem(),
+            )
         }
     }
 
@@ -216,7 +237,7 @@ class SearchViewModelTest : BaseViewModelTest() {
     fun `ItemClick for send item should emit NavigateToEditSend`() = runTest {
         val viewModel = createViewModel(DEFAULT_STATE.copy(searchType = SearchTypeData.Sends.All))
         viewModel.eventFlow.test {
-            viewModel.trySendAction(SearchAction.ItemClick(itemId = "mock"))
+            viewModel.trySendAction(SearchAction.ItemClick(itemId = "mock", cipherType = null))
             assertEquals(SearchEvent.NavigateToEditSend(sendId = "mock"), awaitItem())
         }
     }
@@ -614,7 +635,13 @@ class SearchViewModelTest : BaseViewModelTest() {
                         ),
                     ),
                 )
-                assertEquals(SearchEvent.NavigateToEditCipher(cipherId), awaitItem())
+                assertEquals(
+                    SearchEvent.NavigateToEditCipher(
+                        cipherId = cipherId,
+                        cipherType = VaultItemCipherType.LOGIN,
+                    ),
+                    awaitItem(),
+                )
             }
         }
 
@@ -636,13 +663,20 @@ class SearchViewModelTest : BaseViewModelTest() {
                         masterPasswordRepromptData = MasterPasswordRepromptData.OverflowItem(
                             action = ListingItemOverflowAction.VaultAction.EditClick(
                                 cipherId = cipherId,
+                                cipherType = CipherType.LOGIN,
                                 requiresPasswordReprompt = true,
                             ),
                         ),
                     ),
                 )
                 // Edit actions should navigate to the Edit screen
-                assertEquals(SearchEvent.NavigateToEditCipher(cipherId), awaitItem())
+                assertEquals(
+                    SearchEvent.NavigateToEditCipher(
+                        cipherId = cipherId,
+                        cipherType = VaultItemCipherType.LOGIN,
+                    ),
+                    awaitItem(),
+                )
             }
         }
 
@@ -980,11 +1014,18 @@ class SearchViewModelTest : BaseViewModelTest() {
                 SearchAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = cipherId,
+                        cipherType = CipherType.LOGIN,
                         requiresPasswordReprompt = true,
                     ),
                 ),
             )
-            assertEquals(SearchEvent.NavigateToEditCipher(cipherId), awaitItem())
+            assertEquals(
+                SearchEvent.NavigateToEditCipher(
+                    cipherId = cipherId,
+                    cipherType = VaultItemCipherType.LOGIN,
+                ),
+                awaitItem(),
+            )
         }
     }
 
@@ -1003,16 +1044,25 @@ class SearchViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `OverflowOptionClick Vault ViewClick should emit NavigateToUrl`() = runTest {
+    fun `OverflowOptionClick Vault ViewClick should emit NavigateToViewCipher`() = runTest {
         val cipherId = "cipherId-9876"
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(
                 SearchAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = cipherId),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = cipherId,
+                        cipherType = CipherType.LOGIN,
+                    ),
                 ),
             )
-            assertEquals(SearchEvent.NavigateToViewCipher(cipherId), awaitItem())
+            assertEquals(
+                SearchEvent.NavigateToViewCipher(
+                    cipherId = cipherId,
+                    cipherType = VaultItemCipherType.LOGIN,
+                ),
+                awaitItem(),
+            )
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
@@ -44,9 +44,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = CipherType.LOGIN,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = CipherType.LOGIN,
                         requiresPasswordReprompt = true,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyUsernameClick(
@@ -69,6 +73,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = isTotp,
+                cipherType = CipherType.LOGIN,
             )
         }
 
@@ -93,9 +98,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = CipherType.SECURE_NOTE,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = CipherType.SECURE_NOTE,
                         requiresPasswordReprompt = true,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyNoteClick(
@@ -107,6 +116,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
+                cipherType = CipherType.SECURE_NOTE,
             )
         }
 
@@ -131,9 +141,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = CipherType.CARD,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = CipherType.CARD,
                         requiresPasswordReprompt = true,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyNumberClick(
@@ -151,6 +165,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
+                cipherType = CipherType.CARD,
             )
         }
 
@@ -175,9 +190,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = CipherType.IDENTITY,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = CipherType.IDENTITY,
                         requiresPasswordReprompt = true,
                     ),
                 ),
@@ -186,6 +205,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
+                cipherType = CipherType.IDENTITY,
             )
         }
 
@@ -205,9 +225,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = CipherType.SSH_KEY,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = CipherType.SSH_KEY,
                         requiresPasswordReprompt = true,
                     ),
                 ),
@@ -216,6 +240,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
+                cipherType = CipherType.SSH_KEY,
             )
         }
     }
@@ -265,6 +290,7 @@ fun createMockDisplayItemForSend(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
+                cipherType = null,
             )
         }
 
@@ -303,7 +329,8 @@ fun createMockDisplayItemForSend(
                 totpCode = null,
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
-                isTotp = true,
+                isTotp = false,
+                cipherType = null,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -41,7 +41,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
                 VaultUnlockedNavBarScreen(
                     viewModel = viewModel,
                     navController = fakeNavHostController,
-                    onNavigateToVaultAddItem = { _, _, _ -> },
+                    onNavigateToVaultAddItem = {},
                     onNavigateToVaultItem = {},
                     onNavigateToVaultEditItem = {},
                     onNavigateToAddSend = {},
@@ -56,7 +56,7 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
                     onNavigateToSetupAutoFillScreen = {},
                     onNavigateToSetupUnlockScreen = {},
                     onNavigateToImportLogins = {},
-                    onNavigateToAddFolderScreen = { _ -> },
+                    onNavigateToAddFolderScreen = {},
                 )
             }
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -3375,7 +3375,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     fun `should display policy warning when personal vault is disabled for add item type`() {
         mutableStateFlow.update {
             it.copy(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
                 viewState = VaultAddEditState.ViewState.Content(
                     common = VaultAddEditState.ViewState.Content.Common(
                         originalCipher = createMockCipherView(1),
@@ -3791,7 +3791,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     @Test
     fun `learn about add logins card should show when state is add mode, login type content, and should show coach mark tour is true`() {
         mutableStateFlow.value = DEFAULT_STATE_LOGIN.copy(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+            vaultAddEditType = VaultAddEditType.AddItem,
             shouldShowCoachMarkTour = true,
         )
 
@@ -3804,9 +3804,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     @Test
     fun `learn about add logins card should not show when state is add mode, login type content, and should show coach mark tour is false`() {
         mutableStateFlow.value = DEFAULT_STATE_LOGIN.copy(
-            vaultAddEditType = VaultAddEditType.AddItem(
-                vaultItemCipherType = VaultItemCipherType.LOGIN,
-            ),
+            vaultAddEditType = VaultAddEditType.AddItem,
             shouldShowCoachMarkTour = false,
         )
 
@@ -3845,7 +3843,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     @Test
     fun `when learn about logins card is showing, clicking the close button sends LearnAboutLoginsDismissed action`() {
         mutableStateFlow.value = DEFAULT_STATE_LOGIN.copy(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
             shouldShowCoachMarkTour = true,
         )
 
@@ -3867,7 +3864,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
     @Test
     fun `when learn about logins card is showing, clicking the call to action sends StartLearnAboutLogins action`() {
         mutableStateFlow.value = DEFAULT_STATE_LOGIN.copy(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+            vaultAddEditType = VaultAddEditType.AddItem,
             shouldShowCoachMarkTour = true,
         )
 
@@ -3953,7 +3950,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
         return currentState.copy(viewState = updatedType)
     }
 
-    @Suppress("MaxLineLength")
     private fun updateCommonContent(
         currentState: VaultAddEditState,
         transform: VaultAddEditState.ViewState.Content.Common.()
@@ -3999,19 +3995,21 @@ class VaultAddEditScreenTest : BaseComposeTest() {
 
     companion object {
         private val DEFAULT_STATE_LOGIN_DIALOG = VaultAddEditState(
+            cipherType = VaultItemCipherType.LOGIN,
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 type = VaultAddEditState.ViewState.Content.ItemType.Login(),
                 isIndividualVaultDisabled = false,
             ),
             dialog = VaultAddEditState.DialogState.Generic(message = "test".asText()),
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+            vaultAddEditType = VaultAddEditType.AddItem,
             shouldShowCoachMarkTour = false,
             shouldShowFolderSelectionBottomSheet = false,
         )
 
         private val DEFAULT_STATE_LOGIN = VaultAddEditState(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+            vaultAddEditType = VaultAddEditType.AddItem,
+            cipherType = VaultItemCipherType.LOGIN,
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 type = VaultAddEditState.ViewState.Content.ItemType.Login(),
@@ -4023,7 +4021,8 @@ class VaultAddEditScreenTest : BaseComposeTest() {
         )
 
         private val DEFAULT_STATE_IDENTITY = VaultAddEditState(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.IDENTITY),
+            vaultAddEditType = VaultAddEditType.AddItem,
+            cipherType = VaultItemCipherType.IDENTITY,
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 type = VaultAddEditState.ViewState.Content.ItemType.Identity(),
@@ -4035,7 +4034,8 @@ class VaultAddEditScreenTest : BaseComposeTest() {
         )
 
         private val DEFAULT_STATE_CARD = VaultAddEditState(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.CARD),
+            vaultAddEditType = VaultAddEditType.AddItem,
+            cipherType = VaultItemCipherType.CARD,
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 type = VaultAddEditState.ViewState.Content.ItemType.Card(),
@@ -4053,9 +4053,9 @@ class VaultAddEditScreenTest : BaseComposeTest() {
                         VaultAddEditState.Custom.BooleanField("Test ID 1", "TestBoolean", false),
                         VaultAddEditState.Custom.TextField("Test ID 2", "TestText", "TestTextVal"),
                         VaultAddEditState.Custom.HiddenField(
-                            "Test ID 3",
-                            "TestHidden",
-                            "TestHiddenVal",
+                            itemId = "Test ID 3",
+                            name = "TestHidden",
+                            value = "TestHiddenVal",
                         ),
                     ),
                 ),
@@ -4063,13 +4063,15 @@ class VaultAddEditScreenTest : BaseComposeTest() {
                 isIndividualVaultDisabled = false,
             ),
             dialog = null,
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.SECURE_NOTE),
+            vaultAddEditType = VaultAddEditType.AddItem,
+            cipherType = VaultItemCipherType.SECURE_NOTE,
             shouldShowCoachMarkTour = false,
             shouldShowFolderSelectionBottomSheet = false,
         )
 
         private val DEFAULT_STATE_SECURE_NOTES = VaultAddEditState(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.SECURE_NOTE),
+            vaultAddEditType = VaultAddEditType.AddItem,
+            cipherType = VaultItemCipherType.SECURE_NOTE,
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 type = VaultAddEditState.ViewState.Content.ItemType.SecureNotes,
@@ -4081,7 +4083,8 @@ class VaultAddEditScreenTest : BaseComposeTest() {
         )
 
         private val DEFAULT_STATE_SSH_KEYS = VaultAddEditState(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.SSH_KEY),
+            vaultAddEditType = VaultAddEditType.AddItem,
+            cipherType = VaultItemCipherType.SSH_KEY,
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 type = VaultAddEditState.ViewState.Content.ItemType.SshKey(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -128,7 +128,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     )
     private val loginInitialSavedStateHandle = createSavedStateHandleWithState(
         state = loginInitialState,
-        vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+        vaultAddEditType = VaultAddEditType.AddItem,
+        vaultItemCipherType = VaultItemCipherType.LOGIN,
     )
 
     private val totpTestCodeFlow: MutableSharedFlow<TotpCodeResult> = bufferedMutableSharedFlow()
@@ -198,7 +199,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `initial state should be correct when state is null`() = runTest {
         val expectedState = VaultAddEditState(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+            vaultAddEditType = VaultAddEditType.AddItem,
+            cipherType = VaultItemCipherType.LOGIN,
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 isIndividualVaultDisabled = false,
@@ -214,7 +216,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         val viewModel = createAddVaultItemViewModel(
             savedStateHandle = createSavedStateHandleWithState(
                 state = null,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         viewModel.stateFlow.test {
@@ -230,12 +233,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `initial add state should be correct when not autofill`() = runTest {
-        val vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN)
-        val initState = createVaultAddItemState(vaultAddEditType = vaultAddEditType)
+        val initState = createVaultAddItemState()
         val viewModel = createAddVaultItemViewModel(
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
-                vaultAddEditType = vaultAddEditType,
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         assertEquals(
@@ -263,7 +266,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 data = null,
             ),
         )
-        val vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN)
+        val vaultAddEditType = VaultAddEditType.AddItem
+        val vaultItemCipherType = VaultItemCipherType.LOGIN
         mutableVaultDataFlow.value = DataState.Loaded(
             data = createVaultData(),
         )
@@ -271,11 +275,13 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = null,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = vaultItemCipherType,
             ),
         )
         assertEquals(
             VaultAddEditState(
                 vaultAddEditType = vaultAddEditType,
+                cipherType = vaultItemCipherType,
                 viewState = VaultAddEditState.ViewState.Content(
                     common = createCommonContentViewState(
                         availableOwners = listOf(
@@ -317,7 +323,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         val autofillContentState = autofillSelectionData.toDefaultAddTypeContent(
             isIndividualVaultDisabled = false,
         )
-        val vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN)
+        val vaultAddEditType = VaultAddEditType.AddItem
+        val vaultItemCipherType = VaultItemCipherType.LOGIN
         val initState = createVaultAddItemState(
             vaultAddEditType = vaultAddEditType,
             commonContentViewState = autofillContentState.common,
@@ -327,6 +334,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = vaultItemCipherType,
             ),
         )
         assertEquals(
@@ -349,7 +357,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             autofillSaveItem = autofillSaveItem,
         )
         val autofillContentState = autofillSaveItem.toDefaultAddTypeContent(false)
-        val vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN)
+        val vaultAddEditType = VaultAddEditType.AddItem
+        val vaultItemCipherType = VaultItemCipherType.LOGIN
         val initState = createVaultAddItemState(
             vaultAddEditType = vaultAddEditType,
             commonContentViewState = autofillContentState.common,
@@ -359,6 +368,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = vaultItemCipherType,
             ),
         )
         assertEquals(
@@ -387,7 +397,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             attestationOptions = createMockPasskeyAttestationOptions(number = 1),
             isIndividualVaultDisabled = false,
         )
-        val vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN)
+        val vaultAddEditType = VaultAddEditType.AddItem
+        val vaultItemCipherType = VaultItemCipherType.LOGIN
         val initState = createVaultAddItemState(
             vaultAddEditType = vaultAddEditType,
             commonContentViewState = fido2ContentState.common,
@@ -397,6 +408,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = vaultItemCipherType,
             ),
         )
         assertEquals(
@@ -416,6 +428,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         assertEquals(
@@ -438,6 +451,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         assertEquals(
@@ -469,6 +483,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         viewModel.eventFlow.test {
@@ -488,6 +503,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         viewModel.eventFlow.test {
@@ -507,6 +523,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = createSavedStateHandleWithState(
                 state = initState,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         viewModel.eventFlow.test {
@@ -532,6 +549,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 savedStateHandle = createSavedStateHandleWithState(
                     state = initState,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -570,6 +588,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 savedStateHandle = createSavedStateHandleWithState(
                     state = initState,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -626,7 +645,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     fun `in add mode, SaveClick should show dialog, remove it once an item is saved, and emit NavigateBack`() =
         runTest {
             val stateWithDialog = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 dialogState = VaultAddEditState.DialogState.Loading(
                     R.string.saving.asText(),
                 ),
@@ -635,7 +653,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 ),
             )
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -646,7 +663,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             coEvery {
@@ -690,7 +708,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     autofillSaveItem = autofillSaveItem,
                 )
             val stateWithDialog = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 dialogState = VaultAddEditState.DialogState.Loading(
                     R.string.saving.asText(),
                 ),
@@ -700,7 +717,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
                 .copy(shouldExitOnSave = true)
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -712,7 +728,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             coEvery {
@@ -753,14 +770,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.AddTotpLoginItem(data = totpData)
             val stateWithDialog = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 dialogState = VaultAddEditState.DialogState.Loading(R.string.saving.asText()),
                 commonContentViewState = createCommonContentViewState(name = "issuer"),
                 totpData = totpData,
                 shouldExitOnSave = true,
             )
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(name = "issuer"),
                 totpData = totpData,
                 shouldExitOnSave = true,
@@ -769,7 +784,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 savedStateHandle = createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             coEvery {
@@ -806,14 +822,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     shouldFinishWhenComplete = true,
                 )
             val stateWithDialog = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 dialogState = VaultAddEditState.DialogState.Loading(R.string.saving.asText()),
                 commonContentViewState = createCommonContentViewState(name = "issuer"),
                 shouldExitOnSave = false,
                 shouldClearSpecialCircumstance = false,
             )
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(name = "issuer"),
                 shouldExitOnSave = false,
                 shouldClearSpecialCircumstance = false,
@@ -822,7 +836,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 savedStateHandle = createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             coEvery {
@@ -864,7 +879,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
             val stateWithSavingDialog = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 dialogState = VaultAddEditState.DialogState.Loading(
                     R.string.saving.asText(),
                 ),
@@ -875,7 +889,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 .copy(shouldExitOnSave = true)
 
             val stateWithNewLogin = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -889,7 +902,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithNewLogin,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             val mockCreateResult = Fido2RegisterCredentialResult.Success(
@@ -944,7 +958,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CreateCredentialRequest = fido2CreateCredentialRequest,
                 )
             val stateWithSavingDialog = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 dialogState = VaultAddEditState.DialogState.Loading(
                     R.string.saving.asText(),
                 ),
@@ -955,7 +968,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 .copy(shouldExitOnSave = true)
 
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -968,7 +980,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             val mockCreateResult = Fido2RegisterCredentialResult.Success("mockResponse")
@@ -1024,7 +1037,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CreateCredentialRequest = fido2CredentialRequest,
                 )
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -1037,7 +1049,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1076,7 +1089,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CreateCredentialRequest = fido2CredentialRequest,
                 )
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -1095,7 +1107,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1120,7 +1133,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CreateCredentialRequest = fido2CredentialRequest,
                 )
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -1141,7 +1153,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1165,7 +1178,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     fido2CreateCredentialRequest = fido2CredentialRequest,
                 )
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -1186,7 +1198,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1204,7 +1217,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     fun `in add mode, createCipherInOrganization success should ShowToast and NavigateBack`() =
         runTest {
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -1215,7 +1227,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1282,6 +1295,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1349,6 +1363,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1414,6 +1429,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1481,6 +1497,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1548,6 +1565,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1579,7 +1597,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         val viewModel = createAddVaultItemViewModel(
             createSavedStateHandleWithState(
                 state = stateWithName,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
 
@@ -1602,7 +1621,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     fun `in add mode, SaveClick with no network connection error should show error dialog`() =
         runTest {
             val stateWithName = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 commonContentViewState = createCommonContentViewState(
                     name = "mockName-1",
                 ),
@@ -1613,7 +1631,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = stateWithName,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1691,6 +1710,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1763,6 +1783,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1827,6 +1848,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1891,6 +1913,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 savedStateHandle = createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -1951,6 +1974,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             createSavedStateHandleWithState(
                 state = stateWithName,
                 vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         viewModel.trySendAction(VaultAddEditAction.Common.ConfirmOverwriteExistingPasskeyClick)
@@ -2020,6 +2044,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 createSavedStateHandleWithState(
                     state = stateWithName,
                     vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             viewModel.trySendAction(VaultAddEditAction.Common.ConfirmOverwriteExistingPasskeyClick)
@@ -2050,7 +2075,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         val viewModel = createAddVaultItemViewModel(
             createSavedStateHandleWithState(
                 state = stateWithNoName,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         coEvery { vaultRepository.createCipher(any()) } returns CreateCipherResult.Success
@@ -2067,7 +2093,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             createVaultData(cipherView = createMockCipherView(1)),
         )
         val errorState = createVaultAddItemState(
-            vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
             dialogState = VaultAddEditState.DialogState.Generic(
                 title = R.string.an_error_has_occurred.asText(),
                 message = R.string.validation_field_required.asText(R.string.name.asText()),
@@ -2077,7 +2102,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         val viewModel = createAddVaultItemViewModel(
             createSavedStateHandleWithState(
                 state = errorState,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
 
@@ -2094,7 +2120,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     fun `DismissFido2ErrorDialogClick should clear the dialog state then complete FIDO 2 create`() =
         runTest {
             val errorState = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 dialogState = VaultAddEditState.DialogState.Fido2Error(
                     message = R.string.passkey_operation_failed_because_user_could_not_be_verified.asText(),
                 ),
@@ -2102,7 +2127,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 createSavedStateHandleWithState(
                     state = errorState,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             viewModel.trySendAction(
@@ -2228,7 +2254,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 savedStateHandle = createSavedStateHandleWithState(
                     state = loginState,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -2361,6 +2388,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                         ),
                     ),
                     vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID),
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -2430,6 +2458,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                         ),
                     ),
                     vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID),
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             val expectedState = loginInitialState.copy(
@@ -2465,6 +2494,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                         ),
                     ),
                     vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID),
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -2522,6 +2552,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                         ),
                     ),
                     vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID),
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
 
@@ -2555,9 +2586,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 state = createVaultAddItemState(
                     typeContentViewState = createLoginTypeContentViewState(),
                 ),
-                vaultAddEditType = VaultAddEditType.AddItem(
-                    vaultItemCipherType = VaultItemCipherType.LOGIN,
-                ),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         assertTrue(viewModel.stateFlow.value.shouldShowLearnAboutNewLogins)
@@ -2577,6 +2607,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 vaultAddEditType = VaultAddEditType.EditItem(
                     vaultItemId = "1234",
                 ),
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
         assertFalse(viewModel.stateFlow.value.shouldShowLearnAboutNewLogins)
@@ -2623,7 +2654,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
             identityInitialSavedStateHandle = createSavedStateHandleWithState(
                 state = vaultAddItemInitialState,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             )
             viewModel = createAddVaultItemViewModel(
                 savedStateHandle = identityInitialSavedStateHandle,
@@ -2917,7 +2949,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
             identityInitialSavedStateHandle = createSavedStateHandleWithState(
                 state = vaultAddItemInitialState,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             )
             viewModel = createAddVaultItemViewModel(
                 savedStateHandle = identityInitialSavedStateHandle,
@@ -3032,7 +3065,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             )
             sshKeyInitialSavedStateHandle = createSavedStateHandleWithState(
                 state = vaultAddItemInitialState,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.SSH_KEY),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.SSH_KEY,
             )
             viewModel = createAddVaultItemViewModel(
                 savedStateHandle = sshKeyInitialSavedStateHandle,
@@ -3116,7 +3150,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             vaultAddItemInitialState = createVaultAddItemState()
             secureNotesInitialSavedStateHandle = createSavedStateHandleWithState(
                 state = vaultAddItemInitialState,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             )
             viewModel = VaultAddEditViewModel(
                 savedStateHandle = secureNotesInitialSavedStateHandle,
@@ -3427,14 +3462,13 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         @Test
         fun `CustomFieldValueChange should allow a user to update a text custom field`() = runTest {
             val initState = createVaultAddItemState(
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
                 typeContentViewState = VaultAddEditState.ViewState.Content.ItemType.SecureNotes,
                 commonContentViewState = VaultAddEditState.ViewState.Content.Common(
                     customFieldData = listOf(
                         VaultAddEditState.Custom.TextField(
-                            "TestId 1",
-                            "Test Text",
-                            "Test Text",
+                            itemId = "TestId 1",
+                            name = "Test Text",
+                            value = "Test Text",
                         ),
                     ),
                 ),
@@ -3528,7 +3562,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 savedStateHandle = createSavedStateHandleWithState(
                     state = initState,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             val currentContentState =
@@ -3583,7 +3618,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 savedStateHandle = createSavedStateHandleWithState(
                     state = initState,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             val currentContentState =
@@ -3649,7 +3685,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val viewModel = createAddVaultItemViewModel(
                 savedStateHandle = createSavedStateHandleWithState(
                     state = initState,
-                    vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
                 ),
             )
             val currentContentState =
@@ -4393,7 +4430,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength", "LongParameterList")
     private fun createVaultAddItemState(
-        vaultAddEditType: VaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+        vaultAddEditType: VaultAddEditType = VaultAddEditType.AddItem,
+        vaultItemCipherType: VaultItemCipherType = VaultItemCipherType.LOGIN,
         commonContentViewState: VaultAddEditState.ViewState.Content.Common = createCommonContentViewState(),
         isIndividualVaultDisabled: Boolean = false,
         shouldExitOnSave: Boolean = false,
@@ -4404,6 +4442,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     ): VaultAddEditState =
         VaultAddEditState(
             vaultAddEditType = vaultAddEditType,
+            cipherType = vaultItemCipherType,
             viewState = VaultAddEditState.ViewState.Content(
                 common = commonContentViewState,
                 isIndividualVaultDisabled = isIndividualVaultDisabled,
@@ -4477,7 +4516,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     private fun createSavedStateHandleWithState(
         state: VaultAddEditState?,
         vaultAddEditType: VaultAddEditType,
-    ) = SavedStateHandle().apply {
+        vaultItemCipherType: VaultItemCipherType,
+    ): SavedStateHandle = SavedStateHandle().apply {
         set("state", state)
         set(
             "vault_add_edit_type",
@@ -4489,15 +4529,13 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         )
         set("vault_edit_id", (vaultAddEditType as? VaultAddEditType.EditItem)?.vaultItemId)
         set(
-            "vault_add_item_type",
-            when ((vaultAddEditType as? VaultAddEditType.AddItem)
-                ?.vaultItemCipherType) {
+            "vault_item_type",
+            when (vaultItemCipherType) {
                 VaultItemCipherType.LOGIN -> "login"
                 VaultItemCipherType.CARD -> "card"
                 VaultItemCipherType.IDENTITY -> "identity"
                 VaultItemCipherType.SECURE_NOTE -> "secure_note"
                 VaultItemCipherType.SSH_KEY -> "ssh_key"
-                else -> null
             },
         )
     }
@@ -4676,7 +4714,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         val viewModel = createAddVaultItemViewModel(
             savedStateHandle = createSavedStateHandleWithState(
                 state = initialState,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
 
@@ -4705,7 +4744,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         val viewModel = createAddVaultItemViewModel(
             savedStateHandle = createSavedStateHandleWithState(
                 state = initialState,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
             ),
         )
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -32,7 +32,6 @@ import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 import com.x8bit.bitwarden.ui.vault.model.VaultCollection
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
 import io.mockk.every
 import io.mockk.mockk
@@ -414,7 +413,7 @@ class CipherViewExtensionsTest {
         val result = createMockCipherView(number = 1)
             .validateCipherOrReturnErrorState(
                 currentAccount = createAccount(),
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
             ) { _, _ -> providedState }
 
         assertEquals(providedState, result)
@@ -443,7 +442,7 @@ class CipherViewExtensionsTest {
         val result = createMockCipherView(number = 1)
             .validateCipherOrReturnErrorState(
                 currentAccount = null,
-                vaultAddEditType = VaultAddEditType.AddItem(VaultItemCipherType.LOGIN),
+                vaultAddEditType = VaultAddEditType.AddItem,
             ) { _, _ -> providedState }
 
         assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -38,8 +38,11 @@ import com.x8bit.bitwarden.ui.util.isProgressBar
 import com.x8bit.bitwarden.ui.util.onFirstNodeWithTextAfterScroll
 import com.x8bit.bitwarden.ui.util.onNodeWithContentDescriptionAfterScroll
 import com.x8bit.bitwarden.ui.util.onNodeWithTextAfterScroll
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
 import com.x8bit.bitwarden.ui.vault.feature.item.model.TotpCodeItemData
+import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
 import io.mockk.every
 import io.mockk.just
@@ -58,7 +61,7 @@ import java.time.Instant
 class VaultItemScreenTest : BaseComposeTest() {
 
     private var onNavigateBackCalled = false
-    private var onNavigateToVaultEditItemId: String? = null
+    private var onNavigateToVaultEditItemArgs: VaultAddEditArgs? = null
     private var onNavigateToMoveToOrganizationItemId: String? = null
     private var onNavigateToAttachmentsId: String? = null
     private var onNavigateToPasswordHistoryId: String? = null
@@ -78,7 +81,7 @@ class VaultItemScreenTest : BaseComposeTest() {
             VaultItemScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
-                onNavigateToVaultAddEditItem = { id, _ -> onNavigateToVaultEditItemId = id },
+                onNavigateToVaultAddEditItem = { onNavigateToVaultEditItemArgs = it },
                 onNavigateToMoveToOrganization = { id, _ ->
                     onNavigateToMoveToOrganizationItemId = id
                 },
@@ -94,7 +97,13 @@ class VaultItemScreenTest : BaseComposeTest() {
     fun `NavigateToEdit event should invoke onNavigateToVaultEditItem`() {
         val id = "id1234"
         mutableEventFlow.tryEmit(VaultItemEvent.NavigateToAddEdit(itemId = id, isClone = false))
-        assertEquals(id, onNavigateToVaultEditItemId)
+        assertEquals(
+            VaultAddEditArgs(
+                vaultAddEditType = VaultAddEditType.EditItem(vaultItemId = id),
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
+            ),
+            onNavigateToVaultEditItemArgs,
+        )
     }
 
     @Test
@@ -2720,6 +2729,7 @@ private const val VAULT_ITEM_ID = "vault_item_id"
 
 private val DEFAULT_STATE: VaultItemState = VaultItemState(
     vaultItemId = VAULT_ITEM_ID,
+    cipherType = VaultItemCipherType.LOGIN,
     viewState = VaultItemState.ViewState.Loading,
     dialog = null,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -34,6 +34,7 @@ import com.x8bit.bitwarden.ui.vault.feature.item.util.createLoginContent
 import com.x8bit.bitwarden.ui.vault.feature.item.util.toViewState
 import com.x8bit.bitwarden.ui.vault.feature.verificationcode.util.createVerificationCodeItem
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -3149,6 +3150,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
     private fun createViewModel(
         state: VaultItemState?,
         vaultItemId: String = VAULT_ITEM_ID,
+        vaultItemCipherType: VaultItemCipherType = VaultItemCipherType.LOGIN,
         bitwardenClipboardManager: BitwardenClipboardManager = clipboardManager,
         authRepository: AuthRepository = authRepo,
         vaultRepository: VaultRepository = vaultRepo,
@@ -3159,6 +3161,16 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         savedStateHandle = SavedStateHandle().apply {
             set("state", state)
             set("vault_item_id", vaultItemId)
+            set(
+                "vault_item_cipher_type",
+                when (vaultItemCipherType) {
+                    VaultItemCipherType.LOGIN -> "login"
+                    VaultItemCipherType.CARD -> "card"
+                    VaultItemCipherType.IDENTITY -> "identity"
+                    VaultItemCipherType.SECURE_NOTE -> "secure_note"
+                    VaultItemCipherType.SSH_KEY -> "ssh_key"
+                },
+            )
             set("tempAttachmentFile", tempAttachmentFile)
         },
         clipboardManager = bitwardenClipboardManager,
@@ -3192,6 +3204,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
         private val DEFAULT_STATE: VaultItemState = VaultItemState(
             vaultItemId = VAULT_ITEM_ID,
+            cipherType = VaultItemCipherType.LOGIN,
             viewState = VaultItemState.ViewState.Loading,
             dialog = null,
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.core.net.toUri
+import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsResult
@@ -54,8 +55,11 @@ import com.x8bit.bitwarden.ui.util.performLogoutAccountClick
 import com.x8bit.bitwarden.ui.util.performRemoveAccountClick
 import com.x8bit.bitwarden.ui.util.performYesDialogButtonClick
 import com.x8bit.bitwarden.ui.vault.components.model.CreateVaultItemType
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
+import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
 import io.mockk.every
@@ -82,8 +86,8 @@ class VaultItemListingScreenTest : BaseComposeTest() {
     private var onNavigateToVaultAddItemScreenCalled = false
     private var onNavigateToAddSendScreenCalled = false
     private var onNavigateToEditSendItemId: String? = null
-    private var onNavigateToVaultItemId: String? = null
-    private var onNavigateToVaultEditItemScreenId: String? = null
+    private var onNavigateToVaultItemArgs: VaultItemArgs? = null
+    private var onNavigateToVaultEditItemScreenArgs: VaultAddEditArgs? = null
     private var onNavigateToSearchType: SearchType? = null
     private var onNavigateToVaultItemListingScreenType: VaultItemListingType? = null
     private var onNavigateToAddFolderCalled = false
@@ -121,14 +125,12 @@ class VaultItemListingScreenTest : BaseComposeTest() {
                 fido2CompletionManager = fido2CompletionManager,
                 biometricsManager = biometricsManager,
                 onNavigateBack = { onNavigateBackCalled = true },
-                onNavigateToVaultItem = { onNavigateToVaultItemId = it },
-                onNavigateToVaultAddItemScreen = { _, _, _ ->
-                    onNavigateToVaultAddItemScreenCalled = true
-                },
+                onNavigateToVaultItemScreen = { onNavigateToVaultItemArgs = it },
+                onNavigateToVaultAddItemScreen = { onNavigateToVaultAddItemScreenCalled = true },
                 onNavigateToAddSendItem = { onNavigateToAddSendScreenCalled = true },
                 onNavigateToEditSendItem = { onNavigateToEditSendItemId = it },
                 onNavigateToSearch = { onNavigateToSearchType = it },
-                onNavigateToVaultEditItemScreen = { onNavigateToVaultEditItemScreenId = it },
+                onNavigateToVaultEditItemScreen = { onNavigateToVaultEditItemScreenArgs = it },
                 onNavigateToVaultItemListing = { this.onNavigateToVaultItemListingScreenType = it },
                 onNavigateToAddFolder = { folderName ->
                     onNavigateToAddFolderCalled = true
@@ -487,8 +489,17 @@ class VaultItemListingScreenTest : BaseComposeTest() {
     @Test
     fun `NavigateToEditCipher should call onNavigateToVaultEditItemScreen`() {
         val cipherId = "cipherId"
-        mutableEventFlow.tryEmit(VaultItemListingEvent.NavigateToEditCipher(cipherId))
-        assertEquals(cipherId, onNavigateToVaultEditItemScreenId)
+        val type = VaultItemCipherType.LOGIN
+        mutableEventFlow.tryEmit(
+            VaultItemListingEvent.NavigateToEditCipher(cipherId = cipherId, cipherType = type),
+        )
+        assertEquals(
+            VaultAddEditArgs(
+                vaultAddEditType = VaultAddEditType.EditItem(vaultItemId = cipherId),
+                vaultItemCipherType = type,
+            ),
+            onNavigateToVaultEditItemScreenArgs,
+        )
     }
 
     @Test
@@ -501,8 +512,12 @@ class VaultItemListingScreenTest : BaseComposeTest() {
     @Test
     fun `NavigateToVaultItem event should call NavigateToVaultItemScreen`() {
         val id = "id4321"
-        mutableEventFlow.tryEmit(VaultItemListingEvent.NavigateToVaultItem(id = id))
-        assertEquals(id, onNavigateToVaultItemId)
+        val type = VaultItemCipherType.LOGIN
+        mutableEventFlow.tryEmit(VaultItemListingEvent.NavigateToVaultItem(id = id, type = type))
+        assertEquals(
+            VaultItemArgs(vaultItemId = id, cipherType = type),
+            onNavigateToVaultItemArgs,
+        )
     }
 
     @Test
@@ -1008,7 +1023,12 @@ class VaultItemListingScreenTest : BaseComposeTest() {
             .assertIsDisplayed()
             .performClick()
         verify {
-            viewModel.trySendAction(VaultItemListingsAction.ItemClick("mockId-1"))
+            viewModel.trySendAction(
+                VaultItemListingsAction.ItemClick(
+                    id = "mockId-1",
+                    cipherType = null,
+                ),
+            )
         }
     }
 
@@ -1324,6 +1344,7 @@ class VaultItemListingScreenTest : BaseComposeTest() {
                 VaultItemListingsAction.OverflowOptionClick(
                     action = ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-1",
+                        cipherType = CipherType.LOGIN,
                         requiresPasswordReprompt = true,
                     ),
                 ),
@@ -2285,6 +2306,7 @@ private fun createDisplayItem(number: Int): VaultItemListingState.DisplayItem =
         shouldShowMasterPasswordReprompt = false,
         iconTestTag = null,
         isTotp = false,
+        type = null,
     )
 
 private fun createCipherDisplayItem(number: Int): VaultItemListingState.DisplayItem =
@@ -2301,6 +2323,7 @@ private fun createCipherDisplayItem(number: Int): VaultItemListingState.DisplayI
         overflowOptions = listOf(
             ListingItemOverflowAction.VaultAction.EditClick(
                 cipherId = "mockId-$number",
+                cipherType = CipherType.LOGIN,
                 requiresPasswordReprompt = true,
             ),
         ),
@@ -2310,4 +2333,5 @@ private fun createCipherDisplayItem(number: Int): VaultItemListingState.DisplayI
         shouldShowMasterPasswordReprompt = false,
         iconTestTag = null,
         isTotp = true,
+        type = CipherType.LOGIN,
     )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -6,6 +6,7 @@ import androidx.credentials.provider.CallingAppInfo
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.vault.CipherRepromptType
+import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
@@ -395,7 +396,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val viewModel = createVaultItemListingViewModel()
 
             accessibilitySelectionManager.accessibilitySelectionFlow.test {
-                viewModel.trySendAction(VaultItemListingsAction.ItemClick(id = "mockId-1"))
+                viewModel.trySendAction(
+                    VaultItemListingsAction.ItemClick(
+                        id = "mockId-1",
+                        cipherType = CipherType.LOGIN,
+                    ),
+                )
                 assertEquals(cipherView, awaitItem())
             }
             coVerify(exactly = 1) {
@@ -438,7 +444,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val viewModel = createVaultItemListingViewModel()
 
             autofillSelectionManager.autofillSelectionFlow.test {
-                viewModel.trySendAction(VaultItemListingsAction.ItemClick(id = "mockId-1"))
+                viewModel.trySendAction(
+                    VaultItemListingsAction.ItemClick(
+                        id = "mockId-1",
+                        cipherType = CipherType.LOGIN,
+                    ),
+                )
                 assertEquals(
                     cipherView,
                     awaitItem(),
@@ -467,7 +478,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             ),
         )
         val viewModel = createVaultItemListingViewModel()
-        viewModel.trySendAction(VaultItemListingsAction.ItemClick(cipherView.id.orEmpty()))
+        viewModel.trySendAction(
+            VaultItemListingsAction.ItemClick(
+                id = cipherView.id.orEmpty(),
+                cipherType = CipherType.LOGIN,
+            ),
+        )
 
         assertEquals(
             VaultItemListingState.DialogState.Fido2OperationFail(
@@ -498,7 +514,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         every { fido2CredentialManager.getPasskeyAttestationOptionsOrNull(any()) } returns null
 
         val viewModel = createVaultItemListingViewModel()
-        viewModel.trySendAction(VaultItemListingsAction.ItemClick(cipherView.id.orEmpty()))
+        viewModel.trySendAction(
+            VaultItemListingsAction.ItemClick(
+                id = cipherView.id.orEmpty(),
+                cipherType = CipherType.LOGIN,
+            ),
+        )
 
         assertEquals(
             VaultItemListingState.DialogState.Fido2OperationFail(
@@ -544,7 +565,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             } returns Fido2RegisterCredentialResult.Success("mockResponse")
 
             val viewModel = createVaultItemListingViewModel()
-            viewModel.trySendAction(VaultItemListingsAction.ItemClick(cipherView.id.orEmpty()))
+            viewModel.trySendAction(
+                VaultItemListingsAction.ItemClick(
+                    id = cipherView.id.orEmpty(),
+                    cipherType = CipherType.LOGIN,
+                ),
+            )
 
             assertEquals(
                 VaultItemListingState.DialogState.OverwritePasskeyConfirmationPrompt(
@@ -587,7 +613,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             } returns Fido2RegisterCredentialResult.Success("mockResponse")
 
             val viewModel = createVaultItemListingViewModel()
-            viewModel.trySendAction(VaultItemListingsAction.ItemClick(cipherView.id.orEmpty()))
+            viewModel.trySendAction(
+                VaultItemListingsAction.ItemClick(
+                    id = cipherView.id.orEmpty(),
+                    cipherType = CipherType.LOGIN,
+                ),
+            )
 
             viewModel.eventFlow.test {
                 assertEquals(
@@ -637,7 +668,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             } returns Fido2RegisterCredentialResult.Success("mockResponse")
 
             val viewModel = createVaultItemListingViewModel()
-            viewModel.trySendAction(VaultItemListingsAction.ItemClick(cipherView.id.orEmpty()))
+            viewModel.trySendAction(
+                VaultItemListingsAction.ItemClick(
+                    id = cipherView.id.orEmpty(),
+                    cipherType = CipherType.LOGIN,
+                ),
+            )
 
             coVerify {
                 fido2CredentialManager.registerFido2Credential(
@@ -681,7 +717,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         every { fido2CredentialManager.isUserVerified } returns true
 
         val viewModel = createVaultItemListingViewModel()
-        viewModel.trySendAction(VaultItemListingsAction.ItemClick(cipherView.id.orEmpty()))
+        viewModel.trySendAction(
+            VaultItemListingsAction.ItemClick(
+                id = cipherView.id.orEmpty(),
+                cipherType = CipherType.LOGIN,
+            ),
+        )
 
         coVerify { fido2CredentialManager.isUserVerified }
         coVerify(exactly = 1) {
@@ -697,8 +738,16 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `ItemClick for vault item should emit NavigateToVaultItem`() = runTest {
         val viewModel = createVaultItemListingViewModel()
         viewModel.eventFlow.test {
-            viewModel.trySendAction(VaultItemListingsAction.ItemClick(id = "mock"))
-            assertEquals(VaultItemListingEvent.NavigateToVaultItem(id = "mock"), awaitItem())
+            viewModel.trySendAction(
+                VaultItemListingsAction.ItemClick(id = "mock", cipherType = CipherType.LOGIN),
+            )
+            assertEquals(
+                VaultItemListingEvent.NavigateToVaultItem(
+                    id = "mock",
+                    type = VaultItemCipherType.LOGIN,
+                ),
+                awaitItem(),
+            )
         }
     }
 
@@ -708,7 +757,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             createSavedStateHandleWithVaultItemListingType(VaultItemListingType.SendFile),
         )
         viewModel.eventFlow.test {
-            viewModel.trySendAction(VaultItemListingsAction.ItemClick(id = "mock"))
+            viewModel.trySendAction(
+                VaultItemListingsAction.ItemClick(id = "mock", cipherType = null),
+            )
             assertEquals(VaultItemListingEvent.NavigateToSendItem(id = "mock"), awaitItem())
         }
     }
@@ -930,13 +981,20 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         masterPasswordRepromptData = MasterPasswordRepromptData.OverflowItem(
                             action = ListingItemOverflowAction.VaultAction.EditClick(
                                 cipherId = cipherId,
+                                cipherType = CipherType.LOGIN,
                                 requiresPasswordReprompt = true,
                             ),
                         ),
                     ),
                 )
                 // An Edit action navigates to the Edit screen
-                assertEquals(VaultItemListingEvent.NavigateToEditCipher(cipherId), awaitItem())
+                assertEquals(
+                    VaultItemListingEvent.NavigateToEditCipher(
+                        cipherId = cipherId,
+                        cipherType = VaultItemCipherType.LOGIN,
+                    ),
+                    awaitItem(),
+                )
             }
         }
 
@@ -961,7 +1019,13 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 // An Edit action navigates to the Edit screen
-                assertEquals(VaultItemListingEvent.NavigateToEditCipher(cipherId), awaitItem())
+                assertEquals(
+                    VaultItemListingEvent.NavigateToEditCipher(
+                        cipherId = cipherId,
+                        cipherType = VaultItemCipherType.LOGIN,
+                    ),
+                    awaitItem(),
+                )
             }
         }
 
@@ -1417,11 +1481,18 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 VaultItemListingsAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = cipherId,
+                        cipherType = CipherType.LOGIN,
                         requiresPasswordReprompt = true,
                     ),
                 ),
             )
-            assertEquals(VaultItemListingEvent.NavigateToEditCipher(cipherId), awaitItem())
+            assertEquals(
+                VaultItemListingEvent.NavigateToEditCipher(
+                    cipherId = cipherId,
+                    cipherType = VaultItemCipherType.LOGIN,
+                ),
+                awaitItem(),
+            )
         }
     }
 
@@ -1446,10 +1517,19 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         viewModel.eventFlow.test {
             viewModel.trySendAction(
                 VaultItemListingsAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = cipherId),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = cipherId,
+                        cipherType = CipherType.LOGIN,
+                    ),
                 ),
             )
-            assertEquals(VaultItemListingEvent.NavigateToVaultItem(cipherId), awaitItem())
+            assertEquals(
+                VaultItemListingEvent.NavigateToVaultItem(
+                    id = cipherId,
+                    type = VaultItemCipherType.LOGIN,
+                ),
+                awaitItem(),
+            )
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -48,9 +48,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = cipherType,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = cipherType,
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyUsernameClick(
@@ -74,6 +78,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "LoginCipherIcon",
                 isTotp = isTotp,
+                type = cipherType,
             )
         }
 
@@ -100,9 +105,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = cipherType,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = cipherType,
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyNoteClick(
@@ -115,6 +124,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "SecureNoteCipherIcon",
                 isTotp = false,
+                type = cipherType,
             )
         }
 
@@ -141,9 +151,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = cipherType,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = cipherType,
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.CopyNumberClick(
@@ -162,6 +176,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "CardCipherIcon",
                 isTotp = false,
+                type = cipherType,
             )
         }
 
@@ -188,9 +203,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = cipherType,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = cipherType,
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                 ),
@@ -200,6 +219,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "IdentityCipherIcon",
                 isTotp = false,
+                type = cipherType,
             )
         }
 
@@ -226,9 +246,13 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = "mockId-$number"),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = cipherType,
+                    ),
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
+                        cipherType = cipherType,
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                 ),
@@ -238,6 +262,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "SshKeyCipherIcon",
                 isTotp = false,
+                type = cipherType,
             )
         }
     }
@@ -290,6 +315,7 @@ fun createMockDisplayItemForSend(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = null,
                 isTotp = false,
+                type = null,
             )
         }
 
@@ -332,6 +358,7 @@ fun createMockDisplayItemForSend(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = null,
                 isTotp = false,
+                type = null,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
@@ -30,9 +30,13 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
-                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.LOGIN,
+                ),
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
+                    cipherType = CipherType.LOGIN,
                     requiresPasswordReprompt = false,
                 ),
                 ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = username),
@@ -63,9 +67,13 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
-                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.LOGIN,
+                ),
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
+                    cipherType = CipherType.LOGIN,
                     requiresPasswordReprompt = false,
                 ),
                 ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = username),
@@ -96,9 +104,13 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
-                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.LOGIN,
+                ),
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
+                    cipherType = CipherType.LOGIN,
                     requiresPasswordReprompt = true,
                 ),
                 ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = username),
@@ -128,7 +140,12 @@ class CipherViewExtensionsTest {
         val result = cipher.toOverflowActions(hasMasterPassword = true, isPremiumUser = false)
 
         assertEquals(
-            listOf(ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id)),
+            listOf(
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.LOGIN,
+                ),
+            ),
             result,
         )
     }
@@ -149,9 +166,13 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
-                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.CARD,
+                ),
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
+                    cipherType = CipherType.CARD,
                     requiresPasswordReprompt = true,
                 ),
                 ListingItemOverflowAction.VaultAction.CopyNumberClick(
@@ -186,7 +207,12 @@ class CipherViewExtensionsTest {
         val result = cipher.toOverflowActions(hasMasterPassword = false, isPremiumUser = false)
 
         assertEquals(
-            listOf(ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id)),
+            listOf(
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.CARD,
+                ),
+            ),
             result,
         )
     }
@@ -202,9 +228,13 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
-                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.IDENTITY,
+                ),
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
+                    cipherType = CipherType.IDENTITY,
                     requiresPasswordReprompt = false,
                 ),
             ),
@@ -227,7 +257,12 @@ class CipherViewExtensionsTest {
         val result = cipher.toOverflowActions(hasMasterPassword = true, false)
 
         assertEquals(
-            listOf(ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id)),
+            listOf(
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.IDENTITY,
+                ),
+            ),
             result,
         )
     }
@@ -245,9 +280,13 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
-                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.SECURE_NOTE,
+                ),
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
+                    cipherType = CipherType.SECURE_NOTE,
                     requiresPasswordReprompt = true,
                 ),
                 ListingItemOverflowAction.VaultAction.CopyNoteClick(notes = notes),
@@ -272,7 +311,12 @@ class CipherViewExtensionsTest {
         val result = cipher.toOverflowActions(hasMasterPassword = false, isPremiumUser = false)
 
         assertEquals(
-            listOf(ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id)),
+            listOf(
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.SECURE_NOTE,
+                ),
+            ),
             result,
         )
     }
@@ -298,7 +342,12 @@ class CipherViewExtensionsTest {
         val result = cipher.toOverflowActions(hasMasterPassword = true, isPremiumUser = false)
 
         assertEquals(
-            listOf(ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id)),
+            listOf(
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.LOGIN,
+                ),
+            ),
             result,
         )
     }
@@ -325,9 +374,13 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
-                ListingItemOverflowAction.VaultAction.ViewClick(cipherId = id),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.LOGIN,
+                ),
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
+                    cipherType = CipherType.LOGIN,
                     requiresPasswordReprompt = true,
                 ),
             ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -51,8 +51,11 @@ import com.x8bit.bitwarden.ui.util.performLogoutAccountClick
 import com.x8bit.bitwarden.ui.util.performRemoveAccountClick
 import com.x8bit.bitwarden.ui.util.performYesDialogButtonClick
 import com.x8bit.bitwarden.ui.vault.components.model.CreateVaultItemType
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterData
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
+import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
 import io.mockk.every
@@ -74,8 +77,8 @@ import org.junit.Test
 class VaultScreenTest : BaseComposeTest() {
     private var onNavigateToImportLoginsCalled = false
     private var onNavigateToVaultAddItemScreenCalled = false
-    private var onNavigateToVaultItemId: String? = null
-    private var onNavigateToVaultEditItemId: String? = null
+    private var onNavigateToVaultItemArgs: VaultItemArgs? = null
+    private var onNavigateToVaultEditItemArgs: VaultAddEditArgs? = null
     private var onNavigateToVaultItemListingType: VaultItemListingType? = null
     private var onDimBottomNavBarRequestCalled = false
     private var onNavigateToVerificationCodeScreen = false
@@ -100,8 +103,8 @@ class VaultScreenTest : BaseComposeTest() {
             VaultScreen(
                 viewModel = viewModel,
                 onNavigateToVaultAddItemScreen = { onNavigateToVaultAddItemScreenCalled = true },
-                onNavigateToVaultItemScreen = { onNavigateToVaultItemId = it },
-                onNavigateToVaultEditItemScreen = { onNavigateToVaultEditItemId = it },
+                onNavigateToVaultItemScreen = { onNavigateToVaultItemArgs = it },
+                onNavigateToVaultEditItemScreen = { onNavigateToVaultEditItemArgs = it },
                 onNavigateToVaultItemListingScreen = { onNavigateToVaultItemListingType = it },
                 onDimBottomNavBarRequest = { onDimBottomNavBarRequestCalled = true },
                 onNavigateToVerificationCodeScreen = { onNavigateToVerificationCodeScreen = true },
@@ -699,15 +702,28 @@ class VaultScreenTest : BaseComposeTest() {
     @Test
     fun `NavigateToVaultItem event should call onNavigateToVaultItemScreen`() {
         val id = "id4321"
-        mutableEventFlow.tryEmit(VaultEvent.NavigateToVaultItem(itemId = id))
-        assertEquals(id, onNavigateToVaultItemId)
+        val type = VaultItemCipherType.LOGIN
+        mutableEventFlow.tryEmit(VaultEvent.NavigateToVaultItem(itemId = id, type = type))
+        assertEquals(
+            VaultItemArgs(vaultItemId = id, cipherType = type),
+            onNavigateToVaultItemArgs,
+        )
     }
 
     @Test
     fun `NavigateToEditVaultItem event should call onNavigateToVaultEditItemScreen`() {
         val id = "id1234"
-        mutableEventFlow.tryEmit(VaultEvent.NavigateToEditVaultItem(itemId = id))
-        assertEquals(id, onNavigateToVaultEditItemId)
+        val type = VaultItemCipherType.CARD
+        mutableEventFlow.tryEmit(
+            VaultEvent.NavigateToEditVaultItem(itemId = id, type = type),
+        )
+        assertEquals(
+            VaultAddEditArgs(
+                vaultAddEditType = VaultAddEditType.EditItem(vaultItemId = id),
+                vaultItemCipherType = type,
+            ),
+            onNavigateToVaultEditItemArgs,
+        )
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -150,7 +150,6 @@ class VaultViewModelTest : BaseViewModelTest() {
         } returns mutableSshKeyVaultItemsEnabledFlow.value
     }
     private val reviewPromptManager: ReviewPromptManager = mockk()
-    private val mockAuthRepository = mockk<AuthRepository>(relaxed = true)
 
     private val specialCircumstanceManager: SpecialCircumstanceManager = mockk {
         every { specialCircumstance } returns null
@@ -1291,10 +1290,14 @@ class VaultViewModelTest : BaseViewModelTest() {
         val itemId = "54321"
         val item = mockk<VaultState.ViewState.VaultItem> {
             every { id } returns itemId
+            every { type } returns VaultItemCipherType.LOGIN
         }
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultAction.VaultItemClick(item))
-            assertEquals(VaultEvent.NavigateToVaultItem(itemId), awaitItem())
+            assertEquals(
+                VaultEvent.NavigateToVaultItem(itemId = itemId, type = VaultItemCipherType.LOGIN),
+                awaitItem(),
+            )
         }
     }
 
@@ -1549,11 +1552,18 @@ class VaultViewModelTest : BaseViewModelTest() {
                 VaultAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = cipherId,
+                        cipherType = CipherType.LOGIN,
                         requiresPasswordReprompt = true,
                     ),
                 ),
             )
-            assertEquals(VaultEvent.NavigateToEditVaultItem(cipherId), awaitItem())
+            assertEquals(
+                VaultEvent.NavigateToEditVaultItem(
+                    itemId = cipherId,
+                    type = VaultItemCipherType.LOGIN,
+                ),
+                awaitItem(),
+            )
         }
     }
 
@@ -1578,10 +1588,16 @@ class VaultViewModelTest : BaseViewModelTest() {
         viewModel.eventFlow.test {
             viewModel.trySendAction(
                 VaultAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.ViewClick(cipherId = cipherId),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = cipherId,
+                        cipherType = CipherType.LOGIN,
+                    ),
                 ),
             )
-            assertEquals(VaultEvent.NavigateToVaultItem(cipherId), awaitItem())
+            assertEquals(
+                VaultEvent.NavigateToVaultItem(itemId = cipherId, type = VaultItemCipherType.LOGIN),
+                awaitItem(),
+            )
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
@@ -974,8 +974,15 @@ private fun createMockSshKeyVaultItem(number: Int): VaultState.ViewState.VaultIt
         privateKey = "mockPrivateKey-$number".asText(),
         fingerprint = "mockKeyFingerprint-$number".asText(),
         overflowOptions = listOf(
-            ListingItemOverflowAction.VaultAction.ViewClick("mockId-$number"),
-            ListingItemOverflowAction.VaultAction.EditClick("mockId-$number", true),
+            ListingItemOverflowAction.VaultAction.ViewClick(
+                cipherId = "mockId-$number",
+                cipherType = CipherType.SSH_KEY,
+            ),
+            ListingItemOverflowAction.VaultAction.EditClick(
+                cipherId = "mockId-$number",
+                cipherType = CipherType.SSH_KEY,
+                requiresPasswordReprompt = true,
+            ),
         ),
         startIcon = IconData.Local(iconRes = R.drawable.ic_ssh_key),
         startIconTestTag = "SshKeyCipherIcon",

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
@@ -19,7 +19,9 @@ import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFl
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.util.assertNoPopupExists
+import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -34,7 +36,7 @@ class VerificationCodeScreenTest : BaseComposeTest() {
 
     private var onNavigateBackCalled = false
     private var onNavigateToSearchCalled = false
-    private var onNavigateToVaultItemId: String? = null
+    private var onNavigateToVaultItemArgs: VaultItemArgs? = null
 
     private val mutableEventFlow = bufferedMutableSharedFlow<VerificationCodeEvent>()
     private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
@@ -50,7 +52,7 @@ class VerificationCodeScreenTest : BaseComposeTest() {
             VerificationCodeScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
-                onNavigateToVaultItemScreen = { onNavigateToVaultItemId = it },
+                onNavigateToVaultItemScreen = { onNavigateToVaultItemArgs = it },
                 onNavigateToSearch = { onNavigateToSearchCalled = true },
                 appResumeStateManager = appResumeStateManager,
             )
@@ -73,7 +75,10 @@ class VerificationCodeScreenTest : BaseComposeTest() {
     fun `NavigateToVaultItem event should call onNavigateToVaultItemScreen`() {
         val id = "id4321"
         mutableEventFlow.tryEmit(VerificationCodeEvent.NavigateToVaultItem(id = id))
-        assertEquals(id, onNavigateToVaultItemId)
+        assertEquals(
+            VaultItemArgs(vaultItemId = id, cipherType = VaultItemCipherType.LOGIN),
+            onNavigateToVaultItemArgs,
+        )
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

* [PM-18121](https://bitwarden.atlassian.net/browse/PM-18121)
* [PM-18294](https://bitwarden.atlassian.net/browse/PM-18294)

## 📔 Objective

This PR updates the AddEdit Screen and View Item Screen to require a `VaultItemCipherType` as a param so we always know the type of cipher we are attempting to view.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18121]: https://bitwarden.atlassian.net/browse/PM-18121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-18294]: https://bitwarden.atlassian.net/browse/PM-18294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ