### PR TITLE
PM-19591: Initial flight recorder UI

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/row/BitwardenPushRow.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/row/BitwardenPushRow.kt
@@ -1,0 +1,139 @@
+package com.x8bit.bitwarden.ui.platform.components.row
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.base.util.cardStyle
+import com.x8bit.bitwarden.ui.platform.base.util.mirrorIfRtl
+import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
+import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIcon
+import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
+import com.x8bit.bitwarden.ui.platform.components.model.IconData
+import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+
+/**
+ * Reusable row with push icon built in.
+ *
+ * @param text The displayable text.
+ * @param onClick The callback when the row is clicked.
+ * @param cardStyle The [CardStyle] to be applied to this row.
+ * @param modifier The modifier for this composable.
+ * @param leadingIcon An optional leading icon.
+ * @param notificationCount The optional notification count to be displayed.
+ */
+@Composable
+fun BitwardenPushRow(
+    text: String,
+    onClick: () -> Unit,
+    cardStyle: CardStyle,
+    modifier: Modifier = Modifier,
+    leadingIcon: IconData? = null,
+    notificationCount: Int = 0,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 60.dp)
+            .cardStyle(
+                cardStyle = cardStyle,
+                onClick = onClick,
+                paddingStart = leadingIcon?.let { 12.dp } ?: 16.dp,
+                paddingEnd = 20.dp,
+                paddingTop = 6.dp,
+                paddingBottom = 6.dp,
+            ),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .defaultMinSize(minHeight = 48.dp)
+                .weight(weight = 1f),
+        ) {
+            leadingIcon?.let {
+                BitwardenIcon(
+                    iconData = it,
+                    tint = BitwardenTheme.colorScheme.icon.primary,
+                    modifier = Modifier.size(size = 24.dp),
+                )
+                Spacer(modifier = Modifier.width(width = 12.dp))
+            }
+            Text(
+                text = text,
+                style = BitwardenTheme.typography.bodyLarge,
+                color = BitwardenTheme.colorScheme.text.primary,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        TrailingContent(notificationCount = notificationCount)
+    }
+}
+
+@Composable
+private fun TrailingContent(
+    notificationCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.defaultMinSize(minHeight = 48.dp),
+    ) {
+        val notificationBadgeVisible = notificationCount > 0
+        NotificationBadge(
+            notificationCount = notificationCount,
+            isVisible = notificationBadgeVisible,
+        )
+        if (notificationBadgeVisible) {
+            Spacer(modifier = Modifier.width(12.dp))
+        }
+        Icon(
+            painter = rememberVectorPainter(id = R.drawable.ic_chevron_right),
+            contentDescription = null,
+            tint = BitwardenTheme.colorScheme.icon.primary,
+            modifier = Modifier
+                .mirrorIfRtl()
+                .size(size = 16.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BitwardenPushRow_preview() {
+    BitwardenTheme {
+        Column {
+            BitwardenPushRow(
+                text = "Plain Row",
+                onClick = { },
+                cardStyle = CardStyle.Top(),
+            )
+            BitwardenPushRow(
+                text = "Icon Row",
+                onClick = { },
+                cardStyle = CardStyle.Middle(),
+                leadingIcon = IconData.Local(iconRes = R.drawable.ic_vault),
+            )
+            BitwardenPushRow(
+                text = "Notification Row",
+                onClick = { },
+                cardStyle = CardStyle.Bottom,
+                notificationCount = 3,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenSwitch.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/toggle/BitwardenSwitch.kt
@@ -254,7 +254,7 @@ fun BitwardenSwitch(
                 cardStyle = cardStyle,
                 onClick = onCheckedChange?.let { { it(!isChecked) } },
                 clickEnabled = !readOnly && enabled,
-                paddingTop = 12.dp,
+                paddingTop = 6.dp,
                 paddingBottom = 0.dp,
             )
             .semantics(mergeDescendants = true) {
@@ -264,7 +264,7 @@ fun BitwardenSwitch(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.defaultMinSize(minHeight = 36.dp),
+            modifier = Modifier.defaultMinSize(minHeight = 48.dp),
         ) {
             Spacer(modifier = Modifier.width(width = 16.dp))
             Row(
@@ -329,7 +329,7 @@ fun BitwardenSwitch(
                     content = content,
                 )
             }
-            ?: Spacer(modifier = Modifier.height(height = cardStyle?.let { 12.dp } ?: 0.dp))
+            ?: Spacer(modifier = Modifier.height(height = cardStyle?.let { 6.dp } ?: 0.dp))
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsNavigation.kt
@@ -36,6 +36,8 @@ fun NavGraphBuilder.settingsGraph(
     onNavigateToPendingRequests: () -> Unit,
     onNavigateToSetupUnlockScreen: () -> Unit,
     onNavigateToSetupAutoFillScreen: () -> Unit,
+    onNavigateToFlightRecorder: () -> Unit,
+    onNavigateToRecordedLogs: () -> Unit,
     onNavigateToImportLogins: (SnackbarRelay) -> Unit,
 ) {
     navigation(
@@ -54,7 +56,11 @@ fun NavGraphBuilder.settingsGraph(
                 onNavigateToVault = { navController.navigateToVaultSettings() },
             )
         }
-        aboutDestination(onNavigateBack = { navController.popBackStack() })
+        aboutDestination(
+            onNavigateBack = { navController.popBackStack() },
+            onNavigateToFlightRecorder = onNavigateToFlightRecorder,
+            onNavigateToRecordedLogs = onNavigateToRecordedLogs,
+        )
         accountSecurityDestination(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToDeleteAccount = onNavigateToDeleteAccount,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
@@ -1,51 +1,34 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings
 
-import androidx.annotation.DrawableRes
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
-import com.x8bit.bitwarden.ui.platform.base.util.Text
-import com.x8bit.bitwarden.ui.platform.base.util.cardStyle
-import com.x8bit.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.base.util.toListItemCardStyle
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenMediumTopAppBar
-import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
-import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
+import com.x8bit.bitwarden.ui.platform.components.model.IconData
+import com.x8bit.bitwarden.ui.platform.components.row.BitwardenPushRow
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
-import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
-import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
  * Displays the settings screen.
@@ -91,8 +74,8 @@ fun SettingsScreen(
         ) {
             Spacer(modifier = Modifier.height(height = 12.dp))
             Settings.entries.forEachIndexed { index, settingEntry ->
-                SettingsRow(
-                    text = settingEntry.text,
+                BitwardenPushRow(
+                    text = settingEntry.text(),
                     onClick = remember(viewModel) {
                         { viewModel.trySendAction(SettingsAction.SettingsClick(settingEntry)) }
                     },
@@ -105,7 +88,7 @@ fun SettingsScreen(
                         // Start padding, plus icon, plus spacing between text.
                         dividerPadding = 48.dp,
                     ),
-                    iconVectorResource = settingEntry.vectorIconRes,
+                    leadingIcon = IconData.Local(iconRes = settingEntry.vectorIconRes),
                     modifier = Modifier
                         .testTag(tag = settingEntry.testTag)
                         .standardHorizontalMargin()
@@ -114,105 +97,6 @@ fun SettingsScreen(
             }
             Spacer(modifier = Modifier.height(height = 16.dp))
             Spacer(modifier = Modifier.navigationBarsPadding())
-        }
-    }
-}
-
-@Composable
-private fun SettingsRow(
-    text: Text,
-    onClick: () -> Unit,
-    notificationCount: Int,
-    cardStyle: CardStyle?,
-    @DrawableRes iconVectorResource: Int,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .defaultMinSize(minHeight = 60.dp)
-            .cardStyle(
-                cardStyle = cardStyle,
-                onClick = onClick,
-                paddingStart = 12.dp,
-                paddingEnd = 12.dp,
-            ),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                painter = rememberVectorPainter(iconVectorResource),
-                contentDescription = null,
-                tint = BitwardenTheme.colorScheme.icon.primary,
-                modifier = Modifier.size(24.dp),
-            )
-            Spacer(Modifier.width(12.dp))
-            Text(
-                modifier = Modifier
-                    .padding(end = 16.dp),
-                text = text(),
-                style = BitwardenTheme.typography.bodyLarge,
-                color = BitwardenTheme.colorScheme.text.primary,
-            )
-        }
-        TrailingContent(notificationCount = notificationCount)
-    }
-}
-
-@Composable
-private fun TrailingContent(
-    notificationCount: Int,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        val notificationBadgeVisible = notificationCount > 0
-        NotificationBadge(
-            notificationCount = notificationCount,
-            isVisible = notificationBadgeVisible,
-        )
-        if (notificationBadgeVisible) {
-            Spacer(modifier = Modifier.width(12.dp))
-        }
-        Icon(
-            painter = rememberVectorPainter(id = R.drawable.ic_chevron_right),
-            contentDescription = null,
-            tint = BitwardenTheme.colorScheme.icon.primary,
-            modifier = Modifier
-                .mirrorIfRtl()
-                .size(size = 16.dp),
-        )
-    }
-}
-
-@Preview
-@Preview(name = "Right-To-Left", locale = "ar")
-@Composable
-private fun SettingsRows_preview() {
-    BitwardenTheme {
-        Column(
-            modifier = Modifier
-                .background(BitwardenTheme.colorScheme.background.primary)
-                .padding(16.dp)
-                .fillMaxSize(),
-        ) {
-            Settings.entries.forEachIndexed { index, it ->
-                SettingsRow(
-                    text = it.text,
-                    onClick = { },
-                    notificationCount = index % 3,
-                    iconVectorResource = it.vectorIconRes,
-                    cardStyle = Settings.entries.toListItemCardStyle(
-                        index = index,
-                        dividerPadding = 48.dp,
-                    ),
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutNavigation.kt
@@ -12,11 +12,17 @@ private const val ABOUT_ROUTE = "settings_about"
  */
 fun NavGraphBuilder.aboutDestination(
     onNavigateBack: () -> Unit,
+    onNavigateToFlightRecorder: () -> Unit,
+    onNavigateToRecordedLogs: () -> Unit,
 ) {
     composableWithPushTransitions(
         route = ABOUT_ROUTE,
     ) {
-        AboutScreen(onNavigateBack = onNavigateBack)
+        AboutScreen(
+            onNavigateBack = onNavigateBack,
+            onNavigateToFlightRecorder = onNavigateToFlightRecorder,
+            onNavigateToRecordedLogs = onNavigateToRecordedLogs,
+        )
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderNavigation.kt
@@ -1,0 +1,30 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+
+private const val FLIGHT_RECORDER_ROUTE = "flight_recorder_config"
+
+/**
+ * Add flight recorder destination to the nav graph.
+ */
+fun NavGraphBuilder.flightRecorderDestination(
+    onNavigateBack: () -> Unit,
+) {
+    composableWithPushTransitions(
+        route = FLIGHT_RECORDER_ROUTE,
+    ) {
+        FlightRecorderScreen(
+            onNavigateBack = onNavigateBack,
+        )
+    }
+}
+
+/**
+ * Navigate to the flight recorder screen.
+ */
+fun NavController.navigateToFlightRecorder(navOptions: NavOptions? = null) {
+    navigate(FLIGHT_RECORDER_ROUTE, navOptions)
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreen.kt
@@ -1,0 +1,49 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
+import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
+import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+
+/**
+ * Displays the flight recorder configuration screen.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FlightRecorderScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: FlightRecorderViewModel = hiltViewModel(),
+) {
+    EventsEffect(viewModel) { event ->
+        when (event) {
+            FlightRecorderEvent.NavigateBack -> onNavigateBack()
+        }
+    }
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    BitwardenScaffold(
+        topBar = {
+            BitwardenTopAppBar(
+                title = stringResource(id = R.string.enable_flight_recorder_title),
+                navigationIcon = rememberVectorPainter(id = R.drawable.ic_close),
+                navigationIconContentDescription = stringResource(id = R.string.close),
+                onNavigationIconClick = remember(viewModel) {
+                    { viewModel.trySendAction(FlightRecorderAction.BackClick) }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    ) {
+        // TODO: PM-19592 Create the flight recorder UI.
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderViewModel.kt
@@ -1,0 +1,54 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder
+
+import androidx.lifecycle.SavedStateHandle
+import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+private const val KEY_STATE = "state"
+
+/**
+ *  View model for the flight recorder configuration screen.
+ */
+@HiltViewModel
+class FlightRecorderViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<FlightRecorderState, FlightRecorderEvent, FlightRecorderAction>(
+    // We load the state from the savedStateHandle for testing purposes.
+    initialState = savedStateHandle[KEY_STATE] ?: FlightRecorderState,
+) {
+    override fun handleAction(action: FlightRecorderAction) {
+        when (action) {
+            FlightRecorderAction.BackClick -> handleBackClick()
+        }
+    }
+
+    private fun handleBackClick() {
+        sendEvent(FlightRecorderEvent.NavigateBack)
+    }
+}
+
+/**
+ * Models the UI state for the flight recorder screen.
+ */
+data object FlightRecorderState
+
+/**
+ * Models events for the flight recorder screen.
+ */
+sealed class FlightRecorderEvent {
+    /**
+     * Navigates back.
+     */
+    data object NavigateBack : FlightRecorderEvent()
+}
+
+/**
+ * Models actions for the flight recorder screen.
+ */
+sealed class FlightRecorderAction {
+    /**
+     * Indicates that the user clicked the close button.
+     */
+    data object BackClick : FlightRecorderAction()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsNavigation.kt
@@ -1,0 +1,30 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+
+private const val FLIGHT_RECORDER_RECORDED_LOGS_ROUTE = "flight_recorder_recorded_logs"
+
+/**
+ * Add recorded logs destination to the nav graph.
+ */
+fun NavGraphBuilder.recordedLogsDestination(
+    onNavigateBack: () -> Unit,
+) {
+    composableWithPushTransitions(
+        route = FLIGHT_RECORDER_RECORDED_LOGS_ROUTE,
+    ) {
+        RecordedLogsScreen(
+            onNavigateBack = onNavigateBack,
+        )
+    }
+}
+
+/**
+ * Navigate to the flight recorder recorded logs screen.
+ */
+fun NavController.navigateToRecordedLogs(navOptions: NavOptions? = null) {
+    navigate(FLIGHT_RECORDER_RECORDED_LOGS_ROUTE, navOptions)
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
@@ -1,0 +1,49 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
+import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
+import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+
+/**
+ * Displays the flight recorder recorded logs screen.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecordedLogsScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: RecordedLogsViewModel = hiltViewModel(),
+) {
+    EventsEffect(viewModel) { event ->
+        when (event) {
+            RecordedLogsEvent.NavigateBack -> onNavigateBack()
+        }
+    }
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    BitwardenScaffold(
+        topBar = {
+            BitwardenTopAppBar(
+                title = stringResource(id = R.string.recorded_logs_title),
+                navigationIcon = rememberVectorPainter(id = R.drawable.ic_close),
+                navigationIconContentDescription = stringResource(id = R.string.close),
+                onNavigationIconClick = remember(viewModel) {
+                    { viewModel.trySendAction(RecordedLogsAction.BackClick) }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    ) {
+        // TODO: PM-19593 Create the flight recorder UI.
+    }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsViewModel.kt
@@ -1,0 +1,54 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs
+
+import androidx.lifecycle.SavedStateHandle
+import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+private const val KEY_STATE = "state"
+
+/**
+ * View model for the flight recorder recorded logs screen.
+ */
+@HiltViewModel
+class RecordedLogsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<RecordedLogsState, RecordedLogsEvent, RecordedLogsAction>(
+    // We load the state from the savedStateHandle for testing purposes.
+    initialState = savedStateHandle[KEY_STATE] ?: RecordedLogsState,
+) {
+    override fun handleAction(action: RecordedLogsAction) {
+        when (action) {
+            RecordedLogsAction.BackClick -> handleBackClick()
+        }
+    }
+
+    private fun handleBackClick() {
+        sendEvent(RecordedLogsEvent.NavigateBack)
+    }
+}
+
+/**
+ * Models the UI state for the recorded logs screen.
+ */
+data object RecordedLogsState
+
+/**
+ * Models events for the recorded logs screen.
+ */
+sealed class RecordedLogsEvent {
+    /**
+     * Navigates back.
+     */
+    data object NavigateBack : RecordedLogsEvent()
+}
+
+/**
+ * Models actions for the recorded logs screen.
+ */
+sealed class RecordedLogsAction {
+    /**
+     * Indicates that the user clicked the close button.
+     */
+    data object BackClick : RecordedLogsAction()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -23,6 +23,10 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.pendingr
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.pendingrequests.pendingRequestsDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.exportvault.exportVaultDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.exportvault.navigateToExportVault
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.flightRecorderDestination
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.navigateToFlightRecorder
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.navigateToRecordedLogs
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.recordedLogsDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.folders.addedit.folderAddEditDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.folders.addedit.navigateToFolderAddEdit
 import com.x8bit.bitwarden.ui.platform.feature.settings.folders.foldersDestination
@@ -115,7 +119,11 @@ fun NavGraphBuilder.vaultUnlockedGraph(
                     parentFolderName = it,
                 )
             },
+            onNavigateToFlightRecorder = { navController.navigateToFlightRecorder() },
+            onNavigateToRecordedLogs = { navController.navigateToRecordedLogs() },
         )
+        flightRecorderDestination(onNavigateBack = { navController.popBackStack() })
+        recordedLogsDestination(onNavigateBack = { navController.popBackStack() })
         deleteAccountDestination(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToDeleteAccountConfirmation = {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
@@ -40,6 +40,8 @@ fun NavGraphBuilder.vaultUnlockedNavBarDestination(
     onNavigateToPasswordHistory: () -> Unit,
     onNavigateToSetupUnlockScreen: () -> Unit,
     onNavigateToSetupAutoFillScreen: () -> Unit,
+    onNavigateToFlightRecorder: () -> Unit,
+    onNavigateToRecordedLogs: () -> Unit,
     onNavigateToImportLogins: (SnackbarRelay) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderName: String?) -> Unit,
 ) {
@@ -63,6 +65,8 @@ fun NavGraphBuilder.vaultUnlockedNavBarDestination(
             onNavigateToSetupAutoFillScreen = onNavigateToSetupAutoFillScreen,
             onNavigateToImportLogins = onNavigateToImportLogins,
             onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
+            onNavigateToFlightRecorder = onNavigateToFlightRecorder,
+            onNavigateToRecordedLogs = onNavigateToRecordedLogs,
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -64,6 +64,8 @@ fun VaultUnlockedNavBarScreen(
     onNavigateToPasswordHistory: () -> Unit,
     onNavigateToSetupUnlockScreen: () -> Unit,
     onNavigateToSetupAutoFillScreen: () -> Unit,
+    onNavigateToFlightRecorder: () -> Unit,
+    onNavigateToRecordedLogs: () -> Unit,
     onNavigateToImportLogins: (SnackbarRelay) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
 ) {
@@ -133,6 +135,8 @@ fun VaultUnlockedNavBarScreen(
         onNavigateToSetupAutoFillScreen = onNavigateToSetupAutoFillScreen,
         onNavigateToImportLogins = onNavigateToImportLogins,
         onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
+        onNavigateToFlightRecorder = onNavigateToFlightRecorder,
+        onNavigateToRecordedLogs = onNavigateToRecordedLogs,
     )
 }
 
@@ -162,6 +166,8 @@ private fun VaultUnlockedNavBarScaffold(
     navigateToPasswordHistory: () -> Unit,
     onNavigateToSetupUnlockScreen: () -> Unit,
     onNavigateToSetupAutoFillScreen: () -> Unit,
+    onNavigateToFlightRecorder: () -> Unit,
+    onNavigateToRecordedLogs: () -> Unit,
     onNavigateToImportLogins: (SnackbarRelay) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
 ) {
@@ -237,6 +243,8 @@ private fun VaultUnlockedNavBarScaffold(
                 onNavigateToSetupUnlockScreen = onNavigateToSetupUnlockScreen,
                 onNavigateToSetupAutoFillScreen = onNavigateToSetupAutoFillScreen,
                 onNavigateToImportLogins = onNavigateToImportLogins,
+                onNavigateToFlightRecorder = onNavigateToFlightRecorder,
+                onNavigateToRecordedLogs = onNavigateToRecordedLogs,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1228,4 +1228,9 @@ Do you want to switch to this account?</string>
   <string name="add_field">Add field</string>
   <string name="x_ellipses">%s...</string>
   <string name="share_error_details">Share error details</string>
+  <string name="flight_recorder">Flight recorder</string>
+  <string name="flight_recorder_help">Flight recorder help</string>
+  <string name="view_recorded_logs">View recorded logs</string>
+  <string name="enable_flight_recorder_title">Enable flight recorder</string>
+  <string name="recorded_logs_title">Recorded logs</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreenTest.kt
@@ -1,0 +1,52 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder
+
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class FlightRecorderScreenTest : BaseComposeTest() {
+    private var onNavigateBackCalled = false
+    private val mutableEventFlow = bufferedMutableSharedFlow<FlightRecorderEvent>()
+    private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
+
+    private val viewModel = mockk<FlightRecorderViewModel>(relaxed = true) {
+        every { eventFlow } returns mutableEventFlow
+        every { stateFlow } returns mutableStateFlow
+    }
+
+    @Before
+    fun setUp() {
+        setContent {
+            FlightRecorderScreen(
+                onNavigateBack = { onNavigateBackCalled = true },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    @Test
+    fun `on navigation icon click should emit BackClick action`() {
+        composeTestRule
+            .onNodeWithContentDescription(label = "Close")
+            .performClick()
+        verify(exactly = 1) {
+            viewModel.trySendAction(FlightRecorderAction.BackClick)
+        }
+    }
+
+    @Test
+    fun `on NavigateBack event should invoke onNavigateBack`() {
+        mutableEventFlow.tryEmit(FlightRecorderEvent.NavigateBack)
+        assertTrue(onNavigateBackCalled)
+    }
+}
+
+private val DEFAULT_STATE: FlightRecorderState = FlightRecorderState

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderViewModelTest.kt
@@ -1,0 +1,37 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FlightRecorderViewModelTest : BaseViewModelTest() {
+
+    @Test
+    fun `initial state should be correct`() = runTest {
+        val viewModel = createViewModel()
+        assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
+    }
+
+    @Test
+    fun `on BackClick action should send the NavigateBack event`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(FlightRecorderAction.BackClick)
+            assertEquals(FlightRecorderEvent.NavigateBack, awaitItem())
+        }
+    }
+
+    private fun createViewModel(
+        state: FlightRecorderState? = null,
+    ): FlightRecorderViewModel =
+        FlightRecorderViewModel(
+            savedStateHandle = SavedStateHandle().apply {
+                set("state", state)
+            },
+        )
+}
+
+private val DEFAULT_STATE: FlightRecorderState = FlightRecorderState

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
@@ -1,0 +1,57 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedlogs
+
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsAction
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsEvent
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsScreen
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsViewModel
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RecordedLogsScreenTest : BaseComposeTest() {
+    private var onNavigateBackCalled = false
+    private val mutableEventFlow = bufferedMutableSharedFlow<RecordedLogsEvent>()
+    private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
+
+    private val viewModel = mockk<RecordedLogsViewModel>(relaxed = true) {
+        every { eventFlow } returns mutableEventFlow
+        every { stateFlow } returns mutableStateFlow
+    }
+
+    @Before
+    fun setUp() {
+        setContent {
+            RecordedLogsScreen(
+                onNavigateBack = { onNavigateBackCalled = true },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    @Test
+    fun `on navigation icon click should emit BackClick action`() {
+        composeTestRule
+            .onNodeWithContentDescription(label = "Close")
+            .performClick()
+        verify(exactly = 1) {
+            viewModel.trySendAction(RecordedLogsAction.BackClick)
+        }
+    }
+
+    @Test
+    fun `on NavigateBack event should invoke onNavigateBack`() {
+        mutableEventFlow.tryEmit(RecordedLogsEvent.NavigateBack)
+        assertTrue(onNavigateBackCalled)
+    }
+}
+
+private val DEFAULT_STATE: RecordedLogsState = RecordedLogsState

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
@@ -1,0 +1,41 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedlogs
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsAction
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsEvent
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsViewModel
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RecordedLogsViewModelTest : BaseViewModelTest() {
+
+    @Test
+    fun `initial state should be correct`() = runTest {
+        val viewModel = createViewModel()
+        assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
+    }
+
+    @Test
+    fun `on BackClick action should send the NavigateBack event`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(RecordedLogsAction.BackClick)
+            assertEquals(RecordedLogsEvent.NavigateBack, awaitItem())
+        }
+    }
+
+    private fun createViewModel(
+        state: RecordedLogsState? = null,
+    ): RecordedLogsViewModel =
+        RecordedLogsViewModel(
+            savedStateHandle = SavedStateHandle().apply {
+                set("state", state)
+            },
+        )
+}
+
+private val DEFAULT_STATE: RecordedLogsState = RecordedLogsState

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -57,6 +57,8 @@ class VaultUnlockedNavBarScreenTest : BaseComposeTest() {
                     onNavigateToSetupUnlockScreen = {},
                     onNavigateToImportLogins = {},
                     onNavigateToAddFolderScreen = {},
+                    onNavigateToFlightRecorder = {},
+                    onNavigateToRecordedLogs = {},
                 )
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19591](https://bitwarden.atlassian.net/browse/PM-19591)

## 📔 Objective

This PR adds the basic flight recorder UI to the about screen.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/340ff460-5791-471c-8732-362200d8cd84" width="300" /> | <img src="https://github.com/user-attachments/assets/1a9bea82-c9f4-41ce-b897-cc6980d0a2d4" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19591]: https://bitwarden.atlassian.net/browse/PM-19591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ