### PR TITLE
[deps] Update testng to 7.11.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,11 +56,11 @@ okhttp = "4.12.0"
 retrofitBom = "2.11.0"
 robolectric = "4.14.1"
 sonarqube = "6.0.1.5171"
+testng = "7.11.0"
 timber = "5.0.1"
 turbine = "1.2.0"
 zxcvbn4j = "1.9.0"
 zxing = "3.5.3"
-testng = "7.10.2"
 
 [libraries]
 # Format: <maintainer>-<artifact-name>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Update testng from 7.10.2 to 7.11.0

<details>
<summary>testng-team/testng (org.testng:testng)</summary>

### [`v7.11.0`](https://redirect.github.com/testng-team/testng/releases/tag/7.11.0)

[Compare Source](https://redirect.github.com/testng-team/testng/compare/7.10.2...7.11.0)

#### What's Changed

-   Report deadlocks when running in sharedthreadpool by [@&#8203;krmahadevan](https://redirect.github.com/krmahadevan) in [https://github.com/testng-team/testng/pull/3119](https://redirect.github.com/testng-team/testng/pull/3119)
-   Update JCommander to 1.83 by [@&#8203;adessaigne](https://redirect.github.com/adessaigne) in [https://github.com/testng-team/testng/pull/3123](https://redirect.github.com/testng-team/testng/pull/3123)
-   Update Gradle Wrapper from 8.7 to 8.8 by [@&#8203;github-actions](https://redirect.github.com/github-actions) in [https://github.com/testng-team/testng/pull/3132](https://redirect.github.com/testng-team/testng/pull/3132)
-   Fix array assertEquals failure message when an element is null or non-null by [@&#8203;zAlbee](https://redirect.github.com/zAlbee) in [https://github.com/testng-team/testng/pull/3136](https://redirect.github.com/testng-team/testng/pull/3136)
-   Fix typos on `suiteName` and `testName` attributes by [@&#8203;Philzen](https://redirect.github.com/Philzen) in [https://github.com/testng-team/testng/pull/3137](https://redirect.github.com/testng-team/testng/pull/3137)
-   Fix javadoc for internal/Utils.java by [@&#8203;vlad8x8](https://redirect.github.com/vlad8x8) in [https://github.com/testng-team/testng/pull/3148](https://redirect.github.com/testng-team/testng/pull/3148)
-   Update Gradle Wrapper from 8.8 to 8.9 by [@&#8203;github-actions](https://redirect.github.com/github-actions) in [https://github.com/testng-team/testng/pull/3149](https://redirect.github.com/testng-team/testng/pull/3149)
-   Fix `assertEqualsDeep(Set, Set, String)` wrong comparison and add variant without message by [@&#8203;vuriaval](https://redirect.github.com/vuriaval) in [https://github.com/testng-team/testng/pull/3150](https://redirect.github.com/testng-team/testng/pull/3150)
-   Bump github/combine-prs from 5.0.0 to 5.1.0 by [@&#8203;dependabot](https://redirect.github.com/dependabot) in [https://github.com/testng-team/testng/pull/3151](https://redirect.github.com/testng-team/testng/pull/3151)
-   Bump burrunan/gradle-cache-action from 1 to 2 by [@&#8203;dependabot](https://redirect.github.com/dependabot) in [https://github.com/testng-team/testng/pull/3168](https://redirect.github.com/testng-team/testng/pull/3168)
-   Specifying dataProvider & successPercentage causes test to always pass by [@&#8203;krmahadevan](https://redirect.github.com/krmahadevan) in [https://github.com/testng-team/testng/pull/3171](https://redirect.github.com/testng-team/testng/pull/3171)
-   Update Gradle Wrapper from 8.9 to 8.10.1 by [@&#8203;github-actions](https://redirect.github.com/github-actions) in [https://github.com/testng-team/testng/pull/3174](https://redirect.github.com/testng-team/testng/pull/3174)
-   Update Gradle Wrapper from 8.10.1 to 8.10.2 by [@&#8203;github-actions](https://redirect.github.com/github-actions) in [https://github.com/testng-team/testng/pull/3178](https://redirect.github.com/testng-team/testng/pull/3178)
-   Bump oracle-actions/setup-java from 1.3.4 to 1.4.0 by [@&#8203;dependabot](https://redirect.github.com/dependabot) in [https://github.com/testng-team/testng/pull/3176](https://redirect.github.com/testng-team/testng/pull/3176)
-   Bump gradle-update/update-gradle-wrapper-action from 1 to 2 by [@&#8203;dependabot](https://redirect.github.com/dependabot) in [https://github.com/testng-team/testng/pull/3175](https://redirect.github.com/testng-team/testng/pull/3175)
-   Streamline invocation numbers in failed xml file by [@&#8203;krmahadevan](https://redirect.github.com/krmahadevan) in [https://github.com/testng-team/testng/pull/3181](https://redirect.github.com/testng-team/testng/pull/3181)
-   Bump github/combine-prs from 5.1.0 to 5.2.0 by [@&#8203;dependabot](https://redirect.github.com/dependabot) in [https://github.com/testng-team/testng/pull/3185](https://redirect.github.com/testng-team/testng/pull/3185)
-   Fix for [#&#8203;3189](https://redirect.github.com/testng-team/testng/issues/3189) - fixed ignored testcases count by [@&#8203;Kanaduchi](https://redirect.github.com/Kanaduchi) in [https://github.com/testng-team/testng/pull/3190](https://redirect.github.com/testng-team/testng/pull/3190)
-   update slf4j from 1.7.36 to 2.0.16 by [@&#8203;asolntsev](https://redirect.github.com/asolntsev) in [https://github.com/testng-team/testng/pull/3191](https://redirect.github.com/testng-team/testng/pull/3191)
-   Update Gradle Wrapper from 8.10.2 to 8.11.1 by [@&#8203;github-actions](https://redirect.github.com/github-actions) in [https://github.com/testng-team/testng/pull/3188](https://redirect.github.com/testng-team/testng/pull/3188)
-   Introduce missing `assertEquals(long, Long, String)` overload by [@&#8203;Stephan202](https://redirect.github.com/Stephan202) in [https://github.com/testng-team/testng/pull/3199](https://redirect.github.com/testng-team/testng/pull/3199)
-   Support to execlude somes test in option of command line by [@&#8203;YutingZhang-A](https://redirect.github.com/YutingZhang-A) in [https://github.com/testng-team/testng/pull/3200](https://redirect.github.com/testng-team/testng/pull/3200)
-   Use newer build scan plugin by [@&#8203;jaredsburrows](https://redirect.github.com/jaredsburrows) in [https://github.com/testng-team/testng/pull/3203](https://redirect.github.com/testng-team/testng/pull/3203)

#### New Contributors

-   [@&#8203;adessaigne](https://redirect.github.com/adessaigne) made their first contribution in [https://github.com/testng-team/testng/pull/3123](https://redirect.github.com/testng-team/testng/pull/3123)
-   [@&#8203;zAlbee](https://redirect.github.com/zAlbee) made their first contribution in [https://github.com/testng-team/testng/pull/3136](https://redirect.github.com/testng-team/testng/pull/3136)
-   [@&#8203;Philzen](https://redirect.github.com/Philzen) made their first contribution in [https://github.com/testng-team/testng/pull/3137](https://redirect.github.com/testng-team/testng/pull/3137)
-   [@&#8203;vlad8x8](https://redirect.github.com/vlad8x8) made their first contribution in [https://github.com/testng-team/testng/pull/3148](https://redirect.github.com/testng-team/testng/pull/3148)
-   [@&#8203;vuriaval](https://redirect.github.com/vuriaval) made their first contribution in [https://github.com/testng-team/testng/pull/3150](https://redirect.github.com/testng-team/testng/pull/3150)
-   [@&#8203;Stephan202](https://redirect.github.com/Stephan202) made their first contribution in [https://github.com/testng-team/testng/pull/3199](https://redirect.github.com/testng-team/testng/pull/3199)
-   [@&#8203;YutingZhang-A](https://redirect.github.com/YutingZhang-A) made their first contribution in [https://github.com/testng-team/testng/pull/3200](https://redirect.github.com/testng-team/testng/pull/3200)
-   [@&#8203;jaredsburrows](https://redirect.github.com/jaredsburrows) made their first contribution in [https://github.com/testng-team/testng/pull/3203](https://redirect.github.com/testng-team/testng/pull/3203)

**Full Changelog**: https://github.com/testng-team/testng/compare/7.10.2...7.11.0

</details>

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
