### PR TITLE
Standardize all compose tests with theme and back handling

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/base/util/ColorExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/base/util/ColorExtensionsTest.kt
@@ -26,7 +26,7 @@ class ColorExtensionsTest : BaseComposeTest() {
 
     @Test
     fun `toSafeOverlayColor for a dark color in light mode should use the surface color`() =
-        runTestWithTheme(theme = AppTheme.LIGHT) {
+        setContent(theme = AppTheme.LIGHT) {
             assertEquals(
                 BitwardenTheme.colorScheme.background.primary,
                 Color.Blue.toSafeOverlayColor(),
@@ -35,7 +35,7 @@ class ColorExtensionsTest : BaseComposeTest() {
 
     @Test
     fun `toSafeOverlayColor for a dark color in dark mode should use the onSurface color`() =
-        runTestWithTheme(theme = AppTheme.DARK) {
+        setContent(theme = AppTheme.DARK) {
             assertEquals(
                 BitwardenTheme.colorScheme.text.primary,
                 Color.Blue.toSafeOverlayColor(),
@@ -44,7 +44,7 @@ class ColorExtensionsTest : BaseComposeTest() {
 
     @Test
     fun `toSafeOverlayColor for a light color in light mode should use the onSurface color`() =
-        runTestWithTheme(theme = AppTheme.LIGHT) {
+        setContent(theme = AppTheme.LIGHT) {
             assertEquals(
                 BitwardenTheme.colorScheme.text.primary,
                 Color.Yellow.toSafeOverlayColor(),
@@ -53,7 +53,7 @@ class ColorExtensionsTest : BaseComposeTest() {
 
     @Test
     fun `toSafeOverlayColor for a light color in dark mode should use the surface color`() =
-        runTestWithTheme(theme = AppTheme.DARK) {
+        setContent(theme = AppTheme.DARK) {
             assertEquals(
                 BitwardenTheme.colorScheme.background.primary,
                 Color.Yellow.toSafeOverlayColor(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
@@ -37,7 +37,7 @@ class SetupAutofillScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             SetupAutoFillScreen(
                 intentManager = intentManager,
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteScreenTest.kt
@@ -15,7 +15,7 @@ class SetupCompleteScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContentWithBackDispatcher {
+        setContent {
             SetupCompleteScreen(viewModel = viewModel)
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
@@ -65,7 +65,7 @@ class SetupUnlockScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             SetupUnlockScreen(
                 viewModel = viewModel,
                 biometricsManager = biometricsManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailScreenTest.kt
@@ -32,7 +32,7 @@ class CheckEmailScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             CheckEmailScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationScreenTest.kt
@@ -55,7 +55,7 @@ class CompleteRegistrationScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContentWithBackDispatcher {
+        setContent {
             CompleteRegistrationScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToPasswordGuidance = { onNavigateToPasswordGuidanceCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/PasswordStrengthIndicatorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/PasswordStrengthIndicatorTest.kt
@@ -10,7 +10,7 @@ class PasswordStrengthIndicatorTest : BaseComposeTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `PasswordStrengthIndicator with minimum character count met displays minimum character count`() {
-        composeTestRule.setContent {
+        setContent {
             PasswordStrengthIndicator(
                 state = PasswordStrengthState.WEAK_3,
                 currentCharacterCount = 12,
@@ -27,7 +27,7 @@ class PasswordStrengthIndicatorTest : BaseComposeTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `PasswordStrengthIndicator with no minimum character count met does not minimum character count`() {
-        composeTestRule.setContent {
+        setContent {
             PasswordStrengthIndicator(
                 state = PasswordStrengthState.WEAK_3,
                 currentCharacterCount = 12,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreenTest.kt
@@ -61,7 +61,7 @@ class CreateAccountScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             CreateAccountScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToLogin = { _, _ -> onNavigateToLoginCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreenTest.kt
@@ -47,7 +47,7 @@ class EnterpriseSignOnScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             EnterpriseSignOnScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToSetPassword = { onNavigateToSetPasswordCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
@@ -47,7 +47,7 @@ class EnvironmentScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             EnvironmentScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 intentManager = mockIntentManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/expiredregistrationlink/ExpiredRegistrationLinkScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/expiredregistrationlink/ExpiredRegistrationLinkScreenTest.kt
@@ -25,7 +25,7 @@ class ExpiredRegistrationLinkScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContentWithBackDispatcher {
+        setContent {
             ExpiredRegistrationLinkScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToLogin = { onNavigateToLoginCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
@@ -59,7 +59,7 @@ class LandingScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             LandingScreen(
                 onNavigateToCreateAccount = { onNavigateToCreateAccountCalled = true },
                 onNavigateToLogin = { capturedEmail ->

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreenTest.kt
@@ -64,7 +64,7 @@ class LoginScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             LoginScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToMasterPasswordHint = { onNavigateToMasterPasswordHintCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreenTest.kt
@@ -47,7 +47,7 @@ class LoginWithDeviceScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             LoginWithDeviceScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToTwoFactorLogin = { onNavigateToTwoFactorLoginEmail = it },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreenTest.kt
@@ -32,7 +32,7 @@ class MasterPasswordGeneratorScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             MasterPasswordGeneratorScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToPreventLockout = { onNavigateToPreventLockoutCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceScreenTest.kt
@@ -25,7 +25,7 @@ class MasterPasswordGuidanceScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             MasterPasswordGuidanceScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToGeneratePassword = { onNavigateToGeneratorCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreenTest.kt
@@ -28,7 +28,7 @@ class MasterPasswordHintScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             MasterPasswordHintScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeEmailAccessScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeEmailAccessScreenTest.kt
@@ -37,7 +37,7 @@ class NewDeviceNoticeEmailAccessScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             NewDeviceNoticeEmailAccessScreen(
                 onNavigateBackToVault = { onNavigateBackToVaultCalled = true },
                 onNavigateToTwoFactorOptions = { onNavigateToTwoFactorOptionsCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorScreenTest.kt
@@ -40,7 +40,7 @@ class NewDeviceNoticeTwoFactorScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             NewDeviceNoticeTwoFactorScreen(
                 onNavigateBackToVault = { onNavigateBackToVaultCalled = true },
                 onNavigateBack = { onNavigateBackCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/preventaccountlockout/PreventAccountLockoutScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/preventaccountlockout/PreventAccountLockoutScreenTest.kt
@@ -20,7 +20,7 @@ class PreventAccountLockoutScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             PreventAccountLockoutScreen(
                 onNavigateBack = { onBackHasBeenInvoked = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreenTest.kt
@@ -32,7 +32,7 @@ class RemovePasswordScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             RemovePasswordScreen(
                 viewModel = viewModel,
             )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordScreenTest.kt
@@ -43,7 +43,7 @@ class ResetPasswordScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             ResetPasswordScreen(
                 onNavigateToPreventAccountLockOut = {
                     onNavigateToLearnToPreventLockoutCalled = true

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreenTest.kt
@@ -31,7 +31,7 @@ class SetPasswordScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             SetPasswordScreen(
                 viewModel = viewModel,
             )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
@@ -54,7 +54,7 @@ class StartRegistrationScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             StartRegistrationScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToCompleteRegistration = { _, _ ->

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceScreenTest.kt
@@ -39,7 +39,7 @@ class TrustedDeviceScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             TrustedDeviceScreen(
                 viewModel = viewModel,
                 onNavigateToAdminApproval = { onNavigateToAdminApprovalEmail = it },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
@@ -49,7 +49,7 @@ class TwoFactorLoginScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             TwoFactorLoginScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
@@ -83,7 +83,7 @@ class VaultUnlockScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             VaultUnlockScreen(
                 viewModel = viewModel,
                 biometricsManager = biometricsManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreenTest.kt
@@ -28,7 +28,7 @@ class WelcomeScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             WelcomeScreen(
                 onNavigateToCreateAccount = { onNavigateToCreateAccountCalled = true },
                 onNavigateToLogin = { onNavigateToLoginCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/BaseComposeTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/BaseComposeTest.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.base
 
 import androidx.activity.OnBackPressedDispatcher
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -25,41 +24,25 @@ abstract class BaseComposeTest : BaseRobolectricTest() {
     val composeTestRule = createComposeRule(effectContext = dispatcher)
 
     /**
-     * instance of [OnBackPressedDispatcher] made available if testing using
-     *
-     * [setContentWithBackDispatcher] or [runTestWithTheme]
+     * instance of [OnBackPressedDispatcher] made available if testing using [setContent].
      */
     var backDispatcher: OnBackPressedDispatcher? = null
         private set
 
     /**
-     * Helper for testing a basic Composable function that only requires a Composable environment
-     * with the [BitwardenTheme].
+     * Helper for testing a basic Composable function that only requires a [Composable]. The
+     * [AppTheme] is overridable and the [backDispatcher] is configured automatically.
      */
-    protected fun runTestWithTheme(
-        theme: AppTheme,
+    protected fun setContent(
+        theme: AppTheme = AppTheme.DEFAULT,
         test: @Composable () -> Unit,
     ) {
         composeTestRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
             BitwardenTheme(
                 theme = theme,
-            ) {
-                backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-                test()
-            }
-        }
-    }
-
-    /**
-     * Helper for testing a basic Composable function that provides access to a
-     * [OnBackPressedDispatcher].
-     *
-     * Use if the [Composable] function being tested uses a [BackHandler]
-     */
-    protected fun setContentWithBackDispatcher(test: @Composable () -> Unit) {
-        composeTestRule.setContent {
-            backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-            test()
+                content = test,
+            )
         }
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/util/StringRestExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/util/StringRestExtensionsTest.kt
@@ -16,7 +16,7 @@ class StringRestExtensionsTest : BaseComposeTest() {
     @Test
     fun `toAnnotatedString should add Clickable LinkAnnotation to highlighted string`() {
         var textClickCalled = false
-        composeTestRule.setContent {
+        setContent {
             val annotatedString =
                 R.string.test_for_single_link_annotation.toAnnotatedString {
                     textClickCalled = true
@@ -32,7 +32,7 @@ class StringRestExtensionsTest : BaseComposeTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `toAnnotatedString should add multiple Clickable LinkAnnotations to highlighted string`() {
-        composeTestRule.setContent {
+        setContent {
             val annotatedString =
                 R.string.test_for_multi_link_annotation.toAnnotatedString()
             Text(text = annotatedString)
@@ -45,7 +45,7 @@ class StringRestExtensionsTest : BaseComposeTest() {
 
     @Test
     fun `no link annotations should be applied to non annotated string resource`() {
-        composeTestRule.setContent {
+        setContent {
             Text(text = R.string.test_for_string_with_no_annotations.toAnnotatedString())
         }
 
@@ -65,7 +65,7 @@ class StringRestExtensionsTest : BaseComposeTest() {
 
     @Test
     fun `string with args should only use the arguments available in the string`() {
-        composeTestRule.setContent {
+        setContent {
             Text(
                 text =
                 R.string.test_for_string_with_annotation_and_arg_annotation
@@ -89,7 +89,7 @@ class StringRestExtensionsTest : BaseComposeTest() {
 
     @Test
     fun `string with arg annotations but no passed in args should just append empty string`() {
-        composeTestRule.setContent {
+        setContent {
             Text(
                 text = R.string.test_for_string_with_annotation_and_arg_annotation
                     .toAnnotatedString(),
@@ -104,7 +104,7 @@ class StringRestExtensionsTest : BaseComposeTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `string with no annotations with args should just be handled as normal annotated string`() {
-        composeTestRule.setContent {
+        setContent {
             Text(
                 text = R.string.test_for_string_with_no_annotations_with_format_arg.toAnnotatedString(
                     args = arrayOf("this"),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
@@ -30,7 +30,7 @@ class DebugMenuScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             DebugMenuScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -35,7 +35,7 @@ class RootNavScreenTest : BaseComposeTest() {
             every { eventFlow } returns emptyFlow()
             every { stateFlow } returns MutableStateFlow(RootNavState.Splash)
         }
-        composeTestRule.setContent {
+        setContent {
             RootNavScreen(
                 viewModel = viewModel,
                 navController = fakeNavHostController,
@@ -54,7 +54,7 @@ class RootNavScreenTest : BaseComposeTest() {
             every { stateFlow } returns rootNavStateFlow
         }
         var isSplashScreenRemoved = false
-        composeTestRule.setContent {
+        setContent {
             RootNavScreen(
                 viewModel = viewModel,
                 navController = fakeNavHostController,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
@@ -70,7 +70,7 @@ class SearchScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             SearchScreen(
                 viewModel = viewModel,
                 intentManager = intentManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -28,7 +28,7 @@ class SettingsScreenTest : BaseComposeTest() {
     fun `on about row click should emit SettingsClick`() {
 
         every { viewModel.trySendAction(SettingsAction.SettingsClick(Settings.ABOUT)) } just runs
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -48,7 +48,7 @@ class SettingsScreenTest : BaseComposeTest() {
         every {
             viewModel.trySendAction(SettingsAction.SettingsClick(Settings.ACCOUNT_SECURITY))
         } just runs
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -68,7 +68,7 @@ class SettingsScreenTest : BaseComposeTest() {
         every {
             viewModel.trySendAction(SettingsAction.SettingsClick(Settings.APPEARANCE))
         } just runs
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -89,7 +89,7 @@ class SettingsScreenTest : BaseComposeTest() {
         every {
             viewModel.trySendAction(SettingsAction.SettingsClick(Settings.AUTO_FILL))
         } just runs
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -108,7 +108,7 @@ class SettingsScreenTest : BaseComposeTest() {
     fun `on other row click should emit SettingsClick`() {
 
         every { viewModel.trySendAction(SettingsAction.SettingsClick(Settings.OTHER)) } just runs
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -127,7 +127,7 @@ class SettingsScreenTest : BaseComposeTest() {
     fun `on vault row click should emit SettingsClick`() {
 
         every { viewModel.trySendAction(SettingsAction.SettingsClick(Settings.VAULT)) } just runs
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -145,7 +145,7 @@ class SettingsScreenTest : BaseComposeTest() {
     @Test
     fun `on NavigateAbout should call onNavigateToAbout`() {
         var haveCalledNavigateToAbout = false
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = {
@@ -165,7 +165,7 @@ class SettingsScreenTest : BaseComposeTest() {
     @Test
     fun `on NavigateAccountSecurity should call onNavigateToAccountSecurity`() {
         var haveCalledNavigateToAccountSecurity = false
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -185,7 +185,7 @@ class SettingsScreenTest : BaseComposeTest() {
     @Test
     fun `on NavigateAccountSecurity should call NavigateAppearance`() {
         var haveCalledNavigateToAppearance = false
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -203,7 +203,7 @@ class SettingsScreenTest : BaseComposeTest() {
     @Test
     fun `on NavigateAccountSecurity should call onNavigateToAutoFill`() {
         var haveCalledNavigateToAutoFill = false
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -223,7 +223,7 @@ class SettingsScreenTest : BaseComposeTest() {
     @Test
     fun `on NavigateAccountSecurity should call onNavigateToOther`() {
         var haveCalledNavigateToOther = false
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -243,7 +243,7 @@ class SettingsScreenTest : BaseComposeTest() {
     @Test
     fun `on NavigateAccountSecurity should call NavigateVault`() {
         var haveCalledNavigateToVault = false
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -263,7 +263,7 @@ class SettingsScreenTest : BaseComposeTest() {
     @Test
     fun `on NavigateAccountSecurityShortcut should call onNavigateToAccountSecurity`() {
         var haveCalledNavigateToAccountSecurity = false
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = { },
@@ -281,7 +281,7 @@ class SettingsScreenTest : BaseComposeTest() {
 
     @Test
     fun `Settings screen should show correct number of notification badges based on state`() {
-        composeTestRule.setContent {
+        setContent {
             SettingsScreen(
                 viewModel = viewModel,
                 onNavigateToAbout = {},

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreenTest.kt
@@ -57,7 +57,7 @@ class AboutScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             AboutScreen(
                 viewModel = viewModel,
                 intentManager = intentManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -83,7 +83,7 @@ class AccountSecurityScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             AccountSecurityScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToDeleteAccount = { onNavigateToDeleteAccountCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreenTest.kt
@@ -38,7 +38,7 @@ class DeleteAccountScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             DeleteAccountScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToDeleteAccountConfirmation = {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreenTest.kt
@@ -33,7 +33,7 @@ class DeleteAccountConfirmationScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             DeleteAccountConfirmationScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreenTest.kt
@@ -40,7 +40,7 @@ class LoginApprovalScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContentWithBackDispatcher {
+        setContent {
             LoginApprovalScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreenTest.kt
@@ -55,7 +55,7 @@ class PendingRequestsScreenTest : BaseComposeTest() {
         mockkStatic(::isBuildVersionBelow)
         every { isFdroid } returns false
         every { isBuildVersionBelow(any()) } returns false
-        composeTestRule.setContent {
+        setContent {
             PendingRequestsScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToLoginApproval = { _ -> onNavigateToLoginApprovalCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
@@ -37,7 +37,7 @@ class AppearanceScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             AppearanceScreen(
                 onNavigateBack = { haveCalledNavigateBack = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -55,7 +55,7 @@ class AutoFillScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             AutoFillScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToBlockAutoFillScreen = { onNavigateToBlockAutoFillScreenCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/BlockAutoFillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/BlockAutoFillScreenTest.kt
@@ -33,7 +33,7 @@ class BlockAutoFillScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             BlockAutoFillScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreenTest.kt
@@ -45,7 +45,7 @@ class ExportVaultScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             ExportVaultScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersScreenTest.kt
@@ -35,7 +35,7 @@ class FoldersScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             FoldersScreen(
                 viewModel = viewModel,
                 onNavigateToEditFolderScreen = { onNavigateToEditFolderScreenId = it },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreenTest.kt
@@ -38,7 +38,7 @@ class FolderAddEditScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             FolderAddEditScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreenTest.kt
@@ -38,7 +38,7 @@ class OtherScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             OtherScreen(
                 viewModel = viewModel,
                 onNavigateBack = { haveCalledNavigateBack = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
@@ -54,7 +54,7 @@ class VaultSettingsScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             VaultSettingsScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -66,7 +66,7 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             GeneratorScreen(
                 viewModel = viewModel,
                 onNavigateToPasswordHistory = {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreenTest.kt
@@ -41,7 +41,7 @@ class PasswordHistoryScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             PasswordHistoryScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
@@ -65,7 +65,7 @@ class SendScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             SendScreen(
                 viewModel = viewModel,
                 onNavigateToAddSend = { onNavigateToNewSendCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
@@ -66,7 +66,7 @@ class AddSendScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContentWithBackDispatcher {
+        setContent {
             AddSendScreen(
                 viewModel = viewModel,
                 exitManager = exitManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -117,7 +117,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             VaultAddEditScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToQrCodeScanScreen = { onNavigateQrCodeScanScreenCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
@@ -46,7 +46,7 @@ class AttachmentsScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             AttachmentsScreen(
                 viewModel = viewModel,
                 intentManager = intentManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreenTest.kt
@@ -53,7 +53,7 @@ class ImportLoginsScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContentWithBackDispatcher {
+        setContent {
             ImportLoginsScreen(
                 onNavigateBack = { navigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -77,7 +77,7 @@ class VaultItemScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             VaultItemScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -117,7 +117,7 @@ class VaultItemListingScreenTest : BaseComposeTest() {
     fun setUp() {
         mockkStatic(String::toHostOrPathOrNull)
         every { AUTOFILL_SELECTION_DATA.uri?.toHostOrPathOrNull() } returns "www.test.com"
-        setContentWithBackDispatcher {
+        setContent {
             VaultItemListingScreen(
                 viewModel = viewModel,
                 exitManager = exitManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreenTests.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreenTests.kt
@@ -52,7 +52,7 @@ class ManualCodeEntryScreenTests : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             ManualCodeEntryScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationScreenTest.kt
@@ -45,7 +45,7 @@ class VaultMoveToOrganizationScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             VaultMoveToOrganizationScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreenTest.kt
@@ -31,7 +31,7 @@ class QrCodeScanScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        composeTestRule.setContent {
+        setContent {
             QrCodeScanScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -99,7 +99,7 @@ class VaultScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             VaultScreen(
                 viewModel = viewModel,
                 onNavigateToVaultAddItemScreen = { onNavigateToVaultAddItemScreenCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
@@ -48,7 +48,7 @@ class VerificationCodeScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        composeTestRule.setContent {
+        setContent {
             VerificationCodeScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the compose tests to use a single helper method (`setContent`) and standardizes all the unit tests under a single function.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
