### PR TITLE
PM-18496: Propagate prevalidateSso API error message

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedIdentityApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedIdentityApi.kt
@@ -53,7 +53,7 @@ interface UnauthenticatedIdentityApi {
     @GET("/sso/prevalidate")
     suspend fun prevalidateSso(
         @Query("domainHint") organizationIdentifier: String,
-    ): NetworkResult<PrevalidateSsoResponseJson>
+    ): NetworkResult<PrevalidateSsoResponseJson.Success>
 
     /**
      * This call needs to be synchronous so we need it to return a [Call] directly. The identity

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/PrevalidateSsoResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/PrevalidateSsoResponseJson.kt
@@ -7,6 +7,20 @@ import kotlinx.serialization.Serializable
  * Response body from the SSO prevalidate request.
  */
 @Serializable
-data class PrevalidateSsoResponseJson(
-    @SerialName("token") val token: String?,
-)
+sealed class PrevalidateSsoResponseJson {
+    /**
+     * Models json body of a successful response.
+     */
+    @Serializable
+    data class Success(
+        @SerialName("token") val token: String?,
+    ) : PrevalidateSsoResponseJson()
+
+    /**
+     * Models json body of an error response.
+     */
+    @Serializable
+    data class Error(
+        @SerialName("message") val message: String?,
+    ) : PrevalidateSsoResponseJson()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceImpl.kt
@@ -85,18 +85,23 @@ class IdentityServiceImpl(
         .toResult()
         .recoverCatching { throwable ->
             val bitwardenError = throwable.toBitwardenError()
-            bitwardenError.parseErrorBodyOrNull<GetTokenResponseJson.CaptchaRequired>(
-                code = 400,
-                json = json,
-            ) ?: bitwardenError.parseErrorBodyOrNull<GetTokenResponseJson.TwoFactorRequired>(
-                code = 400,
-                json = json,
-            ) ?: bitwardenError.parseErrorBodyOrNull<GetTokenResponseJson.Invalid>(
-                code = 400,
-                json = json,
-            ) ?: throw throwable
+            bitwardenError
+                .parseErrorBodyOrNull<GetTokenResponseJson.CaptchaRequired>(
+                    code = 400,
+                    json = json,
+                )
+                ?: bitwardenError.parseErrorBodyOrNull<GetTokenResponseJson.TwoFactorRequired>(
+                    code = 400,
+                    json = json,
+                )
+                ?: bitwardenError.parseErrorBodyOrNull<GetTokenResponseJson.Invalid>(
+                    code = 400,
+                    json = json,
+                )
+                ?: throw throwable
         }
 
+    @Suppress("MagicNumber")
     override suspend fun prevalidateSso(
         organizationIdentifier: String,
     ): Result<PrevalidateSsoResponseJson> = unauthenticatedIdentityApi
@@ -104,6 +109,15 @@ class IdentityServiceImpl(
             organizationIdentifier = organizationIdentifier,
         )
         .toResult()
+        .recoverCatching { throwable ->
+            val bitwardenError = throwable.toBitwardenError()
+            bitwardenError
+                .parseErrorBodyOrNull<PrevalidateSsoResponseJson.Error>(
+                    code = 400,
+                    json = json,
+                )
+                ?: throw throwable
+        }
 
     override fun refreshTokenSynchronously(
         refreshToken: String,
@@ -133,6 +147,7 @@ class IdentityServiceImpl(
                     ?: throw throwable
             }
 
+    @Suppress("MagicNumber")
     override suspend fun sendVerificationEmail(
         body: SendVerificationEmailRequestJson,
     ): Result<SendVerificationEmailResponseJson> {
@@ -151,6 +166,7 @@ class IdentityServiceImpl(
             }
     }
 
+    @Suppress("MagicNumber")
     override suspend fun verifyEmailRegistrationToken(
         body: VerifyEmailTokenRequestJson,
     ): Result<VerifyEmailTokenResponseJson> = unauthenticatedIdentityApi

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/PrevalidateSsoResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/PrevalidateSsoResult.kt
@@ -14,5 +14,7 @@ sealed class PrevalidateSsoResult {
     /**
      * There was an error in prevalidation.
      */
-    data object Failure : PrevalidateSsoResult()
+    data class Failure(
+        val message: String? = null,
+    ) : PrevalidateSsoResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
@@ -76,26 +76,12 @@ fun EnterpriseSignOnScreen(
         }
     }
 
-    when (val dialog = state.dialogState) {
-        is EnterpriseSignOnState.DialogState.Error -> {
-            BitwardenBasicDialog(
-                title = dialog
-                    .title
-                    ?.invoke()
-                    ?: stringResource(id = R.string.an_error_has_occurred),
-                message = dialog.message(),
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(EnterpriseSignOnAction.DialogDismiss) }
-                },
-            )
-        }
-
-        is EnterpriseSignOnState.DialogState.Loading -> {
-            BitwardenLoadingDialog(text = dialog.message())
-        }
-
-        null -> Unit
-    }
+    EnterpriseSignOnDialogs(
+        dialogState = state.dialogState,
+        onDismissRequest = remember(viewModel) {
+            { viewModel.trySendAction(EnterpriseSignOnAction.DialogDismiss) }
+        },
+    )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
     BitwardenScaffold(
@@ -172,5 +158,27 @@ private fun EnterpriseSignOnScreenContent(
 
         Spacer(modifier = Modifier.height(16.dp))
         Spacer(modifier = Modifier.navigationBarsPadding())
+    }
+}
+
+@Composable
+private fun EnterpriseSignOnDialogs(
+    dialogState: EnterpriseSignOnState.DialogState?,
+    onDismissRequest: () -> Unit,
+) {
+    when (dialogState) {
+        is EnterpriseSignOnState.DialogState.Error -> {
+            BitwardenBasicDialog(
+                title = dialogState.title(),
+                message = dialogState.message(),
+                onDismissRequest = onDismissRequest,
+            )
+        }
+
+        is EnterpriseSignOnState.DialogState.Loading -> {
+            BitwardenLoadingDialog(text = dialogState.message())
+        }
+
+        null -> Unit
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
@@ -290,22 +290,26 @@ class IdentityServiceTest : BaseServiceTest() {
             assertEquals(LEGACY_INVALID_LOGIN.asSuccess(), result)
         }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `prevalidateSso when response is success should return PrevalidateSsoResponseJson`() =
+    fun `prevalidateSso when response is success should return PrevalidateSsoResponseJson Success`() =
         runTest {
             val organizationId = "organizationId"
-            server.enqueue(MockResponse().setResponseCode(200).setBody(PREVALIDATE_SSO_JSON))
+            server.enqueue(
+                MockResponse().setResponseCode(200).setBody(PREVALIDATE_SSO_SUCCESS_JSON),
+            )
             val result = identityService.prevalidateSso(organizationId)
-            assertEquals(PREVALIDATE_SSO_BODY.asSuccess(), result)
+            assertEquals(PREVALIDATE_SSO_SUCCESS_BODY.asSuccess(), result)
         }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `prevalidateSso when response is an error should return an error`() =
+    fun `prevalidateSso when response is an error should return PrevalidateSsoResponseJson error`() =
         runTest {
             val organizationId = "organizationId"
-            server.enqueue(MockResponse().setResponseCode(400))
+            server.enqueue(MockResponse().setResponseCode(400).setBody(PREVALIDATE_SSO_ERROR_JSON))
             val result = identityService.prevalidateSso(organizationId)
-            assertTrue(result.isFailure)
+            assertEquals(PREVALIDATE_SSO_ERROR_BODY.asSuccess(), result)
         }
 
     @Suppress("MaxLineLength")
@@ -496,14 +500,24 @@ class IdentityServiceTest : BaseServiceTest() {
     }
 }
 
-private const val PREVALIDATE_SSO_JSON = """
+private const val PREVALIDATE_SSO_SUCCESS_JSON = """
 {
   "token": "2ff00750-e2d6-47a6-ae54-67b981e78030"
 }
 """
 
-private val PREVALIDATE_SSO_BODY = PrevalidateSsoResponseJson(
+private const val PREVALIDATE_SSO_ERROR_JSON = """
+{
+  "message": "Organization not found from identifier."
+}
+"""
+
+private val PREVALIDATE_SSO_SUCCESS_BODY = PrevalidateSsoResponseJson.Success(
     token = "2ff00750-e2d6-47a6-ae54-67b981e78030",
+)
+
+private val PREVALIDATE_SSO_ERROR_BODY = PrevalidateSsoResponseJson.Error(
+    message = "Organization not found from identifier.",
 )
 
 private const val REFRESH_TOKEN_JSON = """

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -5356,14 +5356,24 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `prevalidateSso Failure should return Failure `() = runTest {
+    fun `prevalidateSso Failure should return Failure`() = runTest {
         val organizationId = "organizationid"
         val throwable = Throwable()
         coEvery {
             identityService.prevalidateSso(organizationId)
         } returns throwable.asFailure()
         val result = repository.prevalidateSso(organizationId)
-        assertEquals(PrevalidateSsoResult.Failure, result)
+        assertEquals(PrevalidateSsoResult.Failure(), result)
+    }
+
+    @Test
+    fun `prevalidateSso Failure response should return Failure with message`() = runTest {
+        val organizationId = "organizationid"
+        coEvery {
+            identityService.prevalidateSso(organizationId)
+        } returns PrevalidateSsoResponseJson.Error(message = "Fail").asSuccess()
+        val result = repository.prevalidateSso(organizationId)
+        assertEquals(PrevalidateSsoResult.Failure(message = "Fail"), result)
     }
 
     @Test
@@ -5371,9 +5381,9 @@ class AuthRepositoryTest {
         val organizationId = "organizationid"
         coEvery {
             identityService.prevalidateSso(organizationId)
-        } returns PrevalidateSsoResponseJson(token = "").asSuccess()
+        } returns PrevalidateSsoResponseJson.Success(token = "").asSuccess()
         val result = repository.prevalidateSso(organizationId)
-        assertEquals(PrevalidateSsoResult.Failure, result)
+        assertEquals(PrevalidateSsoResult.Failure(), result)
     }
 
     @Test
@@ -5381,7 +5391,7 @@ class AuthRepositoryTest {
         val organizationId = "organizationid"
         coEvery {
             identityService.prevalidateSso(organizationId)
-        } returns PrevalidateSsoResponseJson(token = "token").asSuccess()
+        } returns PrevalidateSsoResponseJson.Success(token = "token").asSuccess()
         val result = repository.prevalidateSso(organizationId)
         assertEquals(PrevalidateSsoResult.Success(token = "token"), result)
     }
@@ -7047,16 +7057,6 @@ class AuthRepositoryTest {
             ),
         )
 
-        private val SINGLE_USER_STATE_1_NEW_ACCOUNT = UserStateJson(
-            activeUserId = USER_ID_1,
-            accounts = mapOf(
-                USER_ID_1 to ACCOUNT_1.copy(
-                    profile = ACCOUNT_1.profile.copy(
-                        creationDate = ZonedDateTime.parse("2024-09-14T01:00:00.00Z"),
-                    ),
-                ),
-            ),
-        )
         private val SINGLE_USER_STATE_2 = UserStateJson(
             activeUserId = USER_ID_2,
             accounts = mapOf(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreenTest.kt
@@ -143,6 +143,7 @@ class EnterpriseSignOnScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 dialogState = EnterpriseSignOnState.DialogState.Error(
+                    title = "Error dialog title".asText(),
                     message = "Error dialog message".asText(),
                 ),
             )
@@ -151,7 +152,7 @@ class EnterpriseSignOnScreenTest : BaseComposeTest() {
         composeTestRule.onNode(isDialog()).assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText("An error has occurred.")
+            .onNodeWithText("Error dialog title")
             .assert(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule
@@ -188,6 +189,7 @@ class EnterpriseSignOnScreenTest : BaseComposeTest() {
         mutableStateFlow.update {
             DEFAULT_STATE.copy(
                 dialogState = EnterpriseSignOnState.DialogState.Error(
+                    title = "title".asText(),
                     message = "message".asText(),
                 ),
             )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
@@ -117,7 +117,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
 
             coEvery {
                 authRepository.prevalidateSso(organizationId)
-            } returns PrevalidateSsoResult.Failure
+            } returns PrevalidateSsoResult.Failure()
 
             val viewModel = createViewModel(state)
             viewModel.stateFlow.test {
@@ -136,6 +136,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     state.copy(
                         dialogState = EnterpriseSignOnState.DialogState.Error(
+                            title = R.string.an_error_has_occurred.asText(),
                             message = R.string.login_sso_error.asText(),
                         ),
                     ),
@@ -198,6 +199,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
             assertEquals(
                 DEFAULT_STATE.copy(
                     dialogState = EnterpriseSignOnState.DialogState.Error(
+                        title = R.string.an_error_has_occurred.asText(),
                         message = R.string.validation_field_required.asText(
                             R.string.org_identifier.asText(),
                         ),
@@ -288,6 +290,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
         assertEquals(
             DEFAULT_STATE.copy(
                 dialogState = EnterpriseSignOnState.DialogState.Error(
+                    title = R.string.an_error_has_occurred.asText(),
                     message = R.string.login_sso_error.asText(),
                 ),
             ),
@@ -305,6 +308,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
         assertEquals(
             DEFAULT_STATE.copy(
                 dialogState = EnterpriseSignOnState.DialogState.Error(
+                    title = R.string.an_error_has_occurred.asText(),
                     message = R.string.login_sso_error.asText(),
                 ),
             ),
@@ -358,6 +362,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_STATE.copy(
                         dialogState = EnterpriseSignOnState.DialogState.Error(
+                            title = R.string.an_error_has_occurred.asText(),
                             message = R.string.login_sso_error.asText(),
                         ),
                         orgIdentifierInput = orgIdentifier,
@@ -424,6 +429,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_STATE.copy(
                         dialogState = EnterpriseSignOnState.DialogState.Error(
+                            title = R.string.an_error_has_occurred.asText(),
                             message = "new device verification required".asText(),
                         ),
                         orgIdentifierInput = orgIdentifier,
@@ -847,6 +853,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
             assertEquals(
                 DEFAULT_STATE.copy(
                     dialogState = EnterpriseSignOnState.DialogState.Error(
+                        title = R.string.an_error_has_occurred.asText(),
                         message = R.string.organization_sso_identifier_required.asText(),
                     ),
                     orgIdentifierInput = "Bitwarden",
@@ -1040,6 +1047,5 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
             codeVerifier = "def",
         )
         private const val DEFAULT_EMAIL = "test@gmail.com"
-        private const val DEFAULT_ORG_ID = "orgId"
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18496](https://bitwarden.atlassian.net/browse/PM-18496)

## 📔 Objective

This PR propagates the the API error from the `prevalidateSso` API to the UI layer.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/29c802a4-bbbc-4348-a820-aa8a57703fa4" width="300" /> | <img src="https://github.com/user-attachments/assets/23e2436b-124f-4775-86a3-7a55f07d1fb7" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18496]: https://bitwarden.atlassian.net/browse/PM-18496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ