### PR TITLE
PM-19241 folder result errors propagated to UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -766,8 +766,8 @@ class VaultRepositoryImpl(
     }
 
     override suspend fun createFolder(folderView: FolderView): CreateFolderResult {
-        val userId =
-            activeUserId ?: return CreateFolderResult.Error(error = NoActiveUserException())
+        val userId = activeUserId
+            ?: return CreateFolderResult.Error(error = NoActiveUserException())
         return vaultSdkSource
             .encryptFolder(
                 userId = userId,
@@ -841,8 +841,8 @@ class VaultRepositoryImpl(
     }
 
     override suspend fun deleteFolder(folderId: String): DeleteFolderResult {
-        val userId =
-            activeUserId ?: return DeleteFolderResult.Error(error = NoActiveUserException())
+        val userId = activeUserId
+            ?: return DeleteFolderResult.Error(error = NoActiveUserException())
         return folderService
             .deleteFolder(
                 folderId = folderId,

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/CreateFolderResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/CreateFolderResult.kt
@@ -15,5 +15,5 @@ sealed class CreateFolderResult {
     /**
      * Generic error while creating a folder.
      */
-    data object Error : CreateFolderResult()
+    data class Error(val error: Throwable) : CreateFolderResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/DeleteFolderResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/DeleteFolderResult.kt
@@ -13,5 +13,5 @@ sealed class DeleteFolderResult {
     /**
      * Generic error while deleting a folder.
      */
-    data object Error : DeleteFolderResult()
+    data class Error(val error: Throwable) : DeleteFolderResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/UpdateFolderResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/UpdateFolderResult.kt
@@ -16,5 +16,5 @@ sealed class UpdateFolderResult {
      * Generic error while updating a folder. The optional [errorMessage]
      * may be displayed directly in the UI when present.
      */
-    data class Error(val errorMessage: String?) : UpdateFolderResult()
+    data class Error(val errorMessage: String?, val error: Throwable?) : UpdateFolderResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreen.kt
@@ -178,6 +178,7 @@ private fun FolderAddEditItemDialogs(
             title = stringResource(id = R.string.an_error_has_occurred),
             message = dialogState.message(),
             onDismissRequest = onDismissRequest,
+            throwable = dialogState.throwable,
         )
 
         null -> Unit

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModel.kt
@@ -250,12 +250,13 @@ class FolderAddEditViewModel @Inject constructor(
             it.copy(dialog = null)
         }
 
-        when (action.result) {
+        when (val result = action.result) {
             is UpdateFolderResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialog = FolderAddEditState.DialogState.Error(
                             message = R.string.generic_error_message.asText(),
+                            throwable = result.error,
                         ),
                     )
                 }
@@ -275,12 +276,13 @@ class FolderAddEditViewModel @Inject constructor(
             it.copy(dialog = null)
         }
 
-        when (action.result) {
+        when (val result = action.result) {
             is CreateFolderResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialog = FolderAddEditState.DialogState.Error(
                             message = R.string.generic_error_message.asText(),
+                            throwable = result.error,
                         ),
                     )
                 }
@@ -296,12 +298,13 @@ class FolderAddEditViewModel @Inject constructor(
     private fun handleDeleteResultReceive(
         action: FolderAddEditAction.Internal.DeleteFolderResultReceive,
     ) {
-        when (action.result) {
-            DeleteFolderResult.Error -> {
+        when (val result = action.result) {
+            is DeleteFolderResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialog = FolderAddEditState.DialogState.Error(
                             message = R.string.generic_error_message.asText(),
+                            throwable = result.error,
                         ),
                     )
                 }
@@ -398,6 +401,7 @@ data class FolderAddEditState(
         @Parcelize
         data class Error(
             val message: Text,
+            val throwable: Throwable? = null,
         ) : DialogState()
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModelTest.kt
@@ -199,10 +199,12 @@ class FolderAddEditViewModelTest : BaseViewModelTest() {
     @Test
     fun `DeleteClick with DeleteFolderResult Failure should show an error dialog`() =
         runTest {
+            val error = Throwable("Oops")
             val stateWithDialog = FolderAddEditState(
                 folderAddEditType = FolderAddEditType.EditItem((DEFAULT_EDIT_ITEM_ID)),
                 dialog = FolderAddEditState.DialogState.Error(
                     R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
                 viewState = FolderAddEditState.ViewState.Content(
                     folderName = DEFAULT_FOLDER_NAME,
@@ -231,7 +233,7 @@ class FolderAddEditViewModelTest : BaseViewModelTest() {
 
             coEvery {
                 vaultRepository.deleteFolder(folderId = DEFAULT_EDIT_ITEM_ID)
-            } returns DeleteFolderResult.Error
+            } returns DeleteFolderResult.Error(error = error)
 
             viewModel.trySendAction(FolderAddEditAction.DeleteClick)
 
@@ -404,9 +406,10 @@ class FolderAddEditViewModelTest : BaseViewModelTest() {
             ),
         )
 
+        val error = Throwable("Oops")
         coEvery {
             vaultRepository.createFolder(any())
-        } returns CreateFolderResult.Error
+        } returns CreateFolderResult.Error(error = error)
 
         viewModel.trySendAction(FolderAddEditAction.SaveClick)
 
@@ -414,6 +417,7 @@ class FolderAddEditViewModelTest : BaseViewModelTest() {
             state.copy(
                 dialog = FolderAddEditState.DialogState.Error(
                     R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -485,6 +489,7 @@ class FolderAddEditViewModelTest : BaseViewModelTest() {
                 state = state,
             ),
         )
+        val error = Throwable("Oops")
 
         mutableFoldersStateFlow.value =
             DataState.Loaded(
@@ -497,14 +502,15 @@ class FolderAddEditViewModelTest : BaseViewModelTest() {
 
         coEvery {
             vaultRepository.updateFolder(any(), any())
-        } returns UpdateFolderResult.Error(errorMessage = null)
+        } returns UpdateFolderResult.Error(errorMessage = null, error = error)
 
         viewModel.trySendAction(FolderAddEditAction.SaveClick)
 
         assertEquals(
             state.copy(
                 dialog = FolderAddEditState.DialogState.Error(
-                    R.string.generic_error_message.asText(),
+                    message = R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-19241
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Propagate the thrown errors to the UI for folder CRUD results.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->



<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
