### PR TITLE
[PM-15873] Add delay to PTR to remove the spinning wheel

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -442,8 +442,8 @@ class VaultViewModel @Inject constructor(
 
     @Suppress("MagicNumber")
     private fun handleRefreshPull() {
+        mutableStateFlow.update { it.copy(isRefreshing = true) }
         viewModelScope.launch {
-            mutableStateFlow.update { it.copy(isRefreshing = true) }
             delay(250)
             if (networkConnectionManager.isNetworkConnected) {
                 vaultRepository.sync(forced = false)
@@ -609,8 +609,9 @@ class VaultViewModel @Inject constructor(
 
             is VaultAction.Internal.SnackbarDataReceive -> handleSnackbarDataReceive(action)
 
-            VaultAction.Internal.InternetConnectionErrorReceived ->
+            VaultAction.Internal.InternetConnectionErrorReceived -> {
                 handleInternetConnectionErrorReceived()
+            }
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -448,15 +448,7 @@ class VaultViewModel @Inject constructor(
             if (networkConnectionManager.isNetworkConnected) {
                 vaultRepository.sync(forced = false)
             } else {
-                mutableStateFlow.update {
-                    it.copy(
-                        isRefreshing = false,
-                        dialog = VaultState.DialogState.Error(
-                            R.string.internet_connection_required_title.asText(),
-                            R.string.internet_connection_required_message.asText(),
-                        ),
-                    )
-                }
+                sendAction(VaultAction.Internal.InternetConnectionErrorReceived)
             }
         }
     }
@@ -616,6 +608,21 @@ class VaultViewModel @Inject constructor(
             }
 
             is VaultAction.Internal.SnackbarDataReceive -> handleSnackbarDataReceive(action)
+
+            VaultAction.Internal.InternetConnectionErrorReceived ->
+                handleInternetConnectionErrorReceived()
+        }
+    }
+
+    private fun handleInternetConnectionErrorReceived() {
+        mutableStateFlow.update {
+            it.copy(
+                isRefreshing = false,
+                dialog = VaultState.DialogState.Error(
+                    R.string.internet_connection_required_title.asText(),
+                    R.string.internet_connection_required_message.asText(),
+                ),
+            )
         }
     }
 
@@ -1447,6 +1454,11 @@ sealed class VaultAction {
         data class IconLoadingSettingReceive(
             val isIconLoadingDisabled: Boolean,
         ) : Internal()
+
+        /**
+         * Indicates that the there is not internet connection.
+         */
+        data object InternetConnectionErrorReceived : Internal()
 
         /**
          * Indicates a result for generating a verification code has been received.

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1389,10 +1389,12 @@ class VaultViewModelTest : BaseViewModelTest() {
         coEvery {
             networkConnectionManager.isNetworkConnected
         } returns false
+
         viewModel.trySendAction(VaultAction.RefreshPull)
         advanceTimeBy(300)
         assertEquals(
             DEFAULT_STATE.copy(
+                isRefreshing = false,
                 dialog = VaultState.DialogState.Error(
                     R.string.internet_connection_required_title.asText(),
                     R.string.internet_connection_required_message.asText(),
@@ -1987,6 +1989,23 @@ class VaultViewModelTest : BaseViewModelTest() {
         )
         assertEquals(
             expectedState,
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `InternetConnectionErrorReceived should show network error if no internet connection`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(VaultAction.Internal.InternetConnectionErrorReceived)
+        assertEquals(
+            DEFAULT_STATE.copy(
+                isRefreshing = false,
+                dialog = VaultState.DialogState.Error(
+                    R.string.internet_connection_required_title.asText(),
+                    R.string.internet_connection_required_message.asText(),
+                ),
+            ),
             viewModel.stateFlow.value,
         )
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -155,8 +155,8 @@ class VaultViewModelTest : BaseViewModelTest() {
     private val reviewPromptManager: ReviewPromptManager = mockk()
 
     private val specialCircumstanceManager: SpecialCircumstanceManager = mockk {
-            every { specialCircumstance } returns null
-        }
+        every { specialCircumstance } returns null
+    }
 
     private val networkConnectionManager: NetworkConnectionManager = mockk {
         every { isNetworkConnected } returns true
@@ -503,7 +503,7 @@ class VaultViewModelTest : BaseViewModelTest() {
     @Test
     fun `on SyncClick should show the no network dialog if not connection is available`() {
         val viewModel = createViewModel()
-        coEvery {
+        every {
             networkConnectionManager.isNetworkConnected
         } returns false
         viewModel.trySendAction(VaultAction.SyncClick)
@@ -1386,7 +1386,7 @@ class VaultViewModelTest : BaseViewModelTest() {
     @Test
     fun `RefreshPull should show network error if no internet connection`() = runTest {
         val viewModel = createViewModel()
-        coEvery {
+        every {
             networkConnectionManager.isNetworkConnected
         } returns false
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1379,6 +1379,29 @@ class VaultViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `RefreshPull should show network error if no internet connection`() = runTest {
+        val viewModel = createViewModel()
+        coEvery {
+            networkConnectionManager.isNetworkConnected
+        } returns false
+        viewModel.trySendAction(VaultAction.RefreshPull)
+        advanceTimeBy(300)
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialog = VaultState.DialogState.Error(
+                    R.string.internet_connection_required_title.asText(),
+                    R.string.internet_connection_required_message.asText(),
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+        verify(exactly = 0) {
+            vaultRepository.sync(forced = false)
+        }
+    }
+
     @Test
     fun `PullToRefreshEnableReceive should update isPullToRefreshEnabled`() = runTest {
         val viewModel = createViewModel()


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-15873
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add delay to `PullToRefresh` to remove the spinning wheel icon when there is not internet connection. This is a workaround for a know issue: https://issuetracker.google.com/issues/248274004
Check internet connection on sync click and show dialog instead of performing the sync.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/3375d2ee-c9b7-49cd-99be-16781d414080


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15873]: https://bitwarden.atlassian.net/browse/PM-15873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ