### PR TITLE
PM-19403: Add better error messages for username generation

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -1222,7 +1222,7 @@ private fun ForwardedEmailAliasTypeContent(
         when (usernameTypeState.selectedServiceType) {
             is ServiceType.AddyIo -> {
                 BitwardenPasswordField(
-                    label = stringResource(id = R.string.api_access_token),
+                    label = stringResource(id = R.string.api_access_token_required_parenthesis),
                     value = usernameTypeState.selectedServiceType.apiAccessToken,
                     onValueChange = forwardedEmailAliasHandlers.onAddyIoAccessTokenTextChange,
                     showPasswordTestTag = "ShowForwardedEmailApiSecretButton",
@@ -1292,7 +1292,7 @@ private fun ForwardedEmailAliasTypeContent(
 
             is ServiceType.FirefoxRelay -> {
                 BitwardenPasswordField(
-                    label = stringResource(id = R.string.api_access_token),
+                    label = stringResource(id = R.string.api_access_token_required_parenthesis),
                     value = usernameTypeState.selectedServiceType.apiAccessToken,
                     onValueChange = forwardedEmailAliasHandlers.onFirefoxRelayAccessTokenTextChange,
                     showPasswordTestTag = "ShowForwardedEmailApiSecretButton",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -773,7 +773,9 @@ select Add TOTP to store the key safely</string>
   <string name="forwarded_email_alias">Forwarded email alias</string>
   <string name="random_word">Random word</string>
   <string name="email_required_parenthesis">Email (required)</string>
+  <string name="domain_name">domain name</string>
   <string name="domain_name_required_parenthesis">Domain name (required)</string>
+  <string name="api_key">API key</string>
   <string name="api_key_required_parenthesis">API key (required)</string>
   <string name="service">Service</string>
   <string name="addy_io">addy.io</string>
@@ -782,6 +784,7 @@ select Add TOTP to store the key safely</string>
   <string name="duck_duck_go">DuckDuckGo</string>
   <string name="fastmail">Fastmail</string>
   <string name="forward_email">ForwardEmail</string>
+  <string name="api_access_token_required_parenthesis">API access token (required)</string>
   <string name="api_access_token">API access token</string>
   <string name="are_you_sure_you_want_to_overwrite_the_current_username">Are you sure you want to overwrite the current username?</string>
   <string name="generate_username">Generate username</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -1064,7 +1064,7 @@ class GeneratorScreenTest : BaseComposeTest() {
         val newAccessToken = "accessToken"
 
         composeTestRule
-            .onNodeWithText("API access token")
+            .onNodeWithText("API access token (required)")
             .performScrollTo()
             .performTextInput(newAccessToken)
 
@@ -1306,7 +1306,7 @@ class GeneratorScreenTest : BaseComposeTest() {
         val newAccessToken = "accessToken"
 
         composeTestRule
-            .onNodeWithText("API access token")
+            .onNodeWithText("API access token (required)")
             .performScrollTo()
             .performTextInput(newAccessToken)
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModelTest.kt
@@ -490,15 +490,14 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
             viewModel.trySendAction(GeneratorAction.RegenerateClick)
 
-            val expectedState =
-                initialPasscodeState.copy(
-                    generatedText = "email+abcd1234@address.com",
-                    selectedType = GeneratorState.MainType.Username(
-                        GeneratorState.MainType.Username.UsernameType.PlusAddressedEmail(
-                            email = "currentEmail",
-                        ),
+            val expectedState = initialPasscodeState.copy(
+                generatedText = "email+abcd1234@address.com",
+                selectedType = GeneratorState.MainType.Username(
+                    GeneratorState.MainType.Username.UsernameType.PlusAddressedEmail(
+                        email = "currentEmail",
                     ),
-                )
+                ),
+            )
 
             assertEquals(expectedState, viewModel.stateFlow.value)
         }
@@ -514,16 +513,37 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
             viewModel.trySendAction(GeneratorAction.RegenerateClick)
 
-            val expectedState =
-                initialCatchAllEmailState.copy(
-                    generatedText = "DifferentUsername",
-                    selectedType = GeneratorState.MainType.Username(
-                        GeneratorState.MainType.Username.UsernameType.CatchAllEmail(
-                            domainName = "defaultDomain",
+            val expectedState = initialCatchAllEmailState.copy(
+                generatedText = "DifferentUsername",
+                selectedType = GeneratorState.MainType.Username(
+                    GeneratorState.MainType.Username.UsernameType.CatchAllEmail(
+                        domainName = "defaultDomain",
+                    ),
+                ),
+            )
+
+            assertEquals(expectedState, viewModel.stateFlow.value)
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `RegenerateClick for catch all email state should update the catch all email correctly when domain name is blank`() =
+        runTest {
+            val initialState = createCatchAllEmailState(domain = "")
+            val viewModel = createViewModel(createSavedStateHandleWithState(initialState))
+            val expectedState = initialState.copy(generatedText = "-")
+
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(GeneratorAction.RegenerateClick)
+                assertEquals(
+                    GeneratorEvent.ShowSnackbar(
+                        message = R.string.validation_field_required.asText(
+                            R.string.domain_name.asText(),
                         ),
                     ),
+                    awaitItem(),
                 )
-
+            }
             assertEquals(expectedState, viewModel.stateFlow.value)
         }
 
@@ -539,13 +559,12 @@ class GeneratorViewModelTest : BaseViewModelTest() {
 
             viewModel.trySendAction(GeneratorAction.RegenerateClick)
 
-            val expectedState =
-                initialCatchAllEmailState.copy(
-                    generatedText = "DifferentUsername",
-                    selectedType = GeneratorState.MainType.Username(
-                        GeneratorState.MainType.Username.UsernameType.RandomWord(),
-                    ),
-                )
+            val expectedState = initialCatchAllEmailState.copy(
+                generatedText = "DifferentUsername",
+                selectedType = GeneratorState.MainType.Username(
+                    GeneratorState.MainType.Username.UsernameType.RandomWord(),
+                ),
+            )
 
             assertEquals(expectedState, viewModel.stateFlow.value)
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/util/ServiceTypeExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/generator/util/ServiceTypeExtensionsTest.kt
@@ -2,9 +2,10 @@ package com.x8bit.bitwarden.ui.tools.feature.generator.util
 
 import com.bitwarden.generators.ForwarderServiceType
 import com.bitwarden.generators.UsernameGeneratorRequest
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorState.MainType.Username.UsernameType.ForwardedEmailAlias.ServiceType
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 internal class ServiceTypeExtensionsTest {
@@ -21,7 +22,10 @@ internal class ServiceTypeExtensionsTest {
             allowSimpleLoginSelfHostUrl = true,
         )
 
-        assertNull(request)
+        assertEquals(
+            GeneratorRequestResult.MissingField(R.string.api_access_token.asText()),
+            request,
+        )
     }
 
     @Test
@@ -36,7 +40,10 @@ internal class ServiceTypeExtensionsTest {
             allowSimpleLoginSelfHostUrl = true,
         )
 
-        assertNull(request)
+        assertEquals(
+            GeneratorRequestResult.MissingField(R.string.domain_name.asText()),
+            request,
+        )
     }
 
     @Test
@@ -49,13 +56,15 @@ internal class ServiceTypeExtensionsTest {
         val website = "bitwarden.com"
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.AddyIo(
-                    apiToken = "testToken",
-                    domain = "test.com",
-                    baseUrl = "http://test.com",
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.AddyIo(
+                        apiToken = "testToken",
+                        domain = "test.com",
+                        baseUrl = "http://test.com",
+                    ),
+                    website = website,
                 ),
-                website = website,
             ),
             addyIoServiceType.toUsernameGeneratorRequest(
                 website = website,
@@ -66,13 +75,15 @@ internal class ServiceTypeExtensionsTest {
 
         // Verify the correct request is returned when allowAddyIoSelfHostUrl is false
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.AddyIo(
-                    apiToken = "testToken",
-                    domain = "test.com",
-                    baseUrl = ServiceType.AddyIo.DEFAULT_ADDY_IO_URL,
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.AddyIo(
+                        apiToken = "testToken",
+                        domain = "test.com",
+                        baseUrl = ServiceType.AddyIo.DEFAULT_ADDY_IO_URL,
+                    ),
+                    website = website,
                 ),
-                website = website,
             ),
             addyIoServiceType.toUsernameGeneratorRequest(
                 website = website,
@@ -97,13 +108,15 @@ internal class ServiceTypeExtensionsTest {
         )
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.AddyIo(
-                    apiToken = "testToken",
-                    domain = "test.com",
-                    baseUrl = ServiceType.AddyIo.DEFAULT_ADDY_IO_URL,
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.AddyIo(
+                        apiToken = "testToken",
+                        domain = "test.com",
+                        baseUrl = ServiceType.AddyIo.DEFAULT_ADDY_IO_URL,
+                    ),
+                    website = website,
                 ),
-                website = website,
             ),
             request,
         )
@@ -118,7 +131,10 @@ internal class ServiceTypeExtensionsTest {
             allowSimpleLoginSelfHostUrl = true,
         )
 
-        assertNull(request)
+        assertEquals(
+            GeneratorRequestResult.MissingField(R.string.api_key.asText()),
+            request,
+        )
     }
 
     @Test
@@ -132,9 +148,11 @@ internal class ServiceTypeExtensionsTest {
         )
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.DuckDuckGo(token = "testKey"),
-                website = website,
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.DuckDuckGo(token = "testKey"),
+                    website = website,
+                ),
             ),
             request,
         )
@@ -149,7 +167,10 @@ internal class ServiceTypeExtensionsTest {
             allowSimpleLoginSelfHostUrl = true,
         )
 
-        assertNull(request)
+        assertEquals(
+            GeneratorRequestResult.MissingField(R.string.api_access_token.asText()),
+            request,
+        )
     }
 
     @Test
@@ -163,9 +184,11 @@ internal class ServiceTypeExtensionsTest {
         )
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.Firefox(apiToken = "testToken"),
-                website = website,
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.Firefox(apiToken = "testToken"),
+                    website = website,
+                ),
             ),
             request,
         )
@@ -180,7 +203,10 @@ internal class ServiceTypeExtensionsTest {
             allowSimpleLoginSelfHostUrl = true,
         )
 
-        assertNull(request)
+        assertEquals(
+            GeneratorRequestResult.MissingField(R.string.api_key.asText()),
+            request,
+        )
     }
 
     @Test
@@ -196,9 +222,11 @@ internal class ServiceTypeExtensionsTest {
         )
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.Fastmail(apiToken = "testKey"),
-                website = "bitwarden.com",
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.Fastmail(apiToken = "testKey"),
+                    website = "bitwarden.com",
+                ),
             ),
             request,
         )
@@ -216,7 +244,10 @@ internal class ServiceTypeExtensionsTest {
             allowSimpleLoginSelfHostUrl = true,
         )
 
-        assertNull(request)
+        assertEquals(
+            GeneratorRequestResult.MissingField(R.string.api_key.asText()),
+            request,
+        )
     }
 
     @Test
@@ -231,7 +262,10 @@ internal class ServiceTypeExtensionsTest {
             allowSimpleLoginSelfHostUrl = true,
         )
 
-        assertNull(request)
+        assertEquals(
+            GeneratorRequestResult.MissingField(R.string.domain_name.asText()),
+            request,
+        )
     }
 
     @Test
@@ -248,12 +282,14 @@ internal class ServiceTypeExtensionsTest {
         )
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.ForwardEmail(
-                    apiToken = "apiKey",
-                    domain = "domainName",
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.ForwardEmail(
+                        apiToken = "apiKey",
+                        domain = "domainName",
+                    ),
+                    website = website,
                 ),
-                website = website,
             ),
             request,
         )
@@ -268,7 +304,10 @@ internal class ServiceTypeExtensionsTest {
             allowSimpleLoginSelfHostUrl = true,
         )
 
-        assertNull(request)
+        assertEquals(
+            GeneratorRequestResult.MissingField(R.string.api_key.asText()),
+            request,
+        )
     }
 
     @Suppress("MaxLineLength")
@@ -283,12 +322,14 @@ internal class ServiceTypeExtensionsTest {
         )
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.SimpleLogin(
-                    apiKey = "testKey",
-                    ServiceType.SimpleLogin.DEFAULT_SIMPLE_LOGIN_URL,
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.SimpleLogin(
+                        apiKey = "testKey",
+                        ServiceType.SimpleLogin.DEFAULT_SIMPLE_LOGIN_URL,
+                    ),
+                    website = website,
                 ),
-                website = website,
             ),
             request,
         )
@@ -306,12 +347,14 @@ internal class ServiceTypeExtensionsTest {
         )
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.SimpleLogin(
-                    apiKey = "testKey",
-                    ServiceType.SimpleLogin.DEFAULT_SIMPLE_LOGIN_URL,
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.SimpleLogin(
+                        apiKey = "testKey",
+                        ServiceType.SimpleLogin.DEFAULT_SIMPLE_LOGIN_URL,
+                    ),
+                    website = website,
                 ),
-                website = website,
             ),
             request,
         )
@@ -332,12 +375,14 @@ internal class ServiceTypeExtensionsTest {
         )
 
         assertEquals(
-            UsernameGeneratorRequest.Forwarded(
-                service = ForwarderServiceType.SimpleLogin(
-                    apiKey = "testKey",
-                    baseUrl = "https://simplelogin.local",
+            GeneratorRequestResult.Success(
+                result = UsernameGeneratorRequest.Forwarded(
+                    service = ForwarderServiceType.SimpleLogin(
+                        apiKey = "testKey",
+                        baseUrl = "https://simplelogin.local",
+                    ),
+                    website = website,
                 ),
-                website = website,
             ),
             request,
         )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19403](https://bitwarden.atlassian.net/browse/PM-19403)

## 📔 Objective

This PR adds error messaging to the username generation to better indicate that you missed a required field.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ba2c84a8-4360-4a9f-a1f9-41a9e3463ebd" width="300" /> | <video src="https://github.com/user-attachments/assets/4d3a1a86-1540-4987-a057-aef87a480845" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19403]: https://bitwarden.atlassian.net/browse/PM-19403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ