### PR TITLE
PM-19234 propagates attachment result errors to UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
@@ -6,6 +6,7 @@ import com.bitwarden.vault.AttachmentView
 import com.bitwarden.vault.Cipher
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
@@ -152,7 +153,7 @@ class CipherManagerImpl(
         )
             .fold(
                 onSuccess = { DeleteAttachmentResult.Success },
-                onFailure = { DeleteAttachmentResult.Error },
+                onFailure = { DeleteAttachmentResult.Error(error = it) },
             )
 
     private suspend fun deleteCipherAttachmentForResult(
@@ -160,7 +161,7 @@ class CipherManagerImpl(
         attachmentId: String,
         cipherView: CipherView,
     ): Result<Cipher> {
-        val userId = activeUserId ?: return IllegalStateException("No active user").asFailure()
+        val userId = activeUserId ?: return NoActiveUserException().asFailure()
         return ciphersService
             .deleteCipherAttachment(
                 cipherId = cipherId,
@@ -320,7 +321,7 @@ class CipherManagerImpl(
             fileUri = fileUri,
         )
             .fold(
-                onFailure = { CreateAttachmentResult.Error },
+                onFailure = { CreateAttachmentResult.Error(error = it) },
                 onSuccess = { CreateAttachmentResult.Success(cipherView = it) },
             )
 
@@ -332,7 +333,7 @@ class CipherManagerImpl(
         fileName: String?,
         fileUri: Uri,
     ): Result<CipherView> {
-        val userId = activeUserId ?: return IllegalStateException("No active user").asFailure()
+        val userId = activeUserId ?: return NoActiveUserException().asFailure()
         val attachmentView = AttachmentView(
             id = null,
             url = null,
@@ -411,7 +412,7 @@ class CipherManagerImpl(
         cipherView: CipherView,
         attachmentId: String,
     ): Result<File> {
-        val userId = activeUserId ?: return IllegalStateException("No active user").asFailure()
+        val userId = activeUserId ?: return NoActiveUserException().asFailure()
 
         val cipher = cipherView
             .encryptCipherAndCheckForMigration(

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/CreateAttachmentResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/CreateAttachmentResult.kt
@@ -17,5 +17,5 @@ sealed class CreateAttachmentResult {
     /**
      * Generic error while creating an attachment.
      */
-    data object Error : CreateAttachmentResult()
+    data class Error(val error: Throwable) : CreateAttachmentResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/DeleteAttachmentResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/DeleteAttachmentResult.kt
@@ -13,5 +13,5 @@ sealed class DeleteAttachmentResult {
     /**
      * Generic error while deleting an attachment.
      */
-    data object Error : DeleteAttachmentResult()
+    data class Error(val error: Throwable) : DeleteAttachmentResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreen.kt
@@ -125,6 +125,7 @@ private fun AttachmentsDialogs(
             title = dialogState.title?.invoke(),
             message = dialogState.message(),
             onDismissRequest = onDismissRequest,
+            throwable = dialogState.throwable,
         )
 
         is AttachmentsState.DialogState.Loading -> BitwardenLoadingDialog(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
@@ -55,7 +55,6 @@ class AttachmentsViewModel @Inject constructor(
                 dialogState = AttachmentsState.DialogState.Error(
                     title = null,
                     message = R.string.premium_required.asText(),
-                    throwable = null,
                 )
                     .takeUnless { isPremiumUser },
                 isPremiumUser = isPremiumUser,
@@ -100,7 +99,6 @@ class AttachmentsViewModel @Inject constructor(
                         dialogState = AttachmentsState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.premium_required.asText(),
-                            throwable = null,
                         ),
                     )
                 }
@@ -114,7 +112,6 @@ class AttachmentsViewModel @Inject constructor(
                             message = R.string.validation_field_required.asText(
                                 R.string.file.asText(),
                             ),
-                            throwable = null,
                         ),
                     )
                 }
@@ -127,7 +124,6 @@ class AttachmentsViewModel @Inject constructor(
                         dialogState = AttachmentsState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.max_file_size.asText(),
-                            throwable = null,
                         ),
                     )
                 }
@@ -405,7 +401,7 @@ data class AttachmentsState(
         data class Error(
             val title: Text?,
             val message: Text,
-            val throwable: Throwable?,
+            val throwable: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
@@ -55,6 +55,7 @@ class AttachmentsViewModel @Inject constructor(
                 dialogState = AttachmentsState.DialogState.Error(
                     title = null,
                     message = R.string.premium_required.asText(),
+                    throwable = null,
                 )
                     .takeUnless { isPremiumUser },
                 isPremiumUser = isPremiumUser,
@@ -99,6 +100,7 @@ class AttachmentsViewModel @Inject constructor(
                         dialogState = AttachmentsState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.premium_required.asText(),
+                            throwable = null,
                         ),
                     )
                 }
@@ -112,6 +114,7 @@ class AttachmentsViewModel @Inject constructor(
                             message = R.string.validation_field_required.asText(
                                 R.string.file.asText(),
                             ),
+                            throwable = null,
                         ),
                     )
                 }
@@ -124,6 +127,7 @@ class AttachmentsViewModel @Inject constructor(
                         dialogState = AttachmentsState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.max_file_size.asText(),
+                            throwable = null,
                         ),
                     )
                 }
@@ -265,13 +269,14 @@ class AttachmentsViewModel @Inject constructor(
     private fun handleCreateAttachmentResultReceive(
         action: AttachmentsAction.Internal.CreateAttachmentResultReceive,
     ) {
-        when (action.result) {
-            CreateAttachmentResult.Error -> {
+        when (val result = action.result) {
+            is CreateAttachmentResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = AttachmentsState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            throwable = result.error,
                         ),
                     )
                 }
@@ -285,13 +290,14 @@ class AttachmentsViewModel @Inject constructor(
     }
 
     private fun handleDeleteResultReceive(action: AttachmentsAction.Internal.DeleteResultReceive) {
-        when (action.result) {
-            DeleteAttachmentResult.Error -> {
+        when (val result = action.result) {
+            is DeleteAttachmentResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = AttachmentsState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            throwable = result.error,
                         ),
                     )
                 }
@@ -399,6 +405,7 @@ data class AttachmentsState(
         data class Error(
             val title: Text?,
             val message: Text,
+            val throwable: Throwable?,
         ) : DialogState()
 
         /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.util.asFailure
 import com.x8bit.bitwarden.data.platform.util.asSuccess
@@ -607,7 +608,10 @@ class CipherManagerTest {
                 cipherView = mockk(),
             )
 
-            assertEquals(DeleteAttachmentResult.Error, result)
+            assertEquals(
+                DeleteAttachmentResult.Error(error = NoActiveUserException()),
+                result,
+            )
         }
 
     @Suppress("MaxLineLength")
@@ -617,12 +621,13 @@ class CipherManagerTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val cipherId = "mockId-1"
             val attachmentId = "mockId-1"
+            val error = Throwable("Fail")
             coEvery {
                 ciphersService.deleteCipherAttachment(
                     cipherId = cipherId,
                     attachmentId = attachmentId,
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             val result = cipherManager.deleteCipherAttachment(
                 cipherId = cipherId,
@@ -630,7 +635,7 @@ class CipherManagerTest {
                 cipherView = createMockCipherView(number = 1),
             )
 
-            assertEquals(DeleteAttachmentResult.Error, result)
+            assertEquals(DeleteAttachmentResult.Error(error = error), result)
         }
 
     @Suppress("MaxLineLength")
@@ -1138,7 +1143,7 @@ class CipherManagerTest {
                 fileUri = mockk(),
             )
 
-            assertEquals(CreateAttachmentResult.Error, result)
+            assertEquals(CreateAttachmentResult.Error(NoActiveUserException()), result)
         }
 
     @Suppress("MaxLineLength")
@@ -1152,9 +1157,10 @@ class CipherManagerTest {
             val mockCipherView = createMockCipherView(number = 1)
             val mockFileName = "mockFileName-1"
             val mockFileSize = "1"
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.encryptCipher(userId = userId, cipherView = mockCipherView)
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             val result = cipherManager.createAttachment(
                 cipherId = cipherId,
@@ -1164,7 +1170,7 @@ class CipherManagerTest {
                 fileUri = mockUri,
             )
 
-            assertEquals(CreateAttachmentResult.Error, result)
+            assertEquals(CreateAttachmentResult.Error(error = error), result)
         }
 
     @Suppress("MaxLineLength")
@@ -1186,6 +1192,7 @@ class CipherManagerTest {
                 url = null,
                 key = null,
             )
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.encryptCipher(userId = userId, cipherView = mockCipherView)
             } returns mockCipher.asSuccess()
@@ -1200,7 +1207,7 @@ class CipherManagerTest {
                     decryptedFilePath = mockFile.absolutePath,
                     encryptedFilePath = "${mockFile.absolutePath}.enc",
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             val result = cipherManager.createAttachment(
                 cipherId = cipherId,
@@ -1210,7 +1217,7 @@ class CipherManagerTest {
                 fileUri = mockUri,
             )
 
-            assertEquals(CreateAttachmentResult.Error, result)
+            assertEquals(CreateAttachmentResult.Error(error = error), result)
         }
 
     @Suppress("MaxLineLength")
@@ -1225,12 +1232,13 @@ class CipherManagerTest {
             val mockCipher = createMockSdkCipher(number = 1, clock = clock)
             val mockFileName = "mockFileName-1"
             val mockFileSize = "1"
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.encryptCipher(userId = userId, cipherView = mockCipherView)
             } returns mockCipher.asSuccess()
             coEvery {
                 fileManager.writeUriToCache(fileUri = mockUri)
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             val result = cipherManager.createAttachment(
                 cipherId = cipherId,
@@ -1240,7 +1248,7 @@ class CipherManagerTest {
                 fileUri = mockUri,
             )
 
-            assertEquals(CreateAttachmentResult.Error, result)
+            assertEquals(CreateAttachmentResult.Error(error = error), result)
         }
 
     @Suppress("MaxLineLength")
@@ -1263,6 +1271,7 @@ class CipherManagerTest {
             )
             val mockFile = File.createTempFile("mockFile", "temp")
             val mockAttachment = createMockSdkAttachment(number = 1)
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.encryptCipher(userId = userId, cipherView = mockCipherView)
             } returns mockCipher.asSuccess()
@@ -1287,7 +1296,7 @@ class CipherManagerTest {
                         fileSize = mockFileSize,
                     ),
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             val result = cipherManager.createAttachment(
                 cipherId = cipherId,
@@ -1297,7 +1306,7 @@ class CipherManagerTest {
                 fileUri = mockUri,
             )
 
-            assertEquals(CreateAttachmentResult.Error, result)
+            assertEquals(CreateAttachmentResult.Error(error = error), result)
         }
 
     @Suppress("MaxLineLength")
@@ -1321,6 +1330,7 @@ class CipherManagerTest {
             val mockFile = File.createTempFile("mockFile", "temp")
             val mockAttachment = createMockSdkAttachment(number = 1)
             val mockAttachmentJsonResponse = createMockAttachmentJsonResponse(number = 1)
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.encryptCipher(userId = userId, cipherView = mockCipherView)
             } returns mockCipher.asSuccess()
@@ -1351,7 +1361,7 @@ class CipherManagerTest {
                     attachmentJsonResponse = mockAttachmentJsonResponse,
                     encryptedFile = File("${mockFile.absoluteFile}.enc"),
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             val result = cipherManager.createAttachment(
                 cipherId = cipherId,
@@ -1361,7 +1371,7 @@ class CipherManagerTest {
                 fileUri = mockUri,
             )
 
-            assertEquals(CreateAttachmentResult.Error, result)
+            assertEquals(CreateAttachmentResult.Error(error = error), result)
         }
 
     @Suppress("MaxLineLength")
@@ -1389,6 +1399,7 @@ class CipherManagerTest {
             val mockUpdatedCipherResponse = createMockCipher(number = 1).copy(
                 collectionIds = listOf("mockId-1"),
             )
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.encryptCipher(userId = userId, cipherView = mockCipherView)
             } returns mockCipher.asSuccess()
@@ -1428,7 +1439,7 @@ class CipherManagerTest {
                     userId = userId,
                     cipher = mockUpdatedCipherResponse.toEncryptedSdkCipher(),
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
 
             val result = cipherManager.createAttachment(
                 cipherId = cipherId,
@@ -1438,7 +1449,7 @@ class CipherManagerTest {
                 fileUri = mockUri,
             )
 
-            assertEquals(CreateAttachmentResult.Error, result)
+            assertEquals(CreateAttachmentResult.Error(error = error), result)
         }
 
     @Suppress("MaxLineLength")

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
@@ -48,8 +48,10 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkConstructor
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
@@ -94,12 +96,17 @@ class CipherManagerTest {
     @BeforeEach
     fun setup() {
         mockkStatic(Uri::class)
+        mockkConstructor(NoActiveUserException::class)
+        every {
+            anyConstructed<NoActiveUserException>() == any<NoActiveUserException>()
+        } returns true
     }
 
     @AfterEach
     fun tearDown() {
         unmockkStatic(Uri::class, Instant::class)
         unmockkStatic(Cipher::toEncryptedNetworkCipherResponse)
+        unmockkConstructor(NoActiveUserException::class)
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
@@ -217,6 +217,7 @@ class AttachmentsScreenTest : BaseComposeTest() {
                 dialogState = AttachmentsState.DialogState.Error(
                     title = null,
                     message = errorMessage.asText(),
+                    throwable = null,
                 ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
@@ -8,6 +8,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.repository.model.DataState
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
@@ -86,6 +87,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
             dialogState = AttachmentsState.DialogState.Error(
                 title = null,
                 message = R.string.premium_required.asText(),
+                throwable = null,
             ),
             isPremiumUser = false,
         )
@@ -100,6 +102,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                     dialogState = AttachmentsState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = R.string.premium_required.asText(),
+                        throwable = null,
                     ),
                 ),
                 awaitItem(),
@@ -125,6 +128,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                     dialogState = AttachmentsState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = R.string.validation_field_required.asText(R.string.file.asText()),
+                        throwable = null,
                     ),
                 ),
                 awaitItem(),
@@ -168,6 +172,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                     dialogState = AttachmentsState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = R.string.max_file_size.asText(),
+                        throwable = null,
                     ),
                 ),
                 awaitItem(),
@@ -199,6 +204,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
             )
             mutableVaultItemStateFlow.value = DataState.Loaded(cipherView)
             mutableUserStateFlow.value = DEFAULT_USER_STATE
+            val error = NoActiveUserException()
             coEvery {
                 vaultRepository.createAttachment(
                     cipherId = state.cipherId,
@@ -207,7 +213,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                     fileName = fileName,
                     fileUri = uri,
                 )
-            } returns CreateAttachmentResult.Error
+            } returns CreateAttachmentResult.Error(error = error)
 
             val viewModel = createViewModel()
             // Need to populate the VM with a file
@@ -229,6 +235,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                         dialogState = AttachmentsState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            throwable = error,
                         ),
                     ),
                     awaitItem(),
@@ -356,13 +363,14 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
         val attachmentId = "mockId-1"
         val cipherView = createMockCipherView(number = 1)
         val initialState = DEFAULT_STATE.copy(viewState = DEFAULT_CONTENT_WITH_ATTACHMENTS)
+        val error = NoActiveUserException()
         coEvery {
             vaultRepository.deleteCipherAttachment(
                 cipherId = cipherId,
                 attachmentId = attachmentId,
                 cipherView = cipherView,
             )
-        } returns DeleteAttachmentResult.Error
+        } returns DeleteAttachmentResult.Error(error = error)
         mutableVaultItemStateFlow.value = DataState.Loaded(cipherView)
 
         val viewModel = createViewModel()
@@ -382,6 +390,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                     dialogState = AttachmentsState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = R.string.generic_error_message.asText(),
+                        throwable = error,
                     ),
                 ),
                 awaitItem(),


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-19234
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Propagate the errors from creating and deleting attachments to the UI.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
