### PR TITLE
PM-19296: Propagate login errors to the UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResult.kt
@@ -22,7 +22,10 @@ sealed class LoginResult {
     /**
      * There was an error logging in.
      */
-    data class Error(val errorMessage: String?) : LoginResult()
+    data class Error(
+        val errorMessage: String?,
+        val error: Throwable?,
+    ) : LoginResult()
 
     /**
      * There was an error while logging into an unofficial Bitwarden server.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensions.kt
@@ -8,9 +8,12 @@ import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
  * the necessary `message` if applicable.
  */
 fun VaultUnlockError.toLoginErrorResult(): LoginResult.Error = when (this) {
-    is VaultUnlockResult.AuthenticationError -> LoginResult.Error(this.message)
+    is VaultUnlockResult.AuthenticationError -> {
+        LoginResult.Error(errorMessage = this.message, error = this.error)
+    }
+
     is VaultUnlockResult.BiometricDecodingError,
     is VaultUnlockResult.GenericError,
     is VaultUnlockResult.InvalidStateError,
-        -> LoginResult.Error(errorMessage = null)
+        -> LoginResult.Error(errorMessage = null, error = this.error)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModel.kt
@@ -161,6 +161,7 @@ class EnterpriseSignOnViewModel @Inject constructor(
                 showError(
                     message = loginResult.errorMessage?.asText()
                         ?: R.string.login_sso_error.asText(),
+                    error = loginResult.error,
                 )
             }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
@@ -208,6 +208,7 @@ private fun LoginDialogs(
         is LoginState.DialogState.Error -> BitwardenBasicDialog(
             title = dialogState.title?.invoke(),
             message = dialogState.message(),
+            throwable = dialogState.error,
             onDismissRequest = onDismissRequest,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
@@ -172,6 +172,7 @@ class LoginViewModel @Inject constructor(
                             title = R.string.an_error_has_occurred.asText(),
                             message = loginResult.errorMessage?.asText()
                                 ?: R.string.generic_error_message.asText(),
+                            error = loginResult.error,
                         ),
                     )
                 }
@@ -326,6 +327,7 @@ data class LoginState(
         data class Error(
             val title: Text? = null,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
@@ -236,6 +236,7 @@ class LoginWithDeviceViewModel @Inject constructor(
                                 .errorMessage
                                 ?.asText()
                                 ?: R.string.generic_error_message.asText(),
+                            error = loginResult.error,
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
@@ -202,6 +202,7 @@ private fun TwoFactorLoginDialogs(
                 ?.invoke()
                 ?: stringResource(R.string.an_error_has_occurred),
             message = dialogState.message(),
+            throwable = dialogState.error,
             onDismissRequest = onDismissRequest,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -308,6 +308,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                             title = R.string.an_error_has_occurred.asText(),
                             message = loginResult.errorMessage?.asText()
                                 ?: R.string.invalid_verification_code.asText(),
+                            error = loginResult.error,
                         ),
                     )
                 }
@@ -658,6 +659,7 @@ data class TwoFactorLoginState(
         data class Error(
             val title: Text? = null,
             val message: Text,
+            val error: Throwable? = null,
         ) : DialogState()
 
         /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/model/LoginResultExtensionsTest.kt
@@ -16,7 +16,7 @@ class LoginResultExtensionsTest {
                 error = error,
             )
             .toLoginErrorResult()
-        assertEquals(LoginResult.Error(errorMessage), result)
+        assertEquals(LoginResult.Error(errorMessage = errorMessage, error = error), result)
     }
 
     @Test
@@ -24,7 +24,7 @@ class LoginResultExtensionsTest {
     fun `VaultUnlockResult with null error message as default maps to LoginResult Error with null message`() {
         val error = Throwable("Fail")
         val result = VaultUnlockResult.AuthenticationError(error = error).toLoginErrorResult()
-        assertEquals(LoginResult.Error(errorMessage = null), result)
+        assertEquals(LoginResult.Error(errorMessage = null, error = error), result)
     }
 
     @Test
@@ -36,7 +36,7 @@ class LoginResultExtensionsTest {
         val genericErrorResult = VaultUnlockResult.GenericError(error = error).toLoginErrorResult()
         val biometricErrorResult =
             VaultUnlockResult.BiometricDecodingError(error = error).toLoginErrorResult()
-        val expectedResult = LoginResult.Error(errorMessage = null)
+        val expectedResult = LoginResult.Error(errorMessage = null, error = error)
 
         assertEquals(expectedResult, invalidStateResult)
         assertEquals(expectedResult, genericErrorResult)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
@@ -323,9 +323,10 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
     fun `ssoCallbackResultFlow Success with same state with login Error should show loading dialog then show an error when server is an official Bitwarden server`() =
         runTest {
             val orgIdentifier = "Bitwarden"
+            val error = Throwable("Fail!")
             coEvery {
                 authRepository.login(any(), any(), any(), any(), any(), any())
-            } returns LoginResult.Error(null)
+            } returns LoginResult.Error(errorMessage = null, error = error)
 
             val viewModel = createViewModel(
                 ssoData = DEFAULT_SSO_DATA,
@@ -366,6 +367,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
                         dialogState = EnterpriseSignOnState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.login_sso_error.asText(),
+                            error = error,
                         ),
                         orgIdentifierInput = orgIdentifier,
                     ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
@@ -247,13 +247,14 @@ class LoginViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `LoginButtonClick login returns error should update errorDialogState`() = runTest {
+        val error = Throwable("Fail!")
         coEvery {
             authRepository.login(
                 email = EMAIL,
                 password = "",
                 captchaToken = null,
             )
-        } returns LoginResult.Error(errorMessage = "mock_error")
+        } returns LoginResult.Error(errorMessage = "mock_error", error = error)
         val viewModel = createViewModel()
         viewModel.stateFlow.test {
             assertEquals(DEFAULT_STATE, awaitItem())
@@ -271,6 +272,7 @@ class LoginViewModelTest : BaseViewModelTest() {
                     dialogState = LoginState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = "mock_error".asText(),
+                        error = error,
                     ),
                 ),
                 awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
@@ -323,6 +323,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
     @Test
     fun `on createAuthRequestWithUpdates Success and login error should should update the state`() =
         runTest {
+            val error = Throwable("Fail!")
             coEvery {
                 authRepository.login(
                     email = EMAIL,
@@ -333,7 +334,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     masterPasswordHash = DEFAULT_LOGIN_DATA.masterPasswordHash,
                     captchaToken = null,
                 )
-            } returns LoginResult.Error(null)
+            } returns LoginResult.Error(errorMessage = null, error = error)
             val viewModel = createViewModel()
             viewModel.eventFlow.test {
                 viewModel.stateFlow.test {
@@ -365,6 +366,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                             dialogState = LoginWithDeviceState.DialogState.Error(
                                 title = R.string.an_error_has_occurred.asText(),
                                 message = R.string.generic_error_message.asText(),
+                                error = error,
                             ),
                             loginData = DEFAULT_LOGIN_DATA,
                         ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -581,6 +581,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `ContinueButtonClick login returns Error should update dialogState`() = runTest {
+        val error = Throwable("Fail!")
         coEvery {
             authRepository.login(
                 email = DEFAULT_EMAIL_ADDRESS,
@@ -593,7 +594,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                 captchaToken = null,
                 orgIdentifier = DEFAULT_ORG_IDENTIFIER,
             )
-        } returns LoginResult.Error(errorMessage = null)
+        } returns LoginResult.Error(errorMessage = null, error = error)
 
         val viewModel = createViewModel()
         viewModel.stateFlow.test {
@@ -614,6 +615,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     dialogState = TwoFactorLoginState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = R.string.invalid_verification_code.asText(),
+                        error = error,
                     ),
                 ),
                 awaitItem(),
@@ -640,6 +642,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
     @Test
     fun `ContinueButtonClick login returns Error with message should update dialogState`() =
         runTest {
+            val error = Throwable("Fail!")
             coEvery {
                 authRepository.login(
                     email = DEFAULT_EMAIL_ADDRESS,
@@ -652,7 +655,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     captchaToken = null,
                     orgIdentifier = DEFAULT_ORG_IDENTIFIER,
                 )
-            } returns LoginResult.Error(errorMessage = "Mock error message")
+            } returns LoginResult.Error(errorMessage = "Mock error message", error = error)
 
             val viewModel = createViewModel()
             viewModel.stateFlow.test {
@@ -673,6 +676,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = "Mock error message".asText(),
+                            error = error,
                         ),
                     ),
                     awaitItem(),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19296](https://bitwarden.atlassian.net/browse/PM-19296)

## 📔 Objective

This PR propagates the login flow errors up to the UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19296]: https://bitwarden.atlassian.net/browse/PM-19296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ