### PR TITLE
🍒 PM-18636 Hide coach mark card if any login ciphers exist

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -159,6 +159,7 @@ class FirstTimeActionManagerImpl @Inject constructor(
         get() = settingsDiskSource
             .getShouldShowAddLoginCoachMarkFlow()
             .map { it ?: true }
+            .mapFalseIfAnyLoginCiphersAvailable()
             .combine(
                 featureFlagManager.getFeatureFlagFlow(FlagKey.OnboardingFlow),
             ) { shouldShow, featureIsEnabled ->
@@ -172,6 +173,7 @@ class FirstTimeActionManagerImpl @Inject constructor(
         get() = settingsDiskSource
             .getShouldShowGeneratorCoachMarkFlow()
             .map { it ?: true }
+            .mapFalseIfAnyLoginCiphersAvailable()
             .combine(
                 featureFlagManager.getFeatureFlagFlow(FlagKey.OnboardingFlow),
             ) { shouldShow, featureFlagEnabled ->
@@ -294,4 +296,23 @@ class FirstTimeActionManagerImpl @Inject constructor(
         return settingsDiskSource.getShowAutoFillSettingBadge(userId) ?: false &&
             !autofillEnabledManager.isAutofillEnabled
     }
+
+    /**
+     * If there are any existing "Login" type ciphers then we'll map the current value
+     * of the receiver Flow to `false`.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun Flow<Boolean>.mapFalseIfAnyLoginCiphersAvailable(): Flow<Boolean> =
+        authDiskSource
+            .activeUserIdChangesFlow
+            .filterNotNull()
+            .flatMapLatest { activeUserId ->
+                combine(
+                    flow = this,
+                    flow2 = vaultDiskSource.getCiphers(activeUserId),
+                ) { currentValue, ciphers ->
+                    currentValue && ciphers.none { it.login != null }
+                }
+            }
+            .distinctUntilChanged()
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -303,10 +303,10 @@ class FirstTimeActionManagerTest {
 
     @Test
     fun `shouldShowAddLoginCoachMarkFlow updates when disk source updates`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
         // Enable the feature for this test.
         mutableOnboardingFeatureFlow.update { true }
         firstTimeActionManager.shouldShowAddLoginCoachMarkFlow.test {
-            // Null will be mapped to false.
             assertTrue(awaitItem())
             fakeSettingsDiskSource.storeShouldShowAddLoginCoachMark(shouldShow = false)
             assertFalse(awaitItem())
@@ -316,12 +316,42 @@ class FirstTimeActionManagerTest {
     @Test
     fun `shouldShowAddLoginCoachMarkFlow updates when feature flag for onboarding updates`() =
         runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
             firstTimeActionManager.shouldShowAddLoginCoachMarkFlow.test {
-                // Null will be mapped to false but feature being "off" will override to true.
                 assertFalse(awaitItem())
                 mutableOnboardingFeatureFlow.update { true }
-                // Will use the value from disk source (null ?: false).
                 assertTrue(awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `if there are any login ciphers available for the active user should not show add login coach marks`() =
+        runTest {
+            val mockJsonWithNoLogin = mockk<SyncResponseJson.Cipher> {
+                every { login } returns null
+            }
+            val mockJsonWithLogin = mockk<SyncResponseJson.Cipher> {
+                every { login } returns mockk()
+            }
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            // Enable feature flag so flow emits updates from disk.
+            mutableOnboardingFeatureFlow.update { true }
+            mutableCiphersListFlow.update {
+                listOf(
+                    mockJsonWithNoLogin,
+                    mockJsonWithNoLogin,
+                )
+            }
+            firstTimeActionManager.shouldShowAddLoginCoachMarkFlow.test {
+                assertTrue(awaitItem())
+                mutableCiphersListFlow.update {
+                    listOf(
+                        mockJsonWithLogin,
+                        mockJsonWithNoLogin,
+                    )
+                }
+                assertFalse(awaitItem())
             }
         }
 
@@ -335,10 +365,10 @@ class FirstTimeActionManagerTest {
 
     @Test
     fun `shouldShowGeneratorCoachMarkFlow updates when disk source updates`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
         // Enable feature flag so flow emits updates from disk.
         mutableOnboardingFeatureFlow.update { true }
         firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
-            // Null will be mapped to false.
             assertTrue(awaitItem())
             fakeSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = false)
             assertFalse(awaitItem())
@@ -348,12 +378,43 @@ class FirstTimeActionManagerTest {
     @Test
     fun `shouldShowGeneratorCoachMarkFlow updates when onboarding feature value changes`() =
         runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
             firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
-                // Null will be mapped to false
                 assertFalse(awaitItem())
                 mutableOnboardingFeatureFlow.update { true }
                 // Take the value from disk.
                 assertTrue(awaitItem())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `if there are any login ciphers available for the active user should not show generator coach marks`() =
+        runTest {
+            val mockJsonWithNoLogin = mockk<SyncResponseJson.Cipher> {
+                every { login } returns null
+            }
+            val mockJsonWithLogin = mockk<SyncResponseJson.Cipher> {
+                every { login } returns mockk()
+            }
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            // Enable feature flag so flow emits updates from disk.
+            mutableOnboardingFeatureFlow.update { true }
+            mutableCiphersListFlow.update {
+                listOf(
+                    mockJsonWithNoLogin,
+                    mockJsonWithNoLogin,
+                )
+            }
+            firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
+                assertTrue(awaitItem())
+                mutableCiphersListFlow.update {
+                    listOf(
+                        mockJsonWithLogin,
+                        mockJsonWithNoLogin,
+                    )
+                }
+                assertFalse(awaitItem())
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18636](https://bitwarden.atlassian.net/browse/PM-18636)

## 📔 Objective

This is a cherry pick from this [PR](https://github.com/bitwarden/android/pull/4787) to the release branch
Notes from PR:
- To avoid showing the coach mark cards to users who have been using the app and are familiar we are adding a business rule to avoid showing the card if there is any LOGIN type ciphers in the user's vault.
- 
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18636]: https://bitwarden.atlassian.net/browse/PM-18636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ