### PR TITLE
BWA-119 - Unable to Access Manual Code Entry After Denying Camera Permissions on

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -31,10 +31,7 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -100,12 +97,11 @@ fun ItemListingScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
     val context = LocalContext.current
-    var shouldShowPermissionDialog by rememberSaveable { mutableStateOf(false) }
     val launcher = permissionsManager.getLauncher { isGranted ->
         if (isGranted) {
             viewModel.trySendAction(ItemListingAction.ScanQrCodeClick)
         } else {
-            shouldShowPermissionDialog = true
+            viewModel.trySendAction(ItemListingAction.EnterSetupKeyClick)
         }
     }
     val snackbarHostState = remember { SnackbarHostState() }
@@ -149,20 +145,6 @@ fun ItemListingScreen(
                 snackbarHostState.showSnackbar("")
             }
         }
-    }
-
-    if (shouldShowPermissionDialog) {
-        BitwardenTwoButtonDialog(
-            message = stringResource(id = R.string.enable_camera_permission_to_use_the_scanner),
-            confirmButtonText = stringResource(id = R.string.settings),
-            dismissButtonText = stringResource(id = R.string.no_thanks),
-            onConfirmClick = remember(viewModel) {
-                { viewModel.trySendAction(ItemListingAction.SettingsClick) }
-            },
-            onDismissClick = { shouldShowPermissionDialog = false },
-            onDismissRequest = { shouldShowPermissionDialog = false },
-            title = null,
-        )
     }
 
     ItemListingDialogs(
@@ -258,7 +240,7 @@ fun ItemListingScreen(
                         launcher.launch(Manifest.permission.CAMERA)
                     }
                 },
-                onScanQuCodeClick = remember(viewModel) {
+                onScanQrCodeClick = remember(viewModel) {
                     {
                         launcher.launch(Manifest.permission.CAMERA)
                     }
@@ -580,7 +562,7 @@ fun EmptyItemListingContent(
         rememberTopAppBarState(),
     ),
     onAddCodeClick: () -> Unit,
-    onScanQuCodeClick: () -> Unit,
+    onScanQrCodeClick: () -> Unit,
     onEnterSetupKeyClick: () -> Unit,
     onDownloadBitwardenClick: () -> Unit,
     onDismissDownloadBitwardenClick: () -> Unit,
@@ -613,7 +595,7 @@ fun EmptyItemListingContent(
                             contentDescription = stringResource(id = R.string.scan_a_qr_code),
                             testTag = "ScanQRCodeButton",
                         ),
-                        onScanQrCodeClick = onScanQuCodeClick,
+                        onScanQrCodeClick = onScanQrCodeClick,
                     ),
                     ItemListingExpandableFabAction.EnterSetupKey(
                         label = R.string.enter_key_manually.asText(),
@@ -783,7 +765,7 @@ private fun EmptyListingContentPreview() {
         modifier = Modifier.padding(horizontal = 16.dp),
         appTheme = AppTheme.DEFAULT,
         onAddCodeClick = { },
-        onScanQuCodeClick = { },
+        onScanQrCodeClick = { },
         onEnterSetupKeyClick = { },
         actionCardState = ItemListingState.ActionCardState.DownloadBitwardenApp,
         onDownloadBitwardenClick = { },

--- a/authenticator/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
@@ -65,6 +65,38 @@ class ItemListingScreenTest : BaseComposeTest() {
 
     @Test
     @Suppress("MaxLineLength")
+    fun `when denying camera permissions and attempting to add a code we should be shown the manual entry screen`() {
+        permissionsManager.getPermissionsResult = false
+
+        composeTestRule
+            .onNodeWithText("Add code")
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                ItemListingAction.EnterSetupKeyClick,
+            )
+        }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `when allowing camera permissions and attempting to add a code we should be shown the scan QR code screen`() {
+        permissionsManager.getPermissionsResult = true
+
+        composeTestRule
+            .onNodeWithText("Add code")
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                ItemListingAction.ScanQrCodeClick,
+            )
+        }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
     fun `shared accounts error message should show when view is Content with SharedCodesDisplayState Error`() {
         mutableStateFlow.value = DEFAULT_STATE.copy(
             viewState = ItemListingState.ViewState.Content(


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-119](https://bitwarden.atlassian.net/browse/BWA-119)

## 📔 Objective

- The issue was that the manual entry screen was not being displayed when attempting to add a new code. Instead, a dialog prompted the user to open Settings, but upon dismissing the dialog, they remained on the same tab.
- After discussing with Luke, we determined that the expected behavior should match iOS, which does not display a dialog. Instead, if permissions are not granted, the manual entry screen should be shown directly.  This also follows the flow of the Password Manager android app.
- Fixed typo in `onScanQrCodeClick`

## 📸 Screenshots
### Before

https://github.com/user-attachments/assets/6094c1c8-626f-4140-b270-3ee7e23479ee

### After
https://github.com/user-attachments/assets/142ae99e-ad14-4c4b-b9ef-23758bc03faa



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-119]: https://bitwarden.atlassian.net/browse/BWA-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ