### PR TITLE
[PM-19355] Update BrowserUtil.kt: add support for /e/OS Browser package

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/BrowserUtil.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/BrowserUtil.kt
@@ -94,6 +94,7 @@ private val ACCESSIBILITY_SUPPORTED_BROWSERS = listOf(
     Browser(packageName = "com.yjllq.kito", urlFieldId = "search_box"),
     Browser(packageName = "com.yujian.ResideMenuDemo", urlFieldId = "search_box"),
     Browser(packageName = "com.z28j.feel", urlFieldId = "g2"),
+    Browser(packageName = "foundation.e.browser", urlFieldId = "url_bar"),
     Browser(packageName = "idm.internet.download.manager", urlFieldId = "search"),
     Browser(packageName = "idm.internet.download.manager.adm.lite", urlFieldId = "search"),
     Browser(packageName = "idm.internet.download.manager.plus", urlFieldId = "search"),
@@ -123,7 +124,6 @@ private val ACCESSIBILITY_SUPPORTED_BROWSERS = listOf(
     Browser(packageName = "org.chromium.chrome", urlFieldId = "url_bar"),
     Browser(packageName = "org.codeaurora.swe.browser", urlFieldId = "url_bar"),
     Browser(packageName = "org.cromite.cromite", urlFieldId = "url_bar"),
-    Browser(packageName = "foundation.e.browser", urlFieldId = "url_bar"),
     Browser(
         packageName = "org.gnu.icecat",
         // 2nd = Anticipation

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/BrowserUtil.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/accessibility/util/BrowserUtil.kt
@@ -123,6 +123,7 @@ private val ACCESSIBILITY_SUPPORTED_BROWSERS = listOf(
     Browser(packageName = "org.chromium.chrome", urlFieldId = "url_bar"),
     Browser(packageName = "org.codeaurora.swe.browser", urlFieldId = "url_bar"),
     Browser(packageName = "org.cromite.cromite", urlFieldId = "url_bar"),
+    Browser(packageName = "foundation.e.browser", urlFieldId = "url_bar"),
     Browser(
         packageName = "org.gnu.icecat",
         // 2nd = Anticipation

--- a/app/src/main/res/xml/autofill_service_configuration.xml
+++ b/app/src/main/res/xml/autofill_service_configuration.xml
@@ -182,6 +182,9 @@
         android:name="com.z28j.feel"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package
+        android:name="foundation.e.browser"
+        android:maxLongVersionCode="10000000000" />
+    <compatibility-package
         android:name="idm.internet.download.manager"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package


### PR DESCRIPTION
The /e/OS Browser is a fork of Cromite, using the package id `foundation.e.browser`, see https://gitlab.e.foundation/e/os/browser/-/blob/master/build/browser.gn_args?ref_type=heads#L56



## 🎟️ Tracking

I did not saw related issue in this repo, but in /e/ issues tracker there are : 
- https://gitlab.e.foundation/e/backlog/-/issues/3739
- https://gitlab.e.foundation/e/backlog/-/issues/3319

## 📔 Objective

I hope this simple patch can fix the auto-fill with this Browser and Bitwarden on Android. 

## 📸 Screenshots

Not relevant

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
