### PR TITLE
[PM-19860] Migrate UnauthenticateAuthRequestsApi and models to `network` module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestServiceImpl.kt
@@ -2,11 +2,11 @@ package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.network.api.AuthenticatedAuthRequestsApi
+import com.bitwarden.network.api.UnauthenticatedAuthRequestsApi
 import com.bitwarden.network.model.AuthRequestRequestJson
 import com.bitwarden.network.model.AuthRequestTypeJson
 import com.bitwarden.network.model.AuthRequestsResponseJson
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedAuthRequestsApi
 
 /**
  * The default implementation of the [NewAuthRequestService].

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/NewAuthRequestServiceTest.kt
@@ -2,10 +2,10 @@ package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.network.api.AuthenticatedAuthRequestsApi
+import com.bitwarden.network.api.UnauthenticatedAuthRequestsApi
 import com.bitwarden.network.base.BaseServiceTest
 import com.bitwarden.network.model.AuthRequestTypeJson
 import com.bitwarden.network.model.AuthRequestsResponseJson
-import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedAuthRequestsApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/network/src/main/kotlin/com/bitwarden/network/api/UnauthenticatedAuthRequestsApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/UnauthenticatedAuthRequestsApi.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.api
+package com.bitwarden.network.api
 
 import com.bitwarden.network.model.AuthRequestRequestJson
 import com.bitwarden.network.model.AuthRequestsResponseJson


### PR DESCRIPTION
## 🎟️ Tracking

PM-19860

## 📔 Objective

Move `AuthRequestTypeJson`, `AuthRequestsResponseJson`, `UnauthenticatedAuthRequestsApi`, and `AuthRequestRequestJson` to the `network` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
