### PR TITLE
PM-10725: Always show share sheet after creating send regardless of how it was made

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
@@ -199,20 +199,12 @@ class AddSendViewModel @Inject constructor(
 
             is CreateSendResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                if (state.isShared) {
-                    navigateBack()
-                    clipboardManager.setText(
-                        result.sendView.toSendUrl(state.baseWebSendUrl),
-                        toastDescriptorOverride = R.string.send_link.asText(),
-                    )
-                } else {
-                    navigateBack()
-                    sendEvent(
-                        AddSendEvent.ShowShareSheet(
-                            message = result.sendView.toSendUrl(state.baseWebSendUrl),
-                        ),
-                    )
-                }
+                navigateBack()
+                sendEvent(
+                    AddSendEvent.ShowShareSheet(
+                        message = result.sendView.toSendUrl(state.baseWebSendUrl),
+                    ),
+                )
             }
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModelTest.kt
@@ -158,36 +158,6 @@ class AddSendViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `SaveClick with createSend success should emit NavigateBack and ShowShareSheet when not an external shared`() =
-        runTest {
-            val viewState = DEFAULT_VIEW_STATE.copy(
-                common = DEFAULT_COMMON_STATE.copy(name = "input"),
-            )
-            val initialState = DEFAULT_STATE.copy(viewState = viewState)
-            val mockSendView = mockk<SendView>()
-            every { viewState.toSendView(clock) } returns mockSendView
-            val sendUrl = "www.test.com/send/test"
-            val resultSendView = mockk<SendView> {
-                every { toSendUrl(DEFAULT_ENVIRONMENT_URL) } returns sendUrl
-            }
-            coEvery {
-                vaultRepository.createSend(sendView = mockSendView, fileUri = null)
-            } returns CreateSendResult.Success(sendView = resultSendView)
-            val viewModel = createViewModel(initialState)
-
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(AddSendAction.SaveClick)
-                assertEquals(AddSendEvent.NavigateBack, awaitItem())
-                assertEquals(AddSendEvent.ShowShareSheet(sendUrl), awaitItem())
-            }
-            assertEquals(initialState, viewModel.stateFlow.value)
-            coVerify(exactly = 1) {
-                vaultRepository.createSend(sendView = mockSendView, fileUri = null)
-            }
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
     fun `SaveClick with createSend success should copy the send URL to the clipboard and emit NavigateBack`() =
         runTest {
             val viewState = DEFAULT_VIEW_STATE.copy(
@@ -212,15 +182,15 @@ class AddSendViewModelTest : BaseViewModelTest() {
             viewModel.eventFlow.test {
                 viewModel.trySendAction(AddSendAction.SaveClick)
                 assertEquals(AddSendEvent.NavigateBack, awaitItem())
+                assertEquals(
+                    AddSendEvent.ShowShareSheet(message = "www.test.com/send/test"),
+                    awaitItem(),
+                )
             }
             assertEquals(initialState, viewModel.stateFlow.value)
             coVerify(exactly = 1) {
                 vaultRepository.createSend(sendView = mockSendView, fileUri = null)
                 specialCircumstanceManager.specialCircumstance = null
-                clipboardManager.setText(
-                    text = sendUrl,
-                    toastDescriptorOverride = R.string.send_link.asText(),
-                )
             }
         }
 
@@ -250,15 +220,15 @@ class AddSendViewModelTest : BaseViewModelTest() {
             viewModel.eventFlow.test {
                 viewModel.trySendAction(AddSendAction.SaveClick)
                 assertEquals(AddSendEvent.ExitApp, awaitItem())
+                assertEquals(
+                    AddSendEvent.ShowShareSheet(message = "www.test.com/send/test"),
+                    awaitItem(),
+                )
             }
             assertEquals(initialState, viewModel.stateFlow.value)
             coVerify(exactly = 1) {
                 vaultRepository.createSend(sendView = mockSendView, fileUri = null)
                 specialCircumstanceManager.specialCircumstance = null
-                clipboardManager.setText(
-                    text = sendUrl,
-                    toastDescriptorOverride = R.string.send_link.asText(),
-                )
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10725](https://bitwarden.atlassian.net/browse/PM-10725)

## 📔 Objective

This PR updates the the Create Send flow to always display the Share Sheet regardless of whether the Send was created internally or externally.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7041f021-200e-4566-a17e-e0c69d4b7aa8" width="300" /> | <video src="https://github.com/user-attachments/assets/5c7ffeed-657f-4c84-8491-980cbb773293" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10725]: https://bitwarden.atlassian.net/browse/PM-10725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ