### PR TITLE
Migrate the screen capture feature from user-scoped to app-scoped

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -25,6 +25,16 @@ interface SettingsDiskSource {
     val appLanguageFlow: Flow<AppLanguage?>
 
     /**
+     * The currently persisted setting for whether screen capture is allowed.
+     */
+    var screenCaptureAllowed: Boolean?
+
+    /**
+     * Emits updates that track [screenCaptureAllowed].
+     */
+    val screenCaptureAllowedFlow: Flow<Boolean?>
+
+    /**
      * Has the initial autofill dialog been shown to the user.
      */
     var initialAutofillDialogShown: Boolean?
@@ -236,21 +246,6 @@ interface SettingsDiskSource {
         userId: String,
         blockedAutofillUris: List<String>?,
     )
-
-    /**
-     * Gets whether or not the given [userId] has enabled screen capture.
-     */
-    fun getScreenCaptureAllowed(userId: String): Boolean?
-
-    /**
-     * Emits updates that track [getScreenCaptureAllowed] for the given [userId].
-     */
-    fun getScreenCaptureAllowedFlow(userId: String): Flow<Boolean?>
-
-    /**
-     * Stores whether or not [isScreenCaptureAllowed] for the given [userId].
-     */
-    fun storeScreenCaptureAllowed(userId: String, isScreenCaptureAllowed: Boolean?)
 
     /**
      * Records a user sign in for the given [userId]. This data is expected to remain on

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.decodeFromStringOrNull
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
@@ -49,7 +50,7 @@ private const val RESUME_SCREEN = "resumeScreen"
  */
 @Suppress("TooManyFunctions")
 class SettingsDiskSourceImpl(
-    val sharedPreferences: SharedPreferences,
+    private val sharedPreferences: SharedPreferences,
     private val json: Json,
 ) : BaseDiskSource(sharedPreferences = sharedPreferences),
     SettingsDiskSource {
@@ -86,11 +87,14 @@ class SettingsDiskSourceImpl(
 
     private val mutableHasSeenGeneratorCoachMarkFlow = bufferedMutableSharedFlow<Boolean?>()
 
-    private val mutableScreenCaptureAllowedFlowMap =
-        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+    private val mutableScreenCaptureAllowedFlow = MutableSharedFlow<Boolean?>()
 
     private val mutableVaultRegisteredForExportFlow =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    init {
+        migrateScreenCaptureSetting()
+    }
 
     override var appLanguage: AppLanguage?
         get() = getString(key = APP_LANGUAGE_KEY)
@@ -107,6 +111,16 @@ class SettingsDiskSourceImpl(
 
     override val appLanguageFlow: Flow<AppLanguage?>
         get() = mutableAppLanguageFlow.onSubscription { emit(appLanguage) }
+
+    override var screenCaptureAllowed: Boolean?
+        get() = getBoolean(key = SCREEN_CAPTURE_ALLOW_KEY)
+        set(value) {
+            putBoolean(key = SCREEN_CAPTURE_ALLOW_KEY, value = value)
+            mutableScreenCaptureAllowedFlow.tryEmit(value)
+        }
+
+    override val screenCaptureAllowedFlow: Flow<Boolean?>
+        get() = mutableScreenCaptureAllowedFlow.onSubscription { emit(screenCaptureAllowed) }
 
     override var initialAutofillDialogShown: Boolean?
         get() = getBoolean(key = INITIAL_AUTOFILL_DIALOG_SHOWN)
@@ -369,25 +383,6 @@ class SettingsDiskSourceImpl(
         )
     }
 
-    override fun getScreenCaptureAllowed(userId: String): Boolean? {
-        return getBoolean(key = SCREEN_CAPTURE_ALLOW_KEY.appendIdentifier(userId))
-    }
-
-    override fun getScreenCaptureAllowedFlow(userId: String): Flow<Boolean?> =
-        getMutableScreenCaptureAllowedFlow(userId)
-            .onSubscription { emit(getScreenCaptureAllowed(userId)) }
-
-    override fun storeScreenCaptureAllowed(
-        userId: String,
-        isScreenCaptureAllowed: Boolean?,
-    ) {
-        putBoolean(
-            key = SCREEN_CAPTURE_ALLOW_KEY.appendIdentifier(userId),
-            value = isScreenCaptureAllowed,
-        )
-        getMutableScreenCaptureAllowedFlow(userId).tryEmit(isScreenCaptureAllowed)
-    }
-
     override fun storeUseHasLoggedInPreviously(userId: String) {
         putBoolean(
             key = HAS_USER_LOGGED_IN_OR_CREATED_AN_ACCOUNT_KEY.appendIdentifier(userId),
@@ -567,11 +562,6 @@ class SettingsDiskSourceImpl(
             bufferedMutableSharedFlow(replay = 1)
         }
 
-    private fun getMutableScreenCaptureAllowedFlow(userId: String): MutableSharedFlow<Boolean?> =
-        mutableScreenCaptureAllowedFlowMap.getOrPut(userId) {
-            bufferedMutableSharedFlow(replay = 1)
-        }
-
     private fun getMutableShowAutoFillSettingBadgeFlow(
         userId: String,
     ): MutableSharedFlow<Boolean?> = mutableShowAutoFillSettingBadgeFlowMap.getOrPut(userId) {
@@ -594,5 +584,21 @@ class SettingsDiskSourceImpl(
         userId: String,
     ): MutableSharedFlow<Boolean?> = mutableVaultRegisteredForExportFlow.getOrPut(userId) {
         bufferedMutableSharedFlow(replay = 1)
+    }
+
+    /**
+     * Migrates the user-scoped screen capture state to an app-wide state.
+     *
+     * In the case that multiple users have different values stored for this feature, we will
+     * default to _not_ allowing screen capture.
+     */
+    private fun migrateScreenCaptureSetting() {
+        val screenCaptureSettings = sharedPreferences.all.filter {
+            // The underscore is important to not grab the new app-scoped key
+            it.key.contains(other = "${SCREEN_CAPTURE_ALLOW_KEY}_")
+        }
+        if (screenCaptureSettings.isEmpty()) return
+        screenCaptureAllowed = screenCaptureSettings.all { it.value == true }
+        screenCaptureSettings.forEach { sharedPreferences.edit(commit = true) { remove(it.key) } }
     }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -148,10 +148,6 @@ class SettingsDiskSourceTest {
             userId = userId,
             lastSyncTime = Instant.parse("2023-10-27T12:00:00Z"),
         )
-        settingsDiskSource.storeScreenCaptureAllowed(
-            userId = userId,
-            isScreenCaptureAllowed = true,
-        )
         settingsDiskSource.storeClearClipboardFrequencySeconds(userId = userId, frequency = 5)
         val systemBioIntegrityState = "system_biometrics_integrity_state"
         settingsDiskSource.storeAccountBiometricIntegrityValidity(
@@ -166,7 +162,6 @@ class SettingsDiskSourceTest {
         settingsDiskSource.clearData(userId = userId)
 
         // We do not clear these even when you call clear storage
-        assertEquals(true, settingsDiskSource.getScreenCaptureAllowed(userId = userId))
         assertTrue(settingsDiskSource.getShowUnlockSettingBadge(userId = userId) ?: false)
         assertTrue(settingsDiskSource.getShowAutoFillSettingBadge(userId = userId) ?: false)
 
@@ -867,50 +862,31 @@ class SettingsDiskSourceTest {
 
     @Test
     fun `getScreenCaptureAllowed should pull from SharedPreferences`() {
-        val screenCaptureAllowBaseKey = "bwPreferencesStorage:screenCaptureAllowed"
-        val mockUserId = "mockUserId"
+        val screenCaptureAllowKey = "bwPreferencesStorage:screenCaptureAllowed"
         val isScreenCaptureAllowed = true
         fakeSharedPreferences.edit {
-            putBoolean("${screenCaptureAllowBaseKey}_$mockUserId", isScreenCaptureAllowed)
+            putBoolean(screenCaptureAllowKey, isScreenCaptureAllowed)
         }
-        val actual = settingsDiskSource.getScreenCaptureAllowed(userId = mockUserId)
-        assertEquals(
-            isScreenCaptureAllowed,
-            actual,
-        )
+        val actual = settingsDiskSource.screenCaptureAllowed
+        assertEquals(isScreenCaptureAllowed, actual)
     }
 
     @Test
     fun `storeScreenCaptureAllowed for non-null values should update SharedPreferences`() {
-        val screenCaptureAllowBaseKey = "bwPreferencesStorage:screenCaptureAllowed"
-        val mockUserId = "mockUserId"
+        val screenCaptureAllowKey = "bwPreferencesStorage:screenCaptureAllowed"
         val isScreenCaptureAllowed = true
-        settingsDiskSource.storeScreenCaptureAllowed(
-            userId = mockUserId,
-            isScreenCaptureAllowed = isScreenCaptureAllowed,
-        )
-        val actual = fakeSharedPreferences.getBoolean(
-            "${screenCaptureAllowBaseKey}_$mockUserId",
-            false,
-        )
-        assertEquals(
-            isScreenCaptureAllowed,
-            actual,
-        )
+        settingsDiskSource.screenCaptureAllowed = isScreenCaptureAllowed
+        val actual = fakeSharedPreferences.getBoolean(screenCaptureAllowKey, false)
+        assertEquals(isScreenCaptureAllowed, actual)
     }
 
     @Test
     fun `storeScreenCaptureAllowed for null values should clear SharedPreferences`() {
-        val screenCaptureAllowBaseKey = "bwPreferencesStorage:screenCaptureAllowed"
-        val mockUserId = "mockUserId"
-        val screenCaptureAllowKey = "${screenCaptureAllowBaseKey}_$mockUserId"
+        val screenCaptureAllowKey = "bwPreferencesStorage:screenCaptureAllowed"
         fakeSharedPreferences.edit {
             putBoolean(screenCaptureAllowKey, true)
         }
-        settingsDiskSource.storeScreenCaptureAllowed(
-            userId = mockUserId,
-            isScreenCaptureAllowed = null,
-        )
+        settingsDiskSource.screenCaptureAllowed = null
         assertFalse(fakeSharedPreferences.contains(screenCaptureAllowKey))
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1003,22 +1003,19 @@ class SettingsRepositoryTest {
     @Test
     fun `isScreenCaptureAllowed property should update SettingsDiskSource and emit changes`() =
         runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-
-            fakeSettingsDiskSource.storeScreenCaptureAllowed(USER_ID, false)
-
+            fakeSettingsDiskSource.screenCaptureAllowed = false
             settingsRepository.isScreenCaptureAllowedStateFlow.test {
                 assertFalse(awaitItem())
 
                 settingsRepository.isScreenCaptureAllowed = true
                 assertTrue(awaitItem())
 
-                assertEquals(true, fakeSettingsDiskSource.getScreenCaptureAllowed(USER_ID))
+                assertEquals(true, fakeSettingsDiskSource.screenCaptureAllowed)
 
                 settingsRepository.isScreenCaptureAllowed = false
                 assertFalse(awaitItem())
 
-                assertEquals(false, fakeSettingsDiskSource.getScreenCaptureAllowed(USER_ID))
+                assertEquals(false, fakeSettingsDiskSource.screenCaptureAllowed)
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

TBD

## 📔 Objective

This PR migrates the screen capture feature from user-scoped to app-scoped. During migration, if any one user has the feature disabled it will remain disabled for all users.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
