### PR TITLE
PM-18388 add hyphens on segmented button labels

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.Hyphens
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -110,7 +111,10 @@ fun SingleChoiceSegmentedButtonRowScope.SegmentedButtonOptionContent(
         label = {
             Text(
                 text = option.text,
-                style = BitwardenTheme.typography.labelLarge,
+                style = BitwardenTheme.typography.labelLarge.copy(
+                    hyphens = Hyphens.Auto,
+                ),
+                modifier = Modifier.padding(vertical = 8.dp, horizontal = 8.dp),
             )
         },
         icon = {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
@@ -88,7 +88,7 @@ fun BitwardenSegmentedButton(
                 .onGloballyPositioned {
                     weightedWidth = (it.size.width / options.size).toDp(density)
                 }
-                .padding(horizontal = 4.dp, vertical = 2.dp)
+                .padding(horizontal = 2.dp, vertical = 2.dp)
                 .height(IntrinsicSize.Min),
             space = 0.dp,
         ) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
@@ -3,10 +3,12 @@ package com.x8bit.bitwarden.ui.platform.components.segment
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -24,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.Hyphens
 import androidx.compose.ui.unit.Density
@@ -34,6 +37,8 @@ import com.x8bit.bitwarden.ui.platform.base.util.toDp
 import com.x8bit.bitwarden.ui.platform.components.segment.color.bitwardenSegmentedButtonColors
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import kotlinx.collections.immutable.ImmutableList
+
+private const val FONT_SCALE_THRESHOLD = 1.5f
 
 /**
  * Displays a Bitwarden styled row of segmented buttons.
@@ -83,7 +88,8 @@ fun BitwardenSegmentedButton(
                 .onGloballyPositioned {
                     weightedWidth = (it.size.width / options.size).toDp(density)
                 }
-                .padding(horizontal = 4.dp),
+                .padding(horizontal = 4.dp, vertical = 2.dp)
+                .height(IntrinsicSize.Min),
             space = 0.dp,
         ) {
             options.forEachIndexed { index, option ->
@@ -101,6 +107,12 @@ fun SingleChoiceSegmentedButtonRowScope.SegmentedButtonOptionContent(
     option: SegmentedButtonState,
     modifier: Modifier = Modifier,
 ) {
+    val fontScale = LocalConfiguration.current.fontScale
+    val labelVerticalPadding = if (fontScale > FONT_SCALE_THRESHOLD) {
+        8.dp
+    } else {
+        0.dp
+    }
     SegmentedButton(
         enabled = option.isEnabled,
         selected = option.isChecked,
@@ -114,7 +126,10 @@ fun SingleChoiceSegmentedButtonRowScope.SegmentedButtonOptionContent(
                 style = BitwardenTheme.typography.labelLarge.copy(
                     hyphens = Hyphens.Auto,
                 ),
-                modifier = Modifier.padding(vertical = 8.dp, horizontal = 8.dp),
+                modifier = Modifier.padding(
+                    vertical = labelVerticalPadding,
+                    horizontal = 4.dp,
+                ),
             )
         },
         icon = {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -665,7 +665,9 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
                 ) {
                     SegmentedButtonOptionContent(
                         option = option,
-                        modifier = Modifier.width(weightedWidth),
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .width(weightedWidth),
                     )
                 }
             }
@@ -694,7 +696,9 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
                 ) {
                     SegmentedButtonOptionContent(
                         option = option,
-                        modifier = Modifier.width(weightedWidth),
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .width(weightedWidth),
                     )
                 }
             }
@@ -723,7 +727,9 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
                 ) {
                     SegmentedButtonOptionContent(
                         option = option,
-                        modifier = Modifier.width(weightedWidth),
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .width(weightedWidth),
                     )
                 }
             }
@@ -731,7 +737,9 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.MainStateOptionsItem(
             else -> {
                 SegmentedButtonOptionContent(
                     option = option,
-                    modifier = Modifier.width(weightedWidth),
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .width(weightedWidth),
                 )
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18388](https://bitwarden.atlassian.net/browse/PM-18388)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Provide a better experience visually when the options in the generated segmented control wrap to second line by adding a hyphen.
- Adjust some spacing to better match the design. 
- Vertical spacing on buttons determined by font scale.
- Button heights will now fill the row height like in design and button heights will be uniform to match the largest (intrinsic min).
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
**Font scale x1**
| before | after |
|--------|--------|
| ![scale_1_before](https://github.com/user-attachments/assets/c28d4898-e548-48f1-885c-75b7abf1668b) | ![scale_1_after](https://github.com/user-attachments/assets/77be5f17-f330-45fe-994f-e5d737f35a44) | 

**Font scale x1.3**
| before | after |
|--------|--------|
| ![scale_1_3_before](https://github.com/user-attachments/assets/ef118898-6ac9-46b7-95be-3ade16c131e1) | ![scale_1_3_after](https://github.com/user-attachments/assets/1b61c2f6-5ee5-47c1-a1e7-a5d933e7a9e0) | 

**Font scale x2**
| before | after |
|--------|--------|
| ![scale_2_before](https://github.com/user-attachments/assets/29200237-7531-44d8-9d65-8adb33e1cf5e) | ![scale_2_after](https://github.com/user-attachments/assets/f5012683-3b4c-418f-a9ac-9568192ced83) | 

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18388]: https://bitwarden.atlassian.net/browse/PM-18388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ