### PR TITLE
PM-19498: Update cipher migration logic

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
@@ -474,30 +474,36 @@ class CipherManagerImpl(
         userId: String,
         cipherId: String,
     ): Result<Cipher> =
-        if (this.key == null) {
-            vaultSdkSource
-                .encryptCipher(userId = userId, cipherView = this)
-                .flatMap {
-                    ciphersService.updateCipher(
-                        cipherId = cipherId,
-                        body = it.toEncryptedNetworkCipher(),
-                    )
-                }
-                .flatMap { response ->
-                    when (response) {
-                        is UpdateCipherResponseJson.Invalid -> {
-                            IllegalStateException(response.message).asFailure()
-                        }
+        vaultSdkSource
+            .encryptCipher(userId = userId, cipherView = this)
+            .flatMap {
+                // We only migrate the cipher if the original cipher did not have a key and the
+                // new cipher does. This means the SDK created the key and migration is required.
+                if (it.key != null && this.key == null) {
+                    ciphersService
+                        .updateCipher(
+                            cipherId = cipherId,
+                            body = it.toEncryptedNetworkCipher(),
+                        )
+                        .flatMap { response ->
+                            when (response) {
+                                is UpdateCipherResponseJson.Invalid -> {
+                                    IllegalStateException(response.message).asFailure()
+                                }
 
-                        is UpdateCipherResponseJson.Success -> {
-                            vaultDiskSource.saveCipher(userId = userId, cipher = response.cipher)
-                            response.cipher.toEncryptedSdkCipher().asSuccess()
+                                is UpdateCipherResponseJson.Success -> {
+                                    vaultDiskSource.saveCipher(
+                                        userId = userId,
+                                        cipher = response.cipher,
+                                    )
+                                    response.cipher.toEncryptedSdkCipher().asSuccess()
+                                }
+                            }
                         }
-                    }
+                } else {
+                    it.asSuccess()
                 }
-        } else {
-            vaultSdkSource.encryptCipher(userId = userId, cipherView = this)
-        }
+            }
 
     private suspend fun migrateAttachments(
         userId: String,

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
@@ -1707,6 +1707,7 @@ class CipherManagerTest {
 
         val attachmentId = "mockId-1"
         val cipher = mockk<Cipher> {
+            every { key } returns "key"
             every { attachments } returns emptyList()
             every { id } returns "mockId-1"
         }
@@ -1747,6 +1748,7 @@ class CipherManagerTest {
                 every { id } returns attachmentId
             }
             val cipher = mockk<Cipher> {
+                every { key } returns "key"
                 every { attachments } returns listOf(attachment)
                 every { id } returns "mockId-1"
             }
@@ -1792,6 +1794,7 @@ class CipherManagerTest {
             every { id } returns attachmentId
         }
         val cipher = mockk<Cipher> {
+            every { key } returns "key"
             every { attachments } returns listOf(attachment)
             every { id } returns "mockId-1"
         }
@@ -1839,6 +1842,7 @@ class CipherManagerTest {
             every { id } returns attachmentId
         }
         val cipher = mockk<Cipher> {
+            every { key } returns "key"
             every { attachments } returns listOf(attachment)
             every { id } returns "mockId-1"
         }
@@ -1892,6 +1896,7 @@ class CipherManagerTest {
                 every { id } returns attachmentId
             }
             val cipher = mockk<Cipher> {
+                every { key } returns "key"
                 every { attachments } returns listOf(attachment)
                 every { id } returns "mockId-1"
             }
@@ -1967,6 +1972,7 @@ class CipherManagerTest {
                 every { id } returns attachmentId
             }
             val cipher = mockk<Cipher> {
+                every { key } returns "key"
                 every { attachments } returns listOf(attachment)
                 every { id } returns "mockId-1"
             }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19498](https://bitwarden.atlassian.net/browse/PM-19498)

## 📔 Objective

[This is a cherry-pick from main.](https://github.com/bitwarden/android/pull/4920)

This PR updates migration logic to ensure the migration only occurs when the SDK actually generate a key for the cipher. If the SDK feature for generating a key is disabled, the cipher update API seems to fail; this failure does not occur when the key is present.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19498]: https://bitwarden.atlassian.net/browse/PM-19498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ