### PR TITLE
[PM-19947] Provide system clock in the `core` module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -143,10 +143,6 @@ object PlatformManagerModule {
 
     @Provides
     @Singleton
-    fun provideClock(): Clock = Clock.systemDefaultZone()
-
-    @Provides
-    @Singleton
     fun provideBiometricsEncryptionManager(
         authDiskSource: AuthDiskSource,
         settingsDiskSource: SettingsDiskSource,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/di/PlatformManagerModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/di/PlatformManagerModule.kt
@@ -28,7 +28,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -51,10 +50,6 @@ object PlatformManagerModule {
     @Provides
     @Singleton
     fun provideSdkClientManager(): SdkClientManager = SdkClientManagerImpl()
-
-    @Provides
-    @Singleton
-    fun provideClock(): Clock = Clock.systemDefaultZone()
 
     @Provides
     @Singleton

--- a/core/src/main/kotlin/com/bitwarden/core/di/CoreModule.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/di/CoreModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
+import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -35,4 +36,8 @@ object CoreModule {
         // Respect model default property values.
         coerceInputValues = true
     }
+
+    @Provides
+    @Singleton
+    fun provideClock(): Clock = Clock.systemDefaultZone()
 }

--- a/data/src/test/kotlin/com/bitwarden/data/manager/DispatcherManagerTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/manager/DispatcherManagerTest.kt
@@ -2,7 +2,7 @@ package com.bitwarden.data.manager
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class DispatcherManagerTest {
@@ -15,7 +15,7 @@ class DispatcherManagerTest {
 
         val actual = dispatcherManager.io
 
-        Assertions.assertEquals(expected, actual)
+        assertEquals(expected, actual)
     }
 
     @Test
@@ -24,7 +24,7 @@ class DispatcherManagerTest {
 
         val actual = dispatcherManager.main
 
-        Assertions.assertEquals(expected, actual)
+        assertEquals(expected, actual)
     }
 
     @Test
@@ -33,6 +33,6 @@ class DispatcherManagerTest {
 
         val actual = dispatcherManager.default
 
-        Assertions.assertEquals(expected, actual)
+        assertEquals(expected, actual)
     }
 }

--- a/data/src/test/kotlin/com/bitwarden/data/manager/DispatcherManagerTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/manager/DispatcherManagerTest.kt
@@ -2,7 +2,7 @@ package com.bitwarden.data.manager
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class DispatcherManagerTest {
@@ -15,7 +15,7 @@ class DispatcherManagerTest {
 
         val actual = dispatcherManager.io
 
-        assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual)
     }
 
     @Test
@@ -24,7 +24,7 @@ class DispatcherManagerTest {
 
         val actual = dispatcherManager.main
 
-        assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual)
     }
 
     @Test
@@ -33,6 +33,6 @@ class DispatcherManagerTest {
 
         val actual = dispatcherManager.default
 
-        assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-19947

## 📔 Objective

The system `Clock` provider has been moved to the `core` module.

This change removes redundant `Clock` providers from `authenticator` and `app` modules.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
