### PR TITLE
PM-18452: Update BitwardenMultiSelectionButton

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenTextSelectionButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/button/BitwardenTextSelectionButton.kt
@@ -37,6 +37,7 @@ import com.x8bit.bitwarden.ui.platform.components.model.TooltipData
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenRowOfActions
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+import com.x8bit.bitwarden.ui.platform.util.persistentListOfNotNull
 
 /**
  * A button which uses a read-only text field for layout and style purposes.
@@ -49,27 +50,12 @@ fun BitwardenTextSelectionButton(
     onClick: () -> Unit,
     cardStyle: CardStyle?,
     modifier: Modifier = Modifier,
-    enabled: Boolean = false,
-    tooltipEnabled: Boolean = true,
+    enabled: Boolean = true,
     supportingText: String? = null,
     tooltip: TooltipData? = null,
     insets: PaddingValues = PaddingValues(),
     textFieldTestTag: String? = null,
     semanticRole: Role = Role.Button,
-    semanticContentDescription: String = supportingText
-        ?.let { "$selectedOption. $label. $it" }
-        ?: "$selectedOption. $label",
-    customAccessibilityActions: List<CustomAccessibilityAction> = listOfNotNull(
-        tooltip?.let {
-            CustomAccessibilityAction(
-                label = it.contentDescription,
-                action = {
-                    it.onClick()
-                    true
-                },
-            )
-        },
-    ),
     actionsPadding: PaddingValues = PaddingValues(end = 4.dp),
     actions: @Composable RowScope.() -> Unit = {},
 ) {
@@ -77,20 +63,34 @@ fun BitwardenTextSelectionButton(
         modifier = modifier
             .clearAndSetSemantics {
                 role = semanticRole
-                contentDescription = semanticContentDescription
-                customActions = customAccessibilityActions
+                contentDescription = supportingText
+                    ?.let { "$selectedOption. $label. $it" }
+                    ?: "$selectedOption. $label"
+                customActions = persistentListOfNotNull(
+                    tooltip?.let {
+                        CustomAccessibilityAction(
+                            label = it.contentDescription,
+                            action = {
+                                it.onClick()
+                                true
+                            },
+                        )
+                    },
+                )
             }
             .cardStyle(
                 cardStyle = cardStyle,
                 paddingTop = 6.dp,
                 paddingBottom = 0.dp,
                 onClick = onClick,
+                clickEnabled = enabled,
             )
             .padding(paddingValues = insets),
     ) {
         TextField(
             textStyle = BitwardenTheme.typography.bodyLarge,
             readOnly = true,
+            enabled = false,
             label = {
                 Row {
                     Text(
@@ -104,7 +104,6 @@ fun BitwardenTextSelectionButton(
                             vectorIconRes = R.drawable.ic_question_circle_small,
                             contentDescription = it.contentDescription,
                             onClick = it.onClick,
-                            isEnabled = tooltipEnabled,
                             contentColor = BitwardenTheme.colorScheme.icon.secondary,
                             modifier = Modifier.size(16.dp),
                         )
@@ -127,7 +126,6 @@ fun BitwardenTextSelectionButton(
             },
             value = selectedOption.orEmpty(),
             onValueChange = {},
-            enabled = enabled,
             colors = bitwardenTextFieldButtonColors(),
             modifier = Modifier
                 .nullableTestTag(tag = textFieldTestTag)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dropdown/BitwardenMultiSelectButton.kt
@@ -71,8 +71,7 @@ fun BitwardenMultiSelectButton(
             shouldShowDialog = true
         },
         cardStyle = cardStyle,
-        enabled = shouldShowDialog,
-        tooltipEnabled = isEnabled,
+        enabled = isEnabled,
         supportingText = supportingText,
         tooltip = tooltip,
         insets = insets,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -501,6 +501,7 @@ private fun SessionTimeoutPolicyRow(
             text = policyText(),
             modifier = modifier,
         )
+        Spacer(modifier = Modifier.height(height = 8.dp))
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18452](https://bitwarden.atlassian.net/browse/PM-18452)

## 📔 Objective

This PR updates the `BitwardenMultiSelectionButton` and `BitwardenTextSelectionButton` to handle the disabled state in a better way.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/9b69bac1-e685-434c-bf85-a1f8f6efcd9c" width="300" /> | <img src="https://github.com/user-attachments/assets/f6ce4eed-badb-4b31-84d8-125616fd0e11" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18452]: https://bitwarden.atlassian.net/browse/PM-18452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ