### PR TITLE
PM-18862: Update IME handling for BitwardenScaffold and VaultUnlockedNavBarScreen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/scaffold/BitwardenScaffold.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/scaffold/BitwardenScaffold.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -69,7 +70,11 @@ fun BitwardenScaffold(
         contentColor = contentColor,
         contentWindowInsets = WindowInsets(0.dp),
         content = { paddingValues ->
-            Column(modifier = Modifier.padding(paddingValues = paddingValues)) {
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues = paddingValues)
+                    .consumeWindowInsets(paddingValues = paddingValues),
+            ) {
                 utilityBar()
                 val internalPullToRefreshState = rememberPullToRefreshState()
                 Box(
@@ -93,7 +98,11 @@ fun BitwardenScaffold(
                     )
                 }
             }
-            Box(modifier = Modifier.padding(paddingValues = paddingValues)) {
+            Box(
+                modifier = Modifier
+                    .padding(paddingValues = paddingValues)
+                    .consumeWindowInsets(paddingValues = paddingValues),
+            ) {
                 overlay()
             }
         },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.material3.BottomAppBar
@@ -220,8 +219,7 @@ private fun VaultUnlockedNavBarScaffold(
             navController = navController,
             startDestination = VAULT_GRAPH_ROUTE,
             modifier = Modifier
-                .consumeWindowInsets(WindowInsets.navigationBars.only(WindowInsetsSides.Vertical))
-                .consumeWindowInsets(WindowInsets.ime),
+                .consumeWindowInsets(WindowInsets.navigationBars.only(WindowInsetsSides.Vertical)),
             enterTransition = RootTransitionProviders.Enter.fadeIn,
             exitTransition = RootTransitionProviders.Exit.fadeOut,
             popEnterTransition = RootTransitionProviders.Enter.fadeIn,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18862](https://bitwarden.atlassian.net/browse/PM-18862)

## 📔 Objective

This PR updates the IME handling for the `BitwardenScaffold` and `VaultUnlockedNavBarScreen` in order to better accommodate ime when the bottom navigation is present. This realistically only occurs on the generator screen but this fix is generic enough to work everywhere.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/53a3524f-bf50-416e-9263-dc1fe7a036dd" width="300" /> | <video src="https://github.com/user-attachments/assets/6c7625f2-1504-4b51-897d-167d2ad2fa6d" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18862]: https://bitwarden.atlassian.net/browse/PM-18862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ