### PR TITLE
PM-19283: Propagate error from email token and known device flows

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1218,8 +1218,8 @@ class AuthRepositoryImpl(
                 deviceId = authDiskSource.uniqueAppId,
             )
             .fold(
-                onFailure = { KnownDeviceResult.Error },
-                onSuccess = { KnownDeviceResult.Success(it) },
+                onFailure = { KnownDeviceResult.Error(error = it) },
+                onSuccess = { KnownDeviceResult.Success(isKnownDevice = it) },
             )
 
     override suspend fun getPasswordBreachCount(password: String): BreachCountResult =
@@ -1362,15 +1362,13 @@ class AuthRepositoryImpl(
                     when (val json = it) {
                         VerifyEmailTokenResponseJson.Valid -> EmailTokenResult.Success
                         is VerifyEmailTokenResponseJson.Invalid -> {
-                            EmailTokenResult.Error(json.message)
+                            EmailTokenResult.Error(message = json.message, error = null)
                         }
 
                         VerifyEmailTokenResponseJson.TokenExpired -> EmailTokenResult.Expired
                     }
                 },
-                onFailure = {
-                    EmailTokenResult.Error(message = null)
-                },
+                onFailure = { EmailTokenResult.Error(message = null, error = it) },
             )
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/EmailTokenResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/EmailTokenResult.kt
@@ -18,5 +18,8 @@ sealed class EmailTokenResult {
     /**
      * There was an error validating the token.
      */
-    data class Error(val message: String?) : EmailTokenResult()
+    data class Error(
+        val message: String?,
+        val error: Throwable?,
+    ) : EmailTokenResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/KnownDeviceResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/KnownDeviceResult.kt
@@ -12,5 +12,7 @@ sealed class KnownDeviceResult {
     /**
      * There was an error determining if this is a known device.
      */
-    data object Error : KnownDeviceResult()
+    data class Error(
+        val error: Throwable,
+    ) : KnownDeviceResult()
 }

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -558,11 +558,8 @@ class MainViewModelTest : BaseViewModelTest() {
             )
             every { authRepository.activeUserId } returns null
             coEvery {
-                authRepository.validateEmailToken(
-                    intentEmail,
-                    token,
-                )
-            } returns EmailTokenResult.Error(message = null)
+                authRepository.validateEmailToken(email = intentEmail, token = token)
+            } returns EmailTokenResult.Error(message = null, error = Throwable("Fail!"))
 
             viewModel.eventFlow.test {
                 // We skip the first 2 events because they are the default appTheme and appLanguage
@@ -595,11 +592,8 @@ class MainViewModelTest : BaseViewModelTest() {
 
             val expectedMessage = "expectedMessage"
             coEvery {
-                authRepository.validateEmailToken(
-                    intentEmail,
-                    token,
-                )
-            } returns EmailTokenResult.Error(message = expectedMessage)
+                authRepository.validateEmailToken(email = intentEmail, token = token)
+            } returns EmailTokenResult.Error(message = expectedMessage, error = null)
 
             viewModel.eventFlow.test {
                 // We skip the first 2 events because they are the default appTheme and appLanguage

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
@@ -177,7 +177,7 @@ class LoginViewModelTest : BaseViewModelTest() {
     fun `should have default state when isKnownDevice returns error`() = runTest {
         coEvery {
             authRepository.getIsKnownDevice(EMAIL)
-        } returns KnownDeviceResult.Error
+        } returns KnownDeviceResult.Error(error = Throwable("Fail!"))
         val viewModel = createViewModel()
 
         viewModel.stateFlow.test {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19283](https://bitwarden.atlassian.net/browse/PM-19283)

## 📔 Objective

This PR propagates the errors from the email token and known device flows.

These errors are notably not displayed in the UI today because we purposely do not display dialogs here but I am still updating these flows for completeness.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19283]: https://bitwarden.atlassian.net/browse/PM-19283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ