### PR TITLE
PM-19233: Propagate auth request errors to the UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerImpl.kt
@@ -16,6 +16,7 @@ import com.x8bit.bitwarden.data.auth.manager.model.AuthRequestsUpdatesResult
 import com.x8bit.bitwarden.data.auth.manager.model.CreateAuthRequestResult
 import com.x8bit.bitwarden.data.auth.manager.util.isSso
 import com.x8bit.bitwarden.data.auth.manager.util.toAuthRequestTypeJson
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
 import com.x8bit.bitwarden.data.platform.util.flatMap
@@ -51,7 +52,9 @@ class AuthRequestManagerImpl(
     override fun getAuthRequestsWithUpdates(): Flow<AuthRequestsUpdatesResult> = flow {
         while (currentCoroutineContext().isActive) {
             when (val result = getAuthRequests()) {
-                AuthRequestsResult.Error -> emit(AuthRequestsUpdatesResult.Error)
+                is AuthRequestsResult.Error -> {
+                    emit(AuthRequestsUpdatesResult.Error(error = result.error))
+                }
 
                 is AuthRequestsResult.Success -> {
                     emit(AuthRequestsUpdatesResult.Update(authRequests = result.authRequests))
@@ -181,7 +184,7 @@ class AuthRequestManagerImpl(
                     )
                 }
                 .fold(
-                    onFailure = { emit(AuthRequestUpdatesResult.Error) },
+                    onFailure = { emit(AuthRequestUpdatesResult.Error(error = it)) },
                     onSuccess = { updateAuthRequest ->
                         when {
                             updateAuthRequest.requestApproved -> {
@@ -217,13 +220,18 @@ class AuthRequestManagerImpl(
         fingerprint: String,
     ): Flow<AuthRequestUpdatesResult> = getAuthRequest {
         when (val authRequestsResult = getAuthRequests()) {
-            AuthRequestsResult.Error -> AuthRequestUpdatesResult.Error
+            is AuthRequestsResult.Error -> {
+                AuthRequestUpdatesResult.Error(error = authRequestsResult.error)
+            }
+
             is AuthRequestsResult.Success -> {
                 authRequestsResult
                     .authRequests
                     .firstOrNull { it.fingerprint == fingerprint }
                     ?.let { AuthRequestUpdatesResult.Update(it) }
-                    ?: AuthRequestUpdatesResult.Error
+                    ?: AuthRequestUpdatesResult.Error(
+                        error = IllegalStateException("Could not find the auth request."),
+                    )
             }
         }
     }
@@ -233,30 +241,28 @@ class AuthRequestManagerImpl(
     ): Flow<AuthRequestUpdatesResult> = getAuthRequest {
         authRequestsService
             .getAuthRequest(requestId)
-            .map { response ->
-                getFingerprintPhrase(response.publicKey).getOrNull()?.let { fingerprint ->
-                    AuthRequest(
-                        id = response.id,
-                        publicKey = response.publicKey,
-                        platform = response.platform,
-                        ipAddress = response.ipAddress,
-                        key = response.key,
-                        masterPasswordHash = response.masterPasswordHash,
-                        creationDate = response.creationDate,
-                        responseDate = response.responseDate,
-                        requestApproved = response.requestApproved ?: false,
-                        originUrl = response.originUrl,
-                        fingerprint = fingerprint,
-                    )
-                }
+            .mapCatching { response ->
+                getFingerprintPhrase(response.publicKey)
+                    .getOrThrow()
+                    .let { fingerprint ->
+                        AuthRequest(
+                            id = response.id,
+                            publicKey = response.publicKey,
+                            platform = response.platform,
+                            ipAddress = response.ipAddress,
+                            key = response.key,
+                            masterPasswordHash = response.masterPasswordHash,
+                            creationDate = response.creationDate,
+                            responseDate = response.responseDate,
+                            requestApproved = response.requestApproved ?: false,
+                            originUrl = response.originUrl,
+                            fingerprint = fingerprint,
+                        )
+                    }
             }
             .fold(
-                onFailure = { AuthRequestUpdatesResult.Error },
-                onSuccess = { authRequest ->
-                    authRequest
-                        ?.let { AuthRequestUpdatesResult.Update(it) }
-                        ?: AuthRequestUpdatesResult.Error
-                },
+                onFailure = { AuthRequestUpdatesResult.Error(error = it) },
+                onSuccess = { AuthRequestUpdatesResult.Update(authRequest = it) },
             )
     }
 
@@ -308,7 +314,7 @@ class AuthRequestManagerImpl(
                 }
             }
             .fold(
-                onFailure = { AuthRequestsResult.Error },
+                onFailure = { AuthRequestsResult.Error(error = it) },
                 onSuccess = { AuthRequestsResult.Success(authRequests = it) },
             )
 
@@ -318,7 +324,7 @@ class AuthRequestManagerImpl(
         publicKey: String,
         isApproved: Boolean,
     ): AuthRequestResult {
-        val userId = activeUserId ?: return AuthRequestResult.Error
+        val userId = activeUserId ?: return AuthRequestResult.Error(error = NoActiveUserException())
         return vaultSdkSource
             .getAuthRequestKey(
                 publicKey = publicKey,
@@ -349,7 +355,7 @@ class AuthRequestManagerImpl(
                 )
             }
             .fold(
-                onFailure = { AuthRequestResult.Error },
+                onFailure = { AuthRequestResult.Error(error = it) },
                 onSuccess = { AuthRequestResult.Success(authRequest = it) },
             )
     }
@@ -461,7 +467,7 @@ class AuthRequestManagerImpl(
         publicKey: String,
     ): Result<String> {
         val profile = authDiskSource.userState?.activeAccount?.profile
-            ?: return IllegalStateException("No active account").asFailure()
+            ?: return NoActiveUserException().asFailure()
         return authSdkSource.getUserFingerprint(
             email = profile.email,
             publicKey = publicKey,

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/AuthRequestResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/AuthRequestResult.kt
@@ -14,5 +14,7 @@ sealed class AuthRequestResult {
     /**
      * There was an error getting the user's auth requests.
      */
-    data object Error : AuthRequestResult()
+    data class Error(
+        val error: Throwable,
+    ) : AuthRequestResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/AuthRequestUpdatesResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/AuthRequestUpdatesResult.kt
@@ -19,7 +19,9 @@ sealed class AuthRequestUpdatesResult {
     /**
      * There was an error getting the user's auth requests.
      */
-    data object Error : AuthRequestUpdatesResult()
+    data class Error(
+        val error: Throwable,
+    ) : AuthRequestUpdatesResult()
 
     /**
      * The auth request has been declined.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/AuthRequestsResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/AuthRequestsResult.kt
@@ -14,5 +14,7 @@ sealed class AuthRequestsResult {
     /**
      * There was an error getting the user's auth requests.
      */
-    data object Error : AuthRequestsResult()
+    data class Error(
+        val error: Throwable,
+    ) : AuthRequestsResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/AuthRequestsUpdatesResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/model/AuthRequestsUpdatesResult.kt
@@ -14,5 +14,7 @@ sealed class AuthRequestsUpdatesResult {
     /**
      * There was an error getting the user's auth requests.
      */
-    data object Error : AuthRequestsUpdatesResult()
+    data class Error(
+        val error: Throwable,
+    ) : AuthRequestsUpdatesResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/error/NoActiveUserException.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/error/NoActiveUserException.kt
@@ -1,0 +1,6 @@
+package com.x8bit.bitwarden.data.platform.error
+
+/**
+ * An exception indicating that there is currently no active user when one is required.
+ */
+class NoActiveUserException : IllegalStateException("No current active user!")

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreen.kt
@@ -296,6 +296,7 @@ private fun LoginApprovalDialogs(
         is LoginApprovalState.DialogState.Error -> BitwardenBasicDialog(
             title = state.title?.invoke(),
             message = state.message(),
+            throwable = state.error,
             onDismissRequest = onDismissError,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
@@ -177,7 +177,7 @@ class LoginApprovalViewModel @Inject constructor(
     private fun handleApproveRequestResultReceived(
         action: LoginApprovalAction.Internal.ApproveRequestResultReceive,
     ) {
-        when (action.result) {
+        when (val result = action.result) {
             is AuthRequestResult.Success -> {
                 sendEvent(LoginApprovalEvent.ShowToast(R.string.login_approved.asText()))
                 sendClosingEvent()
@@ -189,6 +189,7 @@ class LoginApprovalViewModel @Inject constructor(
                         dialogState = LoginApprovalState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -239,7 +240,7 @@ class LoginApprovalViewModel @Inject constructor(
     private fun handleDeclineRequestResultReceived(
         action: LoginApprovalAction.Internal.DeclineRequestResultReceive,
     ) {
-        when (action.result) {
+        when (val result = action.result) {
             is AuthRequestResult.Success -> {
                 sendEvent(LoginApprovalEvent.ShowToast(R.string.log_in_denied.asText()))
                 sendClosingEvent()
@@ -251,6 +252,7 @@ class LoginApprovalViewModel @Inject constructor(
                         dialogState = LoginApprovalState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -327,6 +329,7 @@ data class LoginApprovalState(
         data class Error(
             val title: Text?,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsViewModel.kt
@@ -169,7 +169,7 @@ class PendingRequestsViewModel @Inject constructor(
                 }
             }
 
-            AuthRequestsUpdatesResult.Error -> {
+            is AuthRequestsUpdatesResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         authRequests = emptyList(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModelTest.kt
@@ -210,7 +210,7 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
             viewState = LoginApprovalState.ViewState.Error,
         )
         val viewModel = createViewModel()
-        mutableAuthRequestSharedFlow.tryEmit(AuthRequestUpdatesResult.Error)
+        mutableAuthRequestSharedFlow.tryEmit(AuthRequestUpdatesResult.Error(error = Throwable()))
         assertEquals(expected, viewModel.stateFlow.value)
     }
 
@@ -383,6 +383,7 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
     @Test
     fun `on ErrorDialogDismiss should update state`() = runTest {
         val viewModel = createViewModel()
+        val error = Throwable("Fail!")
         coEvery {
             mockAuthRepository.updateAuthRequest(
                 requestId = REQUEST_ID,
@@ -390,7 +391,7 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
                 publicKey = PUBLIC_KEY,
                 isApproved = false,
             )
-        } returns AuthRequestResult.Error
+        } returns AuthRequestResult.Error(error = error)
         viewModel.trySendAction(LoginApprovalAction.DeclineRequestClick)
 
         assertEquals(
@@ -399,6 +400,7 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
                 dialogState = LoginApprovalState.DialogState.Error(
                     title = R.string.an_error_has_occurred.asText(),
                     message = R.string.generic_error_message.asText(),
+                    error = error,
                 ),
             ),
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsViewModelTest.kt
@@ -152,7 +152,9 @@ class PendingRequestsViewModelTest : BaseViewModelTest() {
             viewState = PendingRequestsState.ViewState.Error,
         )
         val viewModel = createViewModel()
-        mutableAuthRequestsWithUpdatesFlow.tryEmit(AuthRequestsUpdatesResult.Error)
+        mutableAuthRequestsWithUpdatesFlow.tryEmit(
+            value = AuthRequestsUpdatesResult.Error(error = Throwable()),
+        )
         assertEquals(expected, viewModel.stateFlow.value)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19233](https://bitwarden.atlassian.net/browse/PM-19233)

## 📔 Objective

This PR propagates the errors from the Auth Request flows to the UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19233]: https://bitwarden.atlassian.net/browse/PM-19233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ