### PR TITLE
[PM-8223] new device verification ux improvements

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -188,11 +188,13 @@ class TwoFactorLoginViewModel @Inject constructor(
     /**
      * Update the state with the new text and enable or disable the continue button.
      */
+    @Suppress("MagicNumber")
     private fun handleCodeInputChanged(action: TwoFactorLoginAction.CodeInputChanged) {
+        val minLength = if (state.isNewDeviceVerification) 8 else 6
         mutableStateFlow.update {
             it.copy(
                 codeInput = action.input,
-                isContinueButtonEnabled = action.input.length >= 6,
+                isContinueButtonEnabled = action.input.length >= minLength,
             )
         }
     }
@@ -304,8 +306,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                     it.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = loginResult.errorMessage?.asText()
-                                ?: R.string.invalid_verification_code.asText(),
+                            message = R.string.invalid_verification_code.asText(),
                         ),
                     )
                 }
@@ -328,8 +329,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                     it.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = loginResult.errorMessage?.asText()
-                                ?: R.string.invalid_verification_code.asText(),
+                            message = R.string.invalid_verification_code.asText(),
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -306,7 +306,8 @@ class TwoFactorLoginViewModel @Inject constructor(
                     it.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.invalid_verification_code.asText(),
+                            message = loginResult.errorMessage?.asText()
+                                ?: R.string.invalid_verification_code.asText(),
                         ),
                     )
                 }
@@ -329,7 +330,8 @@ class TwoFactorLoginViewModel @Inject constructor(
                     it.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.invalid_verification_code.asText(),
+                            message = loginResult.errorMessage?.asText()
+                                ?: R.string.invalid_verification_code.asText(),
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -306,8 +306,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                     it.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = loginResult.errorMessage?.asText()
-                                ?: R.string.invalid_verification_code.asText(),
+                            message = R.string.invalid_verification_code.asText(),
                         ),
                     )
                 }
@@ -330,8 +329,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                     it.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = loginResult.errorMessage?.asText()
-                                ?: R.string.invalid_verification_code.asText(),
+                            message = R.string.invalid_verification_code.asText(),
                         ),
                     )
                 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -311,6 +311,33 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    @Suppress("MaxLineLength")
+    fun `Continue buttons should only be enabled when code is 8 digit enough on isNewDeviceVerification`() {
+        val initialState = DEFAULT_STATE.copy(isNewDeviceVerification = true)
+        val viewModel = createViewModel(initialState)
+        viewModel.trySendAction(TwoFactorLoginAction.CodeInputChanged("123456"))
+
+        // 6 digit should be false when isNewDeviceVerification is true.
+        assertEquals(
+            initialState.copy(
+                codeInput = "123456",
+                isContinueButtonEnabled = false,
+            ),
+            viewModel.stateFlow.value,
+        )
+
+        // Set it to true.
+        viewModel.trySendAction(TwoFactorLoginAction.CodeInputChanged("12345678"))
+        assertEquals(
+            initialState.copy(
+                codeInput = "12345678",
+                isContinueButtonEnabled = true,
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
     fun `ContinueButtonClick login returns success should update loadingDialogState`() = runTest {
         coEvery {
             authRepository.login(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -645,7 +645,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.invalid_verification_code.asText(),
+                            message = "Mock error message".asText(),
                         ),
                     ),
                     awaitItem(),
@@ -825,7 +825,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.invalid_verification_code.asText(),
+                            message = "new device verification required".asText(),
                         ),
                     ),
                     awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -672,7 +672,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = "Mock error message".asText(),
+                            message = R.string.invalid_verification_code.asText(),
                         ),
                     ),
                     awaitItem(),
@@ -852,7 +852,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = "new device verification required".asText(),
+                            message = R.string.invalid_verification_code.asText(),
                         ),
                     ),
                     awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -645,7 +645,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = "Mock error message".asText(),
+                            message = R.string.invalid_verification_code.asText(),
                         ),
                     ),
                     awaitItem(),
@@ -825,7 +825,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = "new device verification required".asText(),
+                            message = R.string.invalid_verification_code.asText(),
                         ),
                     ),
                     awaitItem(),


### PR DESCRIPTION
## 🎟️ Tracking

Changing error to always use the localization string and updated "Continue" button to only be enabled when input has eight characters for new device verification

## 📔 Objective

https://bitwarden.atlassian.net/browse/PM-8223

## 📸 Screenshots
<img width="314" alt="New device verification error message" src="https://github.com/user-attachments/assets/8f385d2a-1618-43a1-80a3-61e2e1dac992">
<img width="314" alt="seven characters long button disabled" src="https://github.com/user-attachments/assets/8c999089-2630-46d6-bb5b-80b47717ac64">
<img width="314" alt="eight characters long button enabled" src="https://github.com/user-attachments/assets/d9658248-f1d2-403c-a7a7-ce742eae98dc">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
