### PR TITLE
PM-19275 propagate the errors for the vault unlock error result types

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1115,9 +1115,9 @@ class AuthRepositoryImpl(
                     }
 
                     is VaultUnlockResult.AuthenticationError,
-                    VaultUnlockResult.BiometricDecodingError,
-                    VaultUnlockResult.InvalidStateError,
-                    VaultUnlockResult.GenericError,
+                    is VaultUnlockResult.BiometricDecodingError,
+                    is VaultUnlockResult.InvalidStateError,
+                    is VaultUnlockResult.GenericError,
                         -> {
                         IllegalStateException("Failed to unlock vault").asFailure()
                     }
@@ -1878,7 +1878,7 @@ class AuthRepositoryImpl(
                 }
                 .fold(
                     // If the request failed, we want to abort the login process
-                    onFailure = { VaultUnlockResult.GenericError },
+                    onFailure = { VaultUnlockResult.GenericError(error = it) },
                     onSuccess = { it },
                 )
         } else {
@@ -1918,7 +1918,7 @@ class AuthRepositoryImpl(
                 }
                 .fold(
                     // If the request failed, we want to abort the login process
-                    onFailure = { VaultUnlockResult.GenericError },
+                    onFailure = { VaultUnlockResult.GenericError(error = it) },
                     onSuccess = { it },
                 )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensions.kt
@@ -9,8 +9,8 @@ import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
  */
 fun VaultUnlockError.toLoginErrorResult(): LoginResult.Error = when (this) {
     is VaultUnlockResult.AuthenticationError -> LoginResult.Error(this.message)
-    VaultUnlockResult.BiometricDecodingError,
-    VaultUnlockResult.GenericError,
-    VaultUnlockResult.InvalidStateError,
+    is VaultUnlockResult.BiometricDecodingError,
+    is VaultUnlockResult.GenericError,
+    is VaultUnlockResult.InvalidStateError,
         -> LoginResult.Error(errorMessage = null)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
@@ -72,9 +72,9 @@ class AuthenticatorBridgeRepositoryImpl(
 
                     when (unlockResult) {
                         is VaultUnlockResult.AuthenticationError,
-                        VaultUnlockResult.BiometricDecodingError,
-                        VaultUnlockResult.GenericError,
-                        VaultUnlockResult.InvalidStateError,
+                        is VaultUnlockResult.BiometricDecodingError,
+                        is VaultUnlockResult.GenericError,
+                        is VaultUnlockResult.InvalidStateError,
                             -> {
                             // Not being able to unlock the user's vault with the
                             // decrypted unlock key is an unexpected case, but if it does

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -169,7 +169,10 @@ class VaultSdkSourceImpl(
                 InitializeCryptoResult.Success
             } catch (exception: BitwardenException) {
                 // The only truly expected error from the SDK is an incorrect key/password.
-                InitializeCryptoResult.AuthenticationError(message = exception.message)
+                InitializeCryptoResult.AuthenticationError(
+                    message = exception.message,
+                    error = exception,
+                )
             }
         }
 
@@ -187,6 +190,7 @@ class VaultSdkSourceImpl(
                 // The only truly expected error from the SDK is for incorrect keys.
                 InitializeCryptoResult.AuthenticationError(
                     message = exception.message,
+                    error = exception,
                 )
             }
         }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/InitializeCryptoResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/InitializeCryptoResult.kt
@@ -15,5 +15,6 @@ sealed class InitializeCryptoResult {
      */
     data class AuthenticationError(
         val message: String? = null,
+        val error: Throwable,
     ) : InitializeCryptoResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -16,6 +16,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokens
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
+import com.x8bit.bitwarden.data.platform.error.MissingPropertyException
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.AppStateManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
@@ -30,7 +31,6 @@ import com.x8bit.bitwarden.data.platform.util.flatMap
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.InitializeCryptoResult
 import com.x8bit.bitwarden.data.vault.manager.model.VaultStateEvent
-import com.x8bit.bitwarden.data.vault.repository.model.NoKeyFoundForUserException
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
 import com.x8bit.bitwarden.data.vault.repository.util.statusFor
@@ -609,7 +609,9 @@ class VaultLockManagerImpl(
         val account = authDiskSource.userState?.accounts?.get(userId)
             ?: return VaultUnlockResult.InvalidStateError(error = NoActiveUserException())
         val privateKey = authDiskSource.getPrivateKey(userId = userId)
-            ?: return VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException())
+            ?: return VaultUnlockResult.InvalidStateError(
+                error = MissingPropertyException("Private key"),
+            )
         val organizationKeys = authDiskSource.getOrganizationKeys(userId = userId)
         return unlockVault(
             userId = userId,

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -21,6 +21,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.toUpdatedUserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.network.util.isNoConnectionError
+import com.x8bit.bitwarden.data.platform.error.MissingPropertyException
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
@@ -67,7 +68,6 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
-import com.x8bit.bitwarden.data.vault.repository.model.NoKeyFoundForUserException
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
@@ -551,7 +551,9 @@ class VaultRepositoryImpl(
             ?: return VaultUnlockResult.InvalidStateError(error = NoActiveUserException())
         val biometricsKey = authDiskSource
             .getUserBiometricUnlockKey(userId = userId)
-            ?: return VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException())
+            ?: return VaultUnlockResult.InvalidStateError(
+                error = MissingPropertyException("Biometric key"),
+            )
         val iv = authDiskSource.getUserBiometricInitVector(userId = userId)
         return this
             .unlockVaultForUser(
@@ -592,7 +594,9 @@ class VaultRepositoryImpl(
         val userId = activeUserId
             ?: return VaultUnlockResult.InvalidStateError(error = NoActiveUserException())
         val userKey = authDiskSource.getUserKey(userId = userId)
-            ?: return VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException())
+            ?: return VaultUnlockResult.InvalidStateError(
+                error = MissingPropertyException("User key"),
+            )
         return unlockVaultForUser(
             userId = userId,
             initUserCryptoMethod = InitUserCryptoMethod.Password(
@@ -613,7 +617,9 @@ class VaultRepositoryImpl(
         val userId = activeUserId
             ?: return VaultUnlockResult.InvalidStateError(error = NoActiveUserException())
         val pinProtectedUserKey = authDiskSource.getPinProtectedUserKey(userId = userId)
-            ?: return VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException())
+            ?: return VaultUnlockResult.InvalidStateError(
+                error = MissingPropertyException("Pin protected key"),
+            )
         return unlockVaultForUser(
             userId = userId,
             initUserCryptoMethod = InitUserCryptoMethod.Pin(
@@ -987,7 +993,9 @@ class VaultRepositoryImpl(
         val account = authDiskSource.userState?.accounts?.get(userId)
             ?: return VaultUnlockResult.InvalidStateError(error = NoActiveUserException())
         val privateKey = authDiskSource.getPrivateKey(userId = userId)
-            ?: return VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException())
+            ?: return VaultUnlockResult.InvalidStateError(
+                error = MissingPropertyException("Private key"),
+            )
         val organizationKeys = authDiskSource
             .getOrganizationKeys(userId = userId)
         return unlockVault(

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -565,8 +565,8 @@ class VaultRepositoryImpl(
                                 cipher
                                     .doFinal(biometricsKey.toByteArray(Charsets.ISO_8859_1))
                                     .decodeToString()
-                            } catch (_: GeneralSecurityException) {
-                                return VaultUnlockResult.BiometricDecodingError(error = null)
+                            } catch (e: GeneralSecurityException) {
+                                return VaultUnlockResult.BiometricDecodingError(error = e)
                             }
                         }
                         ?: biometricsKey,

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/NoKeyFoundForUserException.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/NoKeyFoundForUserException.kt
@@ -1,7 +1,0 @@
-package com.x8bit.bitwarden.data.vault.repository.model
-
-/**
- * Exception thrown when there is decrypt key found for a user when it would otherwise be
- * expected to be present.
- */
-class NoKeyFoundForUserException : IllegalStateException("No key found for user.")

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/NoKeyFoundForUserException.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/NoKeyFoundForUserException.kt
@@ -1,0 +1,7 @@
+package com.x8bit.bitwarden.data.vault.repository.model
+
+/**
+ * Exception thrown when there is decrypt key found for a user when it would otherwise be
+ * expected to be present.
+ */
+class NoKeyFoundForUserException : IllegalStateException("No key found for user.")

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/VaultUnlockResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/model/VaultUnlockResult.kt
@@ -15,25 +15,34 @@ sealed class VaultUnlockResult {
      */
     data class AuthenticationError(
         val message: String? = null,
+        override val error: Throwable?,
     ) : VaultUnlockResult(), VaultUnlockError
 
     /**
      * Unable to decode biometrics key.
      */
-    data object BiometricDecodingError : VaultUnlockResult(), VaultUnlockError
+    data class BiometricDecodingError(
+        override val error: Throwable?,
+    ) : VaultUnlockResult(), VaultUnlockError
 
     /**
      * Unable to access user state information.
      */
-    data object InvalidStateError : VaultUnlockResult(), VaultUnlockError
+    data class InvalidStateError(
+        override val error: Throwable?,
+    ) : VaultUnlockResult(), VaultUnlockError
 
     /**
      * Generic error thrown by Bitwarden SDK.
      */
-    data object GenericError : VaultUnlockResult(), VaultUnlockError
+    data class GenericError(
+        override val error: Throwable?,
+    ) : VaultUnlockResult(), VaultUnlockError
 }
 
 /**
  * Sealed interface to denote that a [VaultUnlockResult] is an error result.
  */
-sealed interface VaultUnlockError
+sealed interface VaultUnlockError {
+    val error: Throwable?
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/util/VaultUnlockResultExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/util/VaultUnlockResultExtensions.kt
@@ -11,6 +11,7 @@ fun InitializeCryptoResult.toVaultUnlockResult(): VaultUnlockResult =
         is InitializeCryptoResult.AuthenticationError -> {
             VaultUnlockResult.AuthenticationError(
                 message = this.message,
+                error = error,
             )
         }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -156,6 +156,7 @@ fun VaultUnlockScreen(
             onDismissRequest = remember(viewModel) {
                 { viewModel.trySendAction(VaultUnlockAction.DismissDialog) }
             },
+            throwable = dialog.throwable,
         )
 
         VaultUnlockState.VaultUnlockDialog.Loading -> BitwardenLoadingDialog(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -349,7 +349,6 @@ class VaultUnlockViewModel @Inject constructor(
                         dialog = VaultUnlockState.VaultUnlockDialog.Error(
                             title = R.string.biometrics_failed.asText(),
                             message = R.string.biometrics_decoding_failure.asText(),
-                            throwable = result.error,
                         ),
                     )
                 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -1428,6 +1428,7 @@ class AuthRepositoryTest {
         fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
         fakeAuthDiskSource.storePrivateKey(userId = USER_ID_1, privateKey = privateKey)
         fakeAuthDiskSource.storeOrganizationKeys(userId = USER_ID_1, organizationKeys = orgKeys)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVault(
                 userId = USER_ID_1,
@@ -1440,7 +1441,7 @@ class AuthRepositoryTest {
                 ),
                 organizationKeys = orgKeys,
             )
-        } returns VaultUnlockResult.AuthenticationError(message = null)
+        } returns VaultUnlockResult.AuthenticationError(message = null, error = error)
         coEvery { vaultRepository.syncIfNecessary() } just runs
 
         val result = repository.completeTdeLogin(
@@ -1756,6 +1757,7 @@ class AuthRepositoryTest {
                     uniqueAppId = UNIQUE_APP_ID,
                 )
             } returns successResponse.asSuccess()
+            val error = Throwable("Fail")
             coEvery {
                 vaultRepository.unlockVault(
                     userId = USER_ID_1,
@@ -1768,7 +1770,10 @@ class AuthRepositoryTest {
                     privateKey = successResponse.privateKey!!,
                     organizationKeys = null,
                 )
-            } returns VaultUnlockResult.AuthenticationError(expectedErrorMessage)
+            } returns VaultUnlockResult.AuthenticationError(
+                message = expectedErrorMessage,
+                error = error,
+            )
             coEvery { vaultRepository.syncIfNecessary() } just runs
             every {
                 GET_TOKEN_RESPONSE_SUCCESS.toUserState(
@@ -2222,6 +2227,7 @@ class AuthRepositoryTest {
                     twoFactorData = TWO_FACTOR_DATA,
                 )
             } returns successResponse.asSuccess()
+            val error = Throwable("Fail")
             coEvery {
                 vaultRepository.unlockVault(
                     userId = USER_ID_1,
@@ -2234,7 +2240,7 @@ class AuthRepositoryTest {
                     privateKey = successResponse.privateKey!!,
                     organizationKeys = null,
                 )
-            } returns VaultUnlockResult.InvalidStateError
+            } returns VaultUnlockResult.InvalidStateError(error = error)
             every {
                 successResponse.toUserState(
                     previousUserState = null,
@@ -5151,9 +5157,10 @@ class AuthRepositoryTest {
         coEvery {
             accountsService.setPassword(body = setPasswordRequestJson)
         } returns Unit.asSuccess()
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithMasterPassword(password)
-        } returns VaultUnlockResult.GenericError
+        } returns VaultUnlockResult.GenericError(error = error)
 
         val result = repository.setPassword(
             organizationIdentifier = organizationIdentifier,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensionsTest.kt
@@ -9,23 +9,33 @@ class LoginResultExtensionsTest {
     @Test
     fun `VaultUnlockResult with error message maps to LoginResult Error with correct message`() {
         val errorMessage = "foo"
-        val result = VaultUnlockResult.AuthenticationError(errorMessage).toLoginErrorResult()
+        val error = Throwable("Fail")
+        val result = VaultUnlockResult
+            .AuthenticationError(
+                message = errorMessage,
+                error = error,
+            )
+            .toLoginErrorResult()
         assertEquals(LoginResult.Error(errorMessage), result)
     }
 
     @Test
     @Suppress("MaxLineLength")
     fun `VaultUnlockResult with null error message as default maps to LoginResult Error with null message`() {
-        val result = VaultUnlockResult.AuthenticationError().toLoginErrorResult()
+        val error = Throwable("Fail")
+        val result = VaultUnlockResult.AuthenticationError(error = error).toLoginErrorResult()
         assertEquals(LoginResult.Error(errorMessage = null), result)
     }
 
     @Test
     @Suppress("MaxLineLength")
     fun `VaultUnlockResult with no message value are mapped to LoginResult with null error message`() {
-        val invalidStateResult = VaultUnlockResult.InvalidStateError.toLoginErrorResult()
-        val genericErrorResult = VaultUnlockResult.GenericError.toLoginErrorResult()
-        val biometricErrorResult = VaultUnlockResult.BiometricDecodingError.toLoginErrorResult()
+        val error = Throwable("Fail")
+        val invalidStateResult =
+            VaultUnlockResult.InvalidStateError(error = error).toLoginErrorResult()
+        val genericErrorResult = VaultUnlockResult.GenericError(error = error).toLoginErrorResult()
+        val biometricErrorResult =
+            VaultUnlockResult.BiometricDecodingError(error = error).toLoginErrorResult()
         val expectedResult = LoginResult.Error(errorMessage = null)
 
         assertEquals(expectedResult, invalidStateResult)

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
@@ -235,9 +235,10 @@ class AuthenticatorBridgeRepositoryTest {
     fun `syncAccounts when for user 1 vault is locked and unlock fails should reset authenticator sync unlock key and omit user from the list`() =
         runTest {
             every { vaultRepository.isVaultUnlocked(USER_1_ID) } returns false
+            val error = Throwable("Fail")
             coEvery {
                 vaultRepository.unlockVaultWithDecryptedUserKey(USER_1_ID, USER_1_UNLOCK_KEY)
-            } returns VaultUnlockResult.InvalidStateError
+            } returns VaultUnlockResult.InvalidStateError(error = error)
 
             val sharedAccounts = authenticatorBridgeRepository.getSharedAccounts()
             assertEquals(SharedAccountData(listOf(USER_2_SHARED_ACCOUNT)), sharedAccounts)

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
@@ -415,7 +415,12 @@ class VaultSdkSourceTest {
                 request = mockInitCryptoRequest,
             )
             assertEquals(
-                InitializeCryptoResult.AuthenticationError(expectedErrorMessage).asSuccess(),
+                InitializeCryptoResult
+                    .AuthenticationError(
+                        message = expectedErrorMessage,
+                        error = expectedException,
+                    )
+                    .asSuccess(),
                 result,
             )
             coVerify {
@@ -496,7 +501,12 @@ class VaultSdkSourceTest {
                 request = mockInitCryptoRequest,
             )
             assertEquals(
-                InitializeCryptoResult.AuthenticationError(expectedErrorMessage).asSuccess(),
+                InitializeCryptoResult
+                    .AuthenticationError(
+                        message = expectedErrorMessage,
+                        error = expectedException,
+                    )
+                    .asSuccess(),
                 result,
             )
             coVerify {

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerTest.kt
@@ -1059,6 +1059,7 @@ class VaultLockManagerTest {
             val userKey = "12345"
             val privateKey = "54321"
             val organizationKeys = mapOf("orgId1" to "orgKey1")
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.initializeCrypto(
                     userId = USER_ID,
@@ -1072,7 +1073,7 @@ class VaultLockManagerTest {
                         ),
                     ),
                 )
-            } returns InitializeCryptoResult.AuthenticationError().asSuccess()
+            } returns InitializeCryptoResult.AuthenticationError(error = error).asSuccess()
 
             assertEquals(
                 emptyList<VaultUnlockData>(),
@@ -1095,7 +1096,7 @@ class VaultLockManagerTest {
                 organizationKeys = organizationKeys,
             )
 
-            assertEquals(VaultUnlockResult.AuthenticationError(), result)
+            assertEquals(VaultUnlockResult.AuthenticationError(error = error), result)
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultLockManager.vaultUnlockDataStateFlow.value,
@@ -1144,12 +1145,13 @@ class VaultLockManagerTest {
                     ),
                 )
             } returns InitializeCryptoResult.Success.asSuccess()
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.initializeOrganizationCrypto(
                     userId = USER_ID,
                     request = InitOrgCryptoRequest(organizationKeys = organizationKeys),
                 )
-            } returns InitializeCryptoResult.AuthenticationError().asSuccess()
+            } returns InitializeCryptoResult.AuthenticationError(error = error).asSuccess()
 
             assertEquals(
                 emptyList<VaultUnlockData>(),
@@ -1172,7 +1174,7 @@ class VaultLockManagerTest {
                 organizationKeys = organizationKeys,
             )
 
-            assertEquals(VaultUnlockResult.AuthenticationError(), result)
+            assertEquals(VaultUnlockResult.AuthenticationError(error = error), result)
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultLockManager.vaultUnlockDataStateFlow.value,
@@ -1213,6 +1215,7 @@ class VaultLockManagerTest {
             val userKey = "12345"
             val privateKey = "54321"
             val organizationKeys = mapOf("orgId1" to "orgKey1")
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.initializeCrypto(
                     userId = USER_ID,
@@ -1226,7 +1229,7 @@ class VaultLockManagerTest {
                         ),
                     ),
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultLockManager.vaultUnlockDataStateFlow.value,
@@ -1248,7 +1251,7 @@ class VaultLockManagerTest {
                 organizationKeys = organizationKeys,
             )
 
-            assertEquals(VaultUnlockResult.GenericError, result)
+            assertEquals(VaultUnlockResult.GenericError(error = error), result)
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultLockManager.vaultUnlockDataStateFlow.value,
@@ -1297,12 +1300,13 @@ class VaultLockManagerTest {
                     ),
                 )
             } returns InitializeCryptoResult.Success.asSuccess()
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.initializeOrganizationCrypto(
                     userId = USER_ID,
                     request = InitOrgCryptoRequest(organizationKeys = organizationKeys),
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultLockManager.vaultUnlockDataStateFlow.value,
@@ -1324,7 +1328,7 @@ class VaultLockManagerTest {
                 organizationKeys = organizationKeys,
             )
 
-            assertEquals(VaultUnlockResult.GenericError, result)
+            assertEquals(VaultUnlockResult.GenericError(error = error), result)
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultLockManager.vaultUnlockDataStateFlow.value,
@@ -1379,12 +1383,13 @@ class VaultLockManagerTest {
                     ),
                 )
             } returns InitializeCryptoResult.Success.asSuccess()
+            val error = Throwable("Fail")
             coEvery {
                 vaultSdkSource.initializeOrganizationCrypto(
                     userId = USER_ID,
                     request = InitOrgCryptoRequest(organizationKeys = organizationKeys),
                 )
-            } returns Throwable("Fail").asFailure()
+            } returns error.asFailure()
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultLockManager.vaultUnlockDataStateFlow.value,
@@ -1412,7 +1417,7 @@ class VaultLockManagerTest {
             )
             verify { userLogoutManager.logout(userId = USER_ID) }
 
-            assertEquals(VaultUnlockResult.GenericError, result)
+            assertEquals(VaultUnlockResult.GenericError(error = error), result)
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultLockManager.vaultUnlockDataStateFlow.value,

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -25,6 +25,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.error.MissingPropertyException
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
@@ -87,7 +88,6 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
-import com.x8bit.bitwarden.data.vault.repository.model.NoKeyFoundForUserException
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
@@ -253,12 +253,12 @@ class VaultRepositoryTest {
         mockkStatic(MessageDigest::class)
         mockkStatic(Base64::class)
         mockkConstructor(NoActiveUserException::class)
-        mockkConstructor(NoKeyFoundForUserException::class)
+        mockkConstructor(MissingPropertyException::class)
         every {
             anyConstructed<NoActiveUserException>() == any<NoActiveUserException>()
         } returns true
         every {
-            anyConstructed<NoKeyFoundForUserException>() == any<NoKeyFoundForUserException>()
+            anyConstructed<MissingPropertyException>() == any<MissingPropertyException>()
         } returns true
     }
 
@@ -269,7 +269,7 @@ class VaultRepositoryTest {
         unmockkStatic(MessageDigest::class)
         unmockkStatic(Base64::class)
         unmockkConstructor(NoActiveUserException::class)
-        unmockkConstructor(NoKeyFoundForUserException::class)
+        unmockkConstructor(MissingPropertyException::class)
     }
 
     @Test
@@ -1197,7 +1197,7 @@ class VaultRepositoryTest {
             val result = vaultRepository.unlockVaultWithBiometrics(cipher = cipher)
 
             assertEquals(
-                VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
+                VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
                 result,
             )
             assertEquals(
@@ -1287,7 +1287,7 @@ class VaultRepositoryTest {
 
             assertEquals(
                 VaultUnlockResult.BiometricDecodingError(
-                    error = NoKeyFoundForUserException(),
+                    error = MissingPropertyException("Foo"),
                 ),
                 result,
             )
@@ -1563,7 +1563,7 @@ class VaultRepositoryTest {
             )
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             assertEquals(
-                VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
+                VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
                 result,
             )
             assertEquals(
@@ -1591,7 +1591,7 @@ class VaultRepositoryTest {
             )
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             assertEquals(
-                VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
+                VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
                 result,
             )
 
@@ -1781,7 +1781,7 @@ class VaultRepositoryTest {
             )
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             assertEquals(
-                VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
+                VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
                 result,
             )
             assertEquals(
@@ -1807,7 +1807,7 @@ class VaultRepositoryTest {
         )
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         assertEquals(
-            VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
+            VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
             result,
         )
         assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -87,6 +87,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
+import com.x8bit.bitwarden.data.vault.repository.model.NoKeyFoundForUserException
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
@@ -252,8 +253,12 @@ class VaultRepositoryTest {
         mockkStatic(MessageDigest::class)
         mockkStatic(Base64::class)
         mockkConstructor(NoActiveUserException::class)
+        mockkConstructor(NoKeyFoundForUserException::class)
         every {
             anyConstructed<NoActiveUserException>() == any<NoActiveUserException>()
+        } returns true
+        every {
+            anyConstructed<NoKeyFoundForUserException>() == any<NoKeyFoundForUserException>()
         } returns true
     }
 
@@ -264,6 +269,7 @@ class VaultRepositoryTest {
         unmockkStatic(MessageDigest::class)
         unmockkStatic(Base64::class)
         unmockkConstructor(NoActiveUserException::class)
+        unmockkConstructor(NoKeyFoundForUserException::class)
     }
 
     @Test
@@ -1166,7 +1172,10 @@ class VaultRepositoryTest {
 
             val result = vaultRepository.unlockVaultWithBiometrics(cipher = cipher)
 
-            assertEquals(VaultUnlockResult.InvalidStateError, result)
+            assertEquals(
+                VaultUnlockResult.InvalidStateError(error = NoActiveUserException()),
+                result,
+            )
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultRepository.vaultUnlockDataStateFlow.value,
@@ -1187,7 +1196,10 @@ class VaultRepositoryTest {
 
             val result = vaultRepository.unlockVaultWithBiometrics(cipher = cipher)
 
-            assertEquals(VaultUnlockResult.InvalidStateError, result)
+            assertEquals(
+                VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
+                result,
+            )
             assertEquals(
                 emptyList<VaultUnlockData>(),
                 vaultRepository.vaultUnlockDataStateFlow.value,
@@ -1273,7 +1285,12 @@ class VaultRepositoryTest {
 
             val result = vaultRepository.unlockVaultWithBiometrics(cipher = cipher)
 
-            assertEquals(VaultUnlockResult.BiometricDecodingError, result)
+            assertEquals(
+                VaultUnlockResult.BiometricDecodingError(
+                    error = NoKeyFoundForUserException(),
+                ),
+                result,
+            )
             coVerify(exactly = 0) {
                 vaultSdkSource.derivePinProtectedUserKey(any(), any())
             }
@@ -1466,6 +1483,7 @@ class VaultRepositoryTest {
             val authenticatorSyncUnlockKey = "asdf1234"
             val privateKey = "mockPrivateKey-1"
             fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val error = Throwable("Fail")
             coEvery {
                 vaultLockManager.unlockVault(
                     userId = userId,
@@ -1477,7 +1495,7 @@ class VaultRepositoryTest {
                     ),
                     organizationKeys = null,
                 )
-            } returns VaultUnlockResult.InvalidStateError
+            } returns VaultUnlockResult.InvalidStateError(error = error)
             fakeAuthDiskSource.apply {
                 storeAuthenticatorSyncUnlockKey(
                     userId = userId,
@@ -1490,7 +1508,7 @@ class VaultRepositoryTest {
                 userId = userId,
                 decryptedUserKey = authenticatorSyncUnlockKey,
             )
-            assertEquals(VaultUnlockResult.InvalidStateError, result)
+            assertEquals(VaultUnlockResult.InvalidStateError(error = error), result)
             coVerify {
                 vaultLockManager.unlockVault(
                     userId = userId,
@@ -1517,7 +1535,7 @@ class VaultRepositoryTest {
             val result = vaultRepository.unlockVaultWithMasterPassword(masterPassword = "")
 
             assertEquals(
-                VaultUnlockResult.InvalidStateError,
+                VaultUnlockResult.InvalidStateError(error = NoActiveUserException()),
                 result,
             )
             assertEquals(
@@ -1545,7 +1563,7 @@ class VaultRepositoryTest {
             )
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             assertEquals(
-                VaultUnlockResult.InvalidStateError,
+                VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
                 result,
             )
             assertEquals(
@@ -1573,7 +1591,7 @@ class VaultRepositoryTest {
             )
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             assertEquals(
-                VaultUnlockResult.InvalidStateError,
+                VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
                 result,
             )
 
@@ -1696,7 +1714,7 @@ class VaultRepositoryTest {
     fun `unlockVaultWithMasterPassword with VaultLockManager non-Success should unlock for the current user and return the error`() =
         runTest {
             val userId = "mockId-1"
-            val mockVaultUnlockResult = VaultUnlockResult.InvalidStateError
+            val mockVaultUnlockResult = VaultUnlockResult.InvalidStateError(error = null)
             prepareStateForUnlocking(unlockResult = mockVaultUnlockResult)
 
             val result = vaultRepository.unlockVaultWithMasterPassword(
@@ -1734,7 +1752,7 @@ class VaultRepositoryTest {
         val result = vaultRepository.unlockVaultWithPin(pin = "1234")
 
         assertEquals(
-            VaultUnlockResult.InvalidStateError,
+            VaultUnlockResult.InvalidStateError(error = NoActiveUserException()),
             result,
         )
         assertEquals(
@@ -1763,7 +1781,7 @@ class VaultRepositoryTest {
             )
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             assertEquals(
-                VaultUnlockResult.InvalidStateError,
+                VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
                 result,
             )
             assertEquals(
@@ -1789,7 +1807,7 @@ class VaultRepositoryTest {
         )
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         assertEquals(
-            VaultUnlockResult.InvalidStateError,
+            VaultUnlockResult.InvalidStateError(error = NoKeyFoundForUserException()),
             result,
         )
         assertEquals(
@@ -1832,7 +1850,7 @@ class VaultRepositoryTest {
     fun `unlockVaultWithPin with VaultLockManager non-Success should unlock for the current user and return the error`() =
         runTest {
             val userId = "mockId-1"
-            val mockVaultUnlockResult = VaultUnlockResult.InvalidStateError
+            val mockVaultUnlockResult = VaultUnlockResult.InvalidStateError(error = null)
             prepareStateForUnlocking(unlockResult = mockVaultUnlockResult)
 
             val result = vaultRepository.unlockVaultWithPin(pin = "1234")

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -1132,10 +1132,9 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             accounts = listOf(DEFAULT_ACCOUNT.copy(isBiometricsEnabled = true)),
         )
         val viewModel = createViewModel(state = initialState)
-        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
-        } returns VaultUnlockResult.BiometricDecodingError(error = error)
+        } returns VaultUnlockResult.BiometricDecodingError(error = Throwable("Fail"))
         every { encryptionManager.clearBiometrics(userId = USER_ID) } just runs
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
@@ -1146,7 +1145,6 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
                     title = R.string.biometrics_failed.asText(),
                     message = R.string.biometrics_decoding_failure.asText(),
-                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -743,9 +743,10 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             vaultUnlockType = VaultUnlockType.MASTER_PASSWORD,
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithMasterPassword(password)
-        } returns VaultUnlockResult.AuthenticationError()
+        } returns VaultUnlockResult.AuthenticationError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
@@ -753,6 +754,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
                     R.string.an_error_has_occurred.asText(),
                     R.string.invalid_master_password.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -770,9 +772,10 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             vaultUnlockType = VaultUnlockType.MASTER_PASSWORD,
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithMasterPassword(password)
-        } returns VaultUnlockResult.GenericError
+        } returns VaultUnlockResult.GenericError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
@@ -780,6 +783,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
                     R.string.an_error_has_occurred.asText(),
                     R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -796,10 +800,11 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             input = password,
             vaultUnlockType = VaultUnlockType.MASTER_PASSWORD,
         )
+        val error = Throwable("Fail")
         val viewModel = createViewModel(state = initialState)
         coEvery {
             vaultRepository.unlockVaultWithMasterPassword(password)
-        } returns VaultUnlockResult.InvalidStateError
+        } returns VaultUnlockResult.InvalidStateError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
@@ -807,6 +812,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
                     R.string.an_error_has_occurred.asText(),
                     R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -864,7 +870,8 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
                 accounts = listOf(DEFAULT_ACCOUNT.copy(userId = updatedUserId)),
             )
         }
-        resultFlow.tryEmit(VaultUnlockResult.GenericError)
+        val error = Throwable("Fail")
+        resultFlow.tryEmit(VaultUnlockResult.GenericError(error = error))
 
         assertEquals(
             initialState.copy(dialog = null),
@@ -906,16 +913,18 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             vaultUnlockType = VaultUnlockType.PIN,
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithPin(pin)
-        } returns VaultUnlockResult.AuthenticationError()
+        } returns VaultUnlockResult.AuthenticationError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
-                    R.string.an_error_has_occurred.asText(),
-                    R.string.invalid_pin.asText(),
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.invalid_pin.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -933,16 +942,18 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             vaultUnlockType = VaultUnlockType.PIN,
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithPin(pin)
-        } returns VaultUnlockResult.GenericError
+        } returns VaultUnlockResult.GenericError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
-                    R.string.an_error_has_occurred.asText(),
-                    R.string.generic_error_message.asText(),
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -960,16 +971,18 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             vaultUnlockType = VaultUnlockType.PIN,
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithPin(pin)
-        } returns VaultUnlockResult.InvalidStateError
+        } returns VaultUnlockResult.InvalidStateError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.UnlockClick)
         assertEquals(
             initialState.copy(
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
-                    R.string.an_error_has_occurred.asText(),
-                    R.string.generic_error_message.asText(),
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -1027,7 +1040,8 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
                 accounts = listOf(DEFAULT_ACCOUNT.copy(userId = updatedUserId)),
             )
         }
-        resultFlow.tryEmit(VaultUnlockResult.GenericError)
+        val error = Throwable("Fail")
+        resultFlow.tryEmit(VaultUnlockResult.GenericError(error = error))
 
         assertEquals(
             initialState.copy(dialog = null),
@@ -1058,17 +1072,19 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             accounts = listOf(DEFAULT_ACCOUNT.copy(isBiometricsEnabled = true)),
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
-        } returns VaultUnlockResult.AuthenticationError()
+        } returns VaultUnlockResult.AuthenticationError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
 
         assertEquals(
             initialState.copy(
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
-                    R.string.an_error_has_occurred.asText(),
-                    R.string.generic_error_message.asText(),
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -1086,17 +1102,19 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             accounts = listOf(DEFAULT_ACCOUNT.copy(isBiometricsEnabled = true)),
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
-        } returns VaultUnlockResult.GenericError
+        } returns VaultUnlockResult.GenericError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
 
         assertEquals(
             initialState.copy(
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
-                    R.string.an_error_has_occurred.asText(),
-                    R.string.generic_error_message.asText(),
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -1114,9 +1132,10 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             accounts = listOf(DEFAULT_ACCOUNT.copy(isBiometricsEnabled = true)),
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
-        } returns VaultUnlockResult.BiometricDecodingError
+        } returns VaultUnlockResult.BiometricDecodingError(error = error)
         every { encryptionManager.clearBiometrics(userId = USER_ID) } just runs
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
@@ -1127,6 +1146,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
                     title = R.string.biometrics_failed.asText(),
                     message = R.string.biometrics_decoding_failure.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -1145,17 +1165,19 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
             accounts = listOf(DEFAULT_ACCOUNT.copy(isBiometricsEnabled = true)),
         )
         val viewModel = createViewModel(state = initialState)
+        val error = Throwable("Fail")
         coEvery {
             vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
-        } returns VaultUnlockResult.InvalidStateError
+        } returns VaultUnlockResult.InvalidStateError(error = error)
 
         viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(CIPHER))
 
         assertEquals(
             initialState.copy(
                 dialog = VaultUnlockState.VaultUnlockDialog.Error(
-                    R.string.an_error_has_occurred.asText(),
-                    R.string.generic_error_message.asText(),
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.generic_error_message.asText(),
+                    throwable = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -1212,7 +1234,8 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
                 accounts = listOf(DEFAULT_ACCOUNT.copy(userId = updatedUserId)),
             )
         }
-        resultFlow.tryEmit(VaultUnlockResult.GenericError)
+        val error = Throwable("Fail")
+        resultFlow.tryEmit(VaultUnlockResult.GenericError(error = error))
         assertEquals(initialState.copy(dialog = null), viewModel.stateFlow.value)
         coVerify(exactly = 1) {
             vaultRepository.unlockVaultWithBiometrics(cipher = CIPHER)
@@ -1243,7 +1266,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(
             VaultUnlockAction.Internal.ReceiveVaultUnlockResult(
                 userId = "activeUserId",
-                vaultUnlockResult = VaultUnlockResult.InvalidStateError,
+                vaultUnlockResult = VaultUnlockResult.InvalidStateError(error = null),
                 isBiometricLogin = false,
             ),
         )


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-19275
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Propagate throw errors from vault unlock results.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
