### PR TITLE
PM-18121: Use correct cipher type for edit screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -47,7 +47,6 @@ import com.x8bit.bitwarden.ui.vault.feature.item.handlers.VaultIdentityItemTypeH
 import com.x8bit.bitwarden.ui.vault.feature.item.handlers.VaultLoginItemTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.item.handlers.VaultSshKeyItemTypeHandlers
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 
 /**
  * Displays the vault item screen.
@@ -90,7 +89,7 @@ fun VaultItemScreen(
                         } else {
                             VaultAddEditType.EditItem(vaultItemId = event.itemId)
                         },
-                        vaultItemCipherType = VaultItemCipherType.LOGIN,
+                        vaultItemCipherType = event.type,
                     ),
                 )
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -239,6 +239,7 @@ class VaultItemViewModel @Inject constructor(
                 VaultItemEvent.NavigateToAddEdit(
                     itemId = state.vaultItemId,
                     isClone = false,
+                    type = state.cipherType,
                 ),
             )
         }
@@ -423,7 +424,13 @@ class VaultItemViewModel @Inject constructor(
                 )
                 return@onContent
             }
-            sendEvent(VaultItemEvent.NavigateToAddEdit(itemId = state.vaultItemId, isClone = true))
+            sendEvent(
+                event = VaultItemEvent.NavigateToAddEdit(
+                    itemId = state.vaultItemId,
+                    isClone = true,
+                    type = state.cipherType,
+                ),
+            )
         }
     }
 
@@ -1828,6 +1835,7 @@ sealed class VaultItemEvent {
     data class NavigateToAddEdit(
         val itemId: String,
         val isClone: Boolean,
+        val type: VaultItemCipherType,
     ) : VaultItemEvent()
 
     /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -96,7 +96,13 @@ class VaultItemScreenTest : BaseComposeTest() {
     @Test
     fun `NavigateToEdit event should invoke onNavigateToVaultEditItem`() {
         val id = "id1234"
-        mutableEventFlow.tryEmit(VaultItemEvent.NavigateToAddEdit(itemId = id, isClone = false))
+        mutableEventFlow.tryEmit(
+            value = VaultItemEvent.NavigateToAddEdit(
+                itemId = id,
+                isClone = false,
+                type = VaultItemCipherType.LOGIN,
+            ),
+        )
         assertEquals(
             VaultAddEditArgs(
                 vaultAddEditType = VaultAddEditType.EditItem(vaultItemId = id),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -660,6 +660,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     VaultItemEvent.NavigateToAddEdit(
                         itemId = VAULT_ITEM_ID,
                         isClone = false,
+                        type = VaultItemCipherType.LOGIN,
                     ),
                     awaitItem(),
                 )
@@ -724,6 +725,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         VaultItemEvent.NavigateToAddEdit(
                             itemId = DEFAULT_STATE.vaultItemId,
                             isClone = false,
+                            type = VaultItemCipherType.LOGIN,
                         ),
                         eventFlow.awaitItem(),
                     )
@@ -1345,6 +1347,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         VaultItemEvent.NavigateToAddEdit(
                             itemId = VAULT_ITEM_ID,
                             isClone = true,
+                            type = VaultItemCipherType.LOGIN,
                         ),
                         awaitItem(),
                     )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18121](https://bitwarden.atlassian.net/browse/PM-18121)

## 📔 Objective

This PR updates the cipherType passed to the edit cipher screen from the cipher details screen.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/9be53a49-4ecf-4f73-886b-88920728d140" width="300" /> | <img src="https://github.com/user-attachments/assets/213828cb-dde7-4752-9755-0a5db57e02e9" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18121]: https://bitwarden.atlassian.net/browse/PM-18121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ