### PR TITLE
[PM-19782] Migrate network error handling to `network` module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AccountsServiceImpl.kt
@@ -1,5 +1,8 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
+import com.bitwarden.network.model.toBitwardenError
+import com.bitwarden.network.util.NetworkErrorCode
+import com.bitwarden.network.util.parseErrorBodyOrNull
 import com.bitwarden.network.util.toResult
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAccountsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedKeyConnectorApi
@@ -18,10 +21,7 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.ResendNewDeviceOtp
 import com.x8bit.bitwarden.data.auth.datasource.network.model.ResetPasswordRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.SetPasswordRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.VerifyOtpRequestJson
-import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
 import com.x8bit.bitwarden.data.platform.datasource.network.util.HEADER_VALUE_BEARER_PREFIX
-import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
-import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import kotlinx.serialization.json.Json
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/IdentityServiceImpl.kt
@@ -1,7 +1,10 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
+import com.bitwarden.network.model.toBitwardenError
+import com.bitwarden.network.util.NetworkErrorCode
 import com.bitwarden.network.util.base64UrlEncode
 import com.bitwarden.network.util.executeForNetworkResult
+import com.bitwarden.network.util.parseErrorBodyOrNull
 import com.bitwarden.network.util.toResult
 import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedIdentityApi
 import com.x8bit.bitwarden.data.auth.datasource.network.model.GetTokenResponseJson
@@ -18,9 +21,6 @@ import com.x8bit.bitwarden.data.auth.datasource.network.model.SendVerificationEm
 import com.x8bit.bitwarden.data.auth.datasource.network.model.TwoFactorDataModel
 import com.x8bit.bitwarden.data.auth.datasource.network.model.VerifyEmailTokenRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.VerifyEmailTokenResponseJson
-import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
-import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
-import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import com.x8bit.bitwarden.data.platform.util.DeviceModelProvider
 import kotlinx.serialization.json.Json
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/CiphersServiceImpl.kt
@@ -2,11 +2,11 @@ package com.x8bit.bitwarden.data.vault.datasource.network.service
 
 import androidx.core.net.toUri
 import com.bitwarden.core.data.util.asFailure
+import com.bitwarden.network.model.toBitwardenError
+import com.bitwarden.network.util.NetworkErrorCode
+import com.bitwarden.network.util.parseErrorBodyOrNull
 import com.bitwarden.network.util.toResult
 import com.bitwarden.vault.Attachment
-import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
-import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
-import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import com.x8bit.bitwarden.data.vault.datasource.network.api.AzureApi
 import com.x8bit.bitwarden.data.vault.datasource.network.api.CiphersApi
 import com.x8bit.bitwarden.data.vault.datasource.network.model.AttachmentJsonRequest

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FolderServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FolderServiceImpl.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
+import com.bitwarden.network.model.toBitwardenError
+import com.bitwarden.network.util.NetworkErrorCode
+import com.bitwarden.network.util.parseErrorBodyOrNull
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
-import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
-import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import com.x8bit.bitwarden.data.vault.datasource.network.api.FoldersApi
 import com.x8bit.bitwarden.data.vault.datasource.network.model.FolderJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.SyncResponseJson

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SendsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SendsServiceImpl.kt
@@ -1,10 +1,10 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
 import androidx.core.net.toUri
+import com.bitwarden.network.model.toBitwardenError
+import com.bitwarden.network.util.NetworkErrorCode
+import com.bitwarden.network.util.parseErrorBodyOrNull
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.platform.datasource.network.model.toBitwardenError
-import com.x8bit.bitwarden.data.platform.datasource.network.util.NetworkErrorCode
-import com.x8bit.bitwarden.data.platform.datasource.network.util.parseErrorBodyOrNull
 import com.x8bit.bitwarden.data.vault.datasource.network.api.AzureApi
 import com.x8bit.bitwarden.data.vault.datasource.network.api.SendsApi
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateFileSendResponse

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -36,6 +37,7 @@ dependencies {
     implementation(project(":core"))
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.kotlinx.serialization)
     implementation(libs.square.okhttp)
     implementation(libs.square.okhttp.logging)
     implementation(platform(libs.square.retrofit.bom))

--- a/network/src/main/kotlin/com/bitwarden/network/model/BitwardenError.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/BitwardenError.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.datasource.network.model
+package com.bitwarden.network.model
 
 import retrofit2.HttpException
 import java.io.IOException

--- a/network/src/main/kotlin/com/bitwarden/network/util/ExceptionExtensions.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/util/ExceptionExtensions.kt
@@ -1,7 +1,7 @@
-package com.x8bit.bitwarden.data.platform.datasource.network.util
+package com.bitwarden.network.util
 
 import com.bitwarden.core.data.util.decodeFromStringOrNull
-import com.x8bit.bitwarden.data.platform.datasource.network.model.BitwardenError
+import com.bitwarden.network.model.BitwardenError
 import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 

--- a/network/src/main/kotlin/com/bitwarden/network/util/NetworkErrorCode.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/util/NetworkErrorCode.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.datasource.network.util
+package com.bitwarden.network.util
 
 /**
  * An enum that represents HTTP error codes that we may need to parse for specific responses.


### PR DESCRIPTION
## 🎟️ Tracking

PM-19782

## 📔 Objective

Move `BitwardenError`, `NetworkErrorCode` enum, and `ExceptionExtensions` utility functions from the `app` module to the `network` module.

The build configuration for the `network` module was updated with new dependencies for `kotlinx.serialization`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
