### PR TITLE
Simplify error response models

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/GetTokenResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/GetTokenResponseJson.kt
@@ -1,7 +1,9 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -92,20 +94,21 @@ sealed class GetTokenResponseJson {
 
     /**
      * Models json body of an invalid request.
+     *
+     * This model supports older versions of the error response model that used lower-case keys.
      */
+    @OptIn(ExperimentalSerializationApi::class)
     @Serializable
     data class Invalid(
+        @JsonNames("errorModel")
         @SerialName("ErrorModel")
-        val errorModel: ErrorModel?,
-        @SerialName("errorModel")
-        val legacyErrorModel: LegacyErrorModel?,
+        private val errorModel: ErrorModel?,
     ) : GetTokenResponseJson() {
 
         /**
          * The error message returned from the server, or null.
          */
-        val errorMessage: String?
-            get() = errorModel?.errorMessage ?: legacyErrorModel?.errorMessage
+        val errorMessage: String? get() = errorModel?.errorMessage
 
         /**
          * The type of invalid responses that can be received.
@@ -131,22 +134,14 @@ sealed class GetTokenResponseJson {
 
         /**
          * The error body of an invalid request containing a message.
+         *
+         * This model supports older versions of the error response model that used lower-case
+         * keys.
          */
         @Serializable
         data class ErrorModel(
+            @JsonNames("message")
             @SerialName("Message")
-            val errorMessage: String,
-        )
-
-        /**
-         * The legacy error body of an invalid request containing a message.
-         *
-         * This model is used to support older versions of the error response model that used
-         * lower-case keys.
-         */
-        @Serializable
-        data class LegacyErrorModel(
-            @SerialName("message")
             val errorMessage: String,
         )
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceTest.kt
@@ -287,7 +287,7 @@ class IdentityServiceTest : BaseServiceTest() {
                 captchaToken = null,
                 uniqueAppId = UNIQUE_APP_ID,
             )
-            assertEquals(LEGACY_INVALID_LOGIN.asSuccess(), result)
+            assertEquals(INVALID_LOGIN.asSuccess(), result)
         }
 
     @Suppress("MaxLineLength")
@@ -651,7 +651,7 @@ private const val INVALID_LOGIN_JSON = """
 private const val LEGACY_INVALID_LOGIN_JSON = """
 {
   "errorModel": {
-    "message": "Legacy-123"
+    "message": "123"
   }
 }
 """
@@ -687,14 +687,6 @@ private const val CAPTCHA_BYPASS_TOKEN_RESPONSE_JSON = """
 private val INVALID_LOGIN = GetTokenResponseJson.Invalid(
     errorModel = GetTokenResponseJson.Invalid.ErrorModel(
         errorMessage = "123",
-    ),
-    legacyErrorModel = null,
-)
-
-private val LEGACY_INVALID_LOGIN = GetTokenResponseJson.Invalid(
-    errorModel = null,
-    legacyErrorModel = GetTokenResponseJson.Invalid.LegacyErrorModel(
-        errorMessage = "Legacy-123",
     ),
 )
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -1574,7 +1574,6 @@ class AuthRepositoryTest {
                 errorModel = GetTokenResponseJson.Invalid.ErrorModel(
                     errorMessage = "mock_error_message",
                 ),
-                legacyErrorModel = null,
             )
             .asSuccess()
 
@@ -1617,7 +1616,6 @@ class AuthRepositoryTest {
                     errorModel = GetTokenResponseJson.Invalid.ErrorModel(
                         errorMessage = "new device verification required",
                     ),
-                    legacyErrorModel = null,
                 )
                 .asSuccess()
 
@@ -2401,7 +2399,6 @@ class AuthRepositoryTest {
                     errorModel = GetTokenResponseJson.Invalid.ErrorModel(
                         errorMessage = "mock_error_message",
                     ),
-                    legacyErrorModel = null,
                 )
                 .asSuccess()
 
@@ -2870,7 +2867,6 @@ class AuthRepositoryTest {
                 errorModel = GetTokenResponseJson.Invalid.ErrorModel(
                     errorMessage = "mock_error_message",
                 ),
-                legacyErrorModel = null,
             )
             .asSuccess()
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR simplifies the error response models by using the `JsonNames` annotation instead of creating a separate model with different keys.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
