### PR TITLE
[PM-13257] Checking if user is navigating from vault before showing prompt for biometrics

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
@@ -116,7 +116,10 @@ class AuthenticatorBridgeRepositoryImpl(
 
                 // Lock the user's vault if we unlocked it for this operation:
                 if (!isVaultAlreadyUnlocked) {
-                    vaultRepository.lockVault(userId)
+                    vaultRepository.lockVault(
+                        userId = userId,
+                        isUserInitiated = false,
+                    )
                 }
 
                 SharedAccountData.Account(

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManager.kt
@@ -45,7 +45,7 @@ interface VaultLockManager {
     /**
      * Locks the vault for the current user if currently unlocked.
      */
-    fun lockVaultForCurrentUser()
+    fun lockVaultForCurrentUser(isUserInitiated: Boolean)
 
     /**
      * Attempt to unlock the vault with the specified user information.

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManager.kt
@@ -23,6 +23,11 @@ interface VaultLockManager {
     val vaultStateEventFlow: Flow<VaultStateEvent>
 
     /**
+     * Whether the user is coming from the lock flow or not.
+     */
+    var isFromLockFlow: Boolean
+
+    /**
      * Whether or not the vault is currently locked for the given [userId].
      */
     fun isVaultUnlocked(userId: String): Boolean

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManager.kt
@@ -40,7 +40,7 @@ interface VaultLockManager {
     /**
      * Locks the vault for the user with the given [userId].
      */
-    fun lockVault(userId: String)
+    fun lockVault(userId: String, isUserInitiated: Boolean)
 
     /**
      * Locks the vault for the current user if currently unlocked.

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -99,6 +99,8 @@ class VaultLockManagerImpl(
     override val vaultStateEventFlow: Flow<VaultStateEvent>
         get() = mutableVaultStateEventSharedFlow.asSharedFlow()
 
+    override var isFromLockFlow: Boolean = false
+
     init {
         observeAppCreationChanges()
         observeAppForegroundChanges()
@@ -118,6 +120,7 @@ class VaultLockManagerImpl(
         mutableVaultUnlockDataStateFlow.value.statusFor(userId) == VaultUnlockData.Status.UNLOCKING
 
     override fun lockVault(userId: String) {
+        isFromLockFlow = true
         setVaultToLocked(userId = userId)
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -119,14 +119,17 @@ class VaultLockManagerImpl(
     override fun isVaultUnlocking(userId: String): Boolean =
         mutableVaultUnlockDataStateFlow.value.statusFor(userId) == VaultUnlockData.Status.UNLOCKING
 
-    override fun lockVault(userId: String) {
-        isFromLockFlow = true
+    override fun lockVault(userId: String, isUserInitiated: Boolean) {
+        isFromLockFlow = isUserInitiated
         setVaultToLocked(userId = userId)
     }
 
     override fun lockVaultForCurrentUser() {
         activeUserId?.let {
-            lockVault(it)
+            lockVault(
+                userId = it,
+                isUserInitiated = true,
+            )
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -124,11 +124,11 @@ class VaultLockManagerImpl(
         setVaultToLocked(userId = userId)
     }
 
-    override fun lockVaultForCurrentUser() {
+    override fun lockVaultForCurrentUser(isUserInitiated: Boolean) {
         activeUserId?.let {
             lockVault(
                 userId = it,
-                isUserInitiated = true,
+                isUserInitiated = isUserInitiated,
             )
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -127,7 +127,7 @@ class LandingViewModel @Inject constructor(
     }
 
     private fun handleLockAccountClicked(action: LandingAction.LockAccountClick) {
-        vaultRepository.lockVault(userId = action.accountSummary.userId)
+        vaultRepository.lockVault(userId = action.accountSummary.userId, isUserInitiated = true)
     }
 
     private fun handleLogoutAccountClicked(action: LandingAction.LogoutAccountClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
@@ -108,7 +108,7 @@ class LoginViewModel @Inject constructor(
     }
 
     private fun handleLockAccountClicked(action: LoginAction.LockAccountClick) {
-        vaultRepository.lockVault(userId = action.accountSummary.userId)
+        vaultRepository.lockVault(userId = action.accountSummary.userId, isUserInitiated = true)
     }
 
     private fun handleLogoutAccountClicked(action: LoginAction.LogoutAccountClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -121,6 +121,8 @@ class VaultUnlockViewModel @Inject constructor(
             }
             .launchIn(viewModelScope)
 
+        promptForBiometricsIfAvailable()
+
         // only when navigating from vault to lock we should not display biometrics
         // subsequent views of the lock screen should display biometrics if available
         vaultLockManager.isFromLockFlow = false

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -215,7 +215,7 @@ class VaultUnlockViewModel @Inject constructor(
     }
 
     private fun handleLockAccountClick(action: VaultUnlockAction.LockAccountClick) {
-        vaultRepo.lockVault(userId = action.accountSummary.userId)
+        vaultRepo.lockVault(userId = action.accountSummary.userId, isUserInitiated = true)
     }
 
     private fun handleLogoutAccountClick(action: VaultUnlockAction.LogoutAccountClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -102,6 +102,7 @@ class VaultUnlockViewModel @Inject constructor(
             // TODO: [PM-13076] Handle Fido2CredentialAssertionRequest special circumstance
             fido2CredentialAssertionRequest = null,
             hasMasterPassword = activeAccount.hasMasterPassword,
+            isFromLockFlow = vaultLockManager.isFromLockFlow,
         )
     },
 ) {
@@ -428,7 +429,7 @@ class VaultUnlockViewModel @Inject constructor(
 
     private fun promptForBiometricsIfAvailable() {
         val cipher = biometricsEncryptionManager.getOrCreateCipher(state.userId)
-        if (state.showBiometricLogin && cipher != null && !vaultLockManager.isFromLockFlow) {
+        if (state.showBiometricLogin && cipher != null && !state.isFromLockFlow) {
             sendEvent(
                 VaultUnlockEvent.PromptForBiometrics(
                     cipher = cipher,
@@ -461,6 +462,7 @@ data class VaultUnlockState(
     val fido2GetCredentialsRequest: Fido2GetCredentialsRequest? = null,
     val fido2CredentialAssertionRequest: Fido2CredentialAssertionRequest? = null,
     private val hasMasterPassword: Boolean,
+    val isFromLockFlow: Boolean,
 ) : Parcelable {
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -127,6 +127,7 @@ class VaultUnlockViewModel @Inject constructor(
         // only when navigating from vault to lock we should not display biometrics
         // subsequent views of the lock screen should display biometrics if available
         vaultLockManager.isFromLockFlow = false
+        mutableStateFlow.update { it.copy(isFromLockFlow = false) }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -265,7 +265,7 @@ class AccountSecurityViewModel @Inject constructor(
     }
 
     private fun handleLockNowClick() {
-        vaultRepository.lockVaultForCurrentUser()
+        vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
     }
 
     private fun handlePushNotificationConfirm() {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -257,7 +257,7 @@ class SendViewModel @Inject constructor(
     }
 
     private fun handleLockClick() {
-        vaultRepo.lockVaultForCurrentUser()
+        vaultRepo.lockVaultForCurrentUser(isUserInitiated = true)
     }
 
     private fun handleRefreshClick() {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -286,7 +286,7 @@ class VaultItemListingViewModel @Inject constructor(
 
     //region VaultItemListing Handlers
     private fun handleLockAccountClick(action: VaultItemListingsAction.LockAccountClick) {
-        vaultRepository.lockVault(userId = action.accountSummary.userId)
+        vaultRepository.lockVault(userId = action.accountSummary.userId, isUserInitiated = true)
     }
 
     private fun handleLogoutAccountClick(action: VaultItemListingsAction.LogoutAccountClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1023,7 +1023,7 @@ class VaultItemListingViewModel @Inject constructor(
     }
 
     private fun handleLockClick() {
-        vaultRepository.lockVaultForCurrentUser()
+        vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
     }
 
     private fun handleSyncClick() {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -327,7 +327,7 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleLockAccountClick(action: VaultAction.LockAccountClick) {
-        vaultRepository.lockVault(userId = action.accountSummary.userId)
+        vaultRepository.lockVault(userId = action.accountSummary.userId, isUserInitiated = true)
     }
 
     private fun handleLogoutAccountClick(action: VaultAction.LogoutAccountClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -374,7 +374,7 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleLockClick() {
-        vaultRepository.lockVaultForCurrentUser()
+        vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
     }
 
     private fun handleExitConfirmationClick() {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
@@ -119,7 +119,7 @@ class VerificationCodeViewModel @Inject constructor(
     }
 
     private fun handleLockClick() {
-        vaultRepository.lockVaultForCurrentUser()
+        vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
     }
 
     private fun handleRefreshClick() {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
@@ -88,7 +88,7 @@ class AuthenticatorBridgeRepositoryTest {
         every { vaultRepository.isVaultUnlocked(USER_1_ID) } returns true
         // But locked for user 2:
         every { vaultRepository.isVaultUnlocked(USER_2_ID) } returns false
-        every { vaultRepository.lockVault(USER_2_ID) } returns Unit
+        every { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) } returns Unit
         coEvery {
             vaultRepository.unlockVaultWithDecryptedUserKey(
                 userId = USER_2_ID,
@@ -147,7 +147,7 @@ class AuthenticatorBridgeRepositoryTest {
                     decryptedUserKey = USER_2_UNLOCK_KEY,
                 )
             }
-            verify { vaultRepository.lockVault(USER_2_ID) }
+            verify { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) }
             coVerify { vaultSdkSource.decryptCipher(USER_1_ID, USER_1_ENCRYPTED_SDK_TOTP_CIPHER) }
             coVerify { vaultSdkSource.decryptCipher(USER_2_ID, USER_2_ENCRYPTED_SDK_TOTP_CIPHER) }
         }
@@ -185,7 +185,7 @@ class AuthenticatorBridgeRepositoryTest {
                 )
             }
             verify { vaultRepository.vaultUnlockDataStateFlow }
-            verify { vaultRepository.lockVault(USER_2_ID) }
+            verify { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) }
             verify { vaultDiskSource.getCiphers(USER_2_ID) }
             coVerify { vaultSdkSource.decryptCipher(USER_2_ID, USER_2_ENCRYPTED_SDK_TOTP_CIPHER) }
         }
@@ -198,7 +198,7 @@ class AuthenticatorBridgeRepositoryTest {
             coEvery {
                 vaultRepository.unlockVaultWithDecryptedUserKey(USER_1_ID, USER_1_UNLOCK_KEY)
             } returns VaultUnlockResult.Success
-            every { vaultRepository.lockVault(USER_1_ID) } returns Unit
+            every { vaultRepository.lockVault(USER_1_ID, isUserInitiated = false) } returns Unit
 
             val sharedAccounts = authenticatorBridgeRepository.getSharedAccounts()
             assertEquals(
@@ -216,7 +216,7 @@ class AuthenticatorBridgeRepositoryTest {
                     decryptedUserKey = USER_1_UNLOCK_KEY,
                 )
             }
-            verify { vaultRepository.lockVault(USER_1_ID) }
+            verify { vaultRepository.lockVault(USER_1_ID, isUserInitiated = false) }
             verify { vaultRepository.isVaultUnlocked(USER_2_ID) }
             coVerify {
                 vaultRepository.unlockVaultWithDecryptedUserKey(
@@ -225,7 +225,7 @@ class AuthenticatorBridgeRepositoryTest {
                 )
             }
             verify { vaultRepository.vaultUnlockDataStateFlow }
-            verify { vaultRepository.lockVault(USER_2_ID) }
+            verify { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) }
             verify { vaultDiskSource.getCiphers(USER_2_ID) }
             coVerify { vaultSdkSource.decryptCipher(USER_2_ID, USER_2_ENCRYPTED_SDK_TOTP_CIPHER) }
         }
@@ -259,7 +259,7 @@ class AuthenticatorBridgeRepositoryTest {
                 )
             }
             verify { vaultRepository.vaultUnlockDataStateFlow }
-            verify { vaultRepository.lockVault(USER_2_ID) }
+            verify { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) }
             verify { vaultDiskSource.getCiphers(USER_2_ID) }
             coVerify { vaultSdkSource.decryptCipher(USER_2_ID, USER_2_ENCRYPTED_SDK_TOTP_CIPHER) }
         }
@@ -306,7 +306,7 @@ class AuthenticatorBridgeRepositoryTest {
                     decryptedUserKey = USER_2_UNLOCK_KEY,
                 )
             }
-            verify { vaultRepository.lockVault(USER_2_ID) }
+            verify { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) }
             coVerify { vaultSdkSource.decryptCipher(USER_1_ID, USER_1_ENCRYPTED_SDK_TOTP_CIPHER) }
             coVerify { vaultSdkSource.decryptCipher(USER_2_ID, USER_2_ENCRYPTED_SDK_TOTP_CIPHER) }
         }

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -165,7 +165,7 @@ class VaultLockManagerTest {
             verifyUnlockedVault(userId = USER_ID)
 
             vaultLockManager.vaultStateEventFlow.test {
-                vaultLockManager.lockVault(userId = USER_ID)
+                vaultLockManager.lockVault(userId = USER_ID, isUserInitiated = false)
                 assertEquals(VaultStateEvent.Locked(userId = USER_ID), awaitItem())
                 fakeAuthDiskSource.assertLastLockTimestamp(
                     userId = USER_ID,
@@ -178,10 +178,10 @@ class VaultLockManagerTest {
     fun `vaultStateEventFlow should not emit Locked event when vault state remains locked`() =
         runTest {
             // Ensure the vault is locked
-            vaultLockManager.lockVault(userId = USER_ID)
+            vaultLockManager.lockVault(userId = USER_ID, isUserInitiated = false)
 
             vaultLockManager.vaultStateEventFlow.test {
-                vaultLockManager.lockVault(userId = USER_ID)
+                vaultLockManager.lockVault(userId = USER_ID, isUserInitiated = false)
                 expectNoEvents()
             }
         }
@@ -190,7 +190,7 @@ class VaultLockManagerTest {
     fun `vaultStateEventFlow should emit Unlocked event when vault state changes to unlocked`() =
         runTest {
             // Ensure the vault is locked
-            vaultLockManager.lockVault(userId = USER_ID)
+            vaultLockManager.lockVault(userId = USER_ID, isUserInitiated = false)
 
             vaultLockManager.vaultStateEventFlow.test {
                 verifyUnlockedVault(userId = USER_ID)
@@ -786,7 +786,7 @@ class VaultLockManagerTest {
                 vaultLockManager.vaultUnlockDataStateFlow.value,
             )
 
-            vaultLockManager.lockVault(userId = USER_ID)
+            vaultLockManager.lockVault(userId = USER_ID, isUserInitiated = false)
 
             assertEquals(
                 emptyList<VaultUnlockData>(),
@@ -811,7 +811,7 @@ class VaultLockManagerTest {
                 vaultLockManager.vaultUnlockDataStateFlow.value,
             )
 
-            vaultLockManager.lockVault(userId = USER_ID)
+            vaultLockManager.lockVault(userId = USER_ID, isUserInitiated = false)
 
             assertEquals(
                 emptyList<VaultUnlockData>(),

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -837,7 +837,7 @@ class VaultLockManagerTest {
                 vaultLockManager.vaultUnlockDataStateFlow.value,
             )
 
-            vaultLockManager.lockVaultForCurrentUser()
+            vaultLockManager.lockVaultForCurrentUser(isUserInitiated = true)
 
             assertEquals(
                 emptyList<VaultUnlockData>(),

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -188,7 +188,7 @@ class VaultRepositoryTest {
         }
         every { isVaultUnlocking(any()) } returns false
         every { lockVault(any(), any()) } just runs
-        every { lockVaultForCurrentUser() } just runs
+        every { lockVaultForCurrentUser(any()) } just runs
         coEvery {
             waitUntilUnlocked(any())
         } coAnswers { call ->
@@ -1142,8 +1142,8 @@ class VaultRepositoryTest {
 
     @Test
     fun `lockVaultForCurrentUser should delegate to the VaultLockManager`() {
-        vaultRepository.lockVaultForCurrentUser()
-        verify { vaultLockManager.lockVaultForCurrentUser() }
+        vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
+        verify { vaultLockManager.lockVaultForCurrentUser(isUserInitiated = true) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -187,7 +187,7 @@ class VaultRepositoryTest {
             userId in mutableUnlockedUserIdsStateFlow.value
         }
         every { isVaultUnlocking(any()) } returns false
-        every { lockVault(any()) } just runs
+        every { lockVault(any(), any()) } just runs
         every { lockVaultForCurrentUser() } just runs
         coEvery {
             waitUntilUnlocked(any())

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
@@ -35,7 +35,7 @@ class LandingViewModelTest : BaseViewModelTest() {
         every { logout(any()) } just runs
     }
     private val vaultRepository: VaultRepository = mockk(relaxed = true) {
-        every { lockVault(any()) } just runs
+        every { lockVault(any(), any()) } just runs
     }
     private val fakeEnvironmentRepository = FakeEnvironmentRepository()
 
@@ -126,7 +126,7 @@ class LandingViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(LandingAction.LockAccountClick(accountSummary))
 
-        verify { vaultRepository.lockVault(userId = accountUserId) }
+        verify { vaultRepository.lockVault(userId = accountUserId, isUserInitiated = true) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
@@ -51,7 +51,7 @@ class LoginViewModelTest : BaseViewModelTest() {
         every { logout(any()) } just runs
     }
     private val vaultRepository: VaultRepository = mockk(relaxed = true) {
-        every { lockVault(any()) } just runs
+        every { lockVault(any(), any()) } just runs
     }
     private val fakeEnvironmentRepository = FakeEnvironmentRepository()
 
@@ -204,7 +204,7 @@ class LoginViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(LoginAction.LockAccountClick(accountSummary))
 
-        verify { vaultRepository.lockVault(userId = accountUserId) }
+        verify { vaultRepository.lockVault(userId = accountUserId, isUserInitiated = true) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
@@ -642,4 +642,5 @@ private val DEFAULT_STATE: VaultUnlockState = VaultUnlockState(
     userId = ACTIVE_ACCOUNT_SUMMARY.userId,
     vaultUnlockType = VaultUnlockType.MASTER_PASSWORD,
     hasMasterPassword = true,
+    isFromLockFlow = false,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -61,7 +61,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         every { switchAccount(any()) } returns SwitchAccountResult.AccountSwitched
     }
     private val vaultRepository: VaultRepository = mockk(relaxed = true) {
-        every { lockVault(any()) } just runs
+        every { lockVault(any(), any()) } just runs
     }
     private val encryptionManager: BiometricsEncryptionManager = mockk {
         every { getOrCreateCipher(USER_ID) } returns CIPHER
@@ -652,7 +652,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(VaultUnlockAction.LockAccountClick(accountSummary))
 
-        verify { vaultRepository.lockVault(userId = accountUserId) }
+        verify { vaultRepository.lockVault(userId = accountUserId, isUserInitiated = false) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -512,12 +512,13 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
     fun `on BiometricsUnlockClick should not emit PromptForBiometrics when isFromLockFlow is true`() =
         runTest {
             val initialState =
-                DEFAULT_STATE.copy(isBiometricsValid = true, isBiometricEnabled = true)
+                DEFAULT_STATE.copy(
+                    isBiometricsValid = true,
+                    isBiometricEnabled = true,
+                    isFromLockFlow = true,
+                )
             val viewModel = createViewModel(
                 state = initialState,
-                lockManager = mockk(relaxed = true) {
-                    every { isFromLockFlow } returns true
-                },
             )
 
             viewModel.eventFlow.test {
@@ -652,7 +653,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(VaultUnlockAction.LockAccountClick(accountSummary))
 
-        verify { vaultRepository.lockVault(userId = accountUserId, isUserInitiated = false) }
+        verify { vaultRepository.lockVault(userId = accountUserId, isUserInitiated = true) }
     }
 
     @Test
@@ -1356,6 +1357,7 @@ private val DEFAULT_STATE: VaultUnlockState = VaultUnlockState(
     userId = USER_ID,
     vaultUnlockType = VaultUnlockType.MASTER_PASSWORD,
     hasMasterPassword = true,
+    isFromLockFlow = false,
 )
 
 private val TRUSTED_DEVICE: UserState.TrustedDevice = UserState.TrustedDevice(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -382,10 +382,10 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `on LockNowClick should call lockVaultForCurrentUser`() {
-        every { vaultRepository.lockVaultForCurrentUser() } just runs
+        every { vaultRepository.lockVaultForCurrentUser(any()) } just runs
         val viewModel = createViewModel()
         viewModel.trySendAction(AccountSecurityAction.LockNowClick)
-        verify { vaultRepository.lockVaultForCurrentUser() }
+        verify { vaultRepository.lockVaultForCurrentUser(any()) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
@@ -102,12 +102,12 @@ class SendViewModelTest : BaseViewModelTest() {
     @Test
     fun `LockClick should lock the vault`() {
         val viewModel = createViewModel()
-        every { vaultRepo.lockVaultForCurrentUser() } just runs
+        every { vaultRepo.lockVaultForCurrentUser(any()) } just runs
 
         viewModel.trySendAction(SendAction.LockClick)
 
         verify {
-            vaultRepo.lockVaultForCurrentUser()
+            vaultRepo.lockVaultForCurrentUser(isUserInitiated = true)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -341,13 +341,13 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `LockClick should call lockVaultForCurrentUser`() {
-        every { vaultRepository.lockVaultForCurrentUser() } just runs
+        every { vaultRepository.lockVaultForCurrentUser(any()) } just runs
         val viewModel = createVaultItemListingViewModel()
 
         viewModel.trySendAction(VaultItemListingsAction.LockClick)
 
         verify(exactly = 1) {
-            vaultRepository.lockVaultForCurrentUser()
+            vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -142,7 +142,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     private val vaultRepository: VaultRepository = mockk {
         every { vaultFilterType } returns VaultFilterType.AllVaults
         every { vaultDataStateFlow } returns mutableVaultDataStateFlow
-        every { lockVault(any()) } just runs
+        every { lockVault(any(), any()) } just runs
         every { sync(forced = any()) } just runs
         coEvery {
             getDecryptedFido2CredentialAutofillViews(any())
@@ -246,7 +246,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(VaultItemListingsAction.LockAccountClick(accountSummary))
 
-        verify { vaultRepository.lockVault(userId = accountUserId) }
+        verify { vaultRepository.lockVault(userId = accountUserId, isUserInitiated = true) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -132,7 +132,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             every { sync(forced = any()) } just runs
             every { syncIfNecessary() } just runs
             every { lockVaultForCurrentUser() } just runs
-            every { lockVault(any()) } just runs
+            every { lockVault(any(), any()) } just runs
         }
 
     private val organizationEventManager = mockk<OrganizationEventManager> {
@@ -382,7 +382,7 @@ class VaultViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(VaultAction.LockAccountClick(accountSummary))
 
-        verify { vaultRepository.lockVault(userId = accountUserId) }
+        verify { vaultRepository.lockVault(userId = accountUserId, isUserInitiated = true) }
     }
 
     @Suppress("MaxLineLength")
@@ -1945,20 +1945,21 @@ class VaultViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `InternetConnectionErrorReceived should show network error if no internet connection`() = runTest {
-        val viewModel = createViewModel()
-        viewModel.trySendAction(VaultAction.Internal.InternetConnectionErrorReceived)
-        assertEquals(
-            DEFAULT_STATE.copy(
-                isRefreshing = false,
-                dialog = VaultState.DialogState.Error(
-                    R.string.internet_connection_required_title.asText(),
-                    R.string.internet_connection_required_message.asText(),
+    fun `InternetConnectionErrorReceived should show network error if no internet connection`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.trySendAction(VaultAction.Internal.InternetConnectionErrorReceived)
+            assertEquals(
+                DEFAULT_STATE.copy(
+                    isRefreshing = false,
+                    dialog = VaultState.DialogState.Error(
+                        R.string.internet_connection_required_title.asText(),
+                        R.string.internet_connection_required_message.asText(),
+                    ),
                 ),
-            ),
-            viewModel.stateFlow.value,
-        )
-    }
+                viewModel.stateFlow.value,
+            )
+        }
 
     private fun createViewModel(): VaultViewModel =
         VaultViewModel(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -131,7 +131,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             every { vaultDataStateFlow } returns mutableVaultDataStateFlow
             every { sync(forced = any()) } just runs
             every { syncIfNecessary() } just runs
-            every { lockVaultForCurrentUser() } just runs
+            every { lockVaultForCurrentUser(any()) } just runs
             every { lockVault(any(), any()) } just runs
         }
 
@@ -520,7 +520,7 @@ class VaultViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.trySendAction(VaultAction.LockClick)
         verify {
-            vaultRepository.lockVaultForCurrentUser()
+            vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModelTest.kt
@@ -131,13 +131,13 @@ class VerificationCodeViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `LockClick should call lockVaultForCurrentUser`() {
-        every { vaultRepository.lockVaultForCurrentUser() } just runs
+        every { vaultRepository.lockVaultForCurrentUser(any()) } just runs
         val viewModel = createViewModel()
 
         viewModel.trySendAction(VerificationCodeAction.LockClick)
 
         verify(exactly = 1) {
-            vaultRepository.lockVaultForCurrentUser()
+            vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13257

## 📔 Objective

User should not be automatically prompted for biometrics when naviting from vault to lock screen. On all other scenarios user should be automatically prompted.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
