### PR TITLE
PM-19547: Delay the delete account success dialog to avoid flicker

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.base.util.Text
 import com.x8bit.bitwarden.ui.platform.base.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -19,6 +20,8 @@ import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 private const val KEY_STATE = "state"
+
+private const val SUCCESS_DIALOG_DELAY = 550L
 
 /**
  * View model for the [DeleteAccountScreen].
@@ -115,7 +118,17 @@ class DeleteAccountViewModel @Inject constructor(
     ) {
         when (val result = action.result) {
             DeleteAccountResult.Success -> {
-                updateDialogState(DeleteAccountState.DeleteAccountDialog.DeleteSuccess)
+                viewModelScope.launch {
+                    // When deleting an account, the current activity is recreated and therefore
+                    // the composition takes place twice. Adding this delay prevents the dialog
+                    // from flashing when it is re-created.
+                    delay(timeMillis = SUCCESS_DIALOG_DELAY)
+                    sendAction(
+                        action = DeleteAccountAction.Internal.UpdateDialogState(
+                            dialog = DeleteAccountState.DeleteAccountDialog.DeleteSuccess,
+                        ),
+                    )
+                }
             }
 
             is DeleteAccountResult.Error -> {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
@@ -87,18 +87,23 @@ class DeleteAccountViewModelTest : BaseViewModelTest() {
                 authRepo.deleteAccountWithMasterPassword(masterPassword)
             } returns DeleteAccountResult.Success
 
-            viewModel.trySendAction(
-                DeleteAccountAction.DeleteAccountConfirmDialogClick(
-                    masterPassword,
-                ),
-            )
-
-            assertEquals(
-                DEFAULT_STATE.copy(dialog = DeleteAccountState.DeleteAccountDialog.DeleteSuccess),
-                viewModel.stateFlow.value,
-            )
-
-            coVerify {
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_STATE, awaitItem())
+                viewModel.trySendAction(
+                    action = DeleteAccountAction.DeleteAccountConfirmDialogClick(masterPassword),
+                )
+                assertEquals(
+                    DEFAULT_STATE.copy(dialog = DeleteAccountState.DeleteAccountDialog.Loading),
+                    awaitItem(),
+                )
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        dialog = DeleteAccountState.DeleteAccountDialog.DeleteSuccess,
+                    ),
+                    awaitItem(),
+                )
+            }
+            coVerify(exactly = 1) {
                 authRepo.deleteAccountWithMasterPassword(masterPassword)
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

PM-19547

## 📔 Objective

This PR adds a small delay to the success dialog when deleting an account. This is needed because the activity restarts when the account is deleted and causes a small flicker in the UI.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/d23beadb-3d63-441f-917e-778f4fff91f1" width="300" /> | <video src="https://github.com/user-attachments/assets/cbce28b3-9725-408d-93a8-be45a3086e6c" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
