### PR TITLE
PM-8953: Require 4 digits for pin entry

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
@@ -38,6 +38,8 @@ import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
 import com.x8bit.bitwarden.ui.platform.components.util.maxDialogHeight
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
+private const val MINIMUM_PIN_LENGTH: Int = 4
+
 /**
  * A dialog for setting a user's PIN.
  *
@@ -138,6 +140,7 @@ fun PinInputDialog(
 
                 BitwardenFilledButton(
                     label = stringResource(id = R.string.submit),
+                    isEnabled = !isPinCreation || pin.length >= MINIMUM_PIN_LENGTH,
                     onClick = { onSubmitClick(pin) },
                     modifier = Modifier.testTag(tag = "AcceptAlertButton"),
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,7 +480,7 @@ Scanning will happen automatically.</string>
   <string name="unlock">Unlock</string>
   <string name="unlock_vault">Unlock vault</string>
   <string name="thirty_minutes">30 minutes</string>
-  <string name="set_pin_description">Set your PIN code for unlocking Bitwarden. Your PIN settings will be reset if you ever fully log out of the application.</string>
+  <string name="set_pin_description">Your PIN must be at least 4 characters. Your PIN settings will be reset if you ever fully log out of the application.</string>
   <string name="logged_in_as_on">Logged in as %1$s on %2$s.</string>
   <string name="vault_locked_master_password">Your vault is locked. Verify your master password to continue.</string>
   <string name="vault_locked_pin">Your vault is locked. Verify your PIN code to continue.</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.auth.feature.accountsetup
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.filterToOne
@@ -257,8 +258,8 @@ class SetupUnlockScreenTest : BaseComposeTest() {
             .assertIsDisplayed()
         composeTestRule
             .onAllNodesWithText(
-                text = "Set your PIN code for unlocking Bitwarden. Your PIN settings will be reset if " +
-                    "you ever fully log out of the application.",
+                text = "Your PIN must be at least 4 characters. Your PIN settings will be reset " +
+                    "if you ever fully log out of the application.",
             )
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
@@ -306,9 +307,8 @@ class SetupUnlockScreenTest : BaseComposeTest() {
         composeTestRule.assertNoDialogExists()
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `PIN input dialog Submit click with empty pin should clear the dialog and send UnlockWithPinToggle Disabled`() {
+    fun `PIN input dialog with empty pin should disable submit button`() {
         mutableStateFlow.update {
             it.copy(isUnlockWithPinEnabled = false)
         }
@@ -320,14 +320,7 @@ class SetupUnlockScreenTest : BaseComposeTest() {
         composeTestRule
             .onAllNodesWithText(text = "Submit")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .performClick()
-
-        verify {
-            viewModel.trySendAction(
-                SetupUnlockAction.UnlockWithPinToggle(UnlockWithPinState.Disabled),
-            )
-        }
-        composeTestRule.assertNoDialogExists()
+            .assertIsNotEnabled()
     }
 
     @Suppress("MaxLineLength")

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.filterToOne
@@ -352,8 +353,8 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .assertIsDisplayed()
         composeTestRule
             .onAllNodesWithText(
-                "Set your PIN code for unlocking Bitwarden. Your PIN settings will be reset if " +
-                    "you ever fully log out of the application.",
+                text = "Your PIN must be at least 4 characters. Your PIN settings will be reset " +
+                    "if you ever fully log out of the application.",
             )
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
@@ -402,9 +403,8 @@ class AccountSecurityScreenTest : BaseComposeTest() {
         composeTestRule.assertNoDialogExists()
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `PIN input dialog Submit click with empty pin should clear the dialog and send UnlockWithPinToggle Disabled`() {
+    fun `PIN input dialog with empty pin should disable the Submit button`() {
         mutableStateFlow.update {
             it.copy(isUnlockWithPinEnabled = false)
         }
@@ -414,16 +414,9 @@ class AccountSecurityScreenTest : BaseComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText("Submit")
+            .onAllNodesWithText(text = "Submit")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .performClick()
-
-        verify {
-            viewModel.trySendAction(
-                AccountSecurityAction.UnlockWithPinToggle(UnlockWithPinState.Disabled),
-            )
-        }
-        composeTestRule.assertNoDialogExists()
+            .assertIsNotEnabled()
     }
 
     @Suppress("MaxLineLength")


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8953](https://bitwarden.atlassian.net/browse/PM-8953)

## 📔 Objective

This PR updates the Pin Entry dialog to require 4 digits minimum when creating a new pin.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/bccd915e-1ce5-41be-80a5-5eff1b00da76" width="300" /> | <img src="https://github.com/user-attachments/assets/83dbd2c9-686c-4e5f-a7f6-9f1863aeeeba" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8953]: https://bitwarden.atlassian.net/browse/PM-8953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ