### PR TITLE
PM-19937: Make navigation rail scrollable

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/navigation/BitwardenNavigationRail.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/navigation/BitwardenNavigationRail.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.NavigationRailDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -54,7 +56,8 @@ fun BitwardenNavigationRail(
                 .windowInsetsPadding(insets = windowInsets)
                 .widthIn(min = 80.dp)
                 .padding(vertical = 4.dp)
-                .selectableGroup(),
+                .selectableGroup()
+                .verticalScroll(state = rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(
                 space = 16.dp,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19937](https://bitwarden.atlassian.net/browse/PM-19937)

## 📔 Objective

This PR makes the navigation rail scrollable for small devices.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/a6ef7f28-43e4-48e9-8c7b-055b8b4b26a5" width="400" /> | <video src="https://github.com/user-attachments/assets/2129439b-d6a8-4ea8-bbc7-da31fea6f8f5" width="400" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19937]: https://bitwarden.atlassian.net/browse/PM-19937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ