### PR TITLE
[PM-19861] Migrate UnauthenticatedDevicesApi to network module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/DevicesServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/service/DevicesServiceImpl.kt
@@ -1,11 +1,11 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.bitwarden.network.api.AuthenticatedDevicesApi
+import com.bitwarden.network.api.UnauthenticatedDevicesApi
 import com.bitwarden.network.model.TrustedDeviceKeysRequestJson
 import com.bitwarden.network.model.TrustedDeviceKeysResponseJson
 import com.bitwarden.network.util.base64UrlEncode
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedDevicesApi
 
 class DevicesServiceImpl(
     private val authenticatedDevicesApi: AuthenticatedDevicesApi,

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/DevicesServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/datasource/network/service/DevicesServiceTest.kt
@@ -2,9 +2,9 @@ package com.x8bit.bitwarden.data.auth.datasource.network.service
 
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.network.api.AuthenticatedDevicesApi
+import com.bitwarden.network.api.UnauthenticatedDevicesApi
 import com.bitwarden.network.base.BaseServiceTest
 import com.bitwarden.network.model.TrustedDeviceKeysResponseJson
-import com.x8bit.bitwarden.data.auth.datasource.network.api.UnauthenticatedDevicesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/network/src/main/kotlin/com/bitwarden/network/api/UnauthenticatedDevicesApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/UnauthenticatedDevicesApi.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.api
+package com.bitwarden.network.api
 
 import com.bitwarden.network.model.NetworkResult
 import retrofit2.http.GET


### PR DESCRIPTION
## 🎟️ Tracking

PM-19861

## 📔 Objective

Move `UnauthenticatedDevicesApi` from the `app` module to the `network` module. Updated its usages in the `app` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
