### PR TITLE
[PM-19949] Provide ConfigDiskSource from `data` module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/di/PlatformDiskModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/di/PlatformDiskModule.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.room.Room
 import com.bitwarden.data.datasource.di.EncryptedPreferences
-import com.bitwarden.data.datasource.disk.ConfigDiskSource
-import com.bitwarden.data.datasource.disk.ConfigDiskSourceImpl
 import com.bitwarden.data.datasource.disk.di.UnencryptedPreferences
 import com.bitwarden.data.manager.DispatcherManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.EnvironmentDiskSource
@@ -53,17 +51,6 @@ object PlatformDiskModule {
         json: Json,
     ): EnvironmentDiskSource =
         EnvironmentDiskSourceImpl(
-            sharedPreferences = sharedPreferences,
-            json = json,
-        )
-
-    @Provides
-    @Singleton
-    fun provideConfigDiskSource(
-        @UnencryptedPreferences sharedPreferences: SharedPreferences,
-        json: Json,
-    ): ConfigDiskSource =
-        ConfigDiskSourceImpl(
             sharedPreferences = sharedPreferences,
             json = json,
         )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/di/PlatformDiskModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/disk/di/PlatformDiskModule.kt
@@ -5,14 +5,11 @@ import com.bitwarden.authenticator.data.platform.datasource.disk.FeatureFlagOver
 import com.bitwarden.authenticator.data.platform.datasource.disk.FeatureFlagOverrideDiskSourceImpl
 import com.bitwarden.authenticator.data.platform.datasource.disk.SettingsDiskSource
 import com.bitwarden.authenticator.data.platform.datasource.disk.SettingsDiskSourceImpl
-import com.bitwarden.data.datasource.disk.ConfigDiskSource
-import com.bitwarden.data.datasource.disk.ConfigDiskSourceImpl
 import com.bitwarden.data.datasource.disk.di.UnencryptedPreferences
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.serialization.json.Json
 import javax.inject.Singleton
 
 @Module
@@ -21,17 +18,6 @@ import javax.inject.Singleton
  * Provides persistence-related dependencies in the platform package.
  */
 object PlatformDiskModule {
-
-    @Provides
-    @Singleton
-    fun provideConfigDiskSource(
-        @UnencryptedPreferences sharedPreferences: SharedPreferences,
-        json: Json,
-    ): ConfigDiskSource =
-        ConfigDiskSourceImpl(
-            sharedPreferences = sharedPreferences,
-            json = json,
-        )
 
     @Provides
     @Singleton

--- a/data/src/main/kotlin/com/bitwarden/data/datasource/disk/ConfigDiskSourceImpl.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/datasource/disk/ConfigDiskSourceImpl.kt
@@ -13,7 +13,7 @@ private const val SERVER_CONFIGURATIONS = "serverConfigurations"
 /**
  * Primary implementation of [ConfigDiskSource].
  */
-class ConfigDiskSourceImpl(
+internal class ConfigDiskSourceImpl(
     sharedPreferences: SharedPreferences,
     private val json: Json,
 ) : BaseDiskSource(sharedPreferences = sharedPreferences),

--- a/data/src/main/kotlin/com/bitwarden/data/datasource/disk/di/DiskModule.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/datasource/disk/di/DiskModule.kt
@@ -1,0 +1,29 @@
+package com.bitwarden.data.datasource.disk.di
+
+import android.content.SharedPreferences
+import com.bitwarden.data.datasource.disk.ConfigDiskSource
+import com.bitwarden.data.datasource.disk.ConfigDiskSourceImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import javax.inject.Singleton
+
+/**
+ * Provides persistence-related dependencies in the data module.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object DiskModule {
+    @Provides
+    @Singleton
+    fun provideConfigDiskSource(
+        @UnencryptedPreferences sharedPreferences: SharedPreferences,
+        json: Json,
+    ): ConfigDiskSource =
+        ConfigDiskSourceImpl(
+            sharedPreferences = sharedPreferences,
+            json = json,
+        )
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-19949

## 📔 Objective

Make the `ConfigDiskSourceImpl` internal and provide `ConfigDiskSource` from the `data` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
