### PR TITLE
PM-18315 add UI when 3pa is available for each chrome channel which s…

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -47,9 +47,11 @@ import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.ChromeAutofillSettingsCard
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.util.displayLabel
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toPersistentList
 
 /**
  * Displays the auto-fill screen.
@@ -95,6 +97,11 @@ fun AutoFillScreen(
             }
 
             AutoFillEvent.NavigateToSetupAutofill -> onNavigateToSetupAutofill()
+            is AutoFillEvent.NavigateToChromeAutofillSettings -> {
+                intentManager.startChromeAutofillSettingsActivity(
+                    releaseChannel = event.releaseChannel,
+                )
+            }
         }
     }
 
@@ -139,7 +146,7 @@ fun AutoFillScreen(
                     actionText = stringResource(R.string.get_started),
                     onActionClick = remember(viewModel) {
                         {
-                            viewModel.trySendAction(AutoFillAction.AutoFillActionCardCtaClick)
+                            viewModel.trySendAction(AutoFillAction.AutofillActionCardCtaClick)
                         }
                     },
                     onDismissClick = remember(viewModel) {
@@ -196,6 +203,20 @@ fun AutoFillScreen(
                 )
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
+
+            if (state.chromeAutofillSettingsOptions.isNotEmpty()) {
+                ChromeAutofillSettingsCard(
+                    options = state.chromeAutofillSettingsOptions.toPersistentList(),
+                    onOptionClicked = remember(viewModel) {
+                        {
+                            viewModel.trySendAction(AutoFillAction.ChromeAutofillSelected(it))
+                        }
+                    },
+                    enabled = state.isAutoFillServicesEnabled,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
             if (state.showPasskeyManagementRow) {
                 BitwardenExternalLinkRow(
                     text = stringResource(id = R.string.passkey_management),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -51,7 +51,6 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.ChromeAu
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.util.displayLabel
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.collections.immutable.toPersistentList
 
 /**
  * Displays the auto-fill screen.
@@ -206,7 +205,7 @@ fun AutoFillScreen(
 
             if (state.chromeAutofillSettingsOptions.isNotEmpty()) {
                 ChromeAutofillSettingsCard(
-                    options = state.chromeAutofillSettingsOptions.toPersistentList(),
+                    options = state.chromeAutofillSettingsOptions,
                     onOptionClicked = remember(viewModel) {
                         {
                             viewModel.trySendAction(AutoFillAction.ChromeAutofillSelected(it))

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -15,12 +15,14 @@ import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.model.ChromeAutofillSettingsOption
+import com.x8bit.bitwarden.ui.platform.util.persistentListOfNotNull
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
@@ -56,6 +58,7 @@ class AutoFillViewModel @Inject constructor(
                 defaultUriMatchType = settingsRepository.defaultUriMatchType,
                 showAutofillActionCard = false,
                 activeUserId = userId,
+                chromeAutofillSettingsOptions = persistentListOf(),
             )
         },
 ) {
@@ -249,8 +252,7 @@ data class AutoFillState(
     val defaultUriMatchType: UriMatchType,
     val showAutofillActionCard: Boolean,
     val activeUserId: String,
-    @IgnoredOnParcel
-    val chromeAutofillSettingsOptions: List<ChromeAutofillSettingsOption> = emptyList(),
+    val chromeAutofillSettingsOptions: ImmutableList<ChromeAutofillSettingsOption>,
 ) : Parcelable {
 
     /**
@@ -262,8 +264,8 @@ data class AutoFillState(
 }
 
 @Suppress("MaxLineLength")
-private fun ChromeThirdPartyAutofillStatus.toChromeAutoFillSettingsOptions(): List<ChromeAutofillSettingsOption> =
-    listOfNotNull(
+private fun ChromeThirdPartyAutofillStatus.toChromeAutoFillSettingsOptions(): ImmutableList<ChromeAutofillSettingsOption> =
+    persistentListOfNotNull(
         ChromeAutofillSettingsOption.Stable(
             enabled = this.stableStatusData.isThirdPartyEnabled,
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/ChromeAutofillSettingsCard.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/ChromeAutofillSettingsCard.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -70,9 +69,11 @@ fun ChromeAutofillSettingsCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin()
-                .cardStyle(cardStyle = CardStyle.Bottom)
-                .defaultMinSize(minHeight = 48.dp)
-                .padding(horizontal = 16.dp),
+                .cardStyle(
+                    cardStyle = CardStyle.Bottom,
+                    paddingHorizontal = 16.dp,
+                )
+                .defaultMinSize(minHeight = 48.dp),
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/ChromeAutofillSettingsCard.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/ChromeAutofillSettingsCard.kt
@@ -1,0 +1,99 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeReleaseChannel
+import com.x8bit.bitwarden.ui.platform.base.util.cardStyle
+import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
+import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.model.ChromeAutofillSettingsOption
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+/**
+ * Card for displaying a list of [ChromeAutofillSettingsOption]s and whether they are
+ * currently enabled.
+ *
+ * @param options List of data to display in the card, if the list is empty nothing will be drawn.
+ * @param onOptionClicked Lambda that is invoked when an option row is clicked and passes back the
+ * [ChromeReleaseChannel] for that option.
+ * @param enabled Whether to show the switches for each option as enabled.
+ */
+@Composable
+fun ChromeAutofillSettingsCard(
+    options: ImmutableList<ChromeAutofillSettingsOption>,
+    onOptionClicked: (ChromeReleaseChannel) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (options.isEmpty()) return
+    Column(modifier = modifier) {
+        options.forEachIndexed { index, option ->
+            BitwardenSwitch(
+                label = option.optionText(),
+                isChecked = option.isEnabled,
+                onCheckedChange = {
+                    onOptionClicked(option.chromeReleaseChannel)
+                },
+                cardStyle = if (index == 0) {
+                    CardStyle.Top(
+                        dividerPadding = 16.dp,
+                    )
+                } else {
+                    CardStyle.Middle(
+                        dividerPadding = 16.dp,
+                    )
+                },
+                enabled = enabled,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+        }
+        Column(
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin()
+                .cardStyle(cardStyle = CardStyle.Bottom)
+                .defaultMinSize(minHeight = 48.dp)
+                .padding(horizontal = 16.dp),
+            content = {
+                Text(
+                    text = stringResource(
+                        R.string.improves_login_filling_for_supported_websites_on_chrome,
+                    ),
+                    style = BitwardenTheme.typography.bodyMedium,
+                    color = BitwardenTheme.colorScheme.text.secondary,
+                )
+            },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ChromeAutofillSettingsCard_preview() {
+    BitwardenTheme {
+        ChromeAutofillSettingsCard(
+            options = persistentListOf(
+                ChromeAutofillSettingsOption.Stable(enabled = false),
+                ChromeAutofillSettingsOption.Beta(enabled = true),
+            ),
+            enabled = true,
+            onOptionClicked = {},
+        )
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/ChromeAutofillSettingsCard.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/ChromeAutofillSettingsCard.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -62,23 +61,18 @@ fun ChromeAutofillSettingsCard(
                     .standardHorizontalMargin(),
             )
         }
-        Column(
-            verticalArrangement = Arrangement.Center,
+        Text(
+            text = stringResource(
+                R.string.improves_login_filling_for_supported_websites_on_chrome,
+            ),
+            style = BitwardenTheme.typography.bodyMedium,
+            color = BitwardenTheme.colorScheme.text.secondary,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin()
                 .cardStyle(cardStyle = CardStyle.Bottom)
                 .defaultMinSize(minHeight = 48.dp)
                 .padding(horizontal = 16.dp),
-            content = {
-                Text(
-                    text = stringResource(
-                        R.string.improves_login_filling_for_supported_websites_on_chrome,
-                    ),
-                    style = BitwardenTheme.typography.bodyMedium,
-                    color = BitwardenTheme.colorScheme.text.secondary,
-                )
-            },
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/model/ChromeAutofillSettingsOption.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/model/ChromeAutofillSettingsOption.kt
@@ -1,0 +1,33 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.model
+
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeReleaseChannel
+import com.x8bit.bitwarden.ui.platform.base.util.Text
+import com.x8bit.bitwarden.ui.platform.base.util.asText
+
+/**
+ * Models an option for an option for each type of supported version of Chrome to enable
+ * third party autofill. Each [ChromeAutofillSettingsOption] contains the associated
+ * [ChromeReleaseChannel], the [optionText] to display in any UI component, and
+ * whether or not the third party autofill [isEnabled].
+ */
+sealed class ChromeAutofillSettingsOption(val isEnabled: Boolean) {
+    abstract val chromeReleaseChannel: ChromeReleaseChannel
+    abstract val optionText: Text
+
+    /**
+     * Represents the stable Chrome release channel.
+     */
+    data class Stable(val enabled: Boolean) : ChromeAutofillSettingsOption(isEnabled = enabled) {
+        override val chromeReleaseChannel: ChromeReleaseChannel = ChromeReleaseChannel.STABLE
+        override val optionText: Text = R.string.use_chrome_autofill_integration.asText()
+    }
+
+    /**
+     * Represents the beta Chrome release channel.
+     */
+    data class Beta(val enabled: Boolean) : ChromeAutofillSettingsOption(isEnabled = enabled) {
+        override val chromeReleaseChannel: ChromeReleaseChannel = ChromeReleaseChannel.BETA
+        override val optionText: Text = R.string.use_chrome_beta_autofill_integration.asText()
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/model/ChromeAutofillSettingsOption.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/model/ChromeAutofillSettingsOption.kt
@@ -1,9 +1,11 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.model
 
+import android.os.Parcelable
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeReleaseChannel
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
+import kotlinx.parcelize.Parcelize
 
 /**
  * Models an option for an option for each type of supported version of Chrome to enable
@@ -11,7 +13,8 @@ import com.x8bit.bitwarden.ui.platform.base.util.asText
  * [ChromeReleaseChannel], the [optionText] to display in any UI component, and
  * whether or not the third party autofill [isEnabled].
  */
-sealed class ChromeAutofillSettingsOption(val isEnabled: Boolean) {
+@Parcelize
+sealed class ChromeAutofillSettingsOption(val isEnabled: Boolean) : Parcelable {
     abstract val chromeReleaseChannel: ChromeReleaseChannel
     abstract val optionText: Text
 
@@ -19,15 +22,19 @@ sealed class ChromeAutofillSettingsOption(val isEnabled: Boolean) {
      * Represents the stable Chrome release channel.
      */
     data class Stable(val enabled: Boolean) : ChromeAutofillSettingsOption(isEnabled = enabled) {
-        override val chromeReleaseChannel: ChromeReleaseChannel = ChromeReleaseChannel.STABLE
-        override val optionText: Text = R.string.use_chrome_autofill_integration.asText()
+        override val chromeReleaseChannel: ChromeReleaseChannel
+            get() = ChromeReleaseChannel.STABLE
+        override val optionText: Text
+            get() = R.string.use_chrome_autofill_integration.asText()
     }
 
     /**
      * Represents the beta Chrome release channel.
      */
     data class Beta(val enabled: Boolean) : ChromeAutofillSettingsOption(isEnabled = enabled) {
-        override val chromeReleaseChannel: ChromeReleaseChannel = ChromeReleaseChannel.BETA
-        override val optionText: Text = R.string.use_chrome_beta_autofill_integration.asText()
+        override val chromeReleaseChannel: ChromeReleaseChannel
+            get() = ChromeReleaseChannel.BETA
+        override val optionText: Text
+            get() = R.string.use_chrome_beta_autofill_integration.asText()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/model/ChromeAutofillSettingsOption.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/chrome/model/ChromeAutofillSettingsOption.kt
@@ -21,6 +21,7 @@ sealed class ChromeAutofillSettingsOption(val isEnabled: Boolean) : Parcelable {
     /**
      * Represents the stable Chrome release channel.
      */
+    @Parcelize
     data class Stable(val enabled: Boolean) : ChromeAutofillSettingsOption(isEnabled = enabled) {
         override val chromeReleaseChannel: ChromeReleaseChannel
             get() = ChromeReleaseChannel.STABLE
@@ -31,6 +32,7 @@ sealed class ChromeAutofillSettingsOption(val isEnabled: Boolean) : Parcelable {
     /**
      * Represents the beta Chrome release channel.
      */
+    @Parcelize
     data class Beta(val enabled: Boolean) : ChromeAutofillSettingsOption(isEnabled = enabled) {
         override val chromeReleaseChannel: ChromeReleaseChannel
             get() = ChromeReleaseChannel.BETA

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -9,6 +9,7 @@ import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeReleaseChannel
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -47,6 +48,11 @@ interface IntentManager {
      * Starts the credential manager settings.
      */
     fun startCredentialManagerSettings(context: Context)
+
+    /**
+     * Starts the Chrome autofill settings activity for the provided [ChromeReleaseChannel].
+     */
+    fun startChromeAutofillSettingsActivity(releaseChannel: ChromeReleaseChannel): Boolean
 
     /**
      * Start an activity to view the given [uri] in an external browser.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -26,6 +26,7 @@ import androidx.credentials.CredentialManager
 import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.MainActivity
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeReleaseChannel
 import com.x8bit.bitwarden.data.autofill.util.toPendingIntentMutabilityFlag
 import com.x8bit.bitwarden.data.platform.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
@@ -131,6 +132,22 @@ class IntentManagerImpl(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             CredentialManager.create(context).createSettingsPendingIntent().send()
         }
+    }
+
+    override fun startChromeAutofillSettingsActivity(
+        releaseChannel: ChromeReleaseChannel,
+    ): Boolean = try {
+        val intent = Intent(Intent.ACTION_APPLICATION_PREFERENCES)
+            .apply {
+                addCategory(Intent.CATEGORY_DEFAULT)
+                addCategory(Intent.CATEGORY_APP_BROWSER)
+                addCategory(Intent.CATEGORY_PREFERENCE)
+                setPackage(releaseChannel.packageName)
+            }
+        context.startActivity(intent)
+        true
+    } catch (_: ActivityNotFoundException) {
+        false
     }
 
     override fun launchUri(uri: Uri) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1221,4 +1221,7 @@ Do you want to switch to this account?</string>
   <string name="passkey_operation_failed_because_user_verification_attempts_exceeded">Passkey operation failed because user verification attempts exceeded.</string>
   <string name="passkey_operation_failed_because_no_item_was_selected">Passkey operation failed because no item was selected.</string>
   <string name="self_host_server_url">Self-host server URL</string>
+  <string name="use_chrome_autofill_integration">Use Chrome autofill integration</string>
+  <string name="use_chrome_beta_autofill_integration">Use Chrome autofill integration (Beta)</string>
+  <string name="improves_login_filling_for_supported_websites_on_chrome">Improves login filling for supported websites on Chrome. Once enabled, you’ll be directed to Chrome settings to enable third-party autofill.</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -26,6 +26,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import org.junit.Assert.assertTrue
@@ -522,7 +523,7 @@ class AutoFillScreenTest : BaseComposeTest() {
 
         mutableStateFlow.update {
             it.copy(
-                chromeAutofillSettingsOptions = listOf(
+                chromeAutofillSettingsOptions = persistentListOf(
                     ChromeAutofillSettingsOption.Stable(enabled = true),
                 ),
             )
@@ -539,7 +540,7 @@ class AutoFillScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 isAutoFillServicesEnabled = true,
-                chromeAutofillSettingsOptions = listOf(
+                chromeAutofillSettingsOptions = persistentListOf(
                     ChromeAutofillSettingsOption.Stable(enabled = true),
                     ChromeAutofillSettingsOption.Beta(enabled = false),
                 ),
@@ -598,5 +599,5 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     defaultUriMatchType = UriMatchType.DOMAIN,
     showAutofillActionCard = false,
     activeUserId = "activeUserId",
-    chromeAutofillSettingsOptions = emptyList(),
+    chromeAutofillSettingsOptions = persistentListOf(),
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -14,9 +14,11 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeReleaseChannel
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.model.ChromeAutofillSettingsOption
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.util.assertNoDialogExists
 import io.mockk.every
@@ -47,6 +49,7 @@ class AutoFillScreenTest : BaseComposeTest() {
         every { startSystemAutofillSettingsActivity() } answers { isSystemSettingsRequestSuccess }
         every { startCredentialManagerSettings(any()) } just runs
         every { startSystemAccessibilitySettingsActivity() } just runs
+        every { startChromeAutofillSettingsActivity(any()) } returns true
     }
 
     @Before
@@ -487,7 +490,7 @@ class AutoFillScreenTest : BaseComposeTest() {
             .performScrollTo()
             .performClick()
 
-        verify { viewModel.trySendAction(AutoFillAction.AutoFillActionCardCtaClick) }
+        verify { viewModel.trySendAction(AutoFillAction.AutofillActionCardCtaClick) }
     }
 
     @Test
@@ -505,6 +508,83 @@ class AutoFillScreenTest : BaseComposeTest() {
         mutableEventFlow.tryEmit(AutoFillEvent.NavigateToSetupAutofill)
         assertTrue(onNavigateToSetupAutoFillScreenCalled)
     }
+
+    @Test
+    fun `ChromeAutofillSettingsCard is only displayed when there are options in the list`() {
+        val chromeAutofillSupportingText =
+            "Improves login filling for supported websites on Chrome. " +
+                "Once enabled, you’ll be directed to Chrome settings to enable " +
+                "third-party autofill."
+
+        composeTestRule
+            .onNodeWithText(chromeAutofillSupportingText)
+            .assertDoesNotExist()
+
+        mutableStateFlow.update {
+            it.copy(
+                chromeAutofillSettingsOptions = listOf(
+                    ChromeAutofillSettingsOption.Stable(enabled = true),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(chromeAutofillSupportingText)
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `when Chrome autofill options are clicked the correct action is sent`() {
+        mutableStateFlow.update {
+            it.copy(
+                isAutoFillServicesEnabled = true,
+                chromeAutofillSettingsOptions = listOf(
+                    ChromeAutofillSettingsOption.Stable(enabled = true),
+                    ChromeAutofillSettingsOption.Beta(enabled = false),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText("Use Chrome autofill integration")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText("Use Chrome autofill integration (Beta)")
+            .performScrollTo()
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(
+                AutoFillAction.ChromeAutofillSelected(ChromeReleaseChannel.BETA),
+            )
+            viewModel.trySendAction(
+                AutoFillAction.ChromeAutofillSelected(ChromeReleaseChannel.STABLE),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when NavigateToChromeAutofillSettings events are sent they invoke the intent manager with the correct release channel`() {
+        mutableEventFlow.tryEmit(
+            AutoFillEvent.NavigateToChromeAutofillSettings(
+                ChromeReleaseChannel.STABLE,
+            ),
+        )
+        mutableEventFlow.tryEmit(
+            AutoFillEvent.NavigateToChromeAutofillSettings(
+                ChromeReleaseChannel.BETA,
+            ),
+        )
+
+        verify(exactly = 1) {
+            intentManager.startChromeAutofillSettingsActivity(ChromeReleaseChannel.BETA)
+            intentManager.startChromeAutofillSettingsActivity(ChromeReleaseChannel.STABLE)
+        }
+    }
 }
 
 private val DEFAULT_STATE: AutoFillState = AutoFillState(
@@ -518,4 +598,5 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     defaultUriMatchType = UriMatchType.DOMAIN,
     showAutofillActionCard = false,
     activeUserId = "activeUserId",
+    chromeAutofillSettingsOptions = emptyList(),
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -4,12 +4,17 @@ import android.os.Build
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.autofill.manager.chrome.ChromeThirdPartyAutofillEnabledManager
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeReleaseChannel
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeThirdPartyAutoFillData
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeThirdPartyAutofillStatus
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.model.ChromeAutofillSettingsOption
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -39,6 +44,12 @@ class AutoFillViewModelTest : BaseViewModelTest() {
         every { firstTimeStateFlow } returns mutableFirstTimeStateFlow
         every { storeShowAutoFillSettingBadge(any()) } just runs
     }
+
+    private val mutableChromeAutofillStatusFlow = MutableStateFlow(DEFAULT_AUTOFILL_STATUS)
+    private val chromeThirdPartyAutofillEnabledManager =
+        mockk<ChromeThirdPartyAutofillEnabledManager> {
+            every { chromeThirdPartyAutofillStatusFlow } returns mutableChromeAutofillStatusFlow
+        }
 
     private val settingsRepository: SettingsRepository = mockk {
         every { isInlineAutofillEnabled } returns true
@@ -330,7 +341,7 @@ class AutoFillViewModelTest : BaseViewModelTest() {
             mutableFirstTimeStateFlow.update { it.copy(showSetupAutofillCard = true) }
             val viewModel = createViewModel()
             viewModel.eventFlow.test {
-                viewModel.trySendAction(AutoFillAction.AutoFillActionCardCtaClick)
+                viewModel.trySendAction(AutoFillAction.AutofillActionCardCtaClick)
                 assertEquals(
                     AutoFillEvent.NavigateToSetupAutofill,
                     awaitItem(),
@@ -354,6 +365,55 @@ class AutoFillViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when ChromeAutofillStatusReceive with updated information is processed state updates as expected`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_STATE,
+                    awaitItem(),
+                )
+                mutableChromeAutofillStatusFlow.update {
+                    it.copy(
+                        stableStatusData = DEFAULT_CHROME_AUTOFILL_DATA.copy(isAvailable = true),
+                    )
+                }
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        chromeAutofillSettingsOptions = listOf(
+                            ChromeAutofillSettingsOption.Stable(enabled = false),
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when ChromeAutofillSelected action is handled the correct NavigateToChromeAutofillSettings event is sent`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(
+                    AutoFillAction.ChromeAutofillSelected(ChromeReleaseChannel.STABLE),
+                )
+                assertEquals(
+                    AutoFillEvent.NavigateToChromeAutofillSettings(ChromeReleaseChannel.STABLE),
+                    awaitItem(),
+                )
+                viewModel.trySendAction(
+                    AutoFillAction.ChromeAutofillSelected(ChromeReleaseChannel.BETA),
+                )
+                assertEquals(
+                    AutoFillEvent.NavigateToChromeAutofillSettings(ChromeReleaseChannel.BETA),
+                    awaitItem(),
+                )
+            }
+        }
+
     private fun createViewModel(
         state: AutoFillState? = DEFAULT_STATE,
     ): AutoFillViewModel = AutoFillViewModel(
@@ -361,6 +421,7 @@ class AutoFillViewModelTest : BaseViewModelTest() {
         settingsRepository = settingsRepository,
         authRepository = authRepository,
         firstTimeActionManager = firstTimeActionManager,
+        chromeThirdPartyAutofillEnabledManager = chromeThirdPartyAutofillEnabledManager,
     )
 }
 
@@ -375,4 +436,15 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     defaultUriMatchType = UriMatchType.DOMAIN,
     showAutofillActionCard = false,
     activeUserId = "activeUserId",
+    chromeAutofillSettingsOptions = emptyList(),
+)
+
+private val DEFAULT_CHROME_AUTOFILL_DATA = ChromeThirdPartyAutoFillData(
+    isAvailable = false,
+    isThirdPartyEnabled = false,
+)
+
+private val DEFAULT_AUTOFILL_STATUS = ChromeThirdPartyAutofillStatus(
+    stableStatusData = DEFAULT_CHROME_AUTOFILL_DATA,
+    betaChannelStatusData = DEFAULT_CHROME_AUTOFILL_DATA,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -22,6 +22,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
@@ -382,7 +383,7 @@ class AutoFillViewModelTest : BaseViewModelTest() {
                 }
                 assertEquals(
                     DEFAULT_STATE.copy(
-                        chromeAutofillSettingsOptions = listOf(
+                        chromeAutofillSettingsOptions = persistentListOf(
                             ChromeAutofillSettingsOption.Stable(enabled = false),
                         ),
                     ),
@@ -436,7 +437,7 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     defaultUriMatchType = UriMatchType.DOMAIN,
     showAutofillActionCard = false,
     activeUserId = "activeUserId",
-    chromeAutofillSettingsOptions = emptyList(),
+    chromeAutofillSettingsOptions = persistentListOf(),
 )
 
 private val DEFAULT_CHROME_AUTOFILL_DATA = ChromeThirdPartyAutoFillData(


### PR DESCRIPTION
## 🎟️ Tracking
[PM-18315](https://bitwarden.atlassian.net/browse/PM-18315)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Display a card with all the available Chrome 3P autofill options and if 3PA is enabled or not.
- When an option is clicked, take the user the Autofill settings for that version of Chrome to update their 3rd party autofill status.
- Options are disabled if BW is not set as the system's Autofill service.
- **Note** currently need to install the Beta version of Chrome to see this.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
_If you are patient through my struggle to delete the Chrome beta, shows that if there is no Chrome app installed supporting 3PA the card does not show._
<video src="https://github.com/user-attachments/assets/ffcb70f7-a5c9-459f-9a0d-41ac17480446" width="300" />


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18315]: https://bitwarden.atlassian.net/browse/PM-18315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ