### PR TITLE
PM-19199: hoist debug menu up to top level of the app

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.core.os.LocaleListCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityCompletionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillActivityManager
@@ -25,9 +26,11 @@ import com.x8bit.bitwarden.data.platform.manager.util.ObserveScreenDataEffect
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.composition.LocalManagerProvider
+import com.x8bit.bitwarden.ui.platform.feature.debugmenu.debugMenuDestination
 import com.x8bit.bitwarden.ui.platform.feature.debugmenu.manager.DebugMenuLaunchManager
 import com.x8bit.bitwarden.ui.platform.feature.debugmenu.navigateToDebugMenuScreen
-import com.x8bit.bitwarden.ui.platform.feature.rootnav.RootNavScreen
+import com.x8bit.bitwarden.ui.platform.feature.rootnav.ROOT_ROUTE
+import com.x8bit.bitwarden.ui.platform.feature.rootnav.rootNavDestination
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.ui.platform.util.appLanguage
 import dagger.hilt.android.AndroidEntryPoint
@@ -121,10 +124,19 @@ class MainActivity : AppCompatActivity() {
                     },
                 )
                 BitwardenTheme(theme = state.theme) {
-                    RootNavScreen(
-                        onSplashScreenRemoved = { shouldShowSplashScreen = false },
+                    NavHost(
                         navController = navController,
-                    )
+                        startDestination = ROOT_ROUTE,
+                    ) {
+                        // Nothing else should end up at this top level, we just want the ability
+                        // to have the debug menu appear on top of the rest of the app without
+                        // interacting with the state-based navigation used by the RootNavScreen.
+                        rootNavDestination { shouldShowSplashScreen = false }
+                        debugMenuDestination(
+                            onNavigateBack = { navController.popBackStack() },
+                            onSplashScreenRemoved = { shouldShowSplashScreen = false },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuNavigation.kt
@@ -18,12 +18,15 @@ fun NavController.navigateToDebugMenuScreen() {
 /**
  * Add the setup unlock screen to the nav graph.
  */
-fun NavGraphBuilder.setupDebugMenuDestination(
+fun NavGraphBuilder.debugMenuDestination(
     onNavigateBack: () -> Unit,
+    onSplashScreenRemoved: () -> Unit,
 ) {
     composableWithPushTransitions(
         route = DEBUG_MENU,
     ) {
         DebugMenuScreen(onNavigateBack = onNavigateBack)
+        // If we are displaying the debug screen, then we can just hide the splash screen.
+        onSplashScreenRemoved()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavNavigation.kt
@@ -1,0 +1,20 @@
+package com.x8bit.bitwarden.ui.platform.feature.rootnav
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+
+/**
+ * The route for the root navigation screen.
+ */
+const val ROOT_ROUTE: String = "root"
+
+/**
+ * Add the root navigation screen to the nav graph.
+ */
+fun NavGraphBuilder.rootNavDestination(
+    onSplashScreenRemoved: () -> Unit,
+) {
+    composable(route = ROOT_ROUTE) {
+        RootNavScreen(onSplashScreenRemoved = onSplashScreenRemoved)
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -45,7 +45,6 @@ import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.VAULT_UNLOCK_ROUTE
 import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.navigateToVaultUnlock
 import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.vaultUnlockDestination
 import com.x8bit.bitwarden.ui.auth.feature.welcome.navigateToWelcome
-import com.x8bit.bitwarden.ui.platform.feature.debugmenu.setupDebugMenuDestination
 import com.x8bit.bitwarden.ui.platform.feature.rootnav.util.toVaultItemListingType
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.loginapproval.navigateToLoginApproval
 import com.x8bit.bitwarden.ui.platform.feature.splash.SPLASH_ROUTE
@@ -104,7 +103,6 @@ fun RootNavScreen(
         trustedDeviceGraph(navController)
         vaultUnlockDestination()
         vaultUnlockedGraph(navController)
-        setupDebugMenuDestination(onNavigateBack = { navController.popBackStack() })
         setupUnlockDestinationAsRoot()
         setupAutoFillDestinationAsRoot()
         setupCompleteDestination()


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19199](https://bitwarden.atlassian.net/browse/PM-19199)

## 📔 Objective

This PR moves the debug menu screen up into the top-most level of the app in order to remove it from the state-based navigation graph.

Having an event-driven screen in the state-driven root nav host was various bugs whenever the state changed which would remove the debug menu from the stack. The most obvious issue was visible during rotation.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/90457f49-9199-4611-9df6-68d0bf41a2d4" width="300" /> | <video src="https://github.com/user-attachments/assets/c2fb190f-ca18-4469-8d89-3618f006ca8c" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19199]: https://bitwarden.atlassian.net/browse/PM-19199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ