### PR TITLE
PM-19284: Propagate SSO flow errors to the UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/NewSsoUserResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/NewSsoUserResult.kt
@@ -12,5 +12,7 @@ sealed class NewSsoUserResult {
     /**
      * There was an error while truing to create the new user.
      */
-    data object Failure : NewSsoUserResult()
+    data class Failure(
+        val error: Throwable,
+    ) : NewSsoUserResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/OrganizationDomainSsoDetailsResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/OrganizationDomainSsoDetailsResult.kt
@@ -22,5 +22,7 @@ sealed class OrganizationDomainSsoDetailsResult {
     /**
      * The request failed.
      */
-    data object Failure : OrganizationDomainSsoDetailsResult()
+    data class Failure(
+        val error: Throwable,
+    ) : OrganizationDomainSsoDetailsResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/PrevalidateSsoResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/PrevalidateSsoResult.kt
@@ -16,5 +16,6 @@ sealed class PrevalidateSsoResult {
      */
     data class Failure(
         val message: String? = null,
+        val error: Throwable?,
     ) : PrevalidateSsoResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
@@ -171,6 +171,7 @@ private fun EnterpriseSignOnDialogs(
             BitwardenBasicDialog(
                 title = dialogState.title(),
                 message = dialogState.message(),
+                throwable = dialogState.error,
                 onDismissRequest = onDismissRequest,
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModel.kt
@@ -211,7 +211,10 @@ class EnterpriseSignOnViewModel @Inject constructor(
     private fun handleOnSsoPrevalidationFailure(
         action: EnterpriseSignOnAction.Internal.OnSsoPrevalidationFailure,
     ) {
-        showError(message = action.message?.asText() ?: R.string.login_sso_error.asText())
+        showError(
+            message = action.message?.asText() ?: R.string.login_sso_error.asText(),
+            error = action.error,
+        )
     }
 
     private fun handleOnOrganizationDomainSsoDetailsFailure() {
@@ -386,6 +389,7 @@ class EnterpriseSignOnViewModel @Inject constructor(
                     sendAction(
                         action = EnterpriseSignOnAction.Internal.OnSsoPrevalidationFailure(
                             message = prevalidateSso.message,
+                            error = prevalidateSso.error,
                         ),
                     )
                 }
@@ -490,12 +494,14 @@ class EnterpriseSignOnViewModel @Inject constructor(
     private fun showError(
         title: Text = R.string.an_error_has_occurred.asText(),
         message: Text = R.string.login_sso_error.asText(),
+        error: Throwable? = null,
     ) {
         mutableStateFlow.update {
             it.copy(
                 dialogState = EnterpriseSignOnState.DialogState.Error(
                     title = title,
                     message = message,
+                    error = error,
                 ),
             )
         }
@@ -533,6 +539,7 @@ data class EnterpriseSignOnState(
         data class Error(
             val title: Text,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**
@@ -628,6 +635,7 @@ sealed class EnterpriseSignOnAction {
          */
         data class OnSsoPrevalidationFailure(
             val message: String?,
+            val error: Throwable?,
         ) : Internal()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceScreen.kt
@@ -223,6 +223,7 @@ private fun TrustedDeviceDialogs(
         is TrustedDeviceState.DialogState.Error -> BitwardenBasicDialog(
             title = dialogState.title?.invoke(),
             message = dialogState.message(),
+            throwable = dialogState.error,
             onDismissRequest = handlers.onDismissDialog,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModel.kt
@@ -74,13 +74,14 @@ class TrustedDeviceViewModel @Inject constructor(
     private fun handleReceiveNewSsoUserResult(
         action: TrustedDeviceAction.Internal.ReceiveNewSsoUserResult,
     ) {
-        when (action.result) {
-            NewSsoUserResult.Failure -> {
+        when (val result = action.result) {
+            is NewSsoUserResult.Failure -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = TrustedDeviceState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -163,6 +164,7 @@ data class TrustedDeviceState(
         data class Error(
             val title: Text?,
             val message: Text,
+            val error: Throwable?,
         ) : DialogState()
 
         /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
@@ -113,11 +113,12 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
     fun `LogInClick with valid organization and failed prevalidation should show a loading dialog, and then show an error`() =
         runTest {
             val organizationId = "Test"
+            val error = Throwable("Fail!")
             val state = DEFAULT_STATE.copy(orgIdentifierInput = organizationId)
 
             coEvery {
                 authRepository.prevalidateSso(organizationId)
-            } returns PrevalidateSsoResult.Failure()
+            } returns PrevalidateSsoResult.Failure(error = error)
 
             val viewModel = createViewModel(state)
             viewModel.stateFlow.test {
@@ -138,6 +139,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
                         dialogState = EnterpriseSignOnState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.login_sso_error.asText(),
+                            error = error,
                         ),
                     ),
                     awaitItem(),
@@ -753,7 +755,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
         runTest {
             coEvery {
                 authRepository.getOrganizationDomainSsoDetails(any())
-            } returns OrganizationDomainSsoDetailsResult.Failure
+            } returns OrganizationDomainSsoDetailsResult.Failure(error = Throwable("Fail!"))
 
             coEvery {
                 authRepository.rememberedOrgIdentifier

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceScreenTest.kt
@@ -265,6 +265,7 @@ class TrustedDeviceScreenTest : BaseComposeTest() {
                 dialogState = TrustedDeviceState.DialogState.Error(
                     title = "Hello".asText(),
                     message = "World".asText(),
+                    error = null,
                 ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModelTest.kt
@@ -109,8 +109,11 @@ class TrustedDeviceViewModelTest : BaseViewModelTest() {
     @Test
     fun `on ContinueClick with createNewSsoUser failure should display the error dialog state`() =
         runTest {
+            val error = Throwable("Fail!")
             every { authRepository.shouldTrustDevice = true } just runs
-            coEvery { authRepository.createNewSsoUser() } returns NewSsoUserResult.Failure
+            coEvery {
+                authRepository.createNewSsoUser()
+            } returns NewSsoUserResult.Failure(error = error)
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
@@ -129,6 +132,7 @@ class TrustedDeviceViewModelTest : BaseViewModelTest() {
                         dialogState = TrustedDeviceState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = error,
                         ),
                     ),
                     awaitItem(),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19284](https://bitwarden.atlassian.net/browse/PM-19284)

## 📔 Objective

This PR propagates all the SSO errors up to the UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19284]: https://bitwarden.atlassian.net/browse/PM-19284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ