### PR TITLE
PM-18677: Policies for disabled organizations apply

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PolicyManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/PolicyManagerImpl.kt
@@ -70,7 +70,6 @@ class PolicyManagerImpl(
             .getOrganizations(userId)
             ?.filter {
                 it.shouldUsePolicies &&
-                    it.isEnabled &&
                     it.status >= OrganizationStatusType.ACCEPTED &&
                     !isOrganizationExemptFromPolicies(it, type)
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendEmpty.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendEmpty.kt
@@ -41,6 +41,7 @@ fun SendEmpty(
         modifier = modifier.verticalScroll(rememberScrollState()),
     ) {
         if (policyDisablesSend) {
+            Spacer(modifier = Modifier.height(12.dp))
             BitwardenInfoCalloutCard(
                 text = stringResource(id = R.string.send_disabled_warning),
                 modifier = Modifier

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseProfileUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SyncResponseProfileUtil.kt
@@ -36,12 +36,13 @@ fun createMockOrganization(
     isEnabled: Boolean = false,
     shouldUsePolicies: Boolean = false,
     shouldManageResetPassword: Boolean = false,
+    type: OrganizationType = OrganizationType.ADMIN,
 ): SyncResponseJson.Profile.Organization =
     SyncResponseJson.Profile.Organization(
         shouldUsePolicies = shouldUsePolicies,
         shouldUseKeyConnector = false,
         keyConnectorUrl = "mockKeyConnectorUrl-$number",
-        type = OrganizationType.ADMIN,
+        type = type,
         seats = 1,
         isEnabled = isEnabled,
         providerType = 1,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18677](https://bitwarden.atlassian.net/browse/PM-18677)

## 📔 Objective

This PR updates the policy manager to allow policies for disabled organizations to still apply.

Also updated a minor margin issue with the policy card.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e831c08c-41af-4453-9ae4-1a9918a7b6c8" width="300" /> | <img src="https://github.com/user-attachments/assets/c3016d37-a9f4-4486-b551-944d77eccb25" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18677]: https://bitwarden.atlassian.net/browse/PM-18677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ