### PR TITLE
PM-19239: Propagate delete account errors to the UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/DeleteAccountResponseJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/DeleteAccountResponseJson.kt
@@ -23,6 +23,15 @@ sealed class DeleteAccountResponseJson {
     @Serializable
     data class Invalid(
         @SerialName("validationErrors")
-        val validationErrors: Map<String, List<String?>>?,
-    ) : DeleteAccountResponseJson()
+        private val validationErrors: Map<String, List<String?>>?,
+    ) : DeleteAccountResponseJson() {
+        /**
+         * A human readable error message.
+         */
+        val message: String?
+            get() = validationErrors
+                ?.values
+                ?.firstOrNull()
+                ?.firstOrNull()
+    }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/DeleteAccountResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/DeleteAccountResult.kt
@@ -12,5 +12,8 @@ sealed class DeleteAccountResult {
     /**
      * There was an error deleting the account.
      */
-    data class Error(val message: String?) : DeleteAccountResult()
+    data class Error(
+        val message: String?,
+        val error: Throwable?,
+    ) : DeleteAccountResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreen.kt
@@ -81,6 +81,7 @@ fun DeleteAccountScreen(
         is DeleteAccountState.DeleteAccountDialog.Error -> BitwardenBasicDialog(
             title = stringResource(id = R.string.an_error_has_occurred),
             message = dialog.message(),
+            throwable = dialog.error,
             onDismissRequest = remember(viewModel) {
                 { viewModel.trySendAction(DeleteAccountAction.DismissDialog) }
             },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreen.kt
@@ -112,6 +112,7 @@ private fun DeleteAccountConfirmationDialogs(
             BitwardenBasicDialog(
                 title = dialogState.title(),
                 message = dialogState.message(),
+                throwable = dialogState.error,
                 onDismissRequest = onDismissDialog,
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
@@ -156,6 +156,7 @@ class DeleteAccountConfirmationViewModel @Inject constructor(
                         DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.Error(
                             message = result.message?.asText()
                                 ?: R.string.generic_error_message.asText(),
+                            error = result.error,
                         )
                     }
 
@@ -201,6 +202,7 @@ data class DeleteAccountConfirmationState(
         data class Error(
             val title: Text = R.string.an_error_has_occurred.asText(),
             val message: Text,
+            val error: Throwable? = null,
         ) : DeleteAccountConfirmationDialog()
 
         /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
@@ -126,12 +126,13 @@ class DeleteAccountViewModelTest : BaseViewModelTest() {
     fun `on DeleteAccountClick should update dialog state when deleteAccount fails`() = runTest {
         val viewModel = createViewModel()
         val masterPassword = "ckasb kcs ja"
+        val error = Throwable("Fail!")
         coEvery {
             authRepo.validatePassword(any())
         } returns ValidatePasswordResult.Success(isValid = true)
         coEvery {
             authRepo.deleteAccountWithMasterPassword(masterPassword)
-        } returns DeleteAccountResult.Error(message = null)
+        } returns DeleteAccountResult.Error(message = null, error = error)
 
         viewModel.trySendAction(DeleteAccountAction.DeleteAccountConfirmDialogClick(masterPassword))
 
@@ -139,6 +140,7 @@ class DeleteAccountViewModelTest : BaseViewModelTest() {
             DEFAULT_STATE.copy(
                 dialog = DeleteAccountState.DeleteAccountDialog.Error(
                     message = R.string.generic_error_message.asText(),
+                    error = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -157,14 +159,9 @@ class DeleteAccountViewModelTest : BaseViewModelTest() {
             coEvery {
                 authRepo.validatePassword(any())
             } returns ValidatePasswordResult.Success(isValid = false)
-            coEvery {
-                authRepo.deleteAccountWithMasterPassword(masterPassword)
-            } returns DeleteAccountResult.Error(message = null)
 
             viewModel.trySendAction(
-                DeleteAccountAction.DeleteAccountConfirmDialogClick(
-                    masterPassword,
-                ),
+                DeleteAccountAction.DeleteAccountConfirmDialogClick(masterPassword),
             )
 
             assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModelTest.kt
@@ -58,7 +58,7 @@ class DeleteAccountConfirmationViewModelTest : BaseViewModelTest() {
             every { authRepo.clearPendingAccountDeletion() } just runs
             val state = DEFAULT_STATE.copy(
                 dialog =
-                DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.DeleteSuccess(),
+                    DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.DeleteSuccess(),
             )
             val viewModel = createViewModel(state = state)
 
@@ -121,9 +121,10 @@ class DeleteAccountConfirmationViewModelTest : BaseViewModelTest() {
     @Suppress("MaxLineLength")
     fun `on DeleteAccountClick with DeleteAccountResult Error should set dialog to Error with message`() =
         runTest {
+            val error = Throwable("Fail!")
             coEvery {
                 authRepo.deleteAccountWithOneTimePassword("123456")
-            } returns DeleteAccountResult.Error(message = "Delete account error")
+            } returns DeleteAccountResult.Error(message = "Delete account error", error = error)
             val initialState = DEFAULT_STATE.copy(
                 verificationCode = "123456",
             )
@@ -145,6 +146,7 @@ class DeleteAccountConfirmationViewModelTest : BaseViewModelTest() {
                     initialState.copy(
                         dialog = DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.Error(
                             message = "Delete account error".asText(),
+                            error = error,
                         ),
                     ),
                     awaitItem(),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19239](https://bitwarden.atlassian.net/browse/PM-19239)

## 📔 Objective

This PR propagates the errors for deleting an account to the apps UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19239]: https://bitwarden.atlassian.net/browse/PM-19239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ