### PR TITLE
PM-18480 Update BitwardenSwitch padding

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenSwitch.kt
@@ -230,7 +230,7 @@ fun BitwardenSwitch(
                 cardStyle = cardStyle,
                 onClick = onCheckedChange?.let { { it(!isChecked) } },
                 clickEnabled = !readOnly && enabled,
-                paddingTop = 6.dp,
+                paddingTop = 12.dp,
                 paddingBottom = 0.dp,
             )
             .semantics(mergeDescendants = true) {
@@ -264,7 +264,7 @@ fun BitwardenSwitch(
             Spacer(modifier = Modifier.width(width = 16.dp))
             Switch(
                 modifier = Modifier
-                    .defaultMinSize(minHeight = 48.dp)
+                    .height(height = 32.dp)
                     .testTag(tag = "SwitchToggle"),
                 enabled = enabled,
                 checked = isChecked,
@@ -274,7 +274,7 @@ fun BitwardenSwitch(
         }
         supportingContent
             ?.let { content ->
-                Spacer(modifier = Modifier.height(height = 6.dp))
+                Spacer(modifier = Modifier.height(height = 12.dp))
                 BitwardenHorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -288,7 +288,7 @@ fun BitwardenSwitch(
                     content = content,
                 )
             }
-            ?: Spacer(modifier = Modifier.height(height = cardStyle?.let { 6.dp } ?: 0.dp))
+            ?: Spacer(modifier = Modifier.height(height = cardStyle?.let { 12.dp } ?: 0.dp))
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18480](https://bitwarden.atlassian.net/browse/PM-18480)

## 📔 Objective

This PR updates the internal padding of the `BitwardenSwitch` to be 12dp and the height of the internal switch component to be 32dp (normally 48dp). This should keep the size of the switch the same under normal circumstances but increase the size when the text exceeds the size of the internal switch (usually when text is two lines).

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/24c06c45-bd87-46fd-b44f-989be517f9bf" width="300" /> | <img src="https://github.com/user-attachments/assets/49875290-a505-4272-b266-a0324c80a783" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18480]: https://bitwarden.atlassian.net/browse/PM-18480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ