### PR TITLE
PM-19295: Propagate password errors to the UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -924,11 +924,15 @@ class AuthRepositoryImpl(
         return accountsService.requestPasswordHint(email).fold(
             onSuccess = {
                 when (it) {
-                    is PasswordHintResponseJson.Error -> PasswordHintResult.Error(it.errorMessage)
+                    is PasswordHintResponseJson.Error -> PasswordHintResult.Error(
+                        message = it.errorMessage,
+                        error = null,
+                    )
+
                     PasswordHintResponseJson.Success -> PasswordHintResult.Success
                 }
             },
-            onFailure = { PasswordHintResult.Error(null) },
+            onFailure = { PasswordHintResult.Error(message = null, error = it) },
         )
     }
 
@@ -936,12 +940,12 @@ class AuthRepositoryImpl(
         val activeAccount = authDiskSource
             .userState
             ?.activeAccount
-            ?: return RemovePasswordResult.Error
+            ?: return RemovePasswordResult.Error(error = NoActiveUserException())
         val profile = activeAccount.profile
         val userId = profile.userId
         val userKey = authDiskSource
             .getUserKey(userId = userId)
-            ?: return RemovePasswordResult.Error
+            ?: return RemovePasswordResult.Error(error = MissingPropertyException("User Key"))
         val keyConnectorUrl = organizations
             .find {
                 it.shouldUseKeyConnector &&
@@ -949,7 +953,9 @@ class AuthRepositoryImpl(
                     it.type != OrganizationType.ADMIN
             }
             ?.keyConnectorUrl
-            ?: return RemovePasswordResult.Error
+            ?: return RemovePasswordResult.Error(
+                error = MissingPropertyException("Key Connector URL"),
+            )
         return keyConnectorManager
             .migrateExistingUserToKeyConnector(
                 userId = userId,
@@ -967,7 +973,7 @@ class AuthRepositoryImpl(
                 settingsRepository.setDefaultsIfNecessary(userId = userId)
             }
             .fold(
-                onFailure = { RemovePasswordResult.Error },
+                onFailure = { RemovePasswordResult.Error(error = it) },
                 onSuccess = { RemovePasswordResult.Success },
             )
     }
@@ -980,7 +986,7 @@ class AuthRepositoryImpl(
         val activeAccount = authDiskSource
             .userState
             ?.activeAccount
-            ?: return ResetPasswordResult.Error
+            ?: return ResetPasswordResult.Error(error = NoActiveUserException())
         val currentPasswordHash = currentPassword?.let { password ->
             authSdkSource
                 .hashPassword(
@@ -990,7 +996,7 @@ class AuthRepositoryImpl(
                     purpose = HashPurpose.SERVER_AUTHORIZATION,
                 )
                 .fold(
-                    onFailure = { return ResetPasswordResult.Error },
+                    onFailure = { return ResetPasswordResult.Error(error = it) },
                     onSuccess = { it },
                 )
         }
@@ -1036,7 +1042,7 @@ class AuthRepositoryImpl(
                     // Return the success.
                     ResetPasswordResult.Success
                 },
-                onFailure = { ResetPasswordResult.Error },
+                onFailure = { ResetPasswordResult.Error(error = it) },
             )
     }
 
@@ -1049,7 +1055,7 @@ class AuthRepositoryImpl(
         val activeAccount = authDiskSource
             .userState
             ?.activeAccount
-            ?: return SetPasswordResult.Error
+            ?: return SetPasswordResult.Error(error = NoActiveUserException())
         val userId = activeAccount.profile.userId
 
         // Update the saved master password hash.
@@ -1060,7 +1066,7 @@ class AuthRepositoryImpl(
                 kdf = activeAccount.profile.toSdkParams(),
                 purpose = HashPurpose.SERVER_AUTHORIZATION,
             )
-            .getOrElse { return@setPassword SetPasswordResult.Error }
+            .getOrElse { return@setPassword SetPasswordResult.Error(error = it) }
 
         return when (activeAccount.profile.forcePasswordResetReason) {
             ForcePasswordResetReason.TDE_USER_WITHOUT_PASSWORD_HAS_PASSWORD_RESET_PERMISSION -> {
@@ -1110,7 +1116,7 @@ class AuthRepositoryImpl(
                     }
             }
             .flatMap {
-                when (vaultRepository.unlockVaultWithMasterPassword(password)) {
+                when (val result = vaultRepository.unlockVaultWithMasterPassword(password)) {
                     is VaultUnlockResult.Success -> {
                         enrollUserInPasswordReset(
                             userId = userId,
@@ -1119,12 +1125,9 @@ class AuthRepositoryImpl(
                         )
                     }
 
-                    is VaultUnlockResult.AuthenticationError,
-                    is VaultUnlockResult.BiometricDecodingError,
-                    is VaultUnlockResult.InvalidStateError,
-                    is VaultUnlockResult.GenericError,
-                        -> {
-                        IllegalStateException("Failed to unlock vault").asFailure()
+                    is VaultUnlockError -> {
+                        (result.error ?: IllegalStateException("Failed to unlock vault"))
+                            .asFailure()
                     }
                 }
             }
@@ -1134,7 +1137,7 @@ class AuthRepositoryImpl(
                 this.organizationIdentifier = null
             }
             .fold(
-                onFailure = { SetPasswordResult.Error },
+                onFailure = { SetPasswordResult.Error(error = it) },
                 onSuccess = { SetPasswordResult.Success },
             )
     }
@@ -1251,7 +1254,7 @@ class AuthRepositoryImpl(
             )
             .fold(
                 onSuccess = { PasswordStrengthResult.Success(passwordStrength = it) },
-                onFailure = { PasswordStrengthResult.Error },
+                onFailure = { PasswordStrengthResult.Error(error = it) },
             )
 
     override suspend fun validatePassword(password: String): ValidatePasswordResult {

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/PasswordHintResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/PasswordHintResult.kt
@@ -13,5 +13,8 @@ sealed class PasswordHintResult {
     /**
      * There was an error.
      */
-    data class Error(val message: String?) : PasswordHintResult()
+    data class Error(
+        val message: String?,
+        val error: Throwable?,
+    ) : PasswordHintResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/PasswordStrengthResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/PasswordStrengthResult.kt
@@ -16,5 +16,7 @@ sealed class PasswordStrengthResult {
     /**
      * There was an error determining the password strength.
      */
-    data object Error : PasswordStrengthResult()
+    data class Error(
+        val error: Throwable,
+    ) : PasswordStrengthResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/RemovePasswordResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/RemovePasswordResult.kt
@@ -12,5 +12,7 @@ sealed class RemovePasswordResult {
     /**
      * There was an error removing the password.
      */
-    data object Error : RemovePasswordResult()
+    data class Error(
+        val error: Throwable,
+    ) : RemovePasswordResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/ResetPasswordResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/ResetPasswordResult.kt
@@ -12,5 +12,7 @@ sealed class ResetPasswordResult {
     /**
      * There was an error resetting the password.
      */
-    data object Error : ResetPasswordResult()
+    data class Error(
+        val error: Throwable,
+    ) : ResetPasswordResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/SetPasswordResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/SetPasswordResult.kt
@@ -12,5 +12,7 @@ sealed class SetPasswordResult {
     /**
      * There was an error setting the password.
      */
-    data object Error : SetPasswordResult()
+    data class Error(
+        val error: Throwable,
+    ) : SetPasswordResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
@@ -187,7 +187,7 @@ class CompleteRegistrationViewModel @Inject constructor(
                 }
             }
 
-            PasswordStrengthResult.Error -> Unit
+            is PasswordStrengthResult.Error -> Unit
         }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModel.kt
@@ -128,7 +128,7 @@ class CreateAccountViewModel @Inject constructor(
                 }
             }
 
-            PasswordStrengthResult.Error -> {
+            is PasswordStrengthResult.Error -> {
                 // Leave UI the same
             }
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreen.kt
@@ -71,6 +71,7 @@ fun MasterPasswordHintScreen(
                     ?.invoke()
                     ?: stringResource(id = R.string.an_error_has_occurred),
                 message = dialogState.message(),
+                throwable = dialogState.error,
                 onDismissRequest = remember(viewModel) {
                     { viewModel.trySendAction(MasterPasswordHintAction.DismissDialog) }
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintViewModel.kt
@@ -77,14 +77,12 @@ class MasterPasswordHintViewModel @Inject constructor(
         }
 
         if (email.isBlank()) {
-            val errorMessage =
-                R.string.validation_field_required.asText(R.string.email_address.asText())
-
             mutableStateFlow.update {
                 it.copy(
                     dialog = MasterPasswordHintState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
-                        message = errorMessage,
+                        message = R.string.validation_field_required
+                            .asText(R.string.email_address.asText()),
                     ),
                 )
             }
@@ -121,7 +119,7 @@ class MasterPasswordHintViewModel @Inject constructor(
     private fun handlePasswordHintResult(
         action: MasterPasswordHintAction.Internal.PasswordHintResultReceive,
     ) {
-        when (action.result) {
+        when (val result = action.result) {
             is PasswordHintResult.Success -> {
                 mutableStateFlow.update {
                     it.copy(dialog = MasterPasswordHintState.DialogState.PasswordHintSent)
@@ -129,13 +127,13 @@ class MasterPasswordHintViewModel @Inject constructor(
             }
 
             is PasswordHintResult.Error -> {
-                val errorMessage = action.result.message?.asText()
-                    ?: R.string.generic_error_message.asText()
                 mutableStateFlow.update {
                     it.copy(
                         dialog = MasterPasswordHintState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
-                            message = errorMessage,
+                            message = result.message?.asText()
+                                ?: R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -192,6 +190,7 @@ data class MasterPasswordHintState(
         data class Error(
             val title: Text? = null,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordViewModel.kt
@@ -89,13 +89,14 @@ class RemovePasswordViewModel @Inject constructor(
     private fun handleReceiveRemovePasswordResult(
         action: RemovePasswordAction.Internal.ReceiveRemovePasswordResult,
     ) {
-        when (action.result) {
-            RemovePasswordResult.Error -> {
+        when (val result = action.result) {
+            is RemovePasswordResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = RemovePasswordState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -130,6 +131,7 @@ data class RemovePasswordState(
         data class Error(
             val title: Text? = null,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordViewModel.kt
@@ -152,7 +152,7 @@ class ResetPasswordViewModel @Inject constructor(
                 }
             }
 
-            PasswordStrengthResult.Error -> Unit
+            is PasswordStrengthResult.Error -> Unit
         }
     }
 
@@ -284,14 +284,15 @@ class ResetPasswordViewModel @Inject constructor(
         // End the loading state.
         mutableStateFlow.update { it.copy(dialogState = null) }
 
-        when (action.result) {
+        when (val result = action.result) {
             // Display an alert if there was an error.
-            ResetPasswordResult.Error -> {
+            is ResetPasswordResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = ResetPasswordState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreen.kt
@@ -193,6 +193,7 @@ private fun SetPasswordDialogs(
             BitwardenBasicDialog(
                 title = dialogState.title?.invoke(),
                 message = dialogState.message(),
+                throwable = dialogState.error,
                 onDismissRequest = onDismissRequest,
             )
         }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordViewModel.kt
@@ -179,13 +179,14 @@ class SetPasswordViewModel @Inject constructor(
     private fun handleReceiveSetPasswordResult(
         action: SetPasswordAction.Internal.ReceiveSetPasswordResult,
     ) {
-        when (action.result) {
-            SetPasswordResult.Error -> {
+        when (val result = action.result) {
+            is SetPasswordResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = SetPasswordState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         ),
                     )
                 }
@@ -267,6 +268,7 @@ data class SetPasswordState(
         data class Error(
             val title: Text? = null,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
@@ -382,7 +382,7 @@ class ExportVaultViewModel @Inject constructor(
                 }
             }
 
-            PasswordStrengthResult.Error -> {
+            is PasswordStrengthResult.Error -> {
                 // Leave UI the same
             }
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
@@ -127,7 +127,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
         val input = "abcdefghikl"
         coEvery {
             mockAuthRepository.getPasswordStrength(EMAIL, input)
-        } returns PasswordStrengthResult.Error
+        } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
         val viewModel = createCompleteRegistrationViewModel()
         viewModel.trySendAction(PasswordInputChange(input))
 
@@ -138,7 +138,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
     fun `Passwords not matching should have non-valid state`() = runTest {
         coEvery {
             mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD)
-        } returns PasswordStrengthResult.Error
+        } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
         val viewModel = createCompleteRegistrationViewModel()
         viewModel.trySendAction(PasswordInputChange(PASSWORD))
 
@@ -448,7 +448,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
     fun `PasswordInputChange update passwordInput and call getPasswordStrength`() = runTest {
         coEvery {
             mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD)
-        } returns PasswordStrengthResult.Error
+        } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
         val viewModel = createCompleteRegistrationViewModel()
         viewModel.trySendAction(PasswordInputChange(PASSWORD))
         viewModel.stateFlow.test {
@@ -483,7 +483,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
         runTest {
             coEvery {
                 mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD)
-            } returns PasswordStrengthResult.Error
+            } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
             val viewModel = createCompleteRegistrationViewModel()
             mutableGeneratorResultFlow.emit(GeneratorResult.Password(PASSWORD))
             viewModel.stateFlow.test {
@@ -602,7 +602,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
             val input = "abcdefghikl"
             coEvery {
                 mockAuthRepository.getPasswordStrength(EMAIL, input)
-            } returns PasswordStrengthResult.Error
+            } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
             val viewModel = createCompleteRegistrationViewModel()
             viewModel.trySendAction(PasswordInputChange(input))
             val expectedState = DEFAULT_STATE.copy(
@@ -623,7 +623,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
         runTest {
             coEvery {
                 mockAuthRepository.getPasswordStrength(EMAIL, PASSWORD)
-            } returns PasswordStrengthResult.Error
+            } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
             val viewModel = createCompleteRegistrationViewModel()
             viewModel.trySendAction(PasswordInputChange(PASSWORD))
             val expectedState = DEFAULT_STATE.copy(
@@ -644,7 +644,7 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
     fun `CreateAccountClick with no email not should show dialog`() = runTest {
         coEvery {
             mockAuthRepository.getPasswordStrength("", PASSWORD)
-        } returns PasswordStrengthResult.Error
+        } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
         val viewModel = createCompleteRegistrationViewModel(
             DEFAULT_STATE.copy(userEmail = ""),
         )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModelTest.kt
@@ -137,7 +137,7 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
         val input = "abcdefghikl"
         coEvery {
             mockAuthRepository.getPasswordStrength("test@test.com", input)
-        } returns PasswordStrengthResult.Error
+        } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
         val viewModel = CreateAccountViewModel(
             savedStateHandle = SavedStateHandle(),
             authRepository = mockAuthRepository,
@@ -163,7 +163,7 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
         val input = "testtesttesttest"
         coEvery {
             mockAuthRepository.getPasswordStrength("test@test.com", input)
-        } returns PasswordStrengthResult.Error
+        } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
         val viewModel = CreateAccountViewModel(
             savedStateHandle = SavedStateHandle(),
             authRepository = mockAuthRepository,
@@ -189,7 +189,7 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
         val password = "testtesttesttest"
         coEvery {
             mockAuthRepository.getPasswordStrength("test@test.com", password)
-        } returns PasswordStrengthResult.Error
+        } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
         val viewModel = CreateAccountViewModel(
             savedStateHandle = SavedStateHandle(),
             authRepository = mockAuthRepository,
@@ -569,7 +569,7 @@ class CreateAccountViewModelTest : BaseViewModelTest() {
     fun `PasswordInputChange update passwordInput and call getPasswordStrength`() = runTest {
         coEvery {
             mockAuthRepository.getPasswordStrength("", "input")
-        } returns PasswordStrengthResult.Error
+        } returns PasswordStrengthResult.Error(error = Throwable("Fail!"))
         val viewModel = CreateAccountViewModel(
             savedStateHandle = SavedStateHandle(),
             authRepository = mockAuthRepository,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordViewModelTest.kt
@@ -46,11 +46,12 @@ class RemovePasswordViewModelTest : BaseViewModelTest() {
     @Test
     fun `ContinueClick with input and remove password error should show error dialog`() = runTest {
         val password = "123"
+        val error = Throwable("Fail!")
         val initialState = DEFAULT_STATE.copy(input = password)
         val viewModel = createViewModel(state = initialState)
         coEvery {
             authRepository.removePassword(masterPassword = password)
-        } returns RemovePasswordResult.Error
+        } returns RemovePasswordResult.Error(error = error)
 
         viewModel.stateFlow.test {
             assertEquals(initialState, awaitItem())
@@ -68,6 +69,7 @@ class RemovePasswordViewModelTest : BaseViewModelTest() {
                     dialogState = RemovePasswordState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = R.string.generic_error_message.asText(),
+                        error = error,
                     ),
                 ),
                 awaitItem(),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19295](https://bitwarden.atlassian.net/browse/PM-19295)

## 📔 Objective

This PR propagates the password errors to the UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19295]: https://bitwarden.atlassian.net/browse/PM-19295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ