### PR TITLE
PM-11356 prevent extra soft-keyboard showing.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -254,10 +254,11 @@ fun VaultUnlockScreen(
         ) {
             Spacer(modifier = Modifier.height(12.dp))
             if (!state.hideInput) {
-                // When switching from an unlocked account to a locked account, garbage collection
-                // is triggered which causing this screen to be composed twice. Adding this delay
-                // prevents the MP or Pin field from auto focusing on the first composition which
-                // creates a visual jank where the keyboard shows, disappears, and then shows again.
+                // When switching from an unlocked account to a locked account, the
+                // current activity is recreated and therefore the composition takes place
+                // twice. Adding this delay prevents the MP or Pin field
+                // from auto focusing on the first composition which creates a visual jank where
+                // the keyboard shows, disappears, and then shows again.
                 var autoFocusDelayCompleted by rememberSaveable {
                     mutableStateOf(false)
                 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2GetCredentialsResult
 import com.x8bit.bitwarden.data.platform.repository.util.bufferedMutableSharedFlow
+import com.x8bit.bitwarden.data.util.advanceTimeByAndRunCurrent
 import com.x8bit.bitwarden.ui.autofill.fido2.manager.Fido2CompletionManager
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
@@ -50,6 +51,7 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import javax.crypto.Cipher
@@ -474,8 +476,9 @@ class VaultUnlockScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `state with input and without biometrics should request focus on input field`() {
+    fun `state with input and without biometrics should request focus on input field`() = runTest {
         mutableStateFlow.update { it.copy(hideInput = false, isBiometricEnabled = false) }
+        dispatcher.advanceTimeByAndRunCurrent(500L)
         composeTestRule
             .onNodeWithText("Master password")
             .performScrollTo()


### PR DESCRIPTION
## 🎟️ Tracking
[PM-11356](https://bitwarden.atlassian.net/browse/PM-11356)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- When the user account and unlocked status change we trigger the garbage collection which causes the screen to completely compose twice, which causes the focus request on the text field to happen twice which is the cause of the "extra" keyboard showing. 
- Adding a small delay means the first attempt to draw the screen that will ultimately get garbage collected will not show the keyboard as the text field will not autofocus.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
# BEFORE: 

https://github.com/user-attachments/assets/0f099687-3232-46e0-98ee-bf5afc6970cc

# AFTER

https://github.com/user-attachments/assets/e109d8f6-d9e9-42ec-9a99-fdcf3f1043e5



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11356]: https://bitwarden.atlassian.net/browse/PM-11356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ