### PR TITLE
PM-18681 - Update Showing Coach Mark Tour Logic To Only Consider User's Personal Vault

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -311,7 +311,9 @@ class FirstTimeActionManagerImpl @Inject constructor(
                     flow = this,
                     flow2 = vaultDiskSource.getCiphers(activeUserId),
                 ) { currentValue, ciphers ->
-                    currentValue && ciphers.none { it.login != null }
+                    currentValue && ciphers.none {
+                        it.login != null && it.organizationId == null
+                    }
                 }
             }
             .distinctUntilChanged()

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -330,9 +330,11 @@ class FirstTimeActionManagerTest {
         runTest {
             val mockJsonWithNoLogin = mockk<SyncResponseJson.Cipher> {
                 every { login } returns null
+                every { organizationId } returns null
             }
             val mockJsonWithLogin = mockk<SyncResponseJson.Cipher> {
                 every { login } returns mockk()
+                every { organizationId } returns null
             }
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             // Enable feature flag so flow emits updates from disk.
@@ -393,9 +395,11 @@ class FirstTimeActionManagerTest {
         runTest {
             val mockJsonWithNoLogin = mockk<SyncResponseJson.Cipher> {
                 every { login } returns null
+                every { organizationId } returns null
             }
             val mockJsonWithLogin = mockk<SyncResponseJson.Cipher> {
                 every { login } returns mockk()
+                every { organizationId } returns null
             }
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             // Enable feature flag so flow emits updates from disk.
@@ -415,6 +419,24 @@ class FirstTimeActionManagerTest {
                     )
                 }
                 assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `if there are login ciphers attached to an organization we should show coach marks`() =
+        runTest {
+            val mockJsonWithNoLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
+                every { login } returns mockk()
+                every { organizationId } returns "1234"
+            }
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            // Enable feature flag so flow emits updates from disk.
+            mutableOnboardingFeatureFlow.update { true }
+            mutableCiphersListFlow.update {
+                listOf(mockJsonWithNoLoginAndWithOrganizationId)
+            }
+            firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
+                assertTrue(awaitItem())
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18681](https://bitwarden.atlassian.net/browse/PM-18681)

## 📔 Objective

- Update logic to determine CTA card visibility based only on the user’s personal vault. Previously, CTA cards were hidden if a user had login ciphers in either their personal or organization vault. With this change, only personal vault login items will prevent the CTA cards from appearing, ensuring that users with access to organization collections still see relevant coach mark tours.

## 📸 Screenshots

https://github.com/user-attachments/assets/650fd200-ce88-4353-b3c3-5e2cd8c15bf7

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18681]: https://bitwarden.atlassian.net/browse/PM-18681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ