### PR TITLE
PM-20123: Add flight recorder metadata

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk
 
+import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
@@ -83,6 +84,16 @@ interface SettingsDiskSource {
      * Emits updates that track [hasUserLoggedInOrCreatedAccount].
      */
     val hasUserLoggedInOrCreatedAccountFlow: Flow<Boolean?>
+
+    /**
+     * The current status of whether the flight recorder is enabled.
+     */
+    var flightRecorderData: FlightRecorderDataSet?
+
+    /**
+     * Emits updates that track [flightRecorderData].
+     */
+    val flightRecorderDataFlow: Flow<FlightRecorderDataSet?>
 
     /**
      * Clears all the settings data for the given user.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/model/FlightRecorderDataSet.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/model/FlightRecorderDataSet.kt
@@ -1,0 +1,46 @@
+package com.x8bit.bitwarden.data.platform.datasource.disk.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Persistable class containing all required data for a all instances of the flight recorder.
+ */
+@Serializable
+data class FlightRecorderDataSet(
+    @SerialName("data")
+    val data: Set<FlightRecorderData>,
+) {
+    /**
+     * Returns `true` is there is an active [FlightRecorderDataSet.FlightRecorderData].
+     */
+    val hasActiveFlightRecorderData: Boolean
+        get() = this.activeFlightRecorderData != null
+
+    /**
+     * Retrieves tha active log if available.
+     */
+    val activeFlightRecorderData: FlightRecorderData?
+        get() = this.data.find { it.isActive }
+
+    /**
+     * Persistable class containing all required data for a single instance of the flight recorder.
+     */
+    @Serializable
+    data class FlightRecorderData(
+        @SerialName("id")
+        val id: String,
+
+        @SerialName("fileName")
+        val fileName: String,
+
+        @SerialName("startTime")
+        val startTimeMs: Long,
+
+        @SerialName("duration")
+        val durationMs: Long,
+
+        @SerialName("isActive")
+        val isActive: Boolean,
+    )
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -5,10 +5,12 @@ import app.cash.turbine.test
 import com.bitwarden.core.data.util.decodeFromStringOrNull
 import com.bitwarden.core.di.CoreModule
 import com.bitwarden.data.datasource.disk.base.FakeSharedPreferences
+import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
+import com.x8bit.bitwarden.data.util.assertJsonEquals
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import kotlinx.coroutines.test.runTest
@@ -81,6 +83,104 @@ class SettingsDiskSourceTest {
             appLanguage.localeName,
             actual,
         )
+    }
+
+    @Test
+    fun `flightRecorderData should pull from SharedPreferences`() {
+        val flightRecorderKey = "bwPreferencesStorage:flightRecorderData"
+        val encodedData = """
+            {
+              "data": [
+                {
+                  "id": "51"
+                  "fileName": "flight_recorder_2025-04-03_14-22-40",
+                  "startTime": 1744059882,
+                  "duration": 3600,
+                  "isActive": false
+                }
+              ]
+            }
+        """
+            .trimIndent()
+        val expected = FlightRecorderDataSet(
+            data = setOf(
+                FlightRecorderDataSet.FlightRecorderData(
+                    id = "51",
+                    fileName = "flight_recorder_2025-04-03_14-22-40",
+                    startTimeMs = 1_744_059_882L,
+                    durationMs = 3_600L,
+                    isActive = false,
+                ),
+            ),
+        )
+
+        // Verify initial value is null and disk source matches shared preferences.
+        assertNull(fakeSharedPreferences.getString(flightRecorderKey, null))
+        assertNull(settingsDiskSource.flightRecorderData)
+
+        // Updating the shared preferences should update disk source.
+        fakeSharedPreferences.edit { putString(flightRecorderKey, encodedData) }
+        val actual = settingsDiskSource.flightRecorderData
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `flightRecorderDataFlow should react to changes in isFLightRecorderEnabled`() = runTest {
+        val expected = FlightRecorderDataSet(
+            data = setOf(
+                FlightRecorderDataSet.FlightRecorderData(
+                    id = "52",
+                    fileName = "flight_recorder_2025-04-03_14-22-40",
+                    startTimeMs = 1_744_059_882L,
+                    durationMs = 3_600L,
+                    isActive = true,
+                ),
+            ),
+        )
+        settingsDiskSource.flightRecorderDataFlow.test {
+            // The initial values of the Flow and the property are in sync
+            assertNull(settingsDiskSource.flightRecorderData)
+            assertNull(awaitItem())
+
+            settingsDiskSource.flightRecorderData = expected
+            assertEquals(expected, awaitItem())
+
+            settingsDiskSource.flightRecorderData = null
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun `setting flightRecorderData should update SharedPreferences`() {
+        val flightRecorderKey = "bwPreferencesStorage:flightRecorderData"
+        val data = FlightRecorderDataSet(
+            data = setOf(
+                FlightRecorderDataSet.FlightRecorderData(
+                    id = "53",
+                    fileName = "flight_recorder_2025-04-03_14-22-40",
+                    startTimeMs = 1_744_059_882L,
+                    durationMs = 3_600L,
+                    isActive = true,
+                ),
+            ),
+        )
+        val expected = """
+            {
+              "data": [
+                {
+                  "id": "53",
+                  "fileName": "flight_recorder_2025-04-03_14-22-40",
+                  "startTime": 1744059882,
+                  "duration": 3600,
+                  "isActive": true
+                }
+              ]
+            }
+        """
+            .trimIndent()
+        settingsDiskSource.flightRecorderData = data
+        val actual = fakeSharedPreferences.getString(flightRecorderKey, null)
+        assertJsonEquals(expected, actual!!)
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.platform.datasource.disk.util
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.decodeFromStringOrNull
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
@@ -50,6 +51,9 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private val mutableShouldShowGeneratorCoachMarkFlow =
         bufferedMutableSharedFlow<Boolean?>()
 
+    private val mutableFlightRecorderDataFlow =
+        bufferedMutableSharedFlow<FlightRecorderDataSet?>(replay = 1)
+
     private var storedAppLanguage: AppLanguage? = null
     private var storedAppTheme: AppTheme = AppTheme.DEFAULT
     private val storedLastSyncTime = mutableMapOf<String, Instant?>()
@@ -80,6 +84,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private var createSendActionCount: Int? = null
     private var hasSeenAddLoginCoachMark: Boolean? = null
     private var hasSeenGeneratorCoachMark: Boolean? = null
+    private var storedFlightRecorderData: FlightRecorderDataSet? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -172,6 +177,17 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         get() = mutableHasUserLoggedInOrCreatedAccount.onSubscription {
             emit(hasUserLoggedInOrCreatedAccount)
         }
+
+    override var flightRecorderData: FlightRecorderDataSet?
+        get() = storedFlightRecorderData
+        set(value) {
+            storedFlightRecorderData = value
+            mutableFlightRecorderDataFlow.tryEmit(value)
+        }
+
+    override val flightRecorderDataFlow: Flow<FlightRecorderDataSet?>
+        get() = mutableFlightRecorderDataFlow
+            .onSubscription { emit(storedFlightRecorderData) }
 
     override fun getAccountBiometricIntegrityValidity(
         userId: String,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20123](https://bitwarden.atlassian.net/browse/PM-20123)

## 📔 Objective

This PR adds persisted metadata for the flight recorder logs to the settings disk source.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20123]: https://bitwarden.atlassian.net/browse/PM-20123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ