### PR TITLE
[PM-19840] Migrate BaseEnumeratedIntSerializer to core module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/AuthRequestTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/AuthRequestTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KdfTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/KdfTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/TwoFactorAuthMethod.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/model/TwoFactorAuthMethod.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/NotificationType.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEventType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEventType.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/model/PasscodeGenerationOptions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/model/PasscodeGenerationOptions.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.tools.generator.repository.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/model/UsernameGenerationOptions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/tools/generator/repository/model/UsernameGenerationOptions.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.tools.generator.repository.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/CipherRepromptTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/CipherRepromptTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/CipherTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/CipherTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/FieldTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/FieldTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/FileUploadType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/FileUploadType.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/LinkedIdTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/LinkedIdTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/OrganizationStatusType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/OrganizationStatusType.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/OrganizationType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/OrganizationType.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/PolicyTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/PolicyTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SecureNoteTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SecureNoteTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SendTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/SendTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/UriMatchTypeJson.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/model/UriMatchTypeJson.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.model
 
 import androidx.annotation.Keep
-import com.x8bit.bitwarden.data.platform.datasource.network.serializer.BaseEnumeratedIntSerializer
+import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/core/src/main/kotlin/com/bitwarden/core/data/serializer/BaseEnumeratedIntSerializer.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/serializer/BaseEnumeratedIntSerializer.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.datasource.network.serializer
+package com.bitwarden.core.data.serializer
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName

--- a/core/src/test/kotlin/com/bitwarden/core/data/serializer/BaseEnumeratedIntSerializerTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/serializer/BaseEnumeratedIntSerializerTest.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.datasource.network.serializer
+package com.bitwarden.core.data.serializer
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable


### PR DESCRIPTION
## 🎟️ Tracking

PM-19840

## 📔 Objective

Move the `BaseEnumeratedIntSerializer` class and its associated test from the `app` module to the `core` module.
It also updates all references to `BaseEnumeratedIntSerializer` to use the new location in the core module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
