### PR TITLE
PM-18877 Respect system app specific language selection on Android 13 and up.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -32,6 +32,7 @@ import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
+import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.util.isAccountSecurityShortcut
@@ -68,7 +69,7 @@ class MainViewModel @Inject constructor(
     private val garbageCollectionManager: GarbageCollectionManager,
     private val fido2CredentialManager: Fido2CredentialManager,
     private val intentManager: IntentManager,
-    settingsRepository: SettingsRepository,
+    private val settingsRepository: SettingsRepository,
     private val vaultRepository: VaultRepository,
     private val authRepository: AuthRepository,
     private val environmentRepository: EnvironmentRepository,
@@ -189,7 +190,12 @@ class MainViewModel @Inject constructor(
             is MainAction.ReceiveNewIntent -> handleNewIntentReceived(action)
             MainAction.OpenDebugMenu -> handleOpenDebugMenu()
             is MainAction.ResumeScreenDataReceived -> handleAppResumeDataUpdated(action)
+            is MainAction.AppSpecificLanguageUpdate -> handleAppSpecificLanguageUpdate(action)
         }
+    }
+
+    private fun handleAppSpecificLanguageUpdate(action: MainAction.AppSpecificLanguageUpdate) {
+        settingsRepository.appLanguage = action.appLanguage
     }
 
     private fun handleAppResumeDataUpdated(action: MainAction.ResumeScreenDataReceived) {
@@ -470,6 +476,12 @@ sealed class MainAction {
      * Receive event to save the app resume screen
      */
     data class ResumeScreenDataReceived(val screenResumeData: AppResumeScreenData?) : MainAction()
+
+    /**
+     * Receive if there is an app specific locale selection made by user
+     * in the device's settings.
+     */
+    data class AppSpecificLanguageUpdate(val appLanguage: AppLanguage) : MainAction()
 
     /**
      * Actions for internal use by the ViewModel.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
@@ -2,11 +2,15 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.appearance
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -28,11 +32,31 @@ class AppearanceViewModel @Inject constructor(
             theme = settingsRepository.appTheme,
         ),
 ) {
+
+    init {
+        settingsRepository
+            .appLanguageStateFlow
+            .map { AppearanceAction.Internal.AppLanguageStateUpdateReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+    }
+
     override fun handleAction(action: AppearanceAction): Unit = when (action) {
         AppearanceAction.BackClick -> handleBackClicked()
         is AppearanceAction.LanguageChange -> handleLanguageChanged(action)
         is AppearanceAction.ShowWebsiteIconsToggle -> handleShowWebsiteIconsToggled(action)
         is AppearanceAction.ThemeChange -> handleThemeChanged(action)
+        is AppearanceAction.Internal.AppLanguageStateUpdateReceive -> {
+            handleLanguageStateChange(action)
+        }
+    }
+
+    private fun handleLanguageStateChange(
+        action: AppearanceAction.Internal.AppLanguageStateUpdateReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(language = action.language)
+        }
     }
 
     private fun handleBackClicked() {
@@ -40,7 +64,6 @@ class AppearanceViewModel @Inject constructor(
     }
 
     private fun handleLanguageChanged(action: AppearanceAction.LanguageChange) {
-        mutableStateFlow.update { it.copy(language = action.language) }
         settingsRepository.appLanguage = action.language
     }
 
@@ -108,4 +131,15 @@ sealed class AppearanceAction {
     data class ThemeChange(
         val theme: AppTheme,
     ) : AppearanceAction()
+
+    /**
+     * Internal actions not sent through the UI.
+     */
+    sealed class Internal : AppearanceAction() {
+
+        /**
+         * The AppLanguageState value has updated.
+         */
+        data class AppLanguageStateUpdateReceive(val language: AppLanguage) : Internal()
+    }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/LocaleExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/LocaleExtensions.kt
@@ -1,0 +1,13 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
+import java.util.Locale
+
+/**
+ * If returns an associated [AppLanguage] with the [Locale]. If there is
+ * none that are mapped to the locale's language then the value is null.
+ */
+val Locale.appLanguage: AppLanguage?
+    get() = AppLanguage
+        .entries
+        .find { it.localeName?.lowercase(this) == this.language.lowercase(this) }

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -97,6 +97,7 @@ class MainViewModelTest : BaseViewModelTest() {
         every { isScreenCaptureAllowed } returns true
         every { isScreenCaptureAllowedStateFlow } returns mutableScreenCaptureAllowedFlow
         every { storeUserHasLoggedInValue(any()) } just runs
+        every { appLanguage = any() } just runs
     }
     private val authRepository = mockk<AuthRepository> {
         every { activeUserId } returns DEFAULT_USER_STATE.activeUserId
@@ -1088,6 +1089,15 @@ class MainViewModelTest : BaseViewModelTest() {
         )
 
         verify { appResumeManager.setResumeScreen(AppResumeScreenData.GeneratorScreen) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on AppSpecificLanguageUpdate, the repository value should be updated with the specified value`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(MainAction.AppSpecificLanguageUpdate(AppLanguage.SPANISH))
+
+        verify { settingsRepository.appLanguage = AppLanguage.SPANISH }
     }
 
     private fun createViewModel(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/LocaleExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/LocaleExtensionsTest.kt
@@ -1,0 +1,34 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import java.util.Locale
+
+class LocaleExtensionsTest {
+
+    @Test
+    fun `locale with Espanol language returns AppLanguage SPANISH`() {
+        val locale = Locale("es")
+        assertEquals(
+            AppLanguage.SPANISH,
+            locale.appLanguage,
+        )
+    }
+
+    @Test
+    fun `locale with GB english returns AppLanguage ENGLISH_BRITISH`() {
+        val locale = Locale("en-GB")
+        assertEquals(
+            AppLanguage.ENGLISH_BRITISH,
+            locale.appLanguage,
+        )
+    }
+
+    @Test
+    fun `locale with non existent app language returns null`() {
+        val locale = Locale("😅😅😅")
+        assertNull(locale.appLanguage)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking
[PM-18877](https://bitwarden.atlassian.net/browse/PM-18877)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- When a user makes a selection for an app specific language through the device settings (Android 13+), we want to respect that setting and update the internal storage to reflect those changes.
- If the user sets an app specific language from the device settings currently, that selection will not be persisted across app restart as it was not being saved. 
- There was also a case where, if the user had set a language in the app's appearance settings and then made a new selection in the device settings it would not be reflected.
- For devices where App specific language APIs are available we will check the API when the app resumes and if one is selected we will save to the storage to keep in sync.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
# BEFORE

https://github.com/user-attachments/assets/a15ef916-b38b-4926-a4bf-9e370f3059f9

# AFTER

https://github.com/user-attachments/assets/1ceb832e-ca42-4398-be62-3afa00f297b0


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18877]: https://bitwarden.atlassian.net/browse/PM-18877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ