### PR TITLE
PM-19226: Propagate error from create auth request flow to UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerImpl.kt
@@ -70,9 +70,8 @@ class AuthRequestManagerImpl(
             email = email,
             authRequestType = authRequestType.toAuthRequestTypeJson(),
         )
-            .getOrNull()
-            ?: run {
-                emit(CreateAuthRequestResult.Error)
+            .getOrElse {
+                emit(CreateAuthRequestResult.Error(error = it))
                 return@flow
             }
         var authRequest = initialResult.authRequest
@@ -103,7 +102,7 @@ class AuthRequestManagerImpl(
                     )
                 }
                 .fold(
-                    onFailure = { emit(CreateAuthRequestResult.Error) },
+                    onFailure = { emit(CreateAuthRequestResult.Error(error = it)) },
                     onSuccess = { updateAuthRequest ->
                         when {
                             updateAuthRequest.requestApproved -> {

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/CreateAuthRequestResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/CreateAuthRequestResult.kt
@@ -23,7 +23,9 @@ sealed class CreateAuthRequestResult {
     /**
      * There was a generic error getting the user's auth requests.
      */
-    data object Error : CreateAuthRequestResult()
+    data class Error(
+        val error: Throwable,
+    ) : CreateAuthRequestResult()
 
     /**
      * The auth request has been declined.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreen.kt
@@ -258,6 +258,7 @@ private fun LoginWithDeviceDialogs(
         is LoginWithDeviceState.DialogState.Error -> BitwardenBasicDialog(
             title = state.title?.invoke(),
             message = state.message(),
+            throwable = state.error,
             onDismissRequest = onDismissDialog,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
@@ -153,6 +153,7 @@ class LoginWithDeviceViewModel @Inject constructor(
                         dialogState = LoginWithDeviceState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -478,6 +479,7 @@ data class LoginWithDeviceState(
         @Parcelize
         data class Error(
             val title: Text? = null,
+            val error: Throwable? = null,
             val message: Text,
         ) : DialogState()
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerTest.kt
@@ -68,6 +68,7 @@ class AuthRequestManagerTest {
         runTest {
             val email = "email@email.com"
             val authRequestResponse = AUTH_REQUEST_RESPONSE
+            val error = Throwable("Fail")
             coEvery {
                 authSdkSource.getNewAuthRequest(email = email)
             } returns authRequestResponse.asSuccess()
@@ -80,7 +81,7 @@ class AuthRequestManagerTest {
                     fingerprint = authRequestResponse.fingerprint,
                     authRequestType = AuthRequestTypeJson.LOGIN_WITH_DEVICE,
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             repository
                 .createAuthRequestWithUpdates(
@@ -88,7 +89,7 @@ class AuthRequestManagerTest {
                     authRequestType = AuthRequestType.OTHER_DEVICE,
                 )
                 .test {
-                    assertEquals(CreateAuthRequestResult.Error, awaitItem())
+                    assertEquals(CreateAuthRequestResult.Error(error = error), awaitItem())
                     awaitComplete()
                 }
         }
@@ -405,9 +406,10 @@ class AuthRequestManagerTest {
     fun `createAuthRequestWithUpdates with authSdkSource getNewAuthRequest error should emit Error`() =
         runTest {
             val email = "email@email.com"
+            val error = Throwable("Fail")
             coEvery {
                 authSdkSource.getNewAuthRequest(email = email)
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             repository
                 .createAuthRequestWithUpdates(
@@ -415,7 +417,7 @@ class AuthRequestManagerTest {
                     authRequestType = AuthRequestType.OTHER_DEVICE,
                 )
                 .test {
-                    assertEquals(CreateAuthRequestResult.Error, awaitItem())
+                    assertEquals(CreateAuthRequestResult.Error(error = error), awaitItem())
                     awaitComplete()
                 }
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
@@ -647,9 +647,12 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `on createAuthRequestWithUpdates Error received should show content with error dialog`() {
+        val error = Throwable("Fail!")
         val viewModel = createViewModel()
         assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
-        mutableCreateAuthRequestWithUpdatesFlow.tryEmit(CreateAuthRequestResult.Error)
+        mutableCreateAuthRequestWithUpdatesFlow.tryEmit(
+            value = CreateAuthRequestResult.Error(error = error),
+        )
         assertEquals(
             DEFAULT_STATE.copy(
                 viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
@@ -659,6 +662,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                 dialogState = LoginWithDeviceState.DialogState.Error(
                     title = R.string.an_error_has_occurred.asText(),
                     message = R.string.generic_error_message.asText(),
+                    error = error,
                 ),
             ),
             viewModel.stateFlow.value,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19226](https://bitwarden.atlassian.net/browse/PM-19226)

## 📔 Objective

This PR propagates the error from create auth request flow to UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19226]: https://bitwarden.atlassian.net/browse/PM-19226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ