### PR TITLE
PM-19705: Log reason for logout

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManager.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.auth.manager
 
 import com.x8bit.bitwarden.data.auth.manager.model.LogoutEvent
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import kotlinx.coroutines.flow.SharedFlow
 
 /**
@@ -14,15 +15,14 @@ interface UserLogoutManager {
     val logoutEventFlow: SharedFlow<LogoutEvent>
 
     /**
-     * Completely logs out the given [userId], removing all data. If [isExpired] is true, a toast
-     * will be displayed letting the user know the session has expired.
+     * Completely logs out the given [userId], removing all data. The [reason] indicates why the
+     * user is being logged out.
      */
-    fun logout(userId: String, isExpired: Boolean = false)
+    fun logout(userId: String, reason: LogoutReason)
 
     /**
      * Partially logs out the given [userId]. All data for the given [userId] will be removed with
-     * the exception of basic account data. If [isExpired] is true, a toast will be displayed
-     * letting the user know the session has expired.
+     * the exception of basic account data. The [reason] indicates why the user is being logged out.
      */
-    fun softLogout(userId: String, isExpired: Boolean = false)
+    fun softLogout(userId: String, reason: LogoutReason)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -7,6 +7,7 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.manager.model.LogoutEvent
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /**
  * Primary implementation of [UserLogoutManager].
@@ -42,9 +44,10 @@ class UserLogoutManagerImpl(
         bufferedMutableSharedFlow()
     override val logoutEventFlow: SharedFlow<LogoutEvent> = mutableLogoutEventFlow.asSharedFlow()
 
-    override fun logout(userId: String, isExpired: Boolean) {
+    override fun logout(userId: String, reason: LogoutReason) {
         authDiskSource.userState ?: return
-
+        Timber.i("logout reason=$reason")
+        val isExpired = reason == LogoutReason.SecurityStamp
         if (isExpired) {
             showToast(message = R.string.login_expired)
         }
@@ -64,7 +67,9 @@ class UserLogoutManagerImpl(
         mutableLogoutEventFlow.tryEmit(LogoutEvent(loggedOutUserId = userId))
     }
 
-    override fun softLogout(userId: String, isExpired: Boolean) {
+    override fun softLogout(userId: String, reason: LogoutReason) {
+        Timber.i("softLogout reason=$reason")
+        val isExpired = reason == LogoutReason.SecurityStamp
         if (isExpired) {
             showToast(message = R.string.login_expired)
         }

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
@@ -12,6 +12,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.DeleteAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.EmailTokenResult
 import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
 import com.x8bit.bitwarden.data.auth.repository.model.OrganizationDomainSsoDetailsResult
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordHintResult
@@ -246,7 +247,7 @@ interface AuthRepository : AuthenticatorProvider, AuthRequestManager {
     /**
      * Log out the current user.
      */
-    fun logout()
+    fun logout(reason: LogoutReason)
 
     /**
      * Requests that a one-time passcode be sent to the user's email.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -55,6 +55,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.DeleteAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.EmailTokenResult
 import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
 import com.x8bit.bitwarden.data.auth.repository.model.OrganizationDomainSsoDetailsResult
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordHintResult
@@ -411,7 +412,7 @@ class AuthRepositoryImpl(
 
         pushManager
             .logoutFlow
-            .onEach { logout(userId = it.userId) }
+            .onEach { logout(userId = it.userId, reason = LogoutReason.Notification) }
             .launchIn(unconfinedScope)
 
         // When the policies for the user have been set, complete the login process.
@@ -513,7 +514,7 @@ class AuthRepositoryImpl(
                     }
 
                     DeleteAccountResponseJson.Success -> {
-                        logout()
+                        logout(reason = LogoutReason.AccountDelete)
                         DeleteAccountResult.Success
                     }
                 }
@@ -764,12 +765,12 @@ class AuthRepositoryImpl(
             }
     }
 
-    override fun logout() {
-        activeUserId?.let { userId -> logout(userId) }
+    override fun logout(reason: LogoutReason) {
+        activeUserId?.let { userId -> logout(userId = userId, reason = reason) }
     }
 
-    override fun logout(userId: String) {
-        userLogoutManager.logout(userId = userId)
+    override fun logout(userId: String, reason: LogoutReason) {
+        userLogoutManager.logout(userId = userId, reason = reason)
     }
 
     override suspend fun requestOneTimePasscode(): RequestOtpResult =

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LogoutReason.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/LogoutReason.kt
@@ -1,0 +1,71 @@
+package com.x8bit.bitwarden.data.auth.repository.model
+
+/**
+ * Indicates the reason that the user is being logged out.
+ */
+sealed class LogoutReason {
+    /**
+     * An optional additional tag for an event.
+     */
+    open val source: String? = null
+
+    /**
+     * Indicates that the logout is happening because the account was deleted.
+     */
+    data object AccountDelete : LogoutReason()
+
+    /**
+     * Indicates that the logout is related to biometrics.
+     */
+    sealed class Biometrics : LogoutReason() {
+        /**
+         * Indicates that the logout is caused by a biometrics lockout.
+         */
+        data object Lockout : Biometrics()
+
+        /**
+         * Indicates that the logout is happening because biometrics is no longer supported.
+         */
+        data object NoLongerSupported : Biometrics()
+    }
+
+    /**
+     * Indicates that the logout is happening because of an invalid state.
+     */
+    data class InvalidState(
+        override val source: String,
+    ) : LogoutReason()
+
+    /**
+     * Indicates that the logout is happening because the user opted to logout via a button.
+     */
+    data class Click(
+        override val source: String,
+    ) : LogoutReason()
+
+    /**
+     * Indicates that the logout is happening because the a logout notification was received.
+     */
+    data object Notification : LogoutReason()
+
+    /**
+     * Indicates that the logout is happening because the sync security stamp was invalidated.
+     */
+    data object SecurityStamp : LogoutReason()
+
+    /**
+     * Indicates that the logout is happening because of a timeout action.
+     */
+    data object Timeout : LogoutReason()
+
+    /**
+     * Indicates that the logout is happening because the access token could not be refreshed.
+     */
+    data object TokenRefreshFail : LogoutReason()
+
+    /**
+     * Indicates that the logout is happening because the user tried to unlock the vault
+     * unsuccessfully too many times.
+     */
+    data object TooManyUnlockAttempts : LogoutReason()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/authenticator/AuthenticatorProvider.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/authenticator/AuthenticatorProvider.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.platform.datasource.network.authenticator
 
 import com.x8bit.bitwarden.data.auth.datasource.network.model.RefreshTokenResponseJson
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 
 /**
  * A provider for all the functionality needed to properly refresh the users access token.
@@ -15,7 +16,7 @@ interface AuthenticatorProvider {
     /**
      * Attempts to logout the user based on the [userId].
      */
-    fun logout(userId: String)
+    fun logout(userId: String, reason: LogoutReason)
 
     /**
      * Attempt to refresh the user's access token based on the [userId].

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/authenticator/RefreshAuthenticator.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/authenticator/RefreshAuthenticator.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.platform.datasource.network.authenticator
 
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.util.parseJwtTokenDataOrNull
 import com.x8bit.bitwarden.data.platform.datasource.network.util.HEADER_KEY_AUTHORIZATION
 import com.x8bit.bitwarden.data.platform.datasource.network.util.HEADER_VALUE_BEARER_PREFIX
@@ -45,7 +46,10 @@ class RefreshAuthenticator : Authenticator {
                     ?.refreshAccessTokenSynchronously(userId)
                     ?.fold(
                         onFailure = {
-                            authenticatorProvider?.logout(userId)
+                            authenticatorProvider?.logout(
+                                userId = userId,
+                                reason = LogoutReason.TokenRefreshFail,
+                            )
                             null
                         },
                         onSuccess = {

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -16,6 +16,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokens
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
@@ -253,7 +254,7 @@ class VaultLockManagerImpl(
         )
 
         if (invalidUnlockAttempts >= MAXIMUM_INVALID_UNLOCK_ATTEMPTS) {
-            userLogoutManager.logout(userId = userId)
+            userLogoutManager.logout(userId = userId, reason = LogoutReason.TooManyUnlockAttempts)
         }
     }
 
@@ -603,7 +604,7 @@ class VaultLockManagerImpl(
             }
 
             VaultTimeoutAction.LOGOUT -> {
-                userLogoutManager.softLogout(userId = userId)
+                userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -25,6 +25,7 @@ import com.bitwarden.vault.CollectionView
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.toUpdatedUserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
@@ -1477,7 +1478,10 @@ class VaultRepositoryImpl(
                     // Log the user out if the stamps do not match
                     localSecurityStamp?.let {
                         if (serverSecurityStamp != localSecurityStamp) {
-                            userLogoutManager.softLogout(userId = userId, isExpired = true)
+                            userLogoutManager.softLogout(
+                                userId = userId,
+                                reason = LogoutReason.SecurityStamp,
+                            )
                             return SyncVaultDataResult.Error(throwable = null)
                         }
                     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
@@ -131,7 +132,10 @@ class LandingViewModel @Inject constructor(
     }
 
     private fun handleLogoutAccountClicked(action: LandingAction.LogoutAccountClick) {
-        authRepository.logout(userId = action.accountSummary.userId)
+        authRepository.logout(
+            userId = action.accountSummary.userId,
+            reason = LogoutReason.Click(source = "LandingViewModel"),
+        )
     }
 
     private fun handleSwitchAccountClicked(action: LandingAction.SwitchAccountClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
@@ -10,6 +10,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.util.CaptchaCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForCaptcha
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
@@ -112,7 +113,10 @@ class LoginViewModel @Inject constructor(
     }
 
     private fun handleLogoutAccountClicked(action: LoginAction.LogoutAccountClick) {
-        authRepository.logout(userId = action.accountSummary.userId)
+        authRepository.logout(
+            userId = action.accountSummary.userId,
+            reason = LogoutReason.Click(source = "LoginViewModel"),
+        )
     }
 
     private fun handleSwitchAccountClicked(action: LoginAction.SwitchAccountClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordViewModel.kt
@@ -7,6 +7,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
 import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
 import com.x8bit.bitwarden.data.auth.repository.model.ResetPasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
@@ -160,7 +161,7 @@ class ResetPasswordViewModel @Inject constructor(
      * Dismiss the view if the user confirms logging out.
      */
     private fun handleConfirmLogoutClick() {
-        authRepository.logout()
+        authRepository.logout(reason = LogoutReason.Click(source = "ResetPasswordViewModel"))
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.SetPasswordResult
 import com.x8bit.bitwarden.ui.auth.feature.resetpassword.util.toDisplayLabels
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
@@ -30,7 +31,11 @@ class SetPasswordViewModel @Inject constructor(
 ) : BaseViewModel<SetPasswordState, SetPasswordEvent, SetPasswordAction>(
     initialState = savedStateHandle[KEY_STATE] ?: run {
         val organizationIdentifier = authRepository.ssoOrganizationIdentifier
-        if (organizationIdentifier.isNullOrBlank()) authRepository.logout()
+        if (organizationIdentifier.isNullOrBlank()) {
+            authRepository.logout(
+                reason = LogoutReason.InvalidState(source = "SetPasswordViewModel"),
+            )
+        }
         SetPasswordState(
             dialogState = null,
             organizationIdentifier = organizationIdentifier.orEmpty(),
@@ -71,7 +76,7 @@ class SetPasswordViewModel @Inject constructor(
      * Dismiss the view if the user cancels the set master password functionality.
      */
     private fun handleCancelClick() {
-        authRepository.logout()
+        authRepository.logout(reason = LogoutReason.Click(source = "SetPasswordViewModel"))
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
@@ -34,7 +35,11 @@ class TrustedDeviceViewModel @Inject constructor(
             val isAuthenticated = authRepository.authStateFlow.value is AuthState.Authenticated
             val account = authRepository.userStateFlow.value?.activeAccount
             val trustedDevice = account?.trustedDevice
-            if (trustedDevice == null || !isAuthenticated) authRepository.logout()
+            if (trustedDevice == null || !isAuthenticated) {
+                authRepository.logout(
+                    reason = LogoutReason.InvalidState(source = "TrustedDeviceViewModel"),
+                )
+            }
             TrustedDeviceState(
                 dialogState = null,
                 emailAddress = account?.email.orEmpty(),
@@ -95,7 +100,7 @@ class TrustedDeviceViewModel @Inject constructor(
     }
 
     private fun handleBackClick() {
-        authRepository.logout()
+        authRepository.logout(reason = LogoutReason.Click(source = "TrustedDeviceViewModel"))
     }
 
     private fun handleDismissDialog() {
@@ -135,7 +140,7 @@ class TrustedDeviceViewModel @Inject constructor(
     }
 
     private fun handleNotYouClick() {
-        authRepository.logout()
+        authRepository.logout(reason = LogoutReason.Click(source = "TrustedDeviceViewModel"))
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.UserFingerprintResult
 import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
@@ -225,7 +226,9 @@ class AccountSecurityViewModel @Inject constructor(
 
     private fun handleConfirmLogoutClick() {
         mutableStateFlow.update { it.copy(dialog = null) }
-        authRepository.logout()
+        authRepository.logout(
+            reason = LogoutReason.Click(source = "AccountSecurityViewModel"),
+        )
     }
 
     private fun handleDeleteAccountClick() {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -12,6 +12,7 @@ import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManager
@@ -290,7 +291,10 @@ class VaultItemListingViewModel @Inject constructor(
     }
 
     private fun handleLogoutAccountClick(action: VaultItemListingsAction.LogoutAccountClick) {
-        authRepository.logout(userId = action.accountSummary.userId)
+        authRepository.logout(
+            userId = action.accountSummary.userId,
+            reason = LogoutReason.Click(source = "VaultItemListingViewModel"),
+        )
     }
 
     private fun handleSwitchAccountClick(action: VaultItemListingsAction.SwitchAccountClick) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.repository.model.DataState
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
@@ -331,7 +332,10 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleLogoutAccountClick(action: VaultAction.LogoutAccountClick) {
-        authRepository.logout(userId = action.accountSummary.userId)
+        authRepository.logout(
+            userId = action.accountSummary.userId,
+            reason = LogoutReason.Click(source = "VaultViewModel"),
+        )
         mutableStateFlow.update {
             it.copy(isSwitchingAccounts = action.accountSummary.isActive)
         }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.KdfTypeJson
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.PushDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
@@ -85,7 +86,7 @@ class UserLogoutManagerTest {
         val userId = USER_ID_1
         every { authDiskSource.userState } returns SINGLE_USER_STATE_1
 
-        userLogoutManager.logout(userId = USER_ID_1)
+        userLogoutManager.logout(userId = USER_ID_1, reason = LogoutReason.Timeout)
 
         verify { authDiskSource.userState = null }
         assertDataCleared(userId = userId)
@@ -99,7 +100,7 @@ class UserLogoutManagerTest {
         val userId = USER_ID_1
         every { authDiskSource.userState } returns MULTI_USER_STATE
 
-        userLogoutManager.logout(userId = USER_ID_1)
+        userLogoutManager.logout(userId = USER_ID_1, reason = LogoutReason.Timeout)
 
         verify { authDiskSource.userState = SINGLE_USER_STATE_2 }
         assertDataCleared(userId = userId)
@@ -111,7 +112,7 @@ class UserLogoutManagerTest {
         val userId = USER_ID_2
         every { authDiskSource.userState } returns MULTI_USER_STATE
 
-        userLogoutManager.logout(userId = USER_ID_2)
+        userLogoutManager.logout(userId = USER_ID_2, reason = LogoutReason.Timeout)
 
         verify { authDiskSource.userState = SINGLE_USER_STATE_1 }
         assertDataCleared(userId = userId)
@@ -134,7 +135,7 @@ class UserLogoutManagerTest {
             settingsDiskSource.getVaultTimeoutAction(userId = userId)
         } returns vaultTimeoutAction
 
-        userLogoutManager.softLogout(userId = userId)
+        userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
 
         verify { authDiskSource.storeAccountTokens(userId = USER_ID_1, accountTokens = null) }
         assertDataCleared(userId = userId)
@@ -170,7 +171,7 @@ class UserLogoutManagerTest {
             settingsDiskSource.getVaultTimeoutAction(userId = userId)
         } returns vaultTimeoutAction
 
-        userLogoutManager.softLogout(userId = userId)
+        userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
 
         verify(exactly = 1) {
             authDiskSource.storeAccountTokens(userId = USER_ID_1, accountTokens = null)
@@ -186,7 +187,7 @@ class UserLogoutManagerTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `softLogout with isExpired true should switch active user and keep previous user in accounts list but display the login expired toast`() {
+    fun `softLogout with security stamp reason should switch active user and keep previous user in accounts list but display the login expired toast`() {
         val userId = USER_ID_1
         val vaultTimeoutInMinutes = 360
         val vaultTimeoutAction = VaultTimeoutAction.LOGOUT
@@ -201,7 +202,7 @@ class UserLogoutManagerTest {
             settingsDiskSource.getVaultTimeoutAction(userId = userId)
         } returns vaultTimeoutAction
 
-        userLogoutManager.softLogout(userId = userId, isExpired = true)
+        userLogoutManager.softLogout(userId = userId, reason = LogoutReason.SecurityStamp)
 
         verify(exactly = 1) {
             authDiskSource.storeAccountTokens(userId = USER_ID_1, accountTokens = null)

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -74,6 +74,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.DeleteAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.EmailTokenResult
 import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
 import com.x8bit.bitwarden.data.auth.repository.model.OrganizationDomainSsoDetailsResult
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordHintResult
@@ -5477,11 +5478,12 @@ class AuthRepositoryTest {
     @Test
     fun `logout for an inactive account should call logout on the UserLogoutManager`() {
         val userId = USER_ID_2
+        val reason = LogoutReason.Timeout
         fakeAuthDiskSource.userState = MULTI_USER_STATE
 
-        repository.logout(userId = userId)
+        repository.logout(userId = userId, reason = reason)
 
-        verify { userLogoutManager.logout(userId = userId) }
+        verify { userLogoutManager.logout(userId = userId, reason = reason) }
     }
 
     @Test
@@ -6113,7 +6115,7 @@ class AuthRepositoryTest {
         mutableLogoutFlow.tryEmit(NotificationLogoutData(userId = userId))
 
         coVerify(exactly = 1) {
-            userLogoutManager.logout(userId = userId)
+            userLogoutManager.logout(userId = userId, reason = LogoutReason.Notification)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/authenticator/RefreshAuthenticatorTests.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/authenticator/RefreshAuthenticatorTests.kt
@@ -4,6 +4,7 @@ import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.x8bit.bitwarden.data.auth.datasource.network.model.RefreshTokenResponseJson
 import com.x8bit.bitwarden.data.auth.repository.model.JwtTokenDataJson
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.util.parseJwtTokenDataOrNull
 import io.mockk.every
 import io.mockk.just
@@ -59,7 +60,7 @@ class RefreshAuthenticatorTests {
         verify(exactly = 0) {
             authenticatorProvider.activeUserId
             authenticatorProvider.refreshAccessTokenSynchronously(any())
-            authenticatorProvider.logout(any())
+            authenticatorProvider.logout(userId = any(), reason = LogoutReason.TokenRefreshFail)
         }
     }
 
@@ -71,14 +72,19 @@ class RefreshAuthenticatorTests {
         every {
             authenticatorProvider.refreshAccessTokenSynchronously(USER_ID)
         } returns Throwable("Fail").asFailure()
-        every { authenticatorProvider.logout(USER_ID) } just runs
+        every {
+            authenticatorProvider.logout(
+                userId = USER_ID,
+                reason = LogoutReason.TokenRefreshFail,
+            )
+        } just runs
 
         assertNull(authenticator.authenticate(null, RESPONSE_401))
 
         verify(exactly = 1) {
             authenticatorProvider.activeUserId
             authenticatorProvider.refreshAccessTokenSynchronously(USER_ID)
-            authenticatorProvider.logout(USER_ID)
+            authenticatorProvider.logout(userId = USER_ID, reason = LogoutReason.TokenRefreshFail)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -26,6 +26,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
@@ -930,8 +931,8 @@ class VaultRepositoryTest {
 
             vaultRepository.sync()
 
-            coVerify {
-                userLogoutManager.softLogout(userId = userId, isExpired = true)
+            coVerify(exactly = 1) {
+                userLogoutManager.softLogout(userId = userId, reason = LogoutReason.SecurityStamp)
             }
 
             coVerify(exactly = 0) {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.test
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
@@ -139,7 +140,12 @@ class LandingViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(LandingAction.LogoutAccountClick(accountSummary))
 
-        verify { authRepository.logout(userId = accountUserId) }
+        verify(exactly = 1) {
+            authRepository.logout(
+                userId = accountUserId,
+                reason = LogoutReason.Click(source = "LandingViewModel"),
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
@@ -10,6 +10,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
 import com.x8bit.bitwarden.data.auth.repository.model.LoginResult
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.util.CaptchaCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForCaptcha
@@ -217,7 +218,12 @@ class LoginViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(LoginAction.LogoutAccountClick(accountSummary))
 
-        verify { authRepository.logout(userId = accountUserId) }
+        verify(exactly = 1) {
+            authRepository.logout(
+                userId = accountUserId,
+                reason = LogoutReason.Click(source = "LoginViewModel"),
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordViewModelTest.kt
@@ -6,6 +6,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
 import com.x8bit.bitwarden.data.auth.datasource.sdk.model.PasswordStrength
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordStrengthResult
 import com.x8bit.bitwarden.data.auth.repository.model.ResetPasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
@@ -37,12 +38,16 @@ class ResetPasswordViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `ConfirmLogoutClick logs out`() = runTest {
-        every { authRepository.logout() } just runs
+        every { authRepository.logout(reason = any()) } just runs
 
         val viewModel = createViewModel()
         viewModel.trySendAction(ResetPasswordAction.ConfirmLogoutClick)
 
-        verify { authRepository.logout() }
+        verify(exactly = 1) {
+            authRepository.logout(
+                reason = LogoutReason.Click(source = "ResetPasswordViewModel"),
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.SetPasswordResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.base.util.asText
@@ -26,21 +27,27 @@ class SetPasswordViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `null ssoOrganizationIdentifier logs user out`() = runTest {
-        every { authRepository.logout() } just runs
+        every { authRepository.logout(reason = any()) } just runs
         every { authRepository.ssoOrganizationIdentifier } returns null
         createViewModel()
-        verify {
-            authRepository.logout()
+        verify(exactly = 1) {
+            authRepository.logout(
+                reason = LogoutReason.InvalidState(source = "SetPasswordViewModel"),
+            )
             authRepository.ssoOrganizationIdentifier
         }
     }
 
     @Test
     fun `CancelClick calls logout`() = runTest {
-        every { authRepository.logout() } just runs
+        every { authRepository.logout(reason = any()) } just runs
         val viewModel = createViewModel()
         viewModel.trySendAction(SetPasswordAction.CancelClick)
-        verify { authRepository.logout() }
+        verify(exactly = 1) {
+            authRepository.logout(
+                reason = LogoutReason.Click(source = "SetPasswordViewModel"),
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModelTest.kt
@@ -6,6 +6,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.NewSsoUserResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
@@ -34,7 +35,7 @@ class TrustedDeviceViewModelTest : BaseViewModelTest() {
         every { authStateFlow } returns mutableAuthStateFlow
         every { userStateFlow } returns mutableUserStateFlow
         every { shouldTrustDevice = any() } just runs
-        every { logout() } just runs
+        every { logout(reason = any()) } just runs
     }
     private val environmentRepo: FakeEnvironmentRepository = FakeEnvironmentRepository()
 
@@ -44,7 +45,9 @@ class TrustedDeviceViewModelTest : BaseViewModelTest() {
         createViewModel()
 
         verify(exactly = 1) {
-            authRepository.logout()
+            authRepository.logout(
+                reason = LogoutReason.InvalidState(source = "TrustedDeviceViewModel"),
+            )
         }
     }
 
@@ -54,7 +57,9 @@ class TrustedDeviceViewModelTest : BaseViewModelTest() {
         createViewModel()
 
         verify(exactly = 1) {
-            authRepository.logout()
+            authRepository.logout(
+                reason = LogoutReason.InvalidState(source = "TrustedDeviceViewModel"),
+            )
         }
     }
 
@@ -66,7 +71,9 @@ class TrustedDeviceViewModelTest : BaseViewModelTest() {
         createViewModel()
 
         verify(exactly = 1) {
-            authRepository.logout()
+            authRepository.logout(
+                reason = LogoutReason.InvalidState(source = "TrustedDeviceViewModel"),
+            )
         }
     }
 
@@ -77,7 +84,9 @@ class TrustedDeviceViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(TrustedDeviceAction.BackClick)
 
         verify(exactly = 1) {
-            authRepository.logout()
+            authRepository.logout(
+                reason = LogoutReason.Click(source = "TrustedDeviceViewModel"),
+            )
         }
     }
 
@@ -222,7 +231,9 @@ class TrustedDeviceViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(TrustedDeviceAction.NotYouClick)
 
         verify(exactly = 1) {
-            authRepository.logout()
+            authRepository.logout(
+                reason = LogoutReason.Click(source = "TrustedDeviceViewModel"),
+            )
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -7,6 +7,7 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.UserFingerprintResult
@@ -786,11 +787,15 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `on ConfirmLogoutClick should call logout and hide confirm dialog`() = runTest {
-        every { authRepository.logout() } just runs
+        every { authRepository.logout(reason = any()) } just runs
         val viewModel = createViewModel()
         viewModel.trySendAction(AccountSecurityAction.ConfirmLogoutClick)
         assertEquals(DEFAULT_STATE.copy(dialog = null), viewModel.stateFlow.value)
-        verify { authRepository.logout() }
+        verify(exactly = 1) {
+            authRepository.logout(
+                reason = LogoutReason.Click(source = "AccountSecurityViewModel"),
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1,10 +1,12 @@
 package com.x8bit.bitwarden.ui.vault.feature.vault
 
 import app.cash.turbine.test
+import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
@@ -22,7 +24,6 @@ import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
-import com.bitwarden.core.data.repository.model.DataState
 import com.x8bit.bitwarden.data.platform.repository.model.Environment
 import com.x8bit.bitwarden.data.platform.repository.util.baseIconUrl
 import com.x8bit.bitwarden.data.vault.datasource.network.model.OrganizationType
@@ -115,7 +116,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             every { userStateFlow } returns mutableUserStateFlow
             every { hasPendingAccountAddition } returns false
             every { hasPendingAccountAddition = any() } just runs
-            every { logout(any()) } just runs
+            every { logout(userId = any(), reason = any()) } just runs
             every { switchAccount(any()) } answers { switchAccountResult }
         }
 
@@ -403,7 +404,12 @@ class VaultViewModelTest : BaseViewModelTest() {
             ),
             viewModel.stateFlow.value,
         )
-        verify { authRepository.logout(userId = accountUserId) }
+        verify(exactly = 1) {
+            authRepository.logout(
+                userId = accountUserId,
+                reason = LogoutReason.Click(source = "VaultViewModel"),
+            )
+        }
     }
 
     @Suppress("MaxLineLength")
@@ -424,7 +430,12 @@ class VaultViewModelTest : BaseViewModelTest() {
             ),
             viewModel.stateFlow.value,
         )
-        verify { authRepository.logout(userId = accountUserId) }
+        verify(exactly = 1) {
+            authRepository.logout(
+                userId = accountUserId,
+                reason = LogoutReason.Click(source = "VaultViewModel"),
+            )
+        }
     }
 
     @Suppress("MaxLineLength")


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19705](https://bitwarden.atlassian.net/browse/PM-19705)

## 📔 Objective

This PR adds additional logging for the reason the user is logging out.

Log example:
```
2025-04-01 15:47:47.342  4837-4837  UserLogoutManagerImpl   com.x8bit.bitwarden.dev              I  logout reason=Click(source=AccountSecurityViewModel)
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19705]: https://bitwarden.atlassian.net/browse/PM-19705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ