### PR TITLE
PM-18844: Update BitwardenBasicDialog to allow it to share error logs

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
@@ -110,7 +110,7 @@ class MainActivity : AppCompatActivity() {
                 }
             }
             updateScreenCapture(isScreenCaptureAllowed = state.isScreenCaptureAllowed)
-            LocalManagerProvider {
+            LocalManagerProvider(featureFlagsState = state.featureFlagsState) {
                 ObserveScreenDataEffect(
                     onDataUpdate = remember(mainViewModel) {
                         {

--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -19,10 +19,12 @@ import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.util.getAutofillSaveItemOrNull
 import com.x8bit.bitwarden.data.autofill.util.getAutofillSelectionDataOrNull
 import com.x8bit.bitwarden.data.platform.manager.AppResumeManager
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.garbage.GarbageCollectionManager
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.manager.model.CompleteRegistrationData
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -35,6 +37,7 @@ import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.x8bit.bitwarden.ui.platform.model.FeatureFlagsState
 import com.x8bit.bitwarden.ui.platform.util.isAccountSecurityShortcut
 import com.x8bit.bitwarden.ui.platform.util.isMyVaultShortcut
 import com.x8bit.bitwarden.ui.platform.util.isPasswordGeneratorShortcut
@@ -64,6 +67,7 @@ private const val SPECIAL_CIRCUMSTANCE_KEY = "special-circumstance"
 class MainViewModel @Inject constructor(
     accessibilitySelectionManager: AccessibilitySelectionManager,
     autofillSelectionManager: AutofillSelectionManager,
+    featureFlagManager: FeatureFlagManager,
     private val addTotpItemFromAuthenticatorManager: AddTotpItemFromAuthenticatorManager,
     private val specialCircumstanceManager: SpecialCircumstanceManager,
     private val garbageCollectionManager: GarbageCollectionManager,
@@ -80,6 +84,9 @@ class MainViewModel @Inject constructor(
     initialState = MainState(
         theme = settingsRepository.appTheme,
         isScreenCaptureAllowed = settingsRepository.isScreenCaptureAllowed,
+        isErrorReportingDialogEnabled = featureFlagManager.getFeatureFlag(
+            key = FlagKey.MobileErrorReporting,
+        ),
     ),
 ) {
     private var specialCircumstance: SpecialCircumstance?
@@ -95,6 +102,12 @@ class MainViewModel @Inject constructor(
         specialCircumstanceManager
             .specialCircumstanceStateFlow
             .onEach { specialCircumstance = it }
+            .launchIn(viewModelScope)
+
+        featureFlagManager
+            .getFeatureFlagFlow(key = FlagKey.MobileErrorReporting)
+            .map { MainAction.Internal.OnMobileErrorReportingReceive(it) }
+            .onEach(::sendAction)
             .launchIn(viewModelScope)
 
         accessibilitySelectionManager
@@ -174,6 +187,17 @@ class MainViewModel @Inject constructor(
 
     override fun handleAction(action: MainAction) {
         when (action) {
+            is MainAction.ReceiveFirstIntent -> handleFirstIntentReceived(action)
+            is MainAction.ReceiveNewIntent -> handleNewIntentReceived(action)
+            MainAction.OpenDebugMenu -> handleOpenDebugMenu()
+            is MainAction.ResumeScreenDataReceived -> handleAppResumeDataUpdated(action)
+            is MainAction.AppSpecificLanguageUpdate -> handleAppSpecificLanguageUpdate(action)
+            is MainAction.Internal -> handleInternalAction(action)
+        }
+    }
+
+    private fun handleInternalAction(action: MainAction.Internal) {
+        when (action) {
             is MainAction.Internal.AccessibilitySelectionReceive -> {
                 handleAccessibilitySelectionReceive(action)
             }
@@ -186,11 +210,17 @@ class MainViewModel @Inject constructor(
             is MainAction.Internal.ScreenCaptureUpdate -> handleScreenCaptureUpdate(action)
             is MainAction.Internal.ThemeUpdate -> handleAppThemeUpdated(action)
             is MainAction.Internal.VaultUnlockStateChange -> handleVaultUnlockStateChange()
-            is MainAction.ReceiveFirstIntent -> handleFirstIntentReceived(action)
-            is MainAction.ReceiveNewIntent -> handleNewIntentReceived(action)
-            MainAction.OpenDebugMenu -> handleOpenDebugMenu()
-            is MainAction.ResumeScreenDataReceived -> handleAppResumeDataUpdated(action)
-            is MainAction.AppSpecificLanguageUpdate -> handleAppSpecificLanguageUpdate(action)
+            is MainAction.Internal.OnMobileErrorReportingReceive -> {
+                handleOnMobileErrorReportingReceive(action)
+            }
+        }
+    }
+
+    private fun handleOnMobileErrorReportingReceive(
+        action: MainAction.Internal.OnMobileErrorReportingReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(isErrorReportingDialogEnabled = action.isErrorReportingEnabled)
         }
     }
 
@@ -451,7 +481,16 @@ class MainViewModel @Inject constructor(
 data class MainState(
     val theme: AppTheme,
     val isScreenCaptureAllowed: Boolean,
-) : Parcelable
+    private val isErrorReportingDialogEnabled: Boolean,
+) : Parcelable {
+    /**
+     * Contains all feature flags that are available to the UI.
+     */
+    val featureFlagsState: FeatureFlagsState
+        get() = FeatureFlagsState(
+            isErrorReportingDialogEnabled = isErrorReportingDialogEnabled,
+        )
+}
 
 /**
  * Models actions for the [MainActivity].
@@ -493,6 +532,13 @@ sealed class MainAction {
          */
         data class AccessibilitySelectionReceive(
             val cipherView: CipherView,
+        ) : Internal()
+
+        /**
+         * Indicates the Mobile Error Reporting feature flag has been updated.
+         */
+        data class OnMobileErrorReportingReceive(
+            val isErrorReportingEnabled: Boolean,
         ) : Internal()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1229,7 +1229,7 @@ class AuthRepositoryImpl(
         haveIBeenPwnedService
             .getPasswordBreachCount(password)
             .fold(
-                onFailure = { BreachCountResult.Error },
+                onFailure = { BreachCountResult.Error(error = it) },
                 onSuccess = { BreachCountResult.Success(it) },
             )
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/BreachCountResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/BreachCountResult.kt
@@ -12,5 +12,8 @@ sealed class BreachCountResult {
     /**
      * There was an error determining if the password has been breached.
      */
-    data object Error : BreachCountResult()
+    data class Error(
+        val error: Throwable,
+        val message: String? = null,
+    ) : BreachCountResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -44,12 +44,13 @@ sealed class FlagKey<out T : Any> {
                 AnonAddySelfHostAlias,
                 SimpleLoginSelfHostAlias,
                 ChromeAutofill,
+                MobileErrorReporting,
             )
         }
     }
 
     /**
-     *  Data object holding the key for syncing with the Bitwarden Authenticator app.
+     * Data object holding the key for syncing with the Bitwarden Authenticator app.
      */
     data object AuthenticatorSync : FlagKey<Boolean>() {
         override val keyName: String = "enable-pm-bwa-sync"
@@ -64,6 +65,15 @@ sealed class FlagKey<out T : Any> {
         override val keyName: String = "email-verification"
         override val defaultValue: Boolean = false
         override val isRemotelyConfigured: Boolean = true
+    }
+
+    /**
+     * Data object holding the key for syncing with the Bitwarden Authenticator app.
+     */
+    data object MobileErrorReporting : FlagKey<Boolean>() {
+        override val keyName: String = "mobile-error-reporting"
+        override val defaultValue: Boolean = false
+        override val isRemotelyConfigured: Boolean = false
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -11,7 +11,6 @@ import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 /**
  * Creates a list item for a [FlagKey].
  */
-@Suppress("UNCHECKED_CAST")
 @Composable
 fun <T : Any> FlagKey<T>.ListItemContent(
     currentValue: T,
@@ -43,14 +42,18 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.AnonAddySelfHostAlias,
     FlagKey.SimpleLoginSelfHostAlias,
     FlagKey.ChromeAutofill,
-        -> BooleanFlagItem(
-        label = flagKey.getDisplayLabel(),
-        key = flagKey as FlagKey<Boolean>,
-        currentValue = currentValue as Boolean,
-        onValueChange = onValueChange as (FlagKey<Boolean>, Boolean) -> Unit,
-        cardStyle = cardStyle,
-        modifier = modifier,
-    )
+    FlagKey.MobileErrorReporting,
+        -> {
+        @Suppress("UNCHECKED_CAST")
+        BooleanFlagItem(
+            label = flagKey.getDisplayLabel(),
+            key = flagKey as FlagKey<Boolean>,
+            currentValue = currentValue as Boolean,
+            onValueChange = onValueChange as (FlagKey<Boolean>, Boolean) -> Unit,
+            cardStyle = cardStyle,
+            modifier = modifier,
+        )
+    }
 }
 
 /**
@@ -96,9 +99,12 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.IgnoreEnvironmentCheck -> stringResource(R.string.ignore_environment_check)
     FlagKey.MutualTls -> stringResource(R.string.mutual_tls)
     FlagKey.SingleTapPasskeyCreation -> stringResource(R.string.single_tap_passkey_creation)
-    FlagKey.SingleTapPasskeyAuthentication ->
+    FlagKey.SingleTapPasskeyAuthentication -> {
         stringResource(R.string.single_tap_passkey_authentication)
+    }
+
     FlagKey.AnonAddySelfHostAlias -> stringResource(R.string.anon_addy_self_hosted_aliases)
     FlagKey.SimpleLoginSelfHostAlias -> stringResource(R.string.simple_login_self_hosted_aliases)
     FlagKey.ChromeAutofill -> stringResource(R.string.enable_chrome_autofill)
+    FlagKey.MobileErrorReporting -> stringResource(R.string.enable_error_reporting_dialog)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/model/FeatureFlagsState.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/model/FeatureFlagsState.kt
@@ -1,0 +1,14 @@
+package com.x8bit.bitwarden.ui.platform.model
+
+import android.os.Parcelable
+import androidx.compose.runtime.Immutable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Models the UI centric feature flags.
+ */
+@Immutable
+@Parcelize
+data class FeatureFlagsState(
+    val isErrorReportingDialogEnabled: Boolean,
+) : Parcelable

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -471,6 +471,7 @@ private fun VaultAddEditItemDialogs(
             BitwardenBasicDialog(
                 title = dialogState.title?.invoke(),
                 message = dialogState.message(),
+                throwable = dialogState.error,
                 onDismissRequest = onDismissRequest,
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -296,6 +296,7 @@ private fun VaultItemDialogs(
         is VaultItemState.DialogState.Generic -> BitwardenBasicDialog(
             title = null,
             message = dialog.message(),
+            throwable = dialog.error,
             onDismissRequest = onDismissRequest,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -1103,17 +1103,25 @@ class VaultItemViewModel @Inject constructor(
     private fun handlePasswordBreachReceive(
         action: VaultItemAction.Internal.PasswordBreachReceive,
     ) {
-        val message = when (val result = action.result) {
-            BreachCountResult.Error -> R.string.generic_error_message.asText()
+        val dialogState = when (val result = action.result) {
+            is BreachCountResult.Error -> {
+                VaultItemState.DialogState.Generic(
+                    message = R.string.generic_error_message.asText(),
+                    error = result.error,
+                )
+            }
+
             is BreachCountResult.Success -> {
-                if (result.breachCount > 0) {
-                    R.string.password_exposed.asText(result.breachCount)
-                } else {
-                    R.string.password_safe.asText()
-                }
+                VaultItemState.DialogState.Generic(
+                    message = if (result.breachCount > 0) {
+                        R.string.password_exposed.asText(result.breachCount)
+                    } else {
+                        R.string.password_safe.asText()
+                    },
+                )
             }
         }
-        updateDialogState(VaultItemState.DialogState.Generic(message = message))
+        updateDialogState(dialogState)
     }
 
     @Suppress("LongMethod")
@@ -1840,6 +1848,7 @@ data class VaultItemState(
         @Parcelize
         data class Generic(
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1228,4 +1228,5 @@ Do you want to switch to this account?</string>
   <string name="show_less">Show less</string>
   <string name="add_field">Add field</string>
   <string name="x_ellipses">%s...</string>
+  <string name="share_error_details">Share error details</string>
 </resources>

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -29,5 +29,6 @@
     <string name="anon_addy_self_hosted_aliases">AnonAddy self-hosted aliases</string>
     <string name="simple_login_self_hosted_aliases">SimpleLogin self-hosted aliases</string>
     <string name="enable_chrome_autofill">Enable chrome autofill</string>
+    <string name="enable_error_reporting_dialog">Enable error reporting dialog</string>
     <!-- /Debug Menu -->
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -35,12 +35,14 @@ import com.x8bit.bitwarden.data.autofill.util.getAutofillSaveItemOrNull
 import com.x8bit.bitwarden.data.autofill.util.getAutofillSelectionDataOrNull
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.manager.AppResumeManager
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.garbage.GarbageCollectionManager
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.manager.model.CompleteRegistrationData
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.model.PasswordlessRequestData
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
@@ -136,6 +138,14 @@ class MainViewModelTest : BaseViewModelTest() {
     private val appResumeManager: AppResumeManager = mockk {
         every { setResumeScreen(any()) } just runs
         every { clearResumeScreen() } just runs
+    }
+
+    private val mutableMobileErrorReportingFeatureFlow = MutableStateFlow(false)
+    private val featureFlagManager: FeatureFlagManager = mockk {
+        every { getFeatureFlag(key = FlagKey.MobileErrorReporting) } returns false
+        every {
+            getFeatureFlagFlow(key = FlagKey.MobileErrorReporting)
+        } returns mutableMobileErrorReportingFeatureFlow
     }
 
     @BeforeEach
@@ -1119,12 +1129,14 @@ class MainViewModelTest : BaseViewModelTest() {
             set(SPECIAL_CIRCUMSTANCE_KEY, initialSpecialCircumstance)
         },
         appResumeManager = appResumeManager,
+        featureFlagManager = featureFlagManager,
     )
 }
 
 private val DEFAULT_STATE: MainState = MainState(
     theme = AppTheme.DEFAULT,
     isScreenCaptureAllowed = true,
+    isErrorReportingDialogEnabled = false,
 )
 
 private val DEFAULT_FIRST_TIME_STATE = FirstTimeState(

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -5670,16 +5670,17 @@ class AuthRepositoryTest {
     @Test
     fun `getPasswordBreachCount should return failure when service returns failure`() = runTest {
         val password = "password"
+        val error = Throwable("Fail")
         coEvery {
             haveIBeenPwnedService.getPasswordBreachCount(password)
-        } returns Throwable("Fail").asFailure()
+        } returns error.asFailure()
 
         val result = repository.getPasswordBreachCount(password)
 
         coVerify(exactly = 1) {
             haveIBeenPwnedService.getPasswordBreachCount(password)
         }
-        assertEquals(BreachCountResult.Error, result)
+        assertEquals(BreachCountResult.Error(error = error), result)
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
@@ -37,9 +37,10 @@ class SetupAutofillScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             SetupAutoFillScreen(
-                intentManager = intentManager,
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
             )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
@@ -65,10 +65,11 @@ class SetupUnlockScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            biometricsManager = biometricsManager,
+        ) {
             SetupUnlockScreen(
                 viewModel = viewModel,
-                biometricsManager = biometricsManager,
                 onNavigateBack = { onNavigateBackCalled = true },
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailScreenTest.kt
@@ -32,11 +32,12 @@ class CheckEmailScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             CheckEmailScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,
-                intentManager = intentManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreenTest.kt
@@ -61,11 +61,12 @@ class CreateAccountScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             CreateAccountScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToLogin = { _, _ -> onNavigateToLoginCalled = true },
-                intentManager = intentManager,
                 viewModel = viewModel,
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreenTest.kt
@@ -47,7 +47,9 @@ class EnterpriseSignOnScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             EnterpriseSignOnScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToSetPassword = { onNavigateToSetPasswordCalled = true },
@@ -55,7 +57,6 @@ class EnterpriseSignOnScreenTest : BaseComposeTest() {
                     onNavigateToTwoFactorLoginEmailAndOrgIdentifier = email to orgIdentifier
                 },
                 viewModel = viewModel,
-                intentManager = intentManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
@@ -47,11 +47,12 @@ class EnvironmentScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = mockIntentManager,
+            keyChainManager = mockKeyChainManager,
+        ) {
             EnvironmentScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
-                intentManager = mockIntentManager,
-                keyChainManager = mockKeyChainManager,
                 viewModel = viewModel,
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreenTest.kt
@@ -64,7 +64,9 @@ class LoginScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             LoginScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToMasterPasswordHint = { onNavigateToMasterPasswordHintCalled = true },
@@ -72,7 +74,6 @@ class LoginScreenTest : BaseComposeTest() {
                 onNavigateToLoginWithDevice = { onNavigateToLoginWithDeviceCalled = true },
                 onNavigateToTwoFactorLogin = { _, _, _ -> onNavigateToTwoFactorLoginCalled = true },
                 viewModel = viewModel,
-                intentManager = intentManager,
                 keyboardController = keyboardController,
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreenTest.kt
@@ -47,12 +47,13 @@ class LoginWithDeviceScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             LoginWithDeviceScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToTwoFactorLogin = { onNavigateToTwoFactorLoginEmail = it },
                 viewModel = viewModel,
-                intentManager = intentManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeEmailAccessScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeEmailAccessScreenTest.kt
@@ -37,12 +37,13 @@ class NewDeviceNoticeEmailAccessScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             NewDeviceNoticeEmailAccessScreen(
                 onNavigateBackToVault = { onNavigateBackToVaultCalled = true },
                 onNavigateToTwoFactorOptions = { onNavigateToTwoFactorOptionsCalled = true },
                 viewModel = viewModel,
-                intentManager = intentManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/newdevicenotice/NewDeviceNoticeTwoFactorScreenTest.kt
@@ -40,11 +40,12 @@ class NewDeviceNoticeTwoFactorScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             NewDeviceNoticeTwoFactorScreen(
                 onNavigateBackToVault = { onNavigateBackToVaultCalled = true },
                 onNavigateBack = { onNavigateBackCalled = true },
-                intentManager,
                 viewModel = viewModel,
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
@@ -54,7 +54,9 @@ class StartRegistrationScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             StartRegistrationScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToCompleteRegistration = { _, _ ->
@@ -62,7 +64,6 @@ class StartRegistrationScreenTest : BaseComposeTest() {
                 },
                 onNavigateToCheckEmail = { _ -> onNavigateToCheckEmailCalled = true },
                 onNavigateToEnvironment = { onNavigateToEnvironmentCalled = true },
-                intentManager = intentManager,
                 viewModel = viewModel,
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
@@ -49,12 +49,13 @@ class TwoFactorLoginScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+            nfcManager = nfcManager,
+        ) {
             TwoFactorLoginScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,
-                intentManager = intentManager,
-                nfcManager = nfcManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
@@ -85,11 +85,12 @@ class VaultUnlockScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            biometricsManager = biometricsManager,
+            fido2CompletionManager = fido2CompletionManager,
+        ) {
             VaultUnlockScreen(
                 viewModel = viewModel,
-                biometricsManager = biometricsManager,
-                fido2CompletionManager = fido2CompletionManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/BaseComposeTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/BaseComposeTest.kt
@@ -5,8 +5,20 @@ import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.x8bit.bitwarden.data.platform.manager.util.AppResumeStateManager
+import com.x8bit.bitwarden.ui.autofill.fido2.manager.Fido2CompletionManager
+import com.x8bit.bitwarden.ui.platform.composition.LocalManagerProvider
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricsManager
+import com.x8bit.bitwarden.ui.platform.manager.exit.ExitManager
+import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.x8bit.bitwarden.ui.platform.manager.keychain.KeyChainManager
+import com.x8bit.bitwarden.ui.platform.manager.nfc.NfcManager
+import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
+import com.x8bit.bitwarden.ui.platform.manager.review.AppReviewManager
+import com.x8bit.bitwarden.ui.platform.model.FeatureFlagsState
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
@@ -33,16 +45,42 @@ abstract class BaseComposeTest : BaseRobolectricTest() {
      * Helper for testing a basic Composable function that only requires a [Composable]. The
      * [AppTheme] is overridable and the [backDispatcher] is configured automatically.
      */
+    @Suppress("LongParameterList")
     protected fun setContent(
         theme: AppTheme = AppTheme.DEFAULT,
+        featureFlagsState: FeatureFlagsState = FeatureFlagsState(
+            isErrorReportingDialogEnabled = false,
+        ),
+        appResumeStateManager: AppResumeStateManager = mockk(),
+        appReviewManager: AppReviewManager = mockk(),
+        biometricsManager: BiometricsManager = mockk(),
+        exitManager: ExitManager = mockk(),
+        intentManager: IntentManager = mockk(),
+        fido2CompletionManager: Fido2CompletionManager = mockk(),
+        keyChainManager: KeyChainManager = mockk(),
+        nfcManager: NfcManager = mockk(),
+        permissionsManager: PermissionsManager = mockk(),
         test: @Composable () -> Unit,
     ) {
         composeTestRule.setContent {
             backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-            BitwardenTheme(
-                theme = theme,
-                content = test,
-            )
+            LocalManagerProvider(
+                featureFlagsState = featureFlagsState,
+                appResumeStateManager = appResumeStateManager,
+                appReviewManager = appReviewManager,
+                biometricsManager = biometricsManager,
+                exitManager = exitManager,
+                intentManager = intentManager,
+                fido2CompletionManager = fido2CompletionManager,
+                keyChainManager = keyChainManager,
+                nfcManager = nfcManager,
+                permissionsManager = permissionsManager,
+            ) {
+                BitwardenTheme(
+                    theme = theme,
+                    content = test,
+                )
+            }
         }
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -136,6 +136,7 @@ private val DEFAULT_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.AnonAddySelfHostAlias to true,
     FlagKey.SimpleLoginSelfHostAlias to true,
     FlagKey.ChromeAutofill to true,
+    FlagKey.MobileErrorReporting to true,
 )
 
 private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
@@ -157,6 +158,7 @@ private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.AnonAddySelfHostAlias to false,
     FlagKey.SimpleLoginSelfHostAlias to false,
     FlagKey.ChromeAutofill to false,
+    FlagKey.MobileErrorReporting to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
@@ -70,15 +70,16 @@ class SearchScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            appResumeStateManager = appResumeStateManager,
+            intentManager = intentManager,
+        ) {
             SearchScreen(
                 viewModel = viewModel,
-                intentManager = intentManager,
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToEditSend = { onNavigateToEditSendId = it },
                 onNavigateToEditCipher = { onNavigateToEditCipherArgs = it },
                 onNavigateToViewCipher = { onNavigateToViewCipherArgs = it },
-                appResumeStateManager = appResumeStateManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreenTest.kt
@@ -59,10 +59,11 @@ class AboutScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             AboutScreen(
                 viewModel = viewModel,
-                intentManager = intentManager,
                 onNavigateBack = { haveCalledNavigateBack = true },
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -83,15 +83,16 @@ class AccountSecurityScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            biometricsManager = biometricsManager,
+            intentManager = intentManager,
+        ) {
             AccountSecurityScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToDeleteAccount = { onNavigateToDeleteAccountCalled = true },
                 onNavigateToPendingRequests = { onNavigateToPendingRequestsCalled = true },
                 onNavigateToSetupUnlockScreen = { onNavigateToUnlockSetupScreenCalled = true },
                 viewModel = viewModel,
-                biometricsManager = biometricsManager,
-                intentManager = intentManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreenTest.kt
@@ -40,11 +40,12 @@ class LoginApprovalScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            exitManager = exitManager,
+        ) {
             LoginApprovalScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,
-                exitManager = exitManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreenTest.kt
@@ -55,12 +55,13 @@ class PendingRequestsScreenTest : BaseComposeTest() {
         mockkStatic(::isBuildVersionBelow)
         every { isFdroid } returns false
         every { isBuildVersionBelow(any()) } returns false
-        setContent {
+        setContent(
+            permissionsManager = permissionsManager,
+        ) {
             PendingRequestsScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToLoginApproval = { _ -> onNavigateToLoginApprovalCalled = true },
                 viewModel = viewModel,
-                permissionsManager = permissionsManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -55,13 +55,14 @@ class AutoFillScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             AutoFillScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToBlockAutoFillScreen = { onNavigateToBlockAutoFillScreenCalled = true },
-                viewModel = viewModel,
-                intentManager = intentManager,
                 onNavigateToSetupAutofill = { onNavigateToSetupAutoFillScreenCalled = true },
+                viewModel = viewModel,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreenTest.kt
@@ -45,11 +45,12 @@ class ExportVaultScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             ExportVaultScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,
-                intentManager = intentManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
@@ -54,13 +54,14 @@ class VaultSettingsScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             VaultSettingsScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToExportVault = { onNavigateToExportVaultCalled = true },
                 onNavigateToFolders = { onNavigateToFoldersCalled = true },
-                intentManager = intentManager,
                 onNavigateToImportLogins = {
                     onNavigateToImportLoginsCalled = true
                     assertEquals(SnackbarRelay.VAULT_SETTINGS_RELAY, it)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -66,16 +66,15 @@ class GeneratorScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+            appResumeStateManager = appResumeStateManager,
+        ) {
             GeneratorScreen(
                 viewModel = viewModel,
-                onNavigateToPasswordHistory = {
-                    onNavigateToPasswordHistoryScreenCalled = true
-                },
+                onNavigateToPasswordHistory = { onNavigateToPasswordHistoryScreenCalled = true },
                 onNavigateBack = {},
                 onDimNavBarRequest = { onDimNavBarRequest = it },
-                intentManager = intentManager,
-                appResumeStateManager = appResumeStateManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
@@ -65,7 +65,10 @@ class SendScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+            appResumeStateManager = appResumeStateManager,
+        ) {
             SendScreen(
                 viewModel = viewModel,
                 onNavigateToAddSend = { onNavigateToNewSendCalled = true },
@@ -73,8 +76,6 @@ class SendScreenTest : BaseComposeTest() {
                 onNavigateToSendFilesList = { onNavigateToSendFilesListCalled = true },
                 onNavigateToSendTextList = { onNavigateToSendTextListCalled = true },
                 onNavigateToSearchSend = { onNavigateToSendSearchCalled = true },
-                intentManager = intentManager,
-                appResumeStateManager = appResumeStateManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
@@ -66,12 +66,13 @@ class AddSendScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            exitManager = exitManager,
+            intentManager = intentManager,
+            permissionsManager = permissionsManager,
+        ) {
             AddSendScreen(
                 viewModel = viewModel,
-                exitManager = exitManager,
-                intentManager = intentManager,
-                permissionsManager = permissionsManager,
                 onNavigateBack = { onNavigateBackCalled = true },
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -117,7 +117,13 @@ class VaultAddEditScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            permissionsManager = fakePermissionManager,
+            exitManager = exitManager,
+            intentManager = intentManager,
+            fido2CompletionManager = fido2CompletionManager,
+            biometricsManager = biometricsManager,
+        ) {
             VaultAddEditScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToQrCodeScanScreen = { onNavigateQrCodeScanScreenCalled = true },
@@ -128,11 +134,6 @@ class VaultAddEditScreenTest : BaseComposeTest() {
                 onNavigateToAttachments = { onNavigateToAttachmentsId = it },
                 onNavigateToMoveToOrganization = { id, _ -> onNavigateToMoveToOrganizationId = id },
                 viewModel = viewModel,
-                permissionsManager = fakePermissionManager,
-                exitManager = exitManager,
-                intentManager = intentManager,
-                fido2CompletionManager = fido2CompletionManager,
-                biometricsManager = biometricsManager,
             )
         }
     }
@@ -2384,8 +2385,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
         mutableStateFlow.update { currentState ->
             updateCommonContent(currentState) {
                 copy(
-                    availableOwners =
-                    listOf(
+                    availableOwners = listOf(
                         VaultAddEditState.Owner(
                             id = ownerId,
                             name = ownerName,
@@ -2661,8 +2661,7 @@ class VaultAddEditScreenTest : BaseComposeTest() {
         mutableStateFlow.update { currentState ->
             updateCommonContent(currentState) {
                 copy(
-                    availableFolders =
-                    listOf(
+                    availableFolders = listOf(
                         VaultAddEditState.Folder(
                             id = folderId,
                             name = folderName,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
@@ -46,10 +46,11 @@ class AttachmentsScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             AttachmentsScreen(
                 viewModel = viewModel,
-                intentManager = intentManager,
                 onNavigateBack = { onNavigateBackCalled = true },
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreenTest.kt
@@ -53,11 +53,12 @@ class ImportLoginsScreenTest : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             ImportLoginsScreen(
                 onNavigateBack = { navigateBackCalled = true },
                 viewModel = viewModel,
-                intentManager = intentManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -82,7 +82,9 @@ class VaultItemScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+        ) {
             VaultItemScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
@@ -92,7 +94,6 @@ class VaultItemScreenTest : BaseComposeTest() {
                 },
                 onNavigateToAttachments = { onNavigateToAttachmentsId = it },
                 onNavigateToPasswordHistory = { onNavigateToPasswordHistoryId = it },
-                intentManager = intentManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -117,13 +117,14 @@ class VaultItemListingScreenTest : BaseComposeTest() {
     fun setUp() {
         mockkStatic(String::toHostOrPathOrNull)
         every { AUTOFILL_SELECTION_DATA.uri?.toHostOrPathOrNull() } returns "www.test.com"
-        setContent {
+        setContent(
+            exitManager = exitManager,
+            intentManager = intentManager,
+            fido2CompletionManager = fido2CompletionManager,
+            biometricsManager = biometricsManager,
+        ) {
             VaultItemListingScreen(
                 viewModel = viewModel,
-                exitManager = exitManager,
-                intentManager = intentManager,
-                fido2CompletionManager = fido2CompletionManager,
-                biometricsManager = biometricsManager,
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToVaultItemScreen = { onNavigateToVaultItemArgs = it },
                 onNavigateToVaultAddItemScreen = { onNavigateToVaultAddItemScreenCalled = true },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreenTests.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreenTests.kt
@@ -52,15 +52,14 @@ class ManualCodeEntryScreenTests : BaseComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            permissionsManager = fakePermissionManager,
+            intentManager = intentManager,
+        ) {
             ManualCodeEntryScreen(
-                onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,
-                onNavigateToQrCodeScreen = {
-                    onNavigateToScanQrCodeCalled = true
-                },
-                permissionsManager = fakePermissionManager,
-                intentManager = intentManager,
+                onNavigateBack = { onNavigateBackCalled = true },
+                onNavigateToQrCodeScreen = { onNavigateToScanQrCodeCalled = true },
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -98,7 +98,11 @@ class VaultScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            exitManager = exitManager,
+            intentManager = intentManager,
+            appReviewManager = appReviewManager,
+        ) {
             VaultScreen(
                 viewModel = viewModel,
                 onNavigateToVaultAddItemScreen = { onNavigateToVaultAddItemScreenCalled = true },
@@ -116,9 +120,6 @@ class VaultScreenTest : BaseComposeTest() {
                     onNavigateToAddFolderCalled = true
                     onNavigateToAddFolderParentFolderName = folderName
                 },
-                exitManager = exitManager,
-                intentManager = intentManager,
-                appReviewManager = appReviewManager,
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
@@ -48,13 +48,14 @@ class VerificationCodeScreenTest : BaseComposeTest() {
 
     @Before
     fun setUp() {
-        setContent {
+        setContent(
+            appResumeStateManager = appResumeStateManager,
+        ) {
             VerificationCodeScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToVaultItemScreen = { onNavigateToVaultItemArgs = it },
                 onNavigateToSearch = { onNavigateToSearchCalled = true },
-                appResumeStateManager = appResumeStateManager,
             )
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18844](https://bitwarden.atlassian.net/browse/PM-18844)

## 📔 Objective

This PR adds support for sharing error logs via the share sheet from the `BitwardenBasicDialog`.

Main changes:
* The `MobileErrorReporting` feature flag has been added to the app with the remote-config and the default value disabled.
* A new flow was added to support scoped feature flags inside the UI.
* Base compose tests have been updated to support having Bitwarden local composition managers injected and overridable without needing to pass the values down from the screen.
* The `Check password for breaches` feature now supports error reporting.

Sample of the copyable data:
```
Stacktrace:
java.lang.IndexOutOfBoundsException: Index 5 out of bounds for length 2
	jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	java.util.Objects.checkIndex(Objects.java:359)
	java.util.ArrayList.get(ArrayList.java:434)
	com.x8bit.bitwarden.data.auth.datasource.network.service.HaveIBeenPwnedServiceImpl.getPasswordBreachCount-gIAlu-s(HaveIBeenPwnedServiceImpl.kt:32)
	com.x8bit.bitwarden.data.auth.datasource.network.service.HaveIBeenPwnedServiceImpl$getPasswordBreachCount$1.invokeSuspend(Unknown Source:15)
	kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	android.os.Handler.handleCallback(Handler.java:991)
	android.os.Handler.dispatchMessage(Handler.java:102)
	android.os.Looper.loopOnce(Looper.java:232)
	android.os.Looper.loop(Looper.java:317)
	android.app.ActivityThread.main(ActivityThread.java:8787)
	java.lang.reflect.Method.invoke(Native Method)
	com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:591)
	com.android.internal.os.ZygoteInit.main(ZygoteInit.java:871)
Version: 2024.9.0 (1)
Device: :iphone: google Pixel 8 :robot_face: 15@35 :package: dev
CI: local
```

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/520887ab-6290-47a9-b808-d4d0bd02b94d" width="300" /> | <img src="https://github.com/user-attachments/assets/3a2d46a4-b93b-4f4d-a774-7470022a34d5" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18844]: https://bitwarden.atlassian.net/browse/PM-18844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ