### PR TITLE
BWA-154: Fix privacy policy padding

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -212,8 +212,6 @@ fun SettingsScreen(
             )
             Spacer(modifier = Modifier.height(16.dp))
             AboutSettings(
-                modifier = Modifier
-                    .padding(horizontal = 16.dp),
                 state = state,
                 onSubmitCrashLogsCheckedChange = remember(viewModel) {
                     { viewModel.trySendAction(SettingsAction.AboutClick.SubmitCrashLogsClick(it)) }
@@ -560,11 +558,12 @@ private fun AboutSettings(
     onVersionClick: () -> Unit,
 ) {
     BitwardenListHeaderText(
-        modifier = modifier,
+        modifier = modifier.padding(horizontal = 16.dp),
         label = stringResource(id = R.string.about),
     )
     BitwardenWideSwitch(
         modifier = modifier
+            .padding(horizontal = 16.dp)
             .semantics { testTag = "SubmitCrashLogs" },
         label = stringResource(id = R.string.submit_crash_logs),
         isChecked = state.isSubmitCrashLogsEnabled,


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-154](https://bitwarden.atlassian.net/browse/BWA-154)

## 📔 Objective

This PR fixes the padding on the privacy policy button.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/dab98a79-f180-40e1-ae13-c950eade1dbf" width="300" /> | <img src="https://github.com/user-attachments/assets/1c52fcf6-8a06-4694-85a9-ba0069c73210" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BWA-154]: https://bitwarden.atlassian.net/browse/BWA-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ