### PR TITLE
PM-17087 update notification payloads to support camelCase JSON keys.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
@@ -19,7 +19,6 @@ sealed class NotificationPayload {
     /**
      * The user ID associated with the push notification.
      */
-    @JsonNames("UserId", "userId")
     abstract val userId: String?
 
     /**
@@ -28,6 +27,7 @@ sealed class NotificationPayload {
     @Serializable
     data class SyncCipherNotification(
         @JsonNames("Id", "id") val cipherId: String?,
+        @JsonNames("UserId", "userId")
         override val userId: String?,
         @JsonNames("OrganizationId", "organizationId") val organizationId: String?,
         @JsonNames("CollectionIds", "collectionIds") val collectionIds: List<String>?,
@@ -41,6 +41,7 @@ sealed class NotificationPayload {
     @Serializable
     data class SyncFolderNotification(
         @JsonNames("Id", "id") val folderId: String?,
+        @JsonNames("UserId", "userId")
         override val userId: String?,
         @Contextual
         @JsonNames("RevisionDate", "revisionDate") val revisionDate: ZonedDateTime?,
@@ -51,6 +52,7 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class UserNotification(
+        @JsonNames("UserId", "userId")
         override val userId: String?,
         @Contextual
         @JsonNames("Date", "date") val date: ZonedDateTime?,
@@ -62,6 +64,7 @@ sealed class NotificationPayload {
     @Serializable
     data class SyncSendNotification(
         @JsonNames("Id", "id") val sendId: String?,
+        @JsonNames("UserId", "userId")
         override val userId: String?,
         @Contextual
         @JsonNames("RevisionDate", "revisionDate") val revisionDate: ZonedDateTime?,
@@ -72,6 +75,7 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class PasswordlessRequestNotification(
+        @JsonNames("UserId", "userId")
         override val userId: String?,
         @JsonNames("Id", "id") val loginRequestId: String?,
     ) : NotificationPayload()

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
@@ -2,8 +2,9 @@ package com.x8bit.bitwarden.data.platform.manager.model
 
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import kotlinx.serialization.Contextual
-import kotlinx.serialization.SerialName
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import java.time.ZonedDateTime
 
 /**
@@ -12,11 +13,13 @@ import java.time.ZonedDateTime
  * Note: The data we receive is not always reliable, so everything is nullable and we validate the
  * data in the [PushManager] as necessary.
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 sealed class NotificationPayload {
     /**
      * The user ID associated with the push notification.
      */
+    @JsonNames("UserId", "userId")
     abstract val userId: String?
 
     /**
@@ -24,12 +27,12 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class SyncCipherNotification(
-        @SerialName("Id") val cipherId: String?,
-        @SerialName("UserId") override val userId: String?,
-        @SerialName("OrganizationId") val organizationId: String?,
-        @SerialName("CollectionIds") val collectionIds: List<String>?,
+        @JsonNames("Id", "id") val cipherId: String?,
+        override val userId: String?,
+        @JsonNames("OrganizationId", "organizationId") val organizationId: String?,
+        @JsonNames("CollectionIds", "collectionIds") val collectionIds: List<String>?,
         @Contextual
-        @SerialName("RevisionDate") val revisionDate: ZonedDateTime?,
+        @JsonNames("RevisionDate", "revisionDate") val revisionDate: ZonedDateTime?,
     ) : NotificationPayload()
 
     /**
@@ -37,10 +40,10 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class SyncFolderNotification(
-        @SerialName("Id") val folderId: String?,
-        @SerialName("UserId") override val userId: String?,
+        @JsonNames("Id", "id") val folderId: String?,
+        override val userId: String?,
         @Contextual
-        @SerialName("RevisionDate") val revisionDate: ZonedDateTime?,
+        @JsonNames("RevisionDate", "revisionDate") val revisionDate: ZonedDateTime?,
     ) : NotificationPayload()
 
     /**
@@ -48,9 +51,9 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class UserNotification(
-        @SerialName("UserId") override val userId: String?,
+        override val userId: String?,
         @Contextual
-        @SerialName("Date") val date: ZonedDateTime?,
+        @JsonNames("Date", "date") val date: ZonedDateTime?,
     ) : NotificationPayload()
 
     /**
@@ -58,10 +61,10 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class SyncSendNotification(
-        @SerialName("Id") val sendId: String?,
-        @SerialName("UserId") override val userId: String?,
+        @JsonNames("Id", "id") val sendId: String?,
+        override val userId: String?,
         @Contextual
-        @SerialName("RevisionDate") val revisionDate: ZonedDateTime?,
+        @JsonNames("RevisionDate", "revisionDate") val revisionDate: ZonedDateTime?,
     ) : NotificationPayload()
 
     /**
@@ -69,7 +72,7 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class PasswordlessRequestNotification(
-        @SerialName("UserId") override val userId: String?,
-        @SerialName("Id") val loginRequestId: String?,
+        override val userId: String?,
+        @JsonNames("Id", "id") val loginRequestId: String?,
     ) : NotificationPayload()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
@@ -27,8 +27,7 @@ sealed class NotificationPayload {
     @Serializable
     data class SyncCipherNotification(
         @JsonNames("Id", "id") val cipherId: String?,
-        @JsonNames("UserId", "userId")
-        override val userId: String?,
+        @JsonNames("UserId", "userId") override val userId: String?,
         @JsonNames("OrganizationId", "organizationId") val organizationId: String?,
         @JsonNames("CollectionIds", "collectionIds") val collectionIds: List<String>?,
         @Contextual
@@ -41,8 +40,7 @@ sealed class NotificationPayload {
     @Serializable
     data class SyncFolderNotification(
         @JsonNames("Id", "id") val folderId: String?,
-        @JsonNames("UserId", "userId")
-        override val userId: String?,
+        @JsonNames("UserId", "userId") override val userId: String?,
         @Contextual
         @JsonNames("RevisionDate", "revisionDate") val revisionDate: ZonedDateTime?,
     ) : NotificationPayload()
@@ -52,8 +50,7 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class UserNotification(
-        @JsonNames("UserId", "userId")
-        override val userId: String?,
+        @JsonNames("UserId", "userId") override val userId: String?,
         @Contextual
         @JsonNames("Date", "date") val date: ZonedDateTime?,
     ) : NotificationPayload()
@@ -64,8 +61,7 @@ sealed class NotificationPayload {
     @Serializable
     data class SyncSendNotification(
         @JsonNames("Id", "id") val sendId: String?,
-        @JsonNames("UserId", "userId")
-        override val userId: String?,
+        @JsonNames("UserId", "userId") override val userId: String?,
         @Contextual
         @JsonNames("RevisionDate", "revisionDate") val revisionDate: ZonedDateTime?,
     ) : NotificationPayload()
@@ -75,8 +71,7 @@ sealed class NotificationPayload {
      */
     @Serializable
     data class PasswordlessRequestNotification(
-        @JsonNames("UserId", "userId")
-        override val userId: String?,
+        @JsonNames("UserId", "userId") override val userId: String?,
         @JsonNames("Id", "id") val loginRequestId: String?,
     ) : NotificationPayload()
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-17087](https://bitwarden.atlassian.net/browse/PM-17087)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Support servers which are pushing the notification payload with `camelCase` key names. (ex: `qa-team.sh.bitwarden.pw`).
- Interestingly it does look like the server code is pushing the response using `camelCase` but we have been using `PascalCase` and are not seeing these issues reported on production builds. [NotificationHubPushService](https://github.com/bitwarden/server/blob/main/src/Core/NotificationHub/NotificationHubPushRegistrationService.cs#L50)
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17087]: https://bitwarden.atlassian.net/browse/PM-17087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ