### PR TITLE
[DynamicColors] Add support for dynamic colors

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
@@ -124,7 +124,10 @@ class MainActivity : AppCompatActivity() {
                         }
                     },
                 )
-                BitwardenTheme(theme = state.theme) {
+                BitwardenTheme(
+                    theme = state.theme,
+                    dynamicColor = state.isDynamicColorsEnabled,
+                ) {
                     NavHost(
                         navController = navController,
                         startDestination = ROOT_ROUTE,

--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -88,6 +88,7 @@ class MainViewModel @Inject constructor(
         isErrorReportingDialogEnabled = featureFlagManager.getFeatureFlag(
             key = FlagKey.MobileErrorReporting,
         ),
+        isDynamicColorsEnabled = settingsRepository.isDynamicColorsEnabled,
     ),
 ) {
     private var specialCircumstance: SpecialCircumstance?
@@ -135,6 +136,12 @@ class MainViewModel @Inject constructor(
         settingsRepository
             .isScreenCaptureAllowedStateFlow
             .map { MainAction.Internal.ScreenCaptureUpdate(it) }
+            .onEach(::trySendAction)
+            .launchIn(viewModelScope)
+
+        settingsRepository
+            .isDynamicColorsEnabledFlow
+            .map { MainAction.Internal.DynamicColorsUpdate(it) }
             .onEach(::trySendAction)
             .launchIn(viewModelScope)
 
@@ -209,6 +216,7 @@ class MainViewModel @Inject constructor(
             is MainAction.Internal.ScreenCaptureUpdate -> handleScreenCaptureUpdate(action)
             is MainAction.Internal.ThemeUpdate -> handleAppThemeUpdated(action)
             is MainAction.Internal.VaultUnlockStateChange -> handleVaultUnlockStateChange()
+            is MainAction.Internal.DynamicColorsUpdate -> handleDynamicColorsUpdate(action)
             is MainAction.Internal.OnMobileErrorReportingReceive -> {
                 handleOnMobileErrorReportingReceive(action)
             }
@@ -267,6 +275,10 @@ class MainViewModel @Inject constructor(
 
     private fun handleVaultUnlockStateChange() {
         recreateUiAndGarbageCollect()
+    }
+
+    private fun handleDynamicColorsUpdate(action: MainAction.Internal.DynamicColorsUpdate) {
+        mutableStateFlow.update { it.copy(isDynamicColorsEnabled = action.isDynamicColorsEnabled) }
     }
 
     private fun handleFirstIntentReceived(action: MainAction.ReceiveFirstIntent) {
@@ -482,6 +494,7 @@ class MainViewModel @Inject constructor(
 data class MainState(
     val theme: AppTheme,
     val isScreenCaptureAllowed: Boolean,
+    val isDynamicColorsEnabled: Boolean,
     private val isErrorReportingDialogEnabled: Boolean,
 ) : Parcelable {
     /**
@@ -572,6 +585,13 @@ sealed class MainAction {
          * Indicates a relevant change in the current vault lock state.
          */
         data object VaultUnlockStateChange : Internal()
+
+        /**
+         * Indicates that the dynamic colors state has changed.
+         */
+        data class DynamicColorsUpdate(
+            val isDynamicColorsEnabled: Boolean,
+        ) : Internal()
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -51,6 +51,16 @@ interface SettingsDiskSource {
     val appThemeFlow: Flow<AppTheme>
 
     /**
+     * The currently persisted dynamic colors setting (or `null` if not set).
+     */
+    var isDynamicColorsEnabled: Boolean?
+
+    /**
+     * Emits updates that track [isDynamicColorsEnabled].
+     */
+    val isDynamicColorsEnabledFlow: Flow<Boolean?>
+
+    /**
      * The currently persisted biometric integrity source for the system.
      */
     var systemBiometricIntegritySource: String?

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -47,6 +47,7 @@ private const val SHOULD_SHOW_ADD_LOGIN_COACH_MARK = "shouldShowAddLoginCoachMar
 private const val SHOULD_SHOW_GENERATOR_COACH_MARK = "shouldShowGeneratorCoachMark"
 private const val RESUME_SCREEN = "resumeScreen"
 private const val FLIGHT_RECORDER_KEY = "flightRecorderData"
+private const val IS_DYNAMIC_COLORS_ENABLED = "isDynamicColorsEnabled"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -96,6 +97,8 @@ class SettingsDiskSourceImpl(
 
     private val mutableVaultRegisteredForExportFlow =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutableIsDynamicColorsEnabledFlow = bufferedMutableSharedFlow<Boolean?>()
 
     init {
         migrateScreenCaptureSetting()
@@ -159,6 +162,18 @@ class SettingsDiskSourceImpl(
     override val appThemeFlow: Flow<AppTheme>
         get() = mutableAppThemeFlow
             .onSubscription { emit(appTheme) }
+    override var isDynamicColorsEnabled: Boolean?
+        get() = getBoolean(key = IS_DYNAMIC_COLORS_ENABLED) ?: false
+        set(value) {
+            putBoolean(
+                key = IS_DYNAMIC_COLORS_ENABLED,
+                value = value,
+            )
+            mutableIsDynamicColorsEnabledFlow.tryEmit(value)
+        }
+    override val isDynamicColorsEnabledFlow: Flow<Boolean?>
+        get() = mutableIsDynamicColorsEnabledFlow
+            .onSubscription { emit(getBoolean(IS_DYNAMIC_COLORS_ENABLED)) }
 
     override var isIconLoadingDisabled: Boolean?
         get() = getBoolean(key = DISABLE_ICON_LOADING_KEY)

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -162,6 +162,7 @@ class SettingsDiskSourceImpl(
     override val appThemeFlow: Flow<AppTheme>
         get() = mutableAppThemeFlow
             .onSubscription { emit(appTheme) }
+
     override var isDynamicColorsEnabled: Boolean?
         get() = getBoolean(key = IS_DYNAMIC_COLORS_ENABLED) ?: false
         set(value) {
@@ -171,6 +172,7 @@ class SettingsDiskSourceImpl(
             )
             mutableIsDynamicColorsEnabledFlow.tryEmit(value)
         }
+
     override val isDynamicColorsEnabledFlow: Flow<Boolean?>
         get() = mutableIsDynamicColorsEnabledFlow
             .onSubscription { emit(getBoolean(IS_DYNAMIC_COLORS_ENABLED)) }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -164,7 +164,7 @@ class SettingsDiskSourceImpl(
             .onSubscription { emit(appTheme) }
 
     override var isDynamicColorsEnabled: Boolean?
-        get() = getBoolean(key = IS_DYNAMIC_COLORS_ENABLED) ?: false
+        get() = getBoolean(key = IS_DYNAMIC_COLORS_ENABLED)
         set(value) {
             putBoolean(
                 key = IS_DYNAMIC_COLORS_ENABLED,

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -40,6 +40,16 @@ interface SettingsRepository : FlightRecorderManager {
     val appThemeStateFlow: StateFlow<AppTheme>
 
     /**
+     * The current setting for enabling dynamic colors.
+     */
+    var isDynamicColorsEnabled: Boolean
+
+    /**
+     * Tracks changes to the [isDynamicColorsEnabled] value.
+     */
+    val isDynamicColorsEnabledFlow: StateFlow<Boolean>
+
+    /**
      * Has the initial autofill dialog been shown to the user.
      */
     var initialAutofillDialogShown: Boolean

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -87,6 +87,22 @@ class SettingsRepositoryImpl(
                 initialValue = settingsDiskSource.appTheme,
             )
 
+    override var isDynamicColorsEnabled: Boolean
+        get() = settingsDiskSource.isDynamicColorsEnabled ?: false
+        set(value) {
+            settingsDiskSource.isDynamicColorsEnabled = value
+        }
+
+    override val isDynamicColorsEnabledFlow: StateFlow<Boolean>
+        get() = settingsDiskSource
+            .isDynamicColorsEnabledFlow
+            .map { it ?: false }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = settingsDiskSource.isDynamicColorsEnabled ?: false,
+            )
+
     override var initialAutofillDialogShown: Boolean
         get() = settingsDiskSource.initialAutofillDialogShown ?: false
         set(value) {

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -100,7 +100,7 @@ class SettingsRepositoryImpl(
             .stateIn(
                 scope = unconfinedScope,
                 started = SharingStarted.Eagerly,
-                initialValue = settingsDiskSource.isDynamicColorsEnabled ?: false,
+                initialValue = isDynamicColorsEnabled,
             )
 
     override var initialAutofillDialogShown: Boolean

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenSwitch.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Wallpapers
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.components.model.CardStyle
@@ -372,21 +373,41 @@ private fun RowScope.ToolTip(
     )
 }
 
-@Preview
+@Suppress("LongMethod")
+@Preview(wallpaper = Wallpapers.GREEN_DOMINATED_EXAMPLE)
 @Composable
 private fun BitwardenSwitch_preview() {
-    Column {
-        BitwardenSwitch(
-            label = "Label",
-            supportingText = "description",
-            isChecked = true,
-            onCheckedChange = {},
-            cardStyle = CardStyle.Top(),
-        )
-        BitwardenSwitch(
-            label = "Label",
-            isChecked = false,
-            onCheckedChange = {},
+    BitwardenTheme(dynamicColor = true) {
+        Column {
+            BitwardenSwitch(
+                label = "Label",
+                supportingText = "description",
+                isChecked = true,
+                onCheckedChange = {},
+                cardStyle = CardStyle.Top(),
+            )
+            BitwardenSwitch(
+                label = "Label",
+                isChecked = false,
+                onCheckedChange = {},
+                cardStyle = CardStyle.Middle(),
+            )
+            BitwardenSwitch(
+                label = "Label",
+                supportingText = "description",
+                isChecked = true,
+                onCheckedChange = {},
+                tooltip = TooltipData(
+                onClick = { },
+                contentDescription = "content description",
+            ),
+                actions = {
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_generate,
+                        contentDescription = "content description",
+                        onClick = {},
+                    )
+                },
             cardStyle = CardStyle.Middle(),
         )
         BitwardenSwitch(
@@ -398,38 +419,21 @@ private fun BitwardenSwitch_preview() {
                 onClick = { },
                 contentDescription = "content description",
             ),
-            actions = {
-                BitwardenStandardIconButton(
-                    vectorIconRes = R.drawable.ic_generate,
-                    contentDescription = "content description",
-                    onClick = {},
-                )
-            },
             cardStyle = CardStyle.Middle(),
         )
-        BitwardenSwitch(
-            label = "Label",
-            supportingText = "description",
-            isChecked = true,
-            onCheckedChange = {},
-            tooltip = TooltipData(
-                onClick = { },
-                contentDescription = "content description",
-            ),
-            cardStyle = CardStyle.Middle(),
-        )
-        BitwardenSwitch(
-            label = "Label",
-            isChecked = false,
-            onCheckedChange = {},
-            actions = {
-                BitwardenStandardIconButton(
-                    vectorIconRes = R.drawable.ic_generate,
-                    contentDescription = "content description",
-                    onClick = {},
-                )
-            },
-            cardStyle = CardStyle.Bottom,
-        )
+            BitwardenSwitch(
+                label = "Label",
+                isChecked = false,
+                onCheckedChange = {},
+                actions = {
+                    BitwardenStandardIconButton(
+                        vectorIconRes = R.drawable.ic_generate,
+                        contentDescription = "content description",
+                        onClick = {},
+                    )
+                },
+                cardStyle = CardStyle.Bottom,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -100,6 +100,20 @@ fun AppearanceScreen(
             )
             Spacer(modifier = Modifier.height(height = 8.dp))
             BitwardenSwitch(
+                label = stringResource(id = R.string.dynamic_colors),
+                supportingText = stringResource(id = R.string.dynamic_colors_description),
+                isChecked = state.isDynamicColorsEnabled,
+                onCheckedChange = remember(viewModel) {
+                    { viewModel.trySendAction(AppearanceAction.DynamicColorsToggle(it)) }
+                },
+                cardStyle = CardStyle.Full,
+                modifier = Modifier
+                    .testTag("DynamicColorsSwitch")
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+            Spacer(modifier = Modifier.height(height = 8.dp))
+            BitwardenSwitch(
                 label = stringResource(id = R.string.show_website_icons),
                 supportingText = stringResource(id = R.string.show_website_icons_description),
                 isChecked = state.showWebsiteIcons,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -55,29 +55,15 @@ fun AppearanceScreen(
         }
     }
 
-    when (state.dialogState) {
-        AppearanceState.DialogState.EnableDynamicColors -> {
-            BitwardenTwoButtonDialog(
-                title = stringResource(id = R.string.dynamic_colors),
-                message = stringResource(
-                    id = R.string.dynamic_colors_may_not_adhere_to_accessibility_guidelines,
-                ),
-                confirmButtonText = stringResource(R.string.ok),
-                dismissButtonText = stringResource(R.string.cancel),
-                onConfirmClick = remember(viewModel) {
-                    { viewModel.trySendAction(AppearanceAction.ConfirmEnableDynamicColorsClick) }
-                },
-                onDismissClick = remember(viewModel) {
-                    { viewModel.trySendAction(AppearanceAction.DismissDialog) }
-                },
-                onDismissRequest = remember {
-                    { viewModel.trySendAction(AppearanceAction.DismissDialog) }
-                },
-            )
-        }
-
-        else -> Unit
-    }
+    AppearanceDialogs(
+        dialogState = state.dialogState,
+        onConfirmEnableDynamicColorsClick = remember(viewModel) {
+            { viewModel.trySendAction(AppearanceAction.ConfirmEnableDynamicColorsClick) }
+        },
+        onDismissDialog = remember(viewModel) {
+            { viewModel.trySendAction(AppearanceAction.DismissDialog) }
+        },
+    )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
     BitwardenScaffold(
@@ -154,6 +140,31 @@ fun AppearanceScreen(
             Spacer(modifier = Modifier.height(height = 16.dp))
             Spacer(modifier = Modifier.navigationBarsPadding())
         }
+    }
+}
+
+@Composable
+private fun AppearanceDialogs(
+    dialogState: AppearanceState.DialogState?,
+    onConfirmEnableDynamicColorsClick: () -> Unit,
+    onDismissDialog: () -> Unit,
+) {
+    when (dialogState) {
+        AppearanceState.DialogState.EnableDynamicColors -> {
+            BitwardenTwoButtonDialog(
+                title = stringResource(id = R.string.dynamic_colors),
+                message = stringResource(
+                    id = R.string.dynamic_colors_may_not_adhere_to_accessibility_guidelines,
+                ),
+                confirmButtonText = stringResource(R.string.ok),
+                dismissButtonText = stringResource(R.string.cancel),
+                onConfirmClick = onConfirmEnableDynamicColorsClick,
+                onDismissClick = onDismissDialog,
+                onDismissRequest = onDismissDialog,
+            )
+        }
+
+        else -> Unit
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -28,6 +28,7 @@ import com.bitwarden.ui.platform.components.model.CardStyle
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
+import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
@@ -52,6 +53,30 @@ fun AppearanceScreen(
         when (event) {
             AppearanceEvent.NavigateBack -> onNavigateBack.invoke()
         }
+    }
+
+    when (state.dialogState) {
+        AppearanceState.DialogState.EnableDynamicColors -> {
+            BitwardenTwoButtonDialog(
+                title = stringResource(id = R.string.dynamic_colors),
+                message = stringResource(
+                    id = R.string.dynamic_colors_may_not_adhere_to_accessibility_guidelines,
+                ),
+                confirmButtonText = stringResource(R.string.ok),
+                dismissButtonText = stringResource(R.string.cancel),
+                onConfirmClick = remember(viewModel) {
+                    { viewModel.trySendAction(AppearanceAction.ConfirmEnableDynamicColorsClick) }
+                },
+                onDismissClick = remember(viewModel) {
+                    { viewModel.trySendAction(AppearanceAction.DismissDialog) }
+                },
+                onDismissRequest = remember {
+                    { viewModel.trySendAction(AppearanceAction.DismissDialog) }
+                },
+            )
+        }
+
+        else -> Unit
     }
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
@@ -30,6 +30,7 @@ class AppearanceViewModel @Inject constructor(
             language = settingsRepository.appLanguage,
             showWebsiteIcons = !settingsRepository.isIconLoadingDisabled,
             theme = settingsRepository.appTheme,
+            isDynamicColorsEnabled = settingsRepository.isDynamicColorsEnabled,
         ),
 ) {
 
@@ -46,6 +47,7 @@ class AppearanceViewModel @Inject constructor(
         is AppearanceAction.LanguageChange -> handleLanguageChanged(action)
         is AppearanceAction.ShowWebsiteIconsToggle -> handleShowWebsiteIconsToggled(action)
         is AppearanceAction.ThemeChange -> handleThemeChanged(action)
+        is AppearanceAction.DynamicColorsToggle -> handleDynamicColorsToggled(action)
         is AppearanceAction.Internal.AppLanguageStateUpdateReceive -> {
             handleLanguageStateChange(action)
         }
@@ -80,6 +82,11 @@ class AppearanceViewModel @Inject constructor(
         mutableStateFlow.update { it.copy(theme = action.theme) }
         settingsRepository.appTheme = action.theme
     }
+
+    private fun handleDynamicColorsToggled(action: AppearanceAction.DynamicColorsToggle) {
+        mutableStateFlow.update { it.copy(isDynamicColorsEnabled = action.isEnabled) }
+        settingsRepository.isDynamicColorsEnabled = action.isEnabled
+    }
 }
 
 /**
@@ -90,6 +97,7 @@ data class AppearanceState(
     val language: AppLanguage,
     val showWebsiteIcons: Boolean,
     val theme: AppTheme,
+    val isDynamicColorsEnabled: Boolean,
 ) : Parcelable
 
 /**
@@ -142,4 +150,11 @@ sealed class AppearanceAction {
          */
         data class AppLanguageStateUpdateReceive(val language: AppLanguage) : Internal()
     }
+
+    /**
+     * Indicates that the user toggled the Dynamic Colors switch to [isEnabled].
+     */
+    data class DynamicColorsToggle(
+        val isEnabled: Boolean,
+    ) : AppearanceAction()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
@@ -41,6 +41,12 @@ class AppearanceViewModel @Inject constructor(
             .map { AppearanceAction.Internal.AppLanguageStateUpdateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
+
+        settingsRepository
+            .isDynamicColorsEnabledFlow
+            .map { AppearanceAction.Internal.DynamicColorsStateUpdateReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
     }
 
     override fun handleAction(action: AppearanceAction): Unit = when (action) {
@@ -49,15 +55,16 @@ class AppearanceViewModel @Inject constructor(
         is AppearanceAction.ShowWebsiteIconsToggle -> handleShowWebsiteIconsToggled(action)
         is AppearanceAction.ThemeChange -> handleThemeChanged(action)
         is AppearanceAction.DynamicColorsToggle -> handleDynamicColorsToggled(action)
+        AppearanceAction.DismissDialog -> handleDismissDialog()
         AppearanceAction.ConfirmEnableDynamicColorsClick -> {
             handleConfirmEnableDynamicColorsClicked()
         }
 
-        AppearanceAction.DismissDialog -> {
-            handleDismissDialog()
-        }
         is AppearanceAction.Internal.AppLanguageStateUpdateReceive -> {
             handleLanguageStateChange(action)
+        }
+        is AppearanceAction.Internal.DynamicColorsStateUpdateReceive -> {
+            handleDynamicColorsStateChange(action)
         }
     }
 
@@ -66,6 +73,14 @@ class AppearanceViewModel @Inject constructor(
     ) {
         mutableStateFlow.update {
             it.copy(language = action.language)
+        }
+    }
+
+    private fun handleDynamicColorsStateChange(
+        action: AppearanceAction.Internal.DynamicColorsStateUpdateReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(isDynamicColorsEnabled = action.isDynamicColorsEnabled)
         }
     }
 
@@ -98,7 +113,6 @@ class AppearanceViewModel @Inject constructor(
             }
         } else {
             settingsRepository.isDynamicColorsEnabled = false
-            mutableStateFlow.update { it.copy(isDynamicColorsEnabled = false) }
         }
     }
 
@@ -191,6 +205,11 @@ sealed class AppearanceAction {
          * The AppLanguageState value has updated.
          */
         data class AppLanguageStateUpdateReceive(val language: AppLanguage) : Internal()
+
+        /**
+         * The DynamicColorsState value has updated.
+         */
+        data class DynamicColorsStateUpdateReceive(val isDynamicColorsEnabled: Boolean) : Internal()
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/color/ColorScheme.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/color/ColorScheme.kt
@@ -216,7 +216,7 @@ fun dynamicBitwardenColorScheme(
         toggleButton = BitwardenColorScheme.ToggleButtonColors(
             backgroundOn = materialColorScheme.primary,
             backgroundOff = materialColorScheme.surfaceContainerHighest,
-            switch = materialColorScheme.onPrimaryContainer,
+            switch = materialColorScheme.onPrimary,
         ),
         sliderButton = BitwardenColorScheme.SliderButtonColors(
             knobBackground = materialColorScheme.primary,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/color/ColorScheme.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/color/ColorScheme.kt
@@ -216,7 +216,7 @@ fun dynamicBitwardenColorScheme(
         toggleButton = BitwardenColorScheme.ToggleButtonColors(
             backgroundOn = materialColorScheme.primary,
             backgroundOff = materialColorScheme.surfaceContainerHighest,
-            switch = materialColorScheme.onPrimary,
+            switch = materialColorScheme.onPrimaryContainer,
         ),
         sliderButton = BitwardenColorScheme.SliderButtonColors(
             knobBackground = materialColorScheme.primary,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1270,4 +1270,6 @@ Do you want to switch to this account?</string>
     <string name="view_text_send">View text Send</string>
     <string name="delete_send">Delete send</string>
     <string name="missing_send_resync_your_vault">Missing Send re-sync your vault</string>
+    <string name="dynamic_colors">Dynamic colors</string>
+    <string name="dynamic_colors_description">Apply dynamic colors based on your wallpaper</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1272,4 +1272,5 @@ Do you want to switch to this account?</string>
     <string name="missing_send_resync_your_vault">Missing Send re-sync your vault</string>
     <string name="dynamic_colors">Dynamic colors</string>
     <string name="dynamic_colors_description">Apply dynamic colors based on your wallpaper</string>
+    <string name="dynamic_colors_may_not_adhere_to_accessibility_guidelines">Dynamic colors uses the system colors and may not meet all accessibility guidelines.</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -96,6 +96,7 @@ class MainViewModelTest : BaseViewModelTest() {
     private val mutableAppThemeFlow = MutableStateFlow(AppTheme.DEFAULT)
     private val mutableAppLanguageFlow = MutableStateFlow(AppLanguage.DEFAULT)
     private val mutableScreenCaptureAllowedFlow = MutableStateFlow(true)
+    private val mutableIsDynamicColorsEnabledFlow = MutableStateFlow(false)
     private val settingsRepository = mockk<SettingsRepository> {
         every { appTheme } returns AppTheme.DEFAULT
         every { appThemeStateFlow } returns mutableAppThemeFlow
@@ -104,6 +105,8 @@ class MainViewModelTest : BaseViewModelTest() {
         every { isScreenCaptureAllowedStateFlow } returns mutableScreenCaptureAllowedFlow
         every { storeUserHasLoggedInValue(any()) } just runs
         every { appLanguage = any() } just runs
+        every { isDynamicColorsEnabled } returns false
+        every { isDynamicColorsEnabledFlow } returns mutableIsDynamicColorsEnabledFlow
     }
     private val authRepository = mockk<AuthRepository> {
         every { activeUserId } returns DEFAULT_USER_STATE.activeUserId
@@ -1141,6 +1144,7 @@ private val DEFAULT_STATE: MainState = MainState(
     theme = AppTheme.DEFAULT,
     isScreenCaptureAllowed = true,
     isErrorReportingDialogEnabled = false,
+    isDynamicColorsEnabled = false,
 )
 
 private val DEFAULT_FIRST_TIME_STATE = FirstTimeState(

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -494,6 +494,47 @@ class SettingsDiskSourceTest {
     }
 
     @Test
+    fun `isDynamicColorsEnabled should pull from and update SharedPreferences`() {
+        val isDynamicColorsEnabled = "bwPreferencesStorage:isDynamicColorsEnabled"
+        val expected = false
+
+        assertNull(settingsDiskSource.isDynamicColorsEnabled)
+
+        fakeSharedPreferences
+            .edit {
+                putBoolean(
+                    isDynamicColorsEnabled,
+                    expected,
+                )
+            }
+
+        assertEquals(
+            expected,
+            settingsDiskSource.isDynamicColorsEnabled,
+        )
+
+        settingsDiskSource.isDynamicColorsEnabled = true
+        assertTrue(
+            fakeSharedPreferences.getBoolean(
+                isDynamicColorsEnabled, false,
+            ),
+        )
+    }
+
+    @Test
+    fun `isDynamicColorsEnabledFlow should react to changes in isDynamicColorsEnabled`() = runTest {
+        settingsDiskSource.isDynamicColorsEnabledFlow.test {
+            // The initial values of the Flow and the property are in sync
+            assertNull(settingsDiskSource.isDynamicColorsEnabled)
+            assertNull(awaitItem())
+            settingsDiskSource.isDynamicColorsEnabled = true
+            assertTrue(awaitItem() ?: false)
+            settingsDiskSource.isDynamicColorsEnabled = false
+            assertFalse(awaitItem() ?: true)
+        }
+    }
+
+    @Test
     fun `getVaultTimeoutInMinutes when values are present should pull from SharedPreferences`() {
         val vaultTimeoutBaseKey = "bwPreferencesStorage:vaultTimeout"
         val mockUserId = "mockUserId"

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -86,6 +86,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private var hasSeenAddLoginCoachMark: Boolean? = null
     private var hasSeenGeneratorCoachMark: Boolean? = null
     private var storedFlightRecorderData: FlightRecorderDataSet? = null
+    private var storedIsDynamicColorsEnabled: Boolean? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -98,6 +99,9 @@ class FakeSettingsDiskSource : SettingsDiskSource {
 
     private val mutableVaultRegisteredForExportFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutableIsDynamicColorsEnabled =
+        bufferedMutableSharedFlow<Boolean?>()
 
     override var appLanguage: AppLanguage?
         get() = storedAppLanguage
@@ -119,6 +123,17 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     override val appThemeFlow: Flow<AppTheme>
         get() = mutableAppThemeFlow.onSubscription {
             emit(appTheme)
+        }
+    override var isDynamicColorsEnabled: Boolean?
+        get() = storedIsDynamicColorsEnabled
+        set(value) {
+            storedIsDynamicColorsEnabled = value
+            mutableIsDynamicColorsEnabled.tryEmit(value)
+        }
+
+    override val isDynamicColorsEnabledFlow: Flow<Boolean?>
+        get() = mutableIsDynamicColorsEnabled.onSubscription {
+            emit(isDynamicColorsEnabled)
         }
 
     override var screenCaptureAllowed: Boolean?

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -124,6 +124,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         get() = mutableAppThemeFlow.onSubscription {
             emit(appTheme)
         }
+
     override var isDynamicColorsEnabled: Boolean?
         get() = storedIsDynamicColorsEnabled
         set(value) {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -414,6 +414,36 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `isDynamicColorsEnabled should pull from and update SettingsDiskSource`() {
+        assertFalse(settingsRepository.isDynamicColorsEnabled)
+
+        // Updates to the disk source change the repository value
+        fakeSettingsDiskSource.isDynamicColorsEnabled = true
+        assertTrue(settingsRepository.isDynamicColorsEnabled)
+
+        // Updates to the repository value change the disk source
+        settingsRepository.isDynamicColorsEnabled = false
+        assertFalse(fakeSettingsDiskSource.isDynamicColorsEnabled!!)
+    }
+
+    @Test
+    fun `isDynamicColorsEnabled should react to changes in SettingsDiskSource`() = runTest {
+        settingsRepository
+            .isDynamicColorsEnabledFlow
+            .test {
+                assertFalse(awaitItem())
+                fakeSettingsDiskSource.isDynamicColorsEnabled = true
+                assertTrue(awaitItem())
+            }
+    }
+
+    @Test
+    fun `isDynamicColorsEnabled should properly update SettingsDiskSource`() {
+        settingsRepository.isDynamicColorsEnabled = true
+        assertTrue(fakeSettingsDiskSource.isDynamicColorsEnabled!!)
+    }
+
+    @Test
     fun `vaultTimeout should pull from and update SettingsDiskSource for the current user`() {
         fakeAuthDiskSource.userState = null
         assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
@@ -175,4 +175,5 @@ private val DEFAULT_STATE = AppearanceState(
     showWebsiteIcons = false,
     theme = AppTheme.DEFAULT,
     isDynamicColorsEnabled = false,
+    dialogState = null,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
@@ -157,7 +157,9 @@ class AppearanceScreenTest : BaseComposeTest() {
 
     @Test
     fun `on show website icons row click should send ShowWebsiteIconsToggled`() {
-        composeTestRule.onNodeWithText("Show website icons").performClick()
+        composeTestRule.onNodeWithText("Show website icons")
+            .performScrollTo()
+            .performClick()
         verify { viewModel.trySendAction(AppearanceAction.ShowWebsiteIconsToggle(true)) }
     }
 
@@ -172,4 +174,5 @@ private val DEFAULT_STATE = AppearanceState(
     language = AppLanguage.DEFAULT,
     showWebsiteIcons = false,
     theme = AppTheme.DEFAULT,
+    isDynamicColorsEnabled = false,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreenTest.kt
@@ -8,10 +8,8 @@ import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.printToLog
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
@@ -21,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -104,7 +103,6 @@ class AppearanceScreenTest : BaseComposeTest() {
 
     @Test
     fun `on theme row click should display theme selection dialog`() {
-        composeTestRule.onRoot().printToLog("Brian")
         composeTestRule
             .onNodeWithContentDescription(
                 label = "Default (System). Theme. Change the application's color theme",
@@ -167,6 +165,36 @@ class AppearanceScreenTest : BaseComposeTest() {
     fun `on NavigateBack should call onNavigateBack`() {
         mutableEventFlow.tryEmit(AppearanceEvent.NavigateBack)
         assertTrue(haveCalledNavigateBack)
+    }
+
+    @Test
+    fun `on DynamicColorsToggle should send DynamicColorsToggle`() {
+        composeTestRule.onNodeWithText("Dynamic colors")
+            .performScrollTo()
+            .performClick()
+        verify { viewModel.trySendAction(AppearanceAction.DynamicColorsToggle(true)) }
+    }
+
+    @Test
+    fun `on ConfirmEnableDynamicColorsClick should send ConfirmEnableDynamicColorsClick`() {
+        mutableStateFlow.update {
+            it.copy(dialogState = AppearanceState.DialogState.EnableDynamicColors)
+        }
+        composeTestRule.onAllNodesWithText("Ok")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+        verify { viewModel.trySendAction(AppearanceAction.ConfirmEnableDynamicColorsClick) }
+    }
+
+    @Test
+    fun `on DismissDialog should send DismissDialog`() {
+        mutableStateFlow.update {
+            it.copy(dialogState = AppearanceState.DialogState.EnableDynamicColors)
+        }
+        composeTestRule.onAllNodesWithText("Cancel")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+        verify { viewModel.trySendAction(AppearanceAction.DismissDialog) }
     }
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModelTest.kt
@@ -27,6 +27,7 @@ class AppearanceViewModelTest : BaseViewModelTest() {
         every { isIconLoadingDisabled = true } just runs
         every { appTheme = AppTheme.DARK } just runs
         every { appLanguageStateFlow } returns mutableAppLanguageStateFlow
+        every { isDynamicColorsEnabled } returns false
     }
 
     @Test
@@ -138,6 +139,7 @@ class AppearanceViewModelTest : BaseViewModelTest() {
             language = AppLanguage.DEFAULT,
             showWebsiteIcons = true,
             theme = AppTheme.DEFAULT,
+            isDynamicColorsEnabled = false,
         )
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModelTest.kt
@@ -140,6 +140,7 @@ class AppearanceViewModelTest : BaseViewModelTest() {
             showWebsiteIcons = true,
             theme = AppTheme.DEFAULT,
             isDynamicColorsEnabled = false,
+            dialogState = null,
         )
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModelTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test
 
 class AppearanceViewModelTest : BaseViewModelTest() {
     private val mutableAppLanguageStateFlow = MutableStateFlow(AppLanguage.DEFAULT)
+    private val mutableIsDynamicColorsEnabledFlow = MutableStateFlow(false)
     private val mockSettingsRepository = mockk<SettingsRepository> {
         every { appLanguage } returns AppLanguage.DEFAULT
         every { appTheme } returns AppTheme.DEFAULT
@@ -28,6 +29,8 @@ class AppearanceViewModelTest : BaseViewModelTest() {
         every { appTheme = AppTheme.DARK } just runs
         every { appLanguageStateFlow } returns mutableAppLanguageStateFlow
         every { isDynamicColorsEnabled } returns false
+        every { isDynamicColorsEnabled = any() } just runs
+        every { isDynamicColorsEnabledFlow } returns mutableIsDynamicColorsEnabledFlow
     }
 
     @Test
@@ -122,6 +125,74 @@ class AppearanceViewModelTest : BaseViewModelTest() {
             mockSettingsRepository.appTheme
             mockSettingsRepository.appTheme = AppTheme.DARK
         }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on DynamicColorsStateFlow value updated, view model isDynamicColorsEnabled state should change`() =
+        runTest {
+            val viewModel = createViewModel(settingsRepository = mockSettingsRepository)
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_STATE,
+                    awaitItem(),
+                )
+                mutableIsDynamicColorsEnabledFlow.update { true }
+                assertEquals(
+                    DEFAULT_STATE.copy(isDynamicColorsEnabled = true),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `DynamicColorsToggle should update state and set isDynamicColorsEnabled in SettingsRepository when disabled`() =
+        runTest {
+            val viewModel = createViewModel()
+                .also { it.trySendAction(AppearanceAction.DynamicColorsToggle(false)) }
+            assertEquals(
+                DEFAULT_STATE.copy(isDynamicColorsEnabled = false),
+                viewModel.stateFlow.value,
+            )
+            verify { mockSettingsRepository.isDynamicColorsEnabled = false }
+        }
+
+    @Test
+    fun `DynamicColorsToggle should update state to show dialog when enabled`() = runTest {
+        val viewModel = createViewModel()
+            .also { it.trySendAction(AppearanceAction.DynamicColorsToggle(true)) }
+        assertEquals(
+            DEFAULT_STATE.copy(dialogState = AppearanceState.DialogState.EnableDynamicColors),
+            viewModel.stateFlow.value,
+        )
+        verify(exactly = 0) { mockSettingsRepository.isDynamicColorsEnabled = any() }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ConfirmEnableDynamicColorsClick should update state and set isDynamicColorsEnabled in SettingsRepository`() =
+        runTest {
+            val viewModel = createViewModel(
+                DEFAULT_STATE.copy(dialogState = AppearanceState.DialogState.EnableDynamicColors),
+            )
+                .also { it.trySendAction(AppearanceAction.ConfirmEnableDynamicColorsClick) }
+            assertEquals(
+                DEFAULT_STATE.copy(isDynamicColorsEnabled = true),
+                viewModel.stateFlow.value,
+            )
+            verify { mockSettingsRepository.isDynamicColorsEnabled = true }
+        }
+
+    @Test
+    fun `DismissDialog should update state to hide dialog`() = runTest {
+        val viewModel = createViewModel(
+            DEFAULT_STATE.copy(dialogState = AppearanceState.DialogState.EnableDynamicColors),
+        )
+            .also { it.trySendAction(AppearanceAction.DismissDialog) }
+        assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
+        // Verify that isDynamicColorsEnabled was not changed
+        verify(exactly = 0) { mockSettingsRepository.isDynamicColorsEnabled = any() }
     }
 
     private fun createViewModel(


### PR DESCRIPTION
## 🎟️ Tracking

PM-10660
PM-20285

## 📔 Objective

Introduce support for dynamic colors in the application.

-   A new setting `isDynamicColorsEnabled` is added to `SettingsDiskSource` and `SettingsRepository` to persist and retrieve the dynamic colors preference.
-   A new flow `isDynamicColorsEnabledFlow` is added to track the changes of `isDynamicColorsEnabled`.
-   A new switch "Dynamic colors" is added in the Appearance Screen.
- The `MainState` is updated with the `isDynamicColorsEnabled` attribute.
- `BitwardenTheme` is updated to set the dynamic color.
- The `AppearanceViewModel` is updated to set the `isDynamicColorsEnabled`.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
