### PR TITLE
PM-19314: Propagate remaining auth errors to the UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/RequestOtpResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/RequestOtpResult.kt
@@ -13,5 +13,8 @@ sealed class RequestOtpResult {
     /**
      * Represents a failure to send the one-time passcode.
      */
-    data class Error(val message: String?) : RequestOtpResult()
+    data class Error(
+        val message: String?,
+        val error: Throwable,
+    ) : RequestOtpResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/ResendEmailResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/ResendEmailResult.kt
@@ -13,5 +13,8 @@ sealed class ResendEmailResult {
     /**
      * There was an error.
      */
-    data class Error(val message: String?) : ResendEmailResult()
+    data class Error(
+        val message: String?,
+        val error: Throwable,
+    ) : ResendEmailResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/SendVerificationEmailResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/SendVerificationEmailResult.kt
@@ -18,5 +18,8 @@ sealed class SendVerificationEmailResult {
      *
      * @param errorMessage a message describing the error.
      */
-    data class Error(val errorMessage: String?) : SendVerificationEmailResult()
+    data class Error(
+        val errorMessage: String?,
+        val error: Throwable?,
+    ) : SendVerificationEmailResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/UserFingerprintResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/UserFingerprintResult.kt
@@ -14,5 +14,7 @@ sealed class UserFingerprintResult {
     /**
      * There was an error getting the user fingerprint.
      */
-    data object Error : UserFingerprintResult()
+    data class Error(
+        val error: Throwable,
+    ) : UserFingerprintResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/ValidatePinResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/ValidatePinResult.kt
@@ -14,5 +14,7 @@ sealed class ValidatePinResult {
     /**
      * There was an error determining if the validity of the PIN.
      */
-    data object Error : ValidatePinResult()
+    data class Error(
+        val error: Throwable,
+    ) : ValidatePinResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/VerifiedOrganizationDomainSsoDetailsResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/VerifiedOrganizationDomainSsoDetailsResult.kt
@@ -18,5 +18,7 @@ sealed class VerifiedOrganizationDomainSsoDetailsResult {
     /**
      * The request failed.
      */
-    data object Failure : VerifiedOrganizationDomainSsoDetailsResult()
+    data class Failure(
+        val error: Throwable,
+    ) : VerifiedOrganizationDomainSsoDetailsResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/VerifyOtpResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/VerifyOtpResult.kt
@@ -13,5 +13,8 @@ sealed class VerifyOtpResult {
     /**
      * Represents a failure to verify the one-time passcode.
      */
-    data class NotVerified(val errorMessage: String?) : VerifyOtpResult()
+    data class NotVerified(
+        val errorMessage: String?,
+        val error: Throwable,
+    ) : VerifyOtpResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
@@ -380,12 +381,13 @@ class SettingsRepositoryImpl(
     }
 
     override suspend fun getUserFingerprint(): UserFingerprintResult {
-        val userId = activeUserId ?: return UserFingerprintResult.Error
+        val userId = activeUserId
+            ?: return UserFingerprintResult.Error(error = NoActiveUserException())
 
         return vaultSdkSource
             .getUserFingerprint(userId)
             .fold(
-                onFailure = { UserFingerprintResult.Error },
+                onFailure = { UserFingerprintResult.Error(error = it) },
                 onSuccess = { UserFingerprintResult.Success(it) },
             )
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -134,6 +134,7 @@ fun StartRegistrationScreen(
             BitwardenBasicDialog(
                 title = dialog.title?.invoke(),
                 message = dialog.message(),
+                throwable = dialog.error,
                 onDismissRequest = remember(viewModel) {
                     { viewModel.trySendAction(ErrorDialogDismiss) }
                 },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
@@ -246,7 +246,6 @@ class StartRegistrationViewModel @Inject constructor(
         result: ReceiveSendVerificationEmailResult,
     ) {
         when (val sendVerificationEmailResult = result.sendVerificationEmailResult) {
-
             is SendVerificationEmailResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
@@ -256,6 +255,7 @@ class StartRegistrationViewModel @Inject constructor(
                                 .errorMessage
                                 ?.asText()
                                 ?: R.string.generic_error_message.asText(),
+                            error = sendVerificationEmailResult.error,
                         ),
                     )
                 }
@@ -314,6 +314,7 @@ sealed class StartRegistrationDialog : Parcelable {
     data class Error(
         val title: Text?,
         val message: Text,
+        val error: Throwable? = null,
     ) : StartRegistrationDialog()
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -430,7 +430,7 @@ class TwoFactorLoginViewModel @Inject constructor(
         // Dismiss the loading overlay.
         mutableStateFlow.update { it.copy(dialogState = null) }
 
-        when (action.resendEmailResult) {
+        when (val result = action.resendEmailResult) {
             // Display a dialog for an error result.
             is ResendEmailResult.Error -> {
                 mutableStateFlow.update {
@@ -438,6 +438,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.verification_email_not_sent.asText(),
+                            error = result.error,
                         ),
                     )
                 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
@@ -132,10 +132,11 @@ class DeleteAccountConfirmationViewModel @Inject constructor(
     ) {
         mutableStateFlow.update {
             it.copy(
-                dialog = when (action.requestOtpResult) {
+                dialog = when (val result = action.requestOtpResult) {
                     is RequestOtpResult.Error -> {
                         DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.Error(
                             message = R.string.generic_error_message.asText(),
+                            error = result.error,
                         )
                     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
@@ -403,11 +403,14 @@ class ExportVaultViewModel @Inject constructor(
     private fun handleReceiveVerifyOneTimePasscodeResult(
         action: ExportVaultAction.Internal.ReceiveVerifyOneTimePasscodeResult,
     ) {
-        when (action.result) {
+        when (val result = action.result) {
             VerifyOtpResult.Verified -> exportVaultData()
 
             is VerifyOtpResult.NotVerified -> {
-                updateStateWithError(R.string.generic_error_message.asText())
+                updateStateWithError(
+                    message = R.string.generic_error_message.asText(),
+                    error = result.error,
+                )
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1862,7 +1862,7 @@ class VaultAddEditViewModel @Inject constructor(
         clearDialogState()
 
         when (action.result) {
-            ValidatePinResult.Error -> {
+            is ValidatePinResult.Error -> {
                 showFido2ErrorDialog()
             }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1409,7 +1409,7 @@ class VaultItemListingViewModel @Inject constructor(
         clearDialogState()
 
         when (action.result) {
-            ValidatePinResult.Error -> {
+            is ValidatePinResult.Error -> {
                 showFido2UserVerificationErrorDialog()
             }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManagerImpl
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
@@ -36,14 +37,18 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.runs
+import io.mockk.unmockkConstructor
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.ZonedDateTime
@@ -76,6 +81,19 @@ class SettingsRepositoryTest {
         dispatcherManager = FakeDispatcherManager(),
         policyManager = policyManager,
     )
+
+    @BeforeEach
+    fun setup() {
+        mockkConstructor(NoActiveUserException::class)
+        every {
+            anyConstructed<NoActiveUserException>() == any<NoActiveUserException>()
+        } returns true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkConstructor(NoActiveUserException::class)
+    }
 
     @Test
     fun `setDefaultsIfNecessary should set LOCK default values for the given user if necessary`() {
@@ -743,23 +761,24 @@ class SettingsRepositoryTest {
 
         val result = settingsRepository.getUserFingerprint()
 
-        assertEquals(UserFingerprintResult.Error, result)
+        assertEquals(UserFingerprintResult.Error(error = NoActiveUserException()), result)
     }
 
     @Test
     fun `getUserFingerprint should return failure with active user when source returns failure`() =
         runTest {
+            val error = Throwable("Fail!")
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             coEvery {
                 vaultSdkSource.getUserFingerprint(userId = USER_ID)
-            } returns Throwable().asFailure()
+            } returns error.asFailure()
 
             val result = settingsRepository.getUserFingerprint()
 
             coVerify(exactly = 1) {
                 vaultSdkSource.getUserFingerprint(userId = USER_ID)
             }
-            assertEquals(UserFingerprintResult.Error, result)
+            assertEquals(UserFingerprintResult.Error(error = error), result)
         }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
@@ -985,7 +985,7 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
         runTest {
             coEvery {
                 authRepository.getVerifiedOrganizationDomainSsoDetails(any())
-            } returns VerifiedOrganizationDomainSsoDetailsResult.Failure
+            } returns VerifiedOrganizationDomainSsoDetailsResult.Failure(error = Throwable("Fail!"))
 
             coEvery {
                 featureFlagManager.getFeatureFlag(FlagKey.VerifiedSsoDomainEndpoint)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModelTest.kt
@@ -189,6 +189,7 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `ContinueClick register returns error should update errorDialogState`() = runTest {
+        val error = Throwable("Fail!")
         val repo = mockk<AuthRepository> {
             every { captchaTokenResultFlow } returns flowOf()
             coEvery {
@@ -197,7 +198,7 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
                     name = NAME,
                     receiveMarketingEmails = true,
                 )
-            } returns SendVerificationEmailResult.Error(errorMessage = "mock_error")
+            } returns SendVerificationEmailResult.Error(errorMessage = "mock_error", error = error)
         }
         val viewModel = StartRegistrationViewModel(
             savedStateHandle = validInputHandle,
@@ -217,6 +218,7 @@ class StartRegistrationViewModelTest : BaseViewModelTest() {
                     dialog = StartRegistrationDialog.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = "mock_error".asText(),
+                        error = error,
                     ),
                 ),
                 awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -926,9 +926,10 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `ResendEmailClick returns error should update dialogState`() = runTest {
+        val error = Throwable("Fail!")
         coEvery {
             authRepository.resendVerificationCodeEmail()
-        } returns ResendEmailResult.Error(message = null)
+        } returns ResendEmailResult.Error(message = null, error = error)
 
         val viewModel = createViewModel()
         viewModel.stateFlow.test {
@@ -951,6 +952,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     dialogState = TwoFactorLoginState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = R.string.verification_email_not_sent.asText(),
+                        error = error,
                     ),
                 ),
                 awaitItem(),
@@ -973,6 +975,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                     dialogState = TwoFactorLoginState.DialogState.Error(
                         title = R.string.an_error_has_occurred.asText(),
                         message = R.string.verification_email_not_sent.asText(),
+                        error = error,
                     ),
                 ),
                 awaitItem(),
@@ -1079,12 +1082,13 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
     @Test
     fun `ReceiveResendEmailResult with ResendEmailResult Error should not emit any events`() =
         runTest {
+            val error = Throwable("Fail!")
             val viewModel = createViewModel()
             viewModel.stateFlow.test {
                 assertEquals(DEFAULT_STATE, awaitItem())
                 viewModel.trySendAction(
                     TwoFactorLoginAction.Internal.ReceiveResendEmailResult(
-                        resendEmailResult = ResendEmailResult.Error(message = null),
+                        resendEmailResult = ResendEmailResult.Error(message = null, error = error),
                         isUserInitiated = true,
                     ),
                 )
@@ -1093,6 +1097,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = R.string.an_error_has_occurred.asText(),
                             message = R.string.verification_email_not_sent.asText(),
+                            error = error,
                         ),
                     ),
                     awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -10,6 +10,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.UserFingerprintResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
@@ -180,7 +181,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                     isEnabled = true,
                     type = PolicyTypeJson.REMOVE_UNLOCK_WITH_PIN,
                     organizationId = "organizationUser",
-                    ),
+                ),
             ),
         )
 
@@ -297,7 +298,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         // Clear fingerprint phrase
         viewModel.trySendAction(
             AccountSecurityAction.Internal.FingerprintResultReceive(
-                UserFingerprintResult.Error,
+                fingerprintResult = UserFingerprintResult.Error(error = NoActiveUserException()),
             ),
         )
         assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModelTest.kt
@@ -183,9 +183,10 @@ class DeleteAccountConfirmationViewModelTest : BaseViewModelTest() {
     @Suppress("MaxLineLength")
     fun `on ResendCodeClick with requestOneTimePasscode Success should set dialog to Error`() =
         runTest {
+            val error = Throwable("Fail!")
             coEvery {
                 authRepo.requestOneTimePasscode()
-            } returns RequestOtpResult.Error(message = "Error")
+            } returns RequestOtpResult.Error(message = "error", error = error)
             val viewModel = createViewModel(state = DEFAULT_STATE)
             viewModel.stateFlow.test {
                 assertEquals(DEFAULT_STATE, awaitItem())
@@ -202,6 +203,7 @@ class DeleteAccountConfirmationViewModelTest : BaseViewModelTest() {
                     DEFAULT_STATE.copy(
                         dialog = DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.Error(
                             message = R.string.generic_error_message.asText(),
+                            error = error,
                         ),
                     ),
                     awaitItem(),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
@@ -146,11 +146,12 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
             passwordInput = passcode,
             showSendCodeButton = true,
         )
+        val error = Throwable("Fail!")
         coEvery {
             authRepository.verifyOneTimePasscode(
                 oneTimePasscode = passcode,
             )
-        } returns VerifyOtpResult.NotVerified("Wrong")
+        } returns VerifyOtpResult.NotVerified(errorMessage = "Wrong", error = error)
 
         val viewModel = createViewModel(initialState)
 
@@ -161,6 +162,7 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
                 dialogState = ExportVaultState.DialogState.Error(
                     title = R.string.an_error_has_occurred.asText(),
                     message = R.string.generic_error_message.asText(),
+                    error = error,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -509,10 +511,11 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
     @Test
     fun `SendCodeClick should call requestOneTimePasscode and update dialog state to sending then back to null when request completes and send correct event on error`() =
         runTest {
+            val error = Throwable("Fail!")
             val viewModel = createViewModel()
             coEvery {
                 authRepository.requestOneTimePasscode()
-            } returns RequestOtpResult.Error(message = null)
+            } returns RequestOtpResult.Error(message = null, error = error)
             viewModel.stateEventFlow(backgroundScope) { stateTurbine, eventTurbine ->
                 assertEquals(DEFAULT_STATE, stateTurbine.awaitItem())
                 viewModel.trySendAction(ExportVaultAction.SendCodeClick)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -4078,7 +4078,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val pin = "PIN"
             coEvery {
                 authRepository.validatePin(pin = pin)
-            } returns ValidatePinResult.Error
+            } returns ValidatePinResult.Error(error = Throwable("Fail!"))
 
             viewModel.trySendAction(
                 VaultAddEditAction.Common.PinFido2VerificationSubmit(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -4216,7 +4216,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         val pin = "PIN"
         coEvery {
             authRepository.validatePin(pin = pin)
-        } returns ValidatePinResult.Error
+        } returns ValidatePinResult.Error(error = Throwable("Fail!"))
 
         viewModel.trySendAction(
             VaultItemListingsAction.PinFido2VerificationSubmit(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19314](https://bitwarden.atlassian.net/browse/PM-19314)

## 📔 Objective

This PR propagates the errors from the remaining auth flows to the UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19314]: https://bitwarden.atlassian.net/browse/PM-19314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ