### PR TITLE
PM-19245: Propagate error from password validation to UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/ValidatePasswordResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/ValidatePasswordResult.kt
@@ -15,5 +15,7 @@ sealed class ValidatePasswordResult {
     /**
      * There was an error determining if the validity of the password.
      */
-    data object Error : ValidatePasswordResult()
+    data class Error(
+        val error: Throwable,
+    ) : ValidatePasswordResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/error/MissingPropertyException.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/error/MissingPropertyException.kt
@@ -1,0 +1,8 @@
+package com.x8bit.bitwarden.data.platform.error
+
+/**
+ * An exception indicating that a required property was missing.
+ */
+class MissingPropertyException(
+    propertyName: String,
+) : IllegalStateException("Missing the required $propertyName property")

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordViewModel.kt
@@ -309,14 +309,15 @@ class ResetPasswordViewModel @Inject constructor(
     private fun handleReceiveValidatePasswordResult(
         action: ResetPasswordAction.Internal.ReceiveValidatePasswordResult,
     ) {
-        when (action.result) {
+        when (val result = action.result) {
             // Display an alert if there was an error.
-            ValidatePasswordResult.Error -> {
+            is ValidatePasswordResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = ResetPasswordState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -441,6 +442,7 @@ data class ResetPasswordState(
         data class Error(
             val title: Text?,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -562,13 +562,14 @@ class SearchViewModel @Inject constructor(
     private fun handleValidatePasswordResultReceive(
         action: SearchAction.Internal.ValidatePasswordResultReceive,
     ) {
-        when (action.result) {
-            ValidatePasswordResult.Error -> {
+        when (val result = action.result) {
+            is ValidatePasswordResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = SearchState.DialogState.Error(
                             title = null,
                             message = R.string.generic_error_message.asText(),
+                            throwable = result.error,
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreen.kt
@@ -124,6 +124,7 @@ fun ExportVaultScreen(
             BitwardenBasicDialog(
                 title = dialog.title?.invoke(),
                 message = dialog.message(),
+                throwable = dialog.error,
                 onDismissRequest = remember(viewModel) {
                     { viewModel.trySendAction(ExportVaultAction.DialogDismiss) }
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
@@ -304,9 +304,12 @@ class ExportVaultViewModel @Inject constructor(
     private fun handleReceiveValidatePasswordResult(
         action: ExportVaultAction.Internal.ReceiveValidatePasswordResult,
     ) {
-        when (action.result) {
-            ValidatePasswordResult.Error -> {
-                updateStateWithError(R.string.generic_error_message.asText())
+        when (val result = action.result) {
+            is ValidatePasswordResult.Error -> {
+                updateStateWithError(
+                    message = R.string.generic_error_message.asText(),
+                    error = result.error,
+                )
             }
 
             is ValidatePasswordResult.Success -> {
@@ -435,12 +438,13 @@ class ExportVaultViewModel @Inject constructor(
         }
     }
 
-    private fun updateStateWithError(message: Text) {
+    private fun updateStateWithError(message: Text, error: Throwable? = null) {
         mutableStateFlow.update {
             it.copy(
                 dialogState = ExportVaultState.DialogState.Error(
                     title = R.string.an_error_has_occurred.asText(),
                     message = message,
+                    error = error,
                 ),
             )
         }
@@ -475,6 +479,7 @@ data class ExportVaultState(
         data class Error(
             val title: Text? = null,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1829,7 +1829,7 @@ class VaultAddEditViewModel @Inject constructor(
         clearDialogState()
 
         when (action.result) {
-            ValidatePasswordResult.Error -> {
+            is ValidatePasswordResult.Error -> {
                 showFido2ErrorDialog()
             }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -1212,10 +1212,11 @@ class VaultItemViewModel @Inject constructor(
         action: VaultItemAction.Internal.ValidatePasswordReceive,
     ) {
         when (val result = action.result) {
-            ValidatePasswordResult.Error -> {
+            is ValidatePasswordResult.Error -> {
                 updateDialogState(
                     VaultItemState.DialogState.Generic(
                         message = R.string.generic_error_message.asText(),
+                        error = result.error,
                     ),
                 )
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1306,14 +1306,13 @@ class VaultItemListingViewModel @Inject constructor(
         clearDialogState()
 
         when (val result = action.result) {
-            ValidatePasswordResult.Error -> {
+            is ValidatePasswordResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = VaultItemListingState.DialogState.Error(
                             title = null,
                             message = R.string.generic_error_message.asText(),
-                            // TODO PM-19425 update ValidatePasswordResult to propagate error.
-                            throwable = null,
+                            throwable = result.error,
                         ),
                     )
                 }
@@ -1326,8 +1325,6 @@ class VaultItemListingViewModel @Inject constructor(
                             dialogState = VaultItemListingState.DialogState.Error(
                                 title = null,
                                 message = R.string.invalid_master_password.asText(),
-                                // TODO PM-19425 update ValidatePasswordResult to propagate error.
-                                throwable = null,
                             ),
                         )
                     }
@@ -1384,7 +1381,7 @@ class VaultItemListingViewModel @Inject constructor(
         clearDialogState()
 
         when (action.result) {
-            ValidatePasswordResult.Error -> {
+            is ValidatePasswordResult.Error -> {
                 showFido2UserVerificationErrorDialog()
             }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -419,6 +419,7 @@ private fun VaultDialogs(
         is VaultState.DialogState.Error -> BitwardenBasicDialog(
             title = dialogState.title(),
             message = dialogState.message(),
+            throwable = dialogState.error,
             onDismissRequest = vaultHandlers.dialogDismiss,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -782,12 +782,13 @@ class VaultViewModel @Inject constructor(
         action: VaultAction.Internal.ValidatePasswordResultReceive,
     ) {
         when (val result = action.result) {
-            ValidatePasswordResult.Error -> {
+            is ValidatePasswordResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialog = VaultState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -1165,6 +1166,7 @@ data class VaultState(
         data class Error(
             val title: Text,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordViewModelTest.kt
@@ -170,12 +170,13 @@ class ResetPasswordViewModelTest : BaseViewModelTest() {
     fun `SubmitClicked with error for validating current password shows error alert`() {
         val currentPassword = "CurrentTest123"
         val password = "Test123"
+        val error = Throwable("Fail!")
         coEvery {
             authRepository.validatePasswordAgainstPolicies(password)
         } returns true
         coEvery {
             authRepository.validatePassword(currentPassword)
-        } returns ValidatePasswordResult.Error
+        } returns ValidatePasswordResult.Error(error = error)
         coEvery {
             authRepository.getPasswordStrength(password = any())
         } returns PasswordStrengthResult.Success(passwordStrength = PasswordStrength.LEVEL_0)
@@ -192,6 +193,7 @@ class ResetPasswordViewModelTest : BaseViewModelTest() {
                 dialogState = ResetPasswordState.DialogState.Error(
                     title = R.string.an_error_has_occurred.asText(),
                     message = R.string.generic_error_message.asText(),
+                    error = error,
                 ),
                 currentPasswordInput = currentPassword,
                 passwordInput = password,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -442,9 +442,10 @@ class SearchViewModelTest : BaseViewModelTest() {
             setupForAutofill()
             val cipherId = CIPHER_ID
             val password = "password"
+            val error = Throwable("Fail!")
             coEvery {
                 authRepository.validatePassword(password = password)
-            } returns ValidatePasswordResult.Error
+            } returns ValidatePasswordResult.Error(error = error)
             val viewModel = createViewModel()
             assertEquals(
                 INITIAL_STATE_FOR_AUTOFILL,
@@ -465,6 +466,7 @@ class SearchViewModelTest : BaseViewModelTest() {
                     dialogState = SearchState.DialogState.Error(
                         title = null,
                         message = R.string.generic_error_message.asText(),
+                        throwable = error,
                     ),
                 ),
                 viewModel.stateFlow.value,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
@@ -385,11 +385,12 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
     @Test
     fun `ConfirmExportVaultClicked error checking password should show an error`() {
         val password = "password"
+        val error = Throwable("Fail!")
         coEvery {
             authRepository.validatePassword(
                 password = password,
             )
-        } returns ValidatePasswordResult.Error
+        } returns ValidatePasswordResult.Error(error = error)
 
         val viewModel = createViewModel()
         viewModel.trySendAction(ExportVaultAction.PasswordInputChanged(password))
@@ -400,6 +401,7 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
                 dialogState = ExportVaultState.DialogState.Error(
                     title = R.string.an_error_has_occurred.asText(),
                     message = R.string.generic_error_message.asText(),
+                    error = error,
                 ),
                 passwordInput = password,
             ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -3969,7 +3969,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val password = "password"
             coEvery {
                 authRepository.validatePassword(password = password)
-            } returns ValidatePasswordResult.Error
+            } returns ValidatePasswordResult.Error(error = Throwable("Fail!"))
 
             viewModel.trySendAction(
                 VaultAddEditAction.Common.MasterPasswordFido2VerificationSubmit(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -895,11 +895,11 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         relatedLocations = persistentListOf(),
                     )
                 } returns loginViewState
-
                 val password = "password"
+                val error = Throwable("Fail!")
                 coEvery {
                     authRepo.validatePassword(password)
-                } returns ValidatePasswordResult.Error
+                } returns ValidatePasswordResult.Error(error = error)
                 mutableVaultItemFlow.value = DataState.Loaded(data = mockCipherView)
                 mutableAuthCodeItemFlow.value = DataState.Loaded(data = null)
                 mutableCollectionsStateFlow.value = DataState.Loaded(emptyList())
@@ -928,6 +928,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         loginState.copy(
                             dialog = VaultItemState.DialogState.Generic(
                                 message = R.string.generic_error_message.asText(),
+                                error = error,
                             ),
                         ),
                         awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -817,6 +817,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val cipherView = createMockCipherView(number = 1)
             val cipherId = "mockId-1"
             val password = "password"
+            val error = Throwable("Fail!")
             mutableVaultDataStateFlow.value = DataState.Loaded(
                 data = VaultData(
                     cipherViewList = listOf(cipherView),
@@ -828,7 +829,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val viewModel = createVaultItemListingViewModel()
             coEvery {
                 authRepository.validatePassword(password = password)
-            } returns ValidatePasswordResult.Error
+            } returns ValidatePasswordResult.Error(error = error)
             val initialState = createVaultItemListingState(
                 viewState = VaultItemListingState.ViewState.Content(
                     displayCollectionList = emptyList(),
@@ -858,6 +859,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     dialogState = VaultItemListingState.DialogState.Error(
                         title = null,
                         message = R.string.generic_error_message.asText(),
+                        throwable = error,
                     ),
                 ),
                 viewModel.stateFlow.value,
@@ -4041,7 +4043,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         val password = "password"
         coEvery {
             authRepository.validatePassword(password = password)
-        } returns ValidatePasswordResult.Error
+        } returns ValidatePasswordResult.Error(error = Throwable("Fail!"))
 
         viewModel.trySendAction(
             VaultItemListingsAction.MasterPasswordFido2VerificationSubmit(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1608,9 +1608,10 @@ class VaultViewModelTest : BaseViewModelTest() {
     fun `MasterPasswordRepromptSubmit for a request Error should show a generic error dialog`() =
         runTest {
             val password = "password"
+            val error = Throwable("Fail!")
             coEvery {
                 authRepository.validatePassword(password = password)
-            } returns ValidatePasswordResult.Error
+            } returns ValidatePasswordResult.Error(error = error)
 
             val viewModel = createViewModel()
             viewModel.stateFlow.test {
@@ -1635,6 +1636,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         dialog = VaultState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = error,
                         ),
                     ),
                     awaitItem(),
@@ -1943,22 +1945,22 @@ class VaultViewModelTest : BaseViewModelTest() {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `InternetConnectionErrorReceived should show network error if no internet connection`() = runTest {
-        val viewModel = createViewModel()
-        viewModel.trySendAction(VaultAction.Internal.InternetConnectionErrorReceived)
-        assertEquals(
-            DEFAULT_STATE.copy(
-                isRefreshing = false,
-                dialog = VaultState.DialogState.Error(
-                    R.string.internet_connection_required_title.asText(),
-                    R.string.internet_connection_required_message.asText(),
+    fun `InternetConnectionErrorReceived should show network error if no internet connection`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.trySendAction(VaultAction.Internal.InternetConnectionErrorReceived)
+            assertEquals(
+                DEFAULT_STATE.copy(
+                    isRefreshing = false,
+                    dialog = VaultState.DialogState.Error(
+                        R.string.internet_connection_required_title.asText(),
+                        R.string.internet_connection_required_message.asText(),
+                    ),
                 ),
-            ),
-            viewModel.stateFlow.value,
-        )
-    }
+                viewModel.stateFlow.value,
+            )
+        }
 
     private fun createViewModel(): VaultViewModel =
         VaultViewModel(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19245](https://bitwarden.atlassian.net/browse/PM-19245)

## 📔 Objective

This PR propagates the error from the password validation flows to the UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19245]: https://bitwarden.atlassian.net/browse/PM-19245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ