### PR TITLE
PM-19723 Group "no folder" items when there is a collection present.

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.ui.vault.feature.vault.util
 
 import android.net.Uri
-import androidx.annotation.VisibleForTesting
 import com.bitwarden.vault.CipherRepromptType
 import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
@@ -198,9 +197,8 @@ fun List<LoginUriView>?.toLoginIconData(
 /**
  * Transforms a [CipherView] into a [VaultState.ViewState.VaultItem].
  */
-@VisibleForTesting
 @Suppress("MagicNumber", "LongMethod")
-fun CipherView.toVaultItemOrNull(
+private fun CipherView.toVaultItemOrNull(
     hasMasterPassword: Boolean,
     isIconLoadingDisabled: Boolean,
     baseIconUrl: String,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.vault.util
 
 import android.net.Uri
+import androidx.annotation.VisibleForTesting
 import com.bitwarden.vault.CipherRepromptType
 import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
@@ -67,6 +68,8 @@ fun VaultData.toViewState(
         VaultState.ViewState.NoItems
     } else {
         val totpItems = filteredCipherViewList.filter { it.login?.totp != null }
+        val shouldShowUnGroupedItems = filteredCollectionViewList.isEmpty() &&
+            noFolderItems.size < NO_FOLDER_ITEM_THRESHOLD
         VaultState.ViewState.Content(
             itemTypesCount = itemTypesCount,
             totpItemsCount = if (isPremium) {
@@ -103,7 +106,7 @@ fun VaultData.toViewState(
                     )
                 }
                 .let { folderItems ->
-                    if (noFolderItems.size < NO_FOLDER_ITEM_THRESHOLD) {
+                    if (shouldShowUnGroupedItems) {
                         folderItems
                     } else {
                         folderItems.plus(
@@ -124,7 +127,7 @@ fun VaultData.toViewState(
                         isPremiumUser = isPremium,
                     )
                 }
-                .takeIf { it.size < NO_FOLDER_ITEM_THRESHOLD }
+                .takeIf { shouldShowUnGroupedItems }
                 .orEmpty(),
             collectionItems = filteredCollectionViewList
                 .filter { it.id != null }
@@ -195,8 +198,9 @@ fun List<LoginUriView>?.toLoginIconData(
 /**
  * Transforms a [CipherView] into a [VaultState.ViewState.VaultItem].
  */
+@VisibleForTesting
 @Suppress("MagicNumber", "LongMethod")
-private fun CipherView.toVaultItemOrNull(
+fun CipherView.toVaultItemOrNull(
     hasMasterPassword: Boolean,
     isIconLoadingDisabled: Boolean,
     baseIconUrl: String,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -672,6 +672,11 @@ class VaultViewModelTest : BaseViewModelTest() {
                             name = "mockName-5".asText(),
                             itemCount = 1,
                         ),
+                        VaultState.ViewState.FolderItem(
+                            id = null,
+                            name = R.string.folder_none.asText(),
+                            itemCount = 0,
+                        ),
                     ),
                     collectionItems = listOf(
                         VaultState.ViewState.CollectionItem(
@@ -830,6 +835,11 @@ class VaultViewModelTest : BaseViewModelTest() {
                             name = "mockName-1".asText(),
                             itemCount = 1,
                         ),
+                        VaultState.ViewState.FolderItem(
+                            id = null,
+                            name = R.string.folder_none.asText(),
+                            itemCount = 0,
+                        ),
                     ),
                     collectionItems = listOf(
                         VaultState.ViewState.CollectionItem(
@@ -930,6 +940,11 @@ class VaultViewModelTest : BaseViewModelTest() {
                                 name = "mockName-1".asText(),
                                 itemCount = 1,
                             ),
+                            VaultState.ViewState.FolderItem(
+                                id = null,
+                                name = R.string.folder_none.asText(),
+                                itemCount = 0,
+                            ),
                         ),
                         collectionItems = listOf(
                             VaultState.ViewState.CollectionItem(
@@ -1027,6 +1042,11 @@ class VaultViewModelTest : BaseViewModelTest() {
                                 id = "mockId-1",
                                 name = "mockName-1".asText(),
                                 itemCount = 1,
+                            ),
+                            VaultState.ViewState.FolderItem(
+                                id = null,
+                                name = R.string.folder_none.asText(),
+                                itemCount = 0,
                             ),
                         ),
                         collectionItems = listOf(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
@@ -849,8 +849,7 @@ class VaultDataExtensionsTest {
                         name = R.string.folder_none.asText(),
                         itemCount = 0,
                     ),
-
-                    ),
+                ),
                 noFolderItems = listOf(),
                 trashItemsCount = 0,
                 totpItemsCount = 1,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
@@ -86,8 +86,12 @@ class VaultDataExtensionsTest {
                         name = "Folder".asText(),
                         itemCount = 0,
                     ),
-
+                    VaultState.ViewState.FolderItem(
+                        id = null,
+                        name = R.string.folder_none.asText(),
+                        itemCount = 0,
                     ),
+                ),
                 collectionItems = listOf(
                     VaultState.ViewState.CollectionItem(
                         id = "mockId-1",
@@ -193,6 +197,11 @@ class VaultDataExtensionsTest {
                         id = "mockId-1",
                         name = "mockName-1".asText(),
                         itemCount = 1,
+                    ),
+                    VaultState.ViewState.FolderItem(
+                        id = null,
+                        name = R.string.folder_none.asText(),
+                        itemCount = 0,
                     ),
                 ),
                 collectionItems = listOf(
@@ -719,6 +728,58 @@ class VaultDataExtensionsTest {
         unmockkStatic(Uri::class)
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toViewState with under 100 no folder items and no collections should not show no folder option`() {
+        mockkStatic(Uri::class)
+        val uriMock = mockk<Uri>()
+        every { Uri.parse(any()) } returns uriMock
+        every { uriMock.host } returns "www.mockuri1.com"
+        val cipherViewList = List(99) {
+            createMockCipherView(number = it, folderId = null)
+        }
+        val vaultData = VaultData(
+            cipherViewList = cipherViewList,
+            collectionViewList = listOf(),
+            folderViewList = listOf(),
+            sendViewList = listOf(),
+        )
+
+        val actual = vaultData.toViewState(
+            isPremium = true,
+            isIconLoadingDisabled = false,
+            baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
+            vaultFilterType = VaultFilterType.AllVaults,
+            hasMasterPassword = true,
+        )
+
+        assertEquals(
+            VaultState.ViewState.Content(
+                loginItemsCount = 99,
+                cardItemsCount = 0,
+                identityItemsCount = 0,
+                secureNoteItemsCount = 0,
+                favoriteItems = listOf(),
+                folderItems = listOf(),
+                collectionItems = listOf(),
+                noFolderItems = cipherViewList.mapNotNull {
+                    it.toVaultItemOrNull(
+                        hasMasterPassword = true,
+                        isIconLoadingDisabled = false,
+                        baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
+                        isPremiumUser = true,
+                    )
+                },
+                trashItemsCount = 0,
+                totpItemsCount = 99,
+                itemTypesCount = 5,
+                sshKeyItemsCount = 0,
+            ),
+            actual,
+        )
+        unmockkStatic(Uri::class)
+    }
+
     @Test
     fun `toViewState should properly filter nested items out`() {
         val vaultData = VaultData(
@@ -781,6 +842,11 @@ class VaultDataExtensionsTest {
                     VaultState.ViewState.FolderItem(
                         id = "5",
                         name = "Folder".asText(),
+                        itemCount = 0,
+                    ),
+                    VaultState.ViewState.FolderItem(
+                        id = null,
+                        name = R.string.folder_none.asText(),
                         itemCount = 0,
                     ),
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
@@ -19,6 +19,8 @@ import com.x8bit.bitwarden.ui.platform.base.util.asText
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 import com.x8bit.bitwarden.ui.platform.components.model.IconRes
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
+import com.x8bit.bitwarden.ui.vault.feature.util.toLabelIcons
+import com.x8bit.bitwarden.ui.vault.feature.util.toOverflowActions
 import com.x8bit.bitwarden.ui.vault.feature.vault.VaultState
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 import io.mockk.every
@@ -735,11 +737,9 @@ class VaultDataExtensionsTest {
         val uriMock = mockk<Uri>()
         every { Uri.parse(any()) } returns uriMock
         every { uriMock.host } returns "www.mockuri1.com"
-        val cipherViewList = List(99) {
-            createMockCipherView(number = it, folderId = null)
-        }
+        val mockCipher = createMockCipherView(number = 1, folderId = null)
         val vaultData = VaultData(
-            cipherViewList = cipherViewList,
+            cipherViewList = listOf(mockCipher),
             collectionViewList = listOf(),
             folderViewList = listOf(),
             sendViewList = listOf(),
@@ -755,23 +755,33 @@ class VaultDataExtensionsTest {
 
         assertEquals(
             VaultState.ViewState.Content(
-                loginItemsCount = 99,
+                loginItemsCount = 1,
                 cardItemsCount = 0,
                 identityItemsCount = 0,
                 secureNoteItemsCount = 0,
                 favoriteItems = listOf(),
                 folderItems = listOf(),
                 collectionItems = listOf(),
-                noFolderItems = cipherViewList.mapNotNull {
-                    it.toVaultItemOrNull(
-                        hasMasterPassword = true,
-                        isIconLoadingDisabled = false,
-                        baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
-                        isPremiumUser = true,
-                    )
-                },
+                noFolderItems = listOf(
+                    VaultState.ViewState.VaultItem.Login(
+                        id = "mockId-1",
+                        name = mockCipher.name.asText(),
+                        startIcon = IconData.Network(
+                            uri = "https://vault.bitwarden.com/icons/www.mockuri1.com/icon.png",
+                            fallbackIconRes = R.drawable.ic_globe,
+                        ),
+                        startIconTestTag = "LoginCipherIcon",
+                        extraIconList = mockCipher.toLabelIcons(),
+                        overflowOptions = mockCipher.toOverflowActions(
+                            hasMasterPassword = true,
+                            isPremiumUser = true,
+                        ),
+                        shouldShowMasterPasswordReprompt = false,
+                        username = "mockUsername-1".asText(),
+                    ),
+                ),
                 trashItemsCount = 0,
-                totpItemsCount = 99,
+                totpItemsCount = 1,
                 itemTypesCount = 5,
                 sshKeyItemsCount = 0,
             ),


### PR DESCRIPTION
## 🎟️ Tracking
[PM-19723](https://bitwarden.atlassian.net/browse/PM-19723)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Add a check to see if any collection view exists.
- If a collection view exists or the vault items with no folder amount is greater than 100 then group all those items in a "No Folder" folder.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
**BEFORE**

https://github.com/user-attachments/assets/c2babfed-0414-468b-8767-467cf8727308

**AFTER**

https://github.com/user-attachments/assets/e7281ad6-36ff-44f5-98d5-a5e01231e325


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19723]: https://bitwarden.atlassian.net/browse/PM-19723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ