### PR TITLE
PM-18681 - Update Showing Coach Mark Tour Logic To Only Consider User's Personal Vault

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -315,12 +315,12 @@ class FirstTimeActionManagerImpl @Inject constructor(
                     flow2 = vaultDiskSource.getCiphers(activeUserId),
                     flow3 = authDiskSource.getPoliciesFlow(activeUserId),
                 ) { receiverCurrentValue, ciphers, policies ->
-                    val hasLoginCiphersWithNoAssociatedOrgs = ciphers.any {
+                    val hasLoginsWithNoOrganizations = ciphers.any {
                         it.login != null && it.organizationId == null
                     }
                     val onlyOrgPolicy = policies?.any { it.type == PolicyTypeJson.ONLY_ORG } == true
 
-                    receiverCurrentValue && (!hasLoginCiphersWithNoAssociatedOrgs || onlyOrgPolicy)
+                    receiverCurrentValue && (!hasLoginsWithNoOrganizations || onlyOrgPolicy)
                 }
             }
             .distinctUntilChanged()

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -9,7 +9,6 @@ import com.x8bit.bitwarden.data.platform.manager.model.CoachMarkTourType
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
-import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -159,7 +158,7 @@ class FirstTimeActionManagerImpl @Inject constructor(
     override val shouldShowAddLoginCoachMarkFlow: Flow<Boolean>
         get() = settingsDiskSource
             .getShouldShowAddLoginCoachMarkFlow()
-            .map { it != false }
+            .map { it ?: true }
             .mapFalseIfAnyLoginCiphersAvailable()
             .combine(
                 featureFlagManager.getFeatureFlagFlow(FlagKey.OnboardingFlow),
@@ -173,13 +172,11 @@ class FirstTimeActionManagerImpl @Inject constructor(
     override val shouldShowGeneratorCoachMarkFlow: Flow<Boolean>
         get() = settingsDiskSource
             .getShouldShowGeneratorCoachMarkFlow()
-            .map { it != false }
+            .map { it ?: true }
             .mapFalseIfAnyLoginCiphersAvailable()
             .combine(
                 featureFlagManager.getFeatureFlagFlow(FlagKey.OnboardingFlow),
             ) { shouldShow, featureFlagEnabled ->
-                // If the feature flag is off always return true so observers know
-                // the card has not been shown.
                 shouldShow && featureFlagEnabled
             }
             .distinctUntilChanged()
@@ -301,8 +298,8 @@ class FirstTimeActionManagerImpl @Inject constructor(
     }
 
     /**
-     * Maps the receiver Flow to `false` if a personal (non-org) Login cipher exists,
-     * unless an `ONLY_ORG` policy is active, in which case it remains `true`.
+     * If there are any existing "Login" type ciphers then we'll map the current value
+     * of the receiver Flow to `false`.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun Flow<Boolean>.mapFalseIfAnyLoginCiphersAvailable(): Flow<Boolean> =
@@ -313,14 +310,10 @@ class FirstTimeActionManagerImpl @Inject constructor(
                 combine(
                     flow = this,
                     flow2 = vaultDiskSource.getCiphers(activeUserId),
-                    flow3 = authDiskSource.getPoliciesFlow(activeUserId),
-                ) { receiverCurrentValue, ciphers, policies ->
-                    val hasLoginsWithNoOrganizations = ciphers.any {
+                ) { currentValue, ciphers ->
+                    currentValue && ciphers.none {
                         it.login != null && it.organizationId == null
                     }
-                    val onlyOrgPolicy = policies?.any { it.type == PolicyTypeJson.ONLY_ORG } == true
-
-                    receiverCurrentValue && (!hasLoginsWithNoOrganizations || onlyOrgPolicy)
                 }
             }
             .distinctUntilChanged()

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -455,8 +455,8 @@ class FirstTimeActionManagerTest {
                         number = 2,
                         organizationId = "1234",
                         type = PolicyTypeJson.ONLY_ORG,
-                    )
-                )
+                    ),
+                ),
             )
             // Enable feature flag so flow emits updates from disk.
             mutableOnboardingFeatureFlow.update { true }
@@ -482,8 +482,8 @@ class FirstTimeActionManagerTest {
                         number = 2,
                         organizationId = "1234",
                         type = PolicyTypeJson.ONLY_ORG,
-                    )
-                )
+                    ),
+                ),
             )
             val mockJsonWithLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
                 every { login } returns mockk()

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -15,9 +15,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.CoachMarkTourType
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
-import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
-import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockPolicy
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -439,67 +437,6 @@ class FirstTimeActionManagerTest {
             }
             firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
                 assertTrue(awaitItem())
-            }
-        }
-
-    @Test
-    fun `if a user has a org only policy with no login items we show coach marks`() =
-        runTest {
-            val userState = MOCK_USER_STATE
-            fakeAuthDiskSource.userState = userState
-            fakeAuthDiskSource.storePolicies(
-                userState.activeUserId,
-                listOf(
-                    createMockPolicy(
-                        isEnabled = true,
-                        number = 2,
-                        organizationId = "1234",
-                        type = PolicyTypeJson.ONLY_ORG,
-                    ),
-                ),
-            )
-            // Enable feature flag so flow emits updates from disk.
-            mutableOnboardingFeatureFlow.update { true }
-
-            firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
-                assertTrue(awaitItem())
-                // Make sure when we change the disk source that we honor that value.
-                fakeSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = false)
-                assertFalse(awaitItem())
-            }
-        }
-
-    @Test
-    fun `if a user has a org only policy with login items we show coach marks`() =
-        runTest {
-            val userState = MOCK_USER_STATE
-            fakeAuthDiskSource.userState = userState
-            fakeAuthDiskSource.storePolicies(
-                userState.activeUserId,
-                listOf(
-                    createMockPolicy(
-                        isEnabled = true,
-                        number = 2,
-                        organizationId = "1234",
-                        type = PolicyTypeJson.ONLY_ORG,
-                    ),
-                ),
-            )
-            val mockJsonWithLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
-                every { login } returns mockk()
-                every { organizationId } returns "1234"
-            }
-            mutableCiphersListFlow.update {
-                listOf(mockJsonWithLoginAndWithOrganizationId)
-            }
-            // Enable feature flag so flow emits updates from disk.
-            mutableOnboardingFeatureFlow.update { true }
-
-            firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
-                assertTrue(awaitItem())
-                // Make sure when we change the disk source that we honor that value.
-                fakeSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = false)
-                assertFalse(awaitItem())
             }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -15,7 +15,9 @@ import com.x8bit.bitwarden.data.platform.manager.model.CoachMarkTourType
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
+import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
+import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockPolicy
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -425,7 +427,7 @@ class FirstTimeActionManagerTest {
     @Test
     fun `if there are login ciphers attached to an organization we should show coach marks`() =
         runTest {
-            val mockJsonWithNoLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
+            val mockJsonWithLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
                 every { login } returns mockk()
                 every { organizationId } returns "1234"
             }
@@ -433,10 +435,71 @@ class FirstTimeActionManagerTest {
             // Enable feature flag so flow emits updates from disk.
             mutableOnboardingFeatureFlow.update { true }
             mutableCiphersListFlow.update {
-                listOf(mockJsonWithNoLoginAndWithOrganizationId)
+                listOf(mockJsonWithLoginAndWithOrganizationId)
             }
             firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
                 assertTrue(awaitItem())
+            }
+        }
+
+    @Test
+    fun `if a user has a org only policy with no login items we show coach marks`() =
+        runTest {
+            val userState = MOCK_USER_STATE
+            fakeAuthDiskSource.userState = userState
+            fakeAuthDiskSource.storePolicies(
+                userState.activeUserId,
+                listOf(
+                    createMockPolicy(
+                        isEnabled = true,
+                        number = 2,
+                        organizationId = "1234",
+                        type = PolicyTypeJson.ONLY_ORG,
+                    )
+                )
+            )
+            // Enable feature flag so flow emits updates from disk.
+            mutableOnboardingFeatureFlow.update { true }
+
+            firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
+                assertTrue(awaitItem())
+                // Make sure when we change the disk source that we honor that value.
+                fakeSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = false)
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `if a user has a org only policy with login items we show coach marks`() =
+        runTest {
+            val userState = MOCK_USER_STATE
+            fakeAuthDiskSource.userState = userState
+            fakeAuthDiskSource.storePolicies(
+                userState.activeUserId,
+                listOf(
+                    createMockPolicy(
+                        isEnabled = true,
+                        number = 2,
+                        organizationId = "1234",
+                        type = PolicyTypeJson.ONLY_ORG,
+                    )
+                )
+            )
+            val mockJsonWithLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
+                every { login } returns mockk()
+                every { organizationId } returns "1234"
+            }
+            mutableCiphersListFlow.update {
+                listOf(mockJsonWithLoginAndWithOrganizationId)
+            }
+            // Enable feature flag so flow emits updates from disk.
+            mutableOnboardingFeatureFlow.update { true }
+
+            firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
+                assertTrue(awaitItem())
+                // Make sure when we change the disk source that we honor that value.
+                fakeSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = false)
+                assertFalse(awaitItem())
             }
         }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -15,9 +15,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.CoachMarkTourType
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
-import com.x8bit.bitwarden.data.vault.datasource.network.model.PolicyTypeJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson
-import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockPolicy
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -427,7 +425,7 @@ class FirstTimeActionManagerTest {
     @Test
     fun `if there are login ciphers attached to an organization we should show coach marks`() =
         runTest {
-            val mockJsonWithLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
+            val mockJsonWithNoLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
                 every { login } returns mockk()
                 every { organizationId } returns "1234"
             }
@@ -435,71 +433,10 @@ class FirstTimeActionManagerTest {
             // Enable feature flag so flow emits updates from disk.
             mutableOnboardingFeatureFlow.update { true }
             mutableCiphersListFlow.update {
-                listOf(mockJsonWithLoginAndWithOrganizationId)
+                listOf(mockJsonWithNoLoginAndWithOrganizationId)
             }
             firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
                 assertTrue(awaitItem())
-            }
-        }
-
-    @Test
-    fun `if a user has a org only policy with no login items we show coach marks`() =
-        runTest {
-            val userState = MOCK_USER_STATE
-            fakeAuthDiskSource.userState = userState
-            fakeAuthDiskSource.storePolicies(
-                userState.activeUserId,
-                listOf(
-                    createMockPolicy(
-                        isEnabled = true,
-                        number = 2,
-                        organizationId = "1234",
-                        type = PolicyTypeJson.ONLY_ORG,
-                    ),
-                ),
-            )
-            // Enable feature flag so flow emits updates from disk.
-            mutableOnboardingFeatureFlow.update { true }
-
-            firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
-                assertTrue(awaitItem())
-                // Make sure when we change the disk source that we honor that value.
-                fakeSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = false)
-                assertFalse(awaitItem())
-            }
-        }
-
-    @Test
-    fun `if a user has a org only policy with login items we show coach marks`() =
-        runTest {
-            val userState = MOCK_USER_STATE
-            fakeAuthDiskSource.userState = userState
-            fakeAuthDiskSource.storePolicies(
-                userState.activeUserId,
-                listOf(
-                    createMockPolicy(
-                        isEnabled = true,
-                        number = 2,
-                        organizationId = "1234",
-                        type = PolicyTypeJson.ONLY_ORG,
-                    ),
-                ),
-            )
-            val mockJsonWithLoginAndWithOrganizationId = mockk<SyncResponseJson.Cipher> {
-                every { login } returns mockk()
-                every { organizationId } returns "1234"
-            }
-            mutableCiphersListFlow.update {
-                listOf(mockJsonWithLoginAndWithOrganizationId)
-            }
-            // Enable feature flag so flow emits updates from disk.
-            mutableOnboardingFeatureFlow.update { true }
-
-            firstTimeActionManager.shouldShowGeneratorCoachMarkFlow.test {
-                assertTrue(awaitItem())
-                // Make sure when we change the disk source that we honor that value.
-                fakeSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = false)
-                assertFalse(awaitItem())
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18681](https://bitwarden.atlassian.net/browse/PM-18681)

## 📔 Objective

- Revert the logical changes from [PR #4854](https://github.com/bitwarden/android/pull/4854). The previous test results were misleading due to personal items being present in the test account for testing out org only policies. The “_Confirm that a user in an organization who has access to org items but has no individual vault due to org policy does see the Tours_” use case was producing a false positive because of this.
- The org-only change caused issues with another use case. However, after reverting to the original implementation and testing with valid accounts, all tests passed successfully.

## 📸 Screenshots

https://github.com/user-attachments/assets/fa0c1e0f-4ce6-444f-b6b7-cafc6ee75bff

- First account has a personal login item and does not see the tours
- Second account is an org only account, with no personal items, and does see the tours

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18681]: https://bitwarden.atlassian.net/browse/PM-18681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ