### PR TITLE
PM-19812: Navigation Rail design feedback

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/navigation/BitwardenNavigationRail.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/navigation/BitwardenNavigationRail.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -18,9 +19,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.x8bit.bitwarden.ui.platform.base.util.endDivider
+import com.x8bit.bitwarden.ui.platform.base.util.toDp
 import com.x8bit.bitwarden.ui.platform.components.model.NavigationItem
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import kotlinx.collections.immutable.ImmutableList
@@ -37,10 +40,13 @@ fun BitwardenNavigationRail(
     windowInsets: WindowInsets = NavigationRailDefaults.windowInsets
         .union(WindowInsets.displayCutout.only(WindowInsetsSides.Start)),
 ) {
+    val density = LocalDensity.current
     Surface(
         color = BitwardenTheme.colorScheme.background.secondary,
         contentColor = Color.Unspecified,
-        modifier = modifier.endDivider(),
+        modifier = modifier.endDivider(
+            paddingTop = WindowInsets.statusBars.getTop(density).toDp(density),
+        ),
     ) {
         Column(
             modifier = Modifier
@@ -51,7 +57,7 @@ fun BitwardenNavigationRail(
                 .selectableGroup(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(
-                space = 4.dp,
+                space = 16.dp,
                 alignment = Alignment.CenterVertically,
             ),
         ) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/scaffold/BitwardenScaffold.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/scaffold/BitwardenScaffold.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.x8bit.bitwarden.ui.platform.base.util.toDp
 import com.x8bit.bitwarden.ui.platform.components.model.BitwardenPullToRefreshState
 import com.x8bit.bitwarden.ui.platform.components.model.ScaffoldNavigationData
@@ -193,7 +194,13 @@ private fun ScaffoldNavigationRail(
     navigationData: ScaffoldNavigationData,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.fillMaxHeight()) {
+    // We set the z-index to 1f in order to make sure the content transitions
+    // animate in under the navigation rail.
+    Box(
+        modifier = modifier
+            .fillMaxHeight()
+            .zIndex(zIndex = 1f),
+    ) {
         var appBarWidthPx by remember { mutableIntStateOf(0) }
         BitwardenNavigationRail(
             navigationItems = navigationData.navigationItems,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19812](https://bitwarden.atlassian.net/browse/PM-19812)

## 📔 Objective

This PR addresses a bit of minor design feedback where the screen transitions were looking a bit weird since the animation were occurring on top of the navigation rail.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/000e858f-e9ca-464c-9aa6-b763a2b1b5d5" width="450" /> | <video src="https://github.com/user-attachments/assets/bc508179-4fcc-447f-8b34-6203af14dd0d" width="450" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19812]: https://bitwarden.atlassian.net/browse/PM-19812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ