### PR TITLE
[PM-18545] Hide section when no unlock option are available

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -62,6 +62,7 @@ import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenUnlockWithPinS
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.composition.LocalBiometricsManager
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
+import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricSupportStatus
 import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricsManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
@@ -228,17 +229,20 @@ fun AccountSecurityScreen(
                     .fillMaxWidth(),
             )
 
-            Spacer(Modifier.height(16.dp))
-            BitwardenListHeaderText(
-                label = stringResource(id = R.string.unlock_options),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin()
-                    .padding(horizontal = 16.dp),
-            )
-            Spacer(modifier = Modifier.height(height = 8.dp))
-
             val biometricSupportStatus = biometricsManager.biometricSupportStatus
+            if (biometricSupportStatus != BiometricSupportStatus.NOT_SUPPORTED ||
+                !state.removeUnlockWithPinPolicyEnabled ||
+                state.isUnlockWithPinEnabled) {
+                Spacer(Modifier.height(16.dp))
+                BitwardenListHeaderText(
+                    label = stringResource(id = R.string.unlock_options),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .standardHorizontalMargin()
+                        .padding(horizontal = 16.dp),
+                )
+                Spacer(modifier = Modifier.height(height = 8.dp))
+            }
             BitwardenUnlockWithBiometricsSwitch(
                 biometricSupportStatus = biometricSupportStatus,
                 isChecked = state.isUnlockWithBiometricsEnabled || showBiometricsPrompt,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -30,6 +30,7 @@ import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricsManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.util.assertNoDialogExists
 import com.x8bit.bitwarden.ui.util.assertNoPopupExists
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -239,6 +240,55 @@ class AccountSecurityScreenTest : BaseComposeTest() {
         composeTestRule.onNodeWithText("Unlock with Biometrics").assertIsOff()
         mutableStateFlow.update { it.copy(isUnlockWithBiometricsEnabled = true) }
         composeTestRule.onNodeWithText("Unlock with Biometrics").assertIsOn()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `unlock option section should be displayed according to state if biometrics is available`() {
+        val section = "UNLOCK OPTIONS"
+        composeTestRule.onNodeWithText(section).performScrollTo().assertIsDisplayed()
+
+        mutableStateFlow.update {
+            DEFAULT_STATE.copy(
+                removeUnlockWithPinPolicyEnabled = true,
+                isUnlockWithPinEnabled = true,
+            )
+        }
+        composeTestRule.onNodeWithText(section).performScrollTo().assertIsDisplayed()
+
+        mutableStateFlow.update {
+            DEFAULT_STATE.copy(
+                removeUnlockWithPinPolicyEnabled = true,
+                isUnlockWithPinEnabled = false,
+            )
+        }
+        composeTestRule.onNodeWithText(section).performScrollTo().assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `unlock option section should be displayed according to state if biometrics is not available`() {
+        coEvery {
+            biometricsManager.biometricSupportStatus
+        } returns BiometricSupportStatus.NOT_SUPPORTED
+        val section = "UNLOCK OPTIONS"
+
+        composeTestRule.onNodeWithText(section).performScrollTo().assertIsDisplayed()
+        mutableStateFlow.update {
+            DEFAULT_STATE.copy(
+                removeUnlockWithPinPolicyEnabled = true,
+                isUnlockWithPinEnabled = true,
+            )
+        }
+        composeTestRule.onNodeWithText(section).performScrollTo().assertIsDisplayed()
+
+        mutableStateFlow.update {
+            DEFAULT_STATE.copy(
+                removeUnlockWithPinPolicyEnabled = true,
+                isUnlockWithPinEnabled = false,
+            )
+        }
+        composeTestRule.onNodeWithText(section).assertDoesNotExist()
     }
 
     @Test


### PR DESCRIPTION

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18454
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Hide `Unlock options` section in `AcountSecurity` page when there aren't methods available.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="233" alt="image" src="https://github.com/user-attachments/assets/1d10b72d-9e66-4dd4-9364-ea7e137b5d90" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
