### PR TITLE
[PM-19841] Migrate Event API and models to network module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/EventDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/EventDiskSource.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk
 
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
+import com.bitwarden.network.model.OrganizationEventJson
 
 /**
  * Primary access point for disk information related to event data.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/EventDiskSourceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/EventDiskSourceImpl.kt
@@ -1,10 +1,10 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk
 
+import com.bitwarden.network.model.OrganizationEventJson
+import com.bitwarden.network.model.OrganizationEventType
 import com.x8bit.bitwarden.data.platform.datasource.disk.dao.OrganizationEventDao
 import com.x8bit.bitwarden.data.platform.datasource.disk.entity.OrganizationEventEntity
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
-import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEventType
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/service/EventService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/service/EventService.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.platform.datasource.network.service
 
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
+import com.bitwarden.network.model.OrganizationEventJson
 
 /**
  * Provides an API for submitting events.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/service/EventServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/service/EventServiceImpl.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.platform.datasource.network.service
 
+import com.bitwarden.network.api.EventApi
+import com.bitwarden.network.model.OrganizationEventJson
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.platform.datasource.network.api.EventApi
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
 
 /**
  * The default implementation of the [EventService].

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/event/OrganizationEventManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/event/OrganizationEventManagerImpl.kt
@@ -3,10 +3,10 @@ package com.x8bit.bitwarden.data.platform.manager.event
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.bitwarden.network.model.OrganizationEventJson
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.platform.datasource.disk.EventDiskSource
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
 import com.x8bit.bitwarden.data.platform.datasource.network.service.EventService
 import com.x8bit.bitwarden.data.platform.manager.dispatcher.DispatcherManager
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEvent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEvent.kt
@@ -1,5 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager.model
 
+import com.bitwarden.network.model.OrganizationEventType
+
 /**
  * A representation of events used for organization tracking.
  */

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/EventDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/EventDiskSourceTest.kt
@@ -1,11 +1,11 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk
 
 import com.bitwarden.core.di.CoreModule
+import com.bitwarden.network.model.OrganizationEventJson
+import com.bitwarden.network.model.OrganizationEventType
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.dao.FakeOrganizationEventDao
 import com.x8bit.bitwarden.data.platform.datasource.disk.entity.OrganizationEventEntity
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
-import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEventType
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/service/EventServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/network/service/EventServiceTest.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.data.platform.datasource.network.service
 
+import com.bitwarden.network.api.EventApi
 import com.bitwarden.network.base.BaseServiceTest
-import com.x8bit.bitwarden.data.platform.datasource.network.api.EventApi
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
-import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEventType
+import com.bitwarden.network.model.OrganizationEventJson
+import com.bitwarden.network.model.OrganizationEventType
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/event/OrganizationEventManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/event/OrganizationEventManagerTest.kt
@@ -2,15 +2,15 @@ package com.x8bit.bitwarden.data.platform.manager.event
 
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.util.asSuccess
+import com.bitwarden.network.model.OrganizationEventJson
+import com.bitwarden.network.model.OrganizationEventType
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.platform.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.EventDiskSource
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
 import com.x8bit.bitwarden.data.platform.datasource.network.service.EventService
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
-import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEventType
 import com.x8bit.bitwarden.data.util.FakeLifecycleOwner
 import com.x8bit.bitwarden.data.util.advanceTimeByAndRunCurrent
 import com.x8bit.bitwarden.data.vault.datasource.network.model.createMockOrganization

--- a/network/src/main/kotlin/com/bitwarden/network/api/EventApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/EventApi.kt
@@ -1,7 +1,7 @@
-package com.x8bit.bitwarden.data.platform.datasource.network.api
+package com.bitwarden.network.api
 
 import com.bitwarden.network.model.NetworkResult
-import com.x8bit.bitwarden.data.platform.datasource.network.model.OrganizationEventJson
+import com.bitwarden.network.model.OrganizationEventJson
 import retrofit2.http.Body
 import retrofit2.http.POST
 

--- a/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventJson.kt
@@ -1,6 +1,5 @@
-package com.x8bit.bitwarden.data.platform.datasource.network.model
+package com.bitwarden.network.model
 
-import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEventType
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventType.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventType.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.manager.model
+package com.bitwarden.network.model
 
 import androidx.annotation.Keep
 import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer


### PR DESCRIPTION
## 🎟️ Tracking

PM-19841

## 📔 Objective

Move `EventApi`, `OrganizationEventJson`, and `OrganizationEventType` to the `network` module.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
