### PR TITLE
Add NetworkErrorCode enum to make error parsing more readable

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
@@ -19,6 +19,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.SetPasswordRequest
 import com.x8bit.bitwarden.data.auth.datasource.network.model.VerifyOtpRequestJson
 import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
 import com.x8bit.bitwarden.data.platform.datasource.network.util.HEADER_VALUE_BEARER_PREFIX
+import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
 import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import com.x8bit.bitwarden.data.platform.datasource.network.util.toResult
 import kotlinx.serialization.json.Json
@@ -73,7 +74,7 @@ class AccountsServiceImpl(
                 throwable
                     .toBitwardenError()
                     .parseErrorBodyOrNull<DeleteAccountResponseJson.Invalid>(
-                        code = 400,
+                        code = NetworkErrorCode.BAD_REQUEST,
                         json = json,
                     )
                     ?: throw throwable
@@ -104,7 +105,7 @@ class AccountsServiceImpl(
                 throwable
                     .toBitwardenError()
                     .parseErrorBodyOrNull<PasswordHintResponseJson.Error>(
-                        code = 429,
+                        code = NetworkErrorCode.TOO_MANY_REQUESTS,
                         json = json,
                     )
                     ?: throw throwable

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/util/ExceptionExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/util/ExceptionExtensions.kt
@@ -17,9 +17,12 @@ import retrofit2.HttpException
  * will be attempted to be parsed.
  * @param json [Json] serializer to use.
  */
-inline fun <reified T> BitwardenError.parseErrorBodyOrNull(codes: List<Int>, json: Json): T? =
+inline fun <reified T> BitwardenError.parseErrorBodyOrNull(
+    codes: List<NetworkErrorCode>,
+    json: Json,
+): T? =
     (this as? BitwardenError.Http)
-        ?.takeIf { codes.any { it == this.code } }
+        ?.takeIf { codes.any { it.code == this.code } }
         ?.responseBodyString
         ?.let { responseBody ->
             json.decodeFromStringOrNull(responseBody)
@@ -28,5 +31,7 @@ inline fun <reified T> BitwardenError.parseErrorBodyOrNull(codes: List<Int>, jso
 /**
  * Helper for calling [parseErrorBodyOrNull] with a single code.
  */
-inline fun <reified T> BitwardenError.parseErrorBodyOrNull(code: Int, json: Json): T? =
-    parseErrorBodyOrNull(listOf(code), json)
+inline fun <reified T> BitwardenError.parseErrorBodyOrNull(
+    code: NetworkErrorCode,
+    json: Json,
+): T? = parseErrorBodyOrNull(codes = listOf(code), json = json)

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/util/NetworkErrorCode.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/util/NetworkErrorCode.kt
@@ -1,0 +1,11 @@
+package com.x8bit.bitwarden.data.platform.datasource.network.util
+
+/**
+ * An enum that represents HTTP error codes that we may need to parse for specific responses.
+ */
+enum class NetworkErrorCode(
+    val code: Int,
+) {
+    BAD_REQUEST(code = 400),
+    TOO_MANY_REQUESTS(code = 429),
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceImpl.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.vault.datasource.network.service
 import androidx.core.net.toUri
 import com.bitwarden.vault.Attachment
 import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
+import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
 import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import com.x8bit.bitwarden.data.platform.datasource.network.util.toResult
 import com.x8bit.bitwarden.data.platform.util.asFailure
@@ -110,7 +111,7 @@ class CiphersServiceImpl(
                 throwable
                     .toBitwardenError()
                     .parseErrorBodyOrNull<UpdateCipherResponseJson.Invalid>(
-                        code = 400,
+                        code = NetworkErrorCode.BAD_REQUEST,
                         json = json,
                     )
                     ?: throw throwable
@@ -229,7 +230,7 @@ class CiphersServiceImpl(
                 throwable
                     .toBitwardenError()
                     .parseErrorBodyOrNull<ImportCiphersResponseJson.Invalid>(
-                        code = 400,
+                        code = NetworkErrorCode.BAD_REQUEST,
                         json = json,
                     )
                     ?: throw throwable

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FolderServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FolderServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
 import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
+import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
 import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import com.x8bit.bitwarden.data.platform.datasource.network.util.toResult
 import com.x8bit.bitwarden.data.vault.datasource.network.api.FoldersApi
@@ -33,7 +34,7 @@ class FolderServiceImpl(
                 throwable
                     .toBitwardenError()
                     .parseErrorBodyOrNull<UpdateFolderResponseJson.Invalid>(
-                        code = 400,
+                        code = NetworkErrorCode.BAD_REQUEST,
                         json = json,
                     )
                     ?: throw throwable

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SendsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SendsServiceImpl.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.vault.datasource.network.service
 
 import androidx.core.net.toUri
 import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
+import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
 import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import com.x8bit.bitwarden.data.platform.datasource.network.util.toResult
 import com.x8bit.bitwarden.data.vault.datasource.network.api.AzureApi
@@ -42,7 +43,7 @@ class SendsServiceImpl(
             .recoverCatching { throwable ->
                 throwable.toBitwardenError()
                     .parseErrorBodyOrNull<CreateSendJsonResponse.Invalid>(
-                        code = 400,
+                        code = NetworkErrorCode.BAD_REQUEST,
                         json = json,
                     )
                     ?: throw throwable
@@ -58,7 +59,7 @@ class SendsServiceImpl(
             .recoverCatching { throwable ->
                 throwable.toBitwardenError()
                     .parseErrorBodyOrNull<CreateFileSendResponse.Invalid>(
-                        code = 400,
+                        code = NetworkErrorCode.BAD_REQUEST,
                         json = json,
                     )
                     ?: throw throwable
@@ -79,7 +80,7 @@ class SendsServiceImpl(
                 throwable
                     .toBitwardenError()
                     .parseErrorBodyOrNull<UpdateSendResponseJson.Invalid>(
-                        code = 400,
+                        code = NetworkErrorCode.BAD_REQUEST,
                         json = json,
                     )
                     ?: throw throwable
@@ -143,7 +144,7 @@ class SendsServiceImpl(
                 throwable
                     .toBitwardenError()
                     .parseErrorBodyOrNull<UpdateSendResponseJson.Invalid>(
-                        code = 400,
+                        code = NetworkErrorCode.BAD_REQUEST,
                         json = json,
                     )
                     ?: throw throwable


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR creates an enum for parsable error codes so we can more easily interpret what each code means and remove magic number suppressions.

No changes in functionality were made in this PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
