### PR TITLE
PM-19830: Updating padding for last sync time label

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreen.kt
@@ -139,7 +139,8 @@ fun OtherScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag("LastSyncLabel")
-                    .padding(horizontal = 16.dp),
+                    .standardHorizontalMargin()
+                    .padding(horizontal = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Start,
             ) {
@@ -147,7 +148,7 @@ fun OtherScreen(
                     text = stringResource(id = R.string.last_sync),
                     style = BitwardenTheme.typography.bodySmall,
                     color = BitwardenTheme.colorScheme.text.secondary,
-                    modifier = Modifier.padding(start = 16.dp, end = 2.dp),
+                    modifier = Modifier.padding(end = 2.dp),
                 )
                 Text(
                     text = state.lastSyncTime,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19830](https://bitwarden.atlassian.net/browse/PM-19830)

## 📔 Objective

This PR updating the margins and padding for the last sync time to be correct in landscape mode.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/56f74d45-4972-4cef-9415-c247ce1c8c82" width="300" /> | <img src="https://github.com/user-attachments/assets/c4c539df-e2d5-4c11-8c03-bf0e84edc0fc" width="300" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
