### PR TITLE
[PM-20071] Migrate FoldersApi to `network` module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FolderService.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FolderService.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
+import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SyncResponseJson
-import com.x8bit.bitwarden.data.vault.datasource.network.model.FolderJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FolderServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FolderServiceImpl.kt
@@ -1,12 +1,12 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
+import com.bitwarden.network.api.FoldersApi
+import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.toBitwardenError
 import com.bitwarden.network.util.NetworkErrorCode
 import com.bitwarden.network.util.parseErrorBodyOrNull
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.vault.datasource.network.api.FoldersApi
-import com.x8bit.bitwarden.data.vault.datasource.network.model.FolderJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
 import kotlinx.serialization.json.Json
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkFolderExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkFolderExtensions.kt
@@ -1,10 +1,10 @@
 package com.x8bit.bitwarden.data.vault.repository.util
 
 import com.bitwarden.core.data.repository.util.SpecialCharWithPrecedenceComparator
+import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.vault.Folder
 import com.bitwarden.vault.FolderView
-import com.x8bit.bitwarden.data.vault.datasource.network.model.FolderJsonRequest
 
 /**
  * Converts a list of [SyncResponseJson.Folder] objects to a list of corresponding

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FoldersServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/FoldersServiceTest.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
+import com.bitwarden.network.api.FoldersApi
 import com.bitwarden.network.base.BaseServiceTest
+import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SyncResponseJson
-import com.x8bit.bitwarden.data.vault.datasource.network.api.FoldersApi
-import com.x8bit.bitwarden.data.vault.datasource.network.model.FolderJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -15,6 +15,7 @@ import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
 import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.exporters.ExportFormat
 import com.bitwarden.fido.Fido2CredentialAutofillView
+import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.createMockCipher
@@ -59,7 +60,6 @@ import com.x8bit.bitwarden.data.platform.manager.model.SyncSendUpsertData
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateFileSendResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateSendJsonResponse
-import com.x8bit.bitwarden.data.vault.datasource.network.model.FolderJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateSendResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.service.CiphersService

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkFolderExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkFolderExtensionsTest.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.vault.repository.util
 
+import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.createMockFolder
-import com.x8bit.bitwarden.data.vault.datasource.network.model.FolderJsonRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFolderView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFolder
 import org.junit.Assert.assertEquals

--- a/network/src/main/kotlin/com/bitwarden/network/api/FoldersApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/FoldersApi.kt
@@ -1,8 +1,8 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.api
+package com.bitwarden.network.api
 
+import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.NetworkResult
 import com.bitwarden.network.model.SyncResponseJson
-import com.x8bit.bitwarden.data.vault.datasource.network.model.FolderJsonRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET

--- a/network/src/main/kotlin/com/bitwarden/network/model/FolderJsonRequest.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/FolderJsonRequest.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.model
+package com.bitwarden.network.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable


### PR DESCRIPTION
## 🎟️ Tracking

PM-20071

## 📔 Objective

Migrated `FoldersApi` and `FolderJsonRequest` from the `app` module to the `network` module. Removed redundant implementations and model from the `app` module. Updated all usages of `FoldersApi` and `FolderJsonRequest` to use the new implementation in `network`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
