### PR TITLE
PM-14435: Improve accessibility service detection

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/BitwardenLegacyAppComponents.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/BitwardenLegacyAppComponents.kt
@@ -7,6 +7,11 @@ const val LEGACY_ACCESSIBILITY_SERVICE_NAME: String =
     "com.x8bit.bitwarden.Accessibility.AccessibilityService"
 
 /**
+ * The short form legacy name for the accessibility service.
+ */
+const val LEGACY_SHORT_ACCESSIBILITY_SERVICE_NAME: String = ".Accessibility.AccessibilityService"
+
+/**
  * The legacy name for the autofill service.
  */
 const val LEGACY_AUTOFILL_SERVICE_NAME: String = "com.x8bit.bitwarden.Autofill.AutofillService"

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/BitwardenAccessibilityService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/BitwardenAccessibilityService.kt
@@ -32,6 +32,11 @@ class BitwardenAccessibilityService : AccessibilityService() {
 
     override fun onInterrupt() = Unit
 
+    override fun onCreate() {
+        super.onCreate()
+        accessibilityEnabledManager.refreshAccessibilityEnabledFromSettings()
+    }
+
     override fun onUnbind(intent: Intent?): Boolean {
         return super
             .onUnbind(intent)

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/ContextExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/ContextExtensions.kt
@@ -3,7 +3,9 @@ package com.x8bit.bitwarden.data.autofill.accessibility.util
 import android.content.Context
 import android.provider.Settings
 import com.x8bit.bitwarden.LEGACY_ACCESSIBILITY_SERVICE_NAME
+import com.x8bit.bitwarden.LEGACY_SHORT_ACCESSIBILITY_SERVICE_NAME
 import com.x8bit.bitwarden.data.autofill.accessibility.BitwardenAccessibilityService
+import com.x8bit.bitwarden.data.autofill.util.containsAnyTerms
 
 /**
  * Helper method to determine if the [BitwardenAccessibilityService] is enabled.
@@ -11,16 +13,25 @@ import com.x8bit.bitwarden.data.autofill.accessibility.BitwardenAccessibilitySer
 val Context.isAccessibilityServiceEnabled: Boolean
     get() {
         val appContext = this.applicationContext
-        val accessibilityServiceName = appContext
-            .packageName
-            ?.let { "$it/$LEGACY_ACCESSIBILITY_SERVICE_NAME" }
-            ?: return false
+        val packageName = appContext.packageName
+        val accessibilityServiceName = packageName?.let {
+            "$it/$LEGACY_ACCESSIBILITY_SERVICE_NAME"
+        }
+        val shortAccessibilityServiceName = packageName.let {
+            "$it/$LEGACY_SHORT_ACCESSIBILITY_SERVICE_NAME"
+        }
         return Settings
             .Secure
             .getString(
                 appContext.contentResolver,
                 Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
             )
-            ?.contains(accessibilityServiceName)
+            ?.containsAnyTerms(
+                terms = listOfNotNull(
+                    accessibilityServiceName,
+                    shortAccessibilityServiceName,
+                ),
+                ignoreCase = true,
+            )
             ?: false
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/util/ContextExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/accessibility/util/ContextExtensionsTest.kt
@@ -29,6 +29,7 @@ class ContextExtensionsTest {
         val context: Context = mockk {
             every { applicationContext } returns this
             every { packageName } returns null
+            every { contentResolver } returns mockk()
         }
 
         assertFalse(context.isAccessibilityServiceEnabled)
@@ -70,6 +71,20 @@ class ContextExtensionsTest {
         }
         mockkSettingsSecureGetString(
             value = "com.x8bit.bitwarden/com.x8bit.bitwarden.Accessibility.AccessibilityService",
+        )
+
+        assertTrue(context.isAccessibilityServiceEnabled)
+    }
+
+    @Test
+    fun `isAccessibilityServiceEnabled with correct abbreviated secure string returns true`() {
+        val context: Context = mockk {
+            every { applicationContext } returns this
+            every { packageName } returns "com.x8bit.bitwarden"
+            every { contentResolver } returns mockk()
+        }
+        mockkSettingsSecureGetString(
+            value = "com.x8bit.bitwarden/.Accessibility.AccessibilityService",
         )
 
         assertTrue(context.isAccessibilityServiceEnabled)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14435](https://bitwarden.atlassian.net/browse/PM-14435)

## 📔 Objective

This PR improves the apps ability to detect if the accessibility service is running or not.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
