### PR TITLE
PM-19099: Centralize app metadata

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/BuildConfigUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/BuildConfigUtils.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.platform.util
 
+import android.os.Build
 import com.x8bit.bitwarden.BuildConfig
 
 /**
@@ -7,3 +8,55 @@ import com.x8bit.bitwarden.BuildConfig
  */
 val isFdroid: Boolean
     get() = BuildConfig.FLAVOR == "fdroid"
+
+/**
+ * A string that represents a displayable app version.
+ */
+val versionData: String
+    get() = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+
+/**
+ * A string that represents device data.
+ */
+val deviceData: String get() = "$deviceBrandModel $osInfo $buildInfo"
+
+/**
+ * A string representing the CI information if available.
+ */
+val ciBuildInfo: String? get() = BuildConfig.CI_INFO.takeUnless { it.isBlank() }
+
+/**
+ * A string representing the build flavor or blank if it is the standard configuration.
+ */
+private val buildFlavorName: String
+    get() = when (BuildConfig.FLAVOR) {
+        "standard" -> ""
+        else -> "-${BuildConfig.FLAVOR}"
+    }
+
+/**
+ * A string representing the build type.
+ */
+private val buildTypeName: String
+    get() = when (BuildConfig.BUILD_TYPE) {
+        "debug" -> "dev"
+        "release" -> "prod"
+        else -> BuildConfig.BUILD_TYPE
+    }
+
+/**
+ * A string representing the device brand and model.
+ */
+private val deviceBrandModel: String get() = "\uD83D\uDCF1 ${Build.BRAND} ${Build.MODEL}"
+
+/**
+ * A string representing the operating system information.
+ */
+private val osInfo: String get() = "\uD83E\uDD16 ${Build.VERSION.RELEASE}@${Build.VERSION.SDK_INT}"
+
+/**
+ * A string representing the build information.
+ */
+private val buildInfo: String
+    get() = "\uD83D\uDCE6 $buildTypeName" +
+        buildFlavorName.takeUnless { it.isBlank() }?.let { " $it" }.orEmpty()

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreenTest.kt
@@ -39,6 +39,8 @@ class AboutScreenTest : BaseComposeTest() {
     private val mutableStateFlow = MutableStateFlow(
         AboutState(
             version = "Version: 1.0.0 (1)".asText(),
+            deviceData = "device_data".asText(),
+            ciData = "ci_data".asText(),
             isSubmitCrashLogsEnabled = false,
             copyrightInfo = "".asText(),
             shouldShowCrashLogsButton = true,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModelTest.kt
@@ -1,9 +1,7 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.about
 
-import android.os.Build
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
@@ -110,31 +108,17 @@ class AboutViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `on VersionClick should call setText on the ClipboardManager with specific Text`() {
-        val versionName = BuildConfig.VERSION_NAME
-        val versionCode = BuildConfig.VERSION_CODE
-
-        val deviceBrandModel = "\uD83D\uDCF1 ${Build.BRAND} ${Build.MODEL}"
-        val osInfo = "\uD83E\uDD16 ${Build.VERSION.RELEASE}@${Build.VERSION.SDK_INT}"
-        val buildInfo = "\uD83D\uDCE6 dev"
-        val ciInfo = BuildConfig.CI_INFO
-
-        val expectedText = "© Bitwarden Inc. 2015-"
-            .asText()
-            .concat(Year.now(fixedClock).value.toString().asText())
+        val state = DEFAULT_ABOUT_STATE
+        val expectedText = state.copyrightInfo
             .concat("\n\n".asText())
-            .concat("Version: $versionName ($versionCode)".asText())
+            .concat(state.version)
             .concat("\n".asText())
-            .concat("$deviceBrandModel $osInfo $buildInfo".asText())
-            .concat(
-                "\n$ciInfo"
-                    .takeUnless { ciInfo.isEmpty() }
-                    .orEmpty()
-                    .asText(),
-            )
+            .concat(state.deviceData)
+            .concat(state.ciData)
 
         every { clipboardManager.setText(expectedText, true, null) } just runs
 
-        val viewModel = createViewModel(DEFAULT_ABOUT_STATE)
+        val viewModel = createViewModel(state)
         viewModel.trySendAction(AboutAction.VersionClick)
 
         verify(exactly = 1) {
@@ -175,10 +159,10 @@ private val fixedClock = Clock.fixed(
     ZoneId.systemDefault(),
 )
 private val DEFAULT_ABOUT_STATE: AboutState = AboutState(
-    version = "Version: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})".asText(),
+    version = "Version: <version_name> (<version_code>)".asText(),
+    deviceData = "<device_data>".asText(),
+    ciData = "\n<ci_info>".asText(),
     isSubmitCrashLogsEnabled = false,
-    copyrightInfo = "© Bitwarden Inc. 2015-"
-        .asText()
-        .concat(Year.now(fixedClock).value.toString().asText()),
+    copyrightInfo = "© Bitwarden Inc. 2015-${Year.now(fixedClock).value}".asText(),
     shouldShowCrashLogsButton = true,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/BuildConfigTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/BuildConfigTest.kt
@@ -1,0 +1,27 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import android.os.Build
+import com.x8bit.bitwarden.BuildConfig
+import com.x8bit.bitwarden.data.platform.util.deviceData
+import com.x8bit.bitwarden.data.platform.util.versionData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BuildConfigTest {
+    @Test
+    fun `deviceData should be formatted correctly`() {
+        val deviceBrandModel = "\uD83D\uDCF1 ${Build.BRAND} ${Build.MODEL}"
+        val osInfo = "\uD83E\uDD16 ${Build.VERSION.RELEASE}@${Build.VERSION.SDK_INT}"
+        val buildInfo = "\uD83D\uDCE6 dev"
+
+        assertEquals("$deviceBrandModel $osInfo $buildInfo", deviceData)
+    }
+
+    @Test
+    fun `versionData should be formatted correctly`() {
+        val versionName = BuildConfig.VERSION_NAME
+        val versionCode = BuildConfig.VERSION_CODE
+
+        assertEquals("$versionName ($versionCode)", versionData)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19099](https://bitwarden.atlassian.net/browse/PM-19099)

## 📔 Objective

This PR moves a lot of the BuildConfig data into the `BuildConfigUtils`, this makes it easier to reuse in the future and makes it mockable.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19099]: https://bitwarden.atlassian.net/browse/PM-19099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ