### PR TITLE
PM-11356 Adjust autofocus delay to be greater than screen refresh delay.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -58,6 +58,7 @@ import java.time.Clock
 import javax.inject.Inject
 
 private const val SPECIAL_CIRCUMSTANCE_KEY = "special-circumstance"
+private const val ANIMATION_REFRESH_DELAY = 500L
 
 /**
  * A view model that helps launch actions for the [MainActivity].
@@ -148,8 +149,7 @@ class MainViewModel @Inject constructor(
                 // Switching between account states often involves some kind of animation (ex:
                 // account switcher) that we might want to give time to finish before triggering
                 // a refresh.
-                @Suppress("MagicNumber")
-                delay(500)
+                delay(ANIMATION_REFRESH_DELAY)
                 trySendAction(MainAction.Internal.CurrentUserStateChange)
             }
             .launchIn(viewModelScope)
@@ -161,8 +161,7 @@ class MainViewModel @Inject constructor(
                     is VaultStateEvent.Locked -> {
                         // Similar to account switching, triggering this action too soon can
                         // interfere with animations or navigation logic, so we will delay slightly.
-                        @Suppress("MagicNumber")
-                        delay(500)
+                        delay(ANIMATION_REFRESH_DELAY)
                         trySendAction(MainAction.Internal.VaultUnlockStateChange)
                     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -70,7 +70,14 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
 import javax.crypto.Cipher
 
-private const val AUTO_FOCUS_DELAY = 415L
+/**
+ * Time slice to delay auto-focusing on the password/pin field. Because of the refresh that
+ * takes place when switching accounts or changing the lock status we want to delay this
+ * longer than the delay in place for sending those actions in [com.x8bit.bitwarden.MainViewModel]
+ * defined by `ANIMATION_REFRESH_DELAY`. We need to  ensure this value is
+ * always greater.
+ */
+private const val AUTO_FOCUS_DELAY = 575L
 
 /**
  * The top level composable for the Vault Unlock screen.

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
@@ -479,7 +479,7 @@ class VaultUnlockScreenTest : BaseComposeTest() {
     @Test
     fun `state with input and without biometrics should request focus on input field`() = runTest {
         mutableStateFlow.update { it.copy(hideInput = false, isBiometricEnabled = false) }
-        dispatcher.advanceTimeByAndRunCurrent(500L)
+        dispatcher.advanceTimeByAndRunCurrent(600L)
         composeTestRule
             .onNodeWithText("Master password")
             .performScrollTo()


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-11356
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Missed the delays in the MainViewModel flows which trigger the screen refresh. Adjusting the time to be greater than that and added comment for added context.
- The result of this can be seen on a release build, seems like in debug the timing was not as exact which is why the smaller time slice seemingly worked originally.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
