### PR TITLE
[PM-20070] Migrate DownloadApi to `network` module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/DownloadServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/DownloadServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
+import com.bitwarden.network.api.DownloadApi
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.vault.datasource.network.api.DownloadApi
 import okhttp3.ResponseBody
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/DownloadServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/DownloadServiceTest.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
+import com.bitwarden.network.api.DownloadApi
 import com.bitwarden.network.base.BaseServiceTest
-import com.x8bit.bitwarden.data.vault.datasource.network.api.DownloadApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/network/src/main/kotlin/com/bitwarden/network/api/DownloadApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/DownloadApi.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.api
+package com.bitwarden.network.api
 
 import com.bitwarden.network.model.NetworkResult
 import okhttp3.ResponseBody


### PR DESCRIPTION
## 🎟️ Tracking

PM-20070

## 📔 Objective

Moved `DownloadApi` from the `app` module to the `network` module. Removed the previous implementation from the `app` module and updated its usages to use the new `network` module implementation.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
