### PR TITLE
[PM-19854] Migrate AuthenticatedAuthRequestsApi to network module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedAuthRequestsApi.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/api/UnauthenticatedAuthRequestsApi.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.api
 
+import com.bitwarden.network.model.AuthRequestRequestJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 import com.bitwarden.network.model.NetworkResult
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestRequestJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AuthRequestsService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AuthRequestsService.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 
 /**
  * Provides an API for interacting with login approval / authentication requests.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AuthRequestsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AuthRequestsServiceImpl.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
+import com.bitwarden.network.api.AuthenticatedAuthRequestsApi
+import com.bitwarden.network.model.AuthRequestUpdateRequestJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAuthRequestsApi
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestUpdateRequestJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
 
 class AuthRequestsServiceImpl(
     private val authenticatedAuthRequestsApi: AuthenticatedAuthRequestsApi,

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestService.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestTypeJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
+import com.bitwarden.network.model.AuthRequestTypeJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 
 /**
  * Provides an API for creating a new authentication request.

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestServiceImpl.kt
@@ -1,12 +1,12 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.bitwarden.core.data.util.asFailure
+import com.bitwarden.network.api.AuthenticatedAuthRequestsApi
+import com.bitwarden.network.model.AuthRequestRequestJson
+import com.bitwarden.network.model.AuthRequestTypeJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAuthRequestsApi
 import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedAuthRequestsApi
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestRequestJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestTypeJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
 
 /**
  * The default implementation of the [NewAuthRequestService].

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerImpl.kt
@@ -4,9 +4,9 @@ import com.bitwarden.core.AuthRequestResponse
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.core.data.util.flatMap
+import com.bitwarden.network.model.AuthRequestTypeJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.PendingAuthRequestJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestTypeJson
 import com.x8bit.bitwarden.data.auth.datasource.network.service.AuthRequestsService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.NewAuthRequestService
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/util/AuthRequestTypeExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/util/AuthRequestTypeExtensions.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.auth.manager.util
 
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestTypeJson
+import com.bitwarden.network.model.AuthRequestTypeJson
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequestType
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AuthRequestsServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/AuthRequestsServiceTest.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.bitwarden.core.data.util.asSuccess
+import com.bitwarden.network.api.AuthenticatedAuthRequestsApi
 import com.bitwarden.network.base.BaseServiceTest
-import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAuthRequestsApi
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestServiceTest.kt
@@ -1,11 +1,11 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.bitwarden.core.data.util.asSuccess
+import com.bitwarden.network.api.AuthenticatedAuthRequestsApi
 import com.bitwarden.network.base.BaseServiceTest
-import com.x8bit.bitwarden.data.auth.datasource.network.api.AuthenticatedAuthRequestsApi
+import com.bitwarden.network.model.AuthRequestTypeJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedAuthRequestsApi
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestTypeJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerTest.kt
@@ -4,13 +4,13 @@ import app.cash.turbine.test
 import com.bitwarden.core.AuthRequestResponse
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
+import com.bitwarden.network.model.AuthRequestTypeJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.PendingAuthRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestTypeJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.KdfTypeJson
 import com.x8bit.bitwarden.data.auth.datasource.network.service.AuthRequestsService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.NewAuthRequestService

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/util/AuthRequestTypeExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/util/AuthRequestTypeExtensionsTest.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.auth.manager.util
 
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestTypeJson
+import com.bitwarden.network.model.AuthRequestTypeJson
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequestType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/network/src/main/kotlin/com/bitwarden/network/api/AuthenticatedAuthRequestsApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/AuthenticatedAuthRequestsApi.kt
@@ -1,9 +1,9 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.api
+package com.bitwarden.network.api
 
+import com.bitwarden.network.model.AuthRequestRequestJson
+import com.bitwarden.network.model.AuthRequestUpdateRequestJson
+import com.bitwarden.network.model.AuthRequestsResponseJson
 import com.bitwarden.network.model.NetworkResult
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestRequestJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestUpdateRequestJson
-import com.x8bit.bitwarden.data.auth.datasource.network.model.AuthRequestsResponseJson
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header

--- a/network/src/main/kotlin/com/bitwarden/network/model/AuthRequestRequestJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/AuthRequestRequestJson.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.model
+package com.bitwarden.network.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/network/src/main/kotlin/com/bitwarden/network/model/AuthRequestTypeJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/AuthRequestTypeJson.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.model
+package com.bitwarden.network.model
 
 import androidx.annotation.Keep
 import com.bitwarden.core.data.serializer.BaseEnumeratedIntSerializer

--- a/network/src/main/kotlin/com/bitwarden/network/model/AuthRequestUpdateRequestJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/AuthRequestUpdateRequestJson.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.model
+package com.bitwarden.network.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/network/src/main/kotlin/com/bitwarden/network/model/AuthRequestsResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/AuthRequestsResponseJson.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.model
+package com.bitwarden.network.model
 
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName


### PR DESCRIPTION
## 🎟️ Tracking

PM-19854

## 📔 Objective

Move AuthenticatedAuthRequestsApi and related models to the `network` module. Update imports in `:app` to use the new location.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
