### PR TITLE
Set SARIF upload branch to the merge commit ref/sha retrieved from GH CLI

### DIFF
--- a/.github/workflows/scan-ci.yml
+++ b/.github/workflows/scan-ci.yml
@@ -37,8 +37,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
         with:
           sarif_file: cx_result.sarif
-          sha: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.sha || github.sha }}
-          ref: ${{ contains(github.event_name, 'pull_request') && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
 
   quality:
     name: Quality scan
@@ -60,4 +58,3 @@ jobs:
           args: >
             -Dsonar.organization=${{ github.repository_owner }}
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
-            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -40,12 +40,27 @@ jobs:
             --filter "state=TO_VERIFY;PROPOSED_NOT_EXPLOITABLE;CONFIRMED;URGENT" \
             --output-path . ${{ env.INCREMENTAL }}
 
+      - name: Get branch refs
+        id: get-branch-refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          _PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ $GITHUB_EVENT_NAME == "pull_request_target" ]]; then
+            MERGE_SHA=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$_PR_NUMBER --jq .merge_commit_sha)
+            echo "SHA=$MERGE_SHA" >> $GITHUB_OUTPUT
+            echo "REF=refs/pull/$_PR_NUMBER/merge" >> $GITHUB_OUTPUT
+          else
+            echo "SHA=$GITHUB_SHA" >> $GITHUB_OUTPUT
+            echo "REF=$GITHUB_REF" >> $GITHUB_OUTPUT
+          fi
+
       - name: Upload Checkmarx results to GitHub
         uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
         with:
           sarif_file: cx_result.sarif
-          sha: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.sha || github.sha }}
-          ref: ${{ contains(github.event_name, 'pull_request') && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+          sha: ${{ steps.get-branch-refs.outputs.SHA }}
+          ref: ${{ steps.get-branch-refs.outputs.REF }}
 
   quality:
     name: Quality scan


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/VULN-226

## 📔 Objective

GitHub Security tab is failing to associate the status os the scan.yml, this change may address that by setting the GitHub merge branch ref and sha instead but we'll need to merge it to confirm.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
