### PR TITLE
[PM-20127] Only prompt passkey user verification once

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/MainViewModel.kt
@@ -374,10 +374,8 @@ class MainViewModel @Inject constructor(
                 // Set the user's verification status when a new FIDO 2 request is received to force
                 // explicit verification if the user's vault is unlocked when the request is
                 // received.
-                fido2CreateCredentialRequest.providerRequest
-                    .biometricPromptResult
-                    ?.isSuccessful
-                    ?.let { isVerified -> fido2CredentialManager.isUserVerified = isVerified }
+                fido2CredentialManager.isUserVerified =
+                    fido2CreateCredentialRequest.isUserPreVerified
 
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.Fido2Save(
@@ -393,12 +391,11 @@ class MainViewModel @Inject constructor(
             }
 
             fido2AssertCredentialRequest != null -> {
-                // If device biometric verification was performed as part of single-tap
-                // authentication, set the user's verification state to the device result.
-                // Otherwise, retain the verification state as-is.
-                fido2AssertCredentialRequest.providerRequest.biometricPromptResult
-                    ?.isSuccessful
-                    ?.let { isVerified -> fido2CredentialManager.isUserVerified = isVerified }
+                // Set the user's verification status when a new FIDO 2 request is received to force
+                // explicit verification if the user's vault is unlocked when the request is
+                // received.
+                fido2CredentialManager.isUserVerified =
+                    fido2AssertCredentialRequest.isUserPreVerified
 
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.Fido2Assertion(

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CreateCredentialRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CreateCredentialRequest.kt
@@ -14,12 +14,15 @@ import kotlinx.parcelize.Parcelize
  * credential manager framework.
  *
  * @property userId The ID of the user creating the passkey.
+ * @property isUserPreVerified Whether the user has already been verified by the OS biometric
+ * prompt.
  * @property requestData Provider request data in the form of a [Bundle].
  */
 @Parcelize
 data class Fido2CreateCredentialRequest(
     val userId: String,
     val requestData: Bundle,
+    val isUserPreVerified: Boolean,
 ) : Parcelable {
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequest.kt
@@ -11,16 +11,19 @@ import kotlinx.parcelize.Parcelize
 /**
  * Models a FIDO 2 credential authentication request parsed from the launching intent.
  *
- * @param userId ID of the user requesting credential authentication.
- * @param cipherId ID of the cipher to be authenticated against.
- * @param credentialId ID of the credential to authenticate.
- * @param requestData Provider request data in the form of a [Bundle].
+ * @property userId ID of the user requesting credential authentication.
+ * @property cipherId ID of the cipher to be authenticated against.
+ * @property credentialId ID of the credential to authenticate.
+ * @property isUserPreVerified Whether the user has already been verified by the OS biometric
+ * prompt.
+ * @property requestData Provider request data in the form of a [Bundle].
  */
 @Parcelize
 data class Fido2CredentialAssertionRequest(
     val userId: String,
     val cipherId: String,
     val credentialId: String,
+    val isUserPreVerified: Boolean,
     private val requestData: Bundle,
 ) : Parcelable {
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
@@ -27,8 +27,16 @@ fun Intent.getFido2CreateCredentialRequestOrNull(): Fido2CreateCredentialRequest
     val userId = getStringExtra(EXTRA_KEY_USER_ID)
         ?: return null
 
+    // Extract the OS biometric prompt result from the request data because it is not included in
+    // the bundle returned by `ProviderGetCredentialRequest.asBundle()`.
+    val isUserPreVerified = systemRequest
+        .biometricPromptResult
+        ?.isSuccessful
+        ?: false
+
     return Fido2CreateCredentialRequest(
         userId = userId,
+        isUserPreVerified = isUserPreVerified,
         requestData = ProviderCreateCredentialRequest.asBundle(systemRequest),
     )
 }
@@ -53,10 +61,18 @@ fun Intent.getFido2AssertionRequestOrNull(): Fido2CredentialAssertionRequest? {
     val userId: String = getStringExtra(EXTRA_KEY_USER_ID)
         ?: return null
 
+    // Extract the OS biometric prompt result from the request data because it is not included in
+    // the bundle returned by `ProviderGetCredentialRequest.asBundle()`.
+    val isUserPreVerified = systemRequest
+        .biometricPromptResult
+        ?.isSuccessful
+        ?: false
+
     return Fido2CredentialAssertionRequest(
         userId = userId,
         cipherId = cipherId,
         credentialId = credentialId,
+        isUserPreVerified = isUserPreVerified,
         requestData = ProviderGetCredentialRequest.asBundle(systemRequest),
     )
 }

--- a/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -691,6 +691,7 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = DEFAULT_USER_STATE.activeUserId,
+            isUserPreVerified = false,
             requestData = bundleOf(),
         )
         val fido2Intent = createMockIntent(
@@ -715,7 +716,10 @@ class MainViewModelTest : BaseViewModelTest() {
     @Test
     fun `on ReceiveFirstIntent with fido2 create request data should set the user verification based on request`() {
         val viewModel = createViewModel()
-        val createCredentialRequest = createMockFido2CreateCredentialRequest(number = 1)
+        val createCredentialRequest = createMockFido2CreateCredentialRequest(
+            number = 1,
+            isUserPreVerified = true,
+        )
         val fido2Intent = createMockIntent(
             mockFido2CreateCredentialRequest = createCredentialRequest,
         )
@@ -739,6 +743,7 @@ class MainViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "selectedUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
             val mockIntent = createMockIntent(
@@ -769,6 +774,7 @@ class MainViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = DEFAULT_USER_STATE.activeUserId,
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
             val mockIntent = createMockIntent(

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequestUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialAssertionRequestUtil.kt
@@ -10,5 +10,6 @@ fun createMockFido2CredentialAssertionRequest(
         userId = userId,
         cipherId = "mockCipherId-$number",
         credentialId = "mockCredentialId-$number",
+        isUserPreVerified = false,
         requestData = bundleOf(),
     )

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialRequestUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/model/Fido2CredentialRequestUtil.kt
@@ -8,8 +8,10 @@ import androidx.core.os.bundleOf
  */
 fun createMockFido2CreateCredentialRequest(
     number: Int,
+    isUserPreVerified: Boolean = false,
     requestData: Bundle = bundleOf(),
 ): Fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
     userId = "mockUserId-$number",
+    isUserPreVerified = isUserPreVerified,
     requestData = requestData,
 )

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
@@ -148,6 +148,7 @@ class SpecialCircumstanceExtensionsTest {
     fun `toFido2RequestOrNull should return a non-null value for Fido2Save`() {
         val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = "mockUserId",
+            isUserPreVerified = false,
             requestData = bundleOf(),
         )
         assertEquals(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -664,6 +664,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
     fun `when the active user has an unlocked vault but there is a Fido2Save special circumstance the nav state should be VaultUnlockedForFido2Save`() {
         val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = "activeUserId",
+            isUserPreVerified = false,
             requestData = bundleOf(),
         )
         specialCircumstanceManager.specialCircumstance =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -396,6 +396,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         } returns mockk(relaxed = true)
         val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = "mockUserId-1",
+            isUserPreVerified = false,
             requestData = bundleOf(),
         )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -880,6 +881,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         runTest {
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
             specialCircumstanceManager.specialCircumstance =
@@ -959,6 +961,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             val mockUserId = "mockUserId"
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = mockUserId,
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
             specialCircumstanceManager.specialCircumstance =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/util/Fido2CredentialRequestExtensionsTest.kt
@@ -59,6 +59,7 @@ class Fido2CredentialRequestExtensionsTest {
             ),
             Fido2CreateCredentialRequest(
                 userId = "mockUserId-1",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
                 .toDefaultAddTypeContent(
@@ -96,6 +97,7 @@ class Fido2CredentialRequestExtensionsTest {
             ),
             Fido2CreateCredentialRequest(
                 userId = "mockUserId-1",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
                 .toDefaultAddTypeContent(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -4,6 +4,8 @@ import android.net.Uri
 import androidx.core.os.bundleOf
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.provider.BeginGetCredentialRequest
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
 import androidx.credentials.provider.ProviderCreateCredentialRequest
 import androidx.credentials.provider.ProviderGetCredentialRequest
 import androidx.lifecycle.SavedStateHandle
@@ -37,6 +39,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
+import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2GetCredentialsRequest
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
@@ -68,6 +71,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.autofill.fido2.manager.model.AssertFido2CredentialResult
+import com.x8bit.bitwarden.ui.autofill.fido2.manager.model.GetFido2CredentialsResult
 import com.x8bit.bitwarden.ui.autofill.fido2.manager.model.RegisterFido2CredentialResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
@@ -217,17 +221,30 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 mockk<GetPublicKeyCredentialOption>(relaxed = true),
             )
         }
+    private val mockBeginGetPublicKeyCredentialOption =
+        mockk<BeginGetPublicKeyCredentialOption>(relaxed = true)
+    private val mockBeginGetCredentialRequest = mockk<BeginGetCredentialRequest>(relaxed = true) {
+        every {
+            beginGetCredentialOptions
+        } returns listOf(
+            mockBeginGetPublicKeyCredentialOption,
+        )
+    }
 
     @BeforeEach
     fun setUp() {
         mockkObject(
             ProviderCreateCredentialRequest.Companion,
             ProviderGetCredentialRequest.Companion,
+            BeginGetCredentialRequest.Companion,
         )
         every { ProviderCreateCredentialRequest.fromBundle(any()) } returns mockk(relaxed = true)
         every {
             ProviderGetCredentialRequest.fromBundle(any())
         } returns mockProviderGetCredentialRequest
+        every {
+            BeginGetCredentialRequest.fromBundle(any())
+        } returns mockBeginGetCredentialRequest
     }
 
     @AfterEach
@@ -235,6 +252,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         unmockkObject(
             ProviderCreateCredentialRequest.Companion,
             ProviderGetCredentialRequest.Companion,
+            BeginGetCredentialRequest.Companion,
         )
     }
 
@@ -252,7 +270,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `initial dialog state should be correct when Fido2CreateCredentialRequest is present`() =
         runTest {
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
-                "mockUserId",
+                userId = "mockUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -1859,6 +1878,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "activeUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
 
@@ -2553,10 +2573,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         )
     }
 
+    //region FIDO2 process handling
     @Test
     fun `Fido2CreateCredentialRequest should be evaluated before observing vault data`() {
         val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
             userId = "mockUserId",
+            isUserPreVerified = false,
             requestData = bundleOf(),
         )
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Save(
@@ -2590,6 +2612,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     fun `Fido2ValidateOriginResult should update dialog state on Unknown error`() = runTest {
         val mockFido2CreateRequest = Fido2CreateCredentialRequest(
             userId = "mockUserId",
+            isUserPreVerified = false,
             requestData = bundleOf(),
         )
 
@@ -2628,6 +2651,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
 
@@ -2666,6 +2690,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
 
@@ -2704,6 +2729,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
 
@@ -2742,6 +2768,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
 
@@ -2780,6 +2807,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
 
@@ -2818,6 +2846,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         runTest {
             val fido2CreateCredentialRequest = Fido2CreateCredentialRequest(
                 userId = "mockUserId",
+                isUserPreVerified = false,
                 requestData = bundleOf(),
             )
 
@@ -2985,6 +3014,261 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 VaultItemListingState.DialogState.Error(
                     title = R.string.an_error_has_occurred.asText(),
                     message = "".asText(),
+                ),
+                viewModel.stateFlow.value.dialogState,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Fido2GetCredentialsRequest should validate request and emit CompleteFido2GetCredentialsRequest event`() =
+        runTest {
+            setupMockUri()
+            val mockGetCredentialsRequest = createMockFido2GetCredentialsRequest(number = 1)
+            val mockFido2CredentialsList = createMockSdkFido2CredentialList(number = 1)
+            val mockCipherView = createMockCipherView(
+                number = 1,
+                fido2Credentials = mockFido2CredentialsList,
+            )
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2GetCredentials(
+                    mockGetCredentialsRequest,
+                )
+            every {
+                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(any())
+            } returns mockk(relaxed = true)
+            coEvery {
+                fido2OriginManager.validateOrigin(
+                    callingAppInfo = any(),
+                    relyingPartyId = any(),
+                )
+            } returns Fido2ValidateOriginResult.Success("mockOrigin")
+            every {
+                vaultRepository
+                    .ciphersStateFlow
+                    .value
+                    .data
+            } returns listOf(mockCipherView)
+
+            val dataState = DataState.Loaded(
+                data = VaultData(
+                    cipherViewList = listOf(mockCipherView),
+                    folderViewList = listOf(createMockFolderView(number = 1)),
+                    collectionViewList = listOf(createMockCollectionView(number = 1)),
+                    sendViewList = listOf(createMockSendView(number = 1)),
+                ),
+            )
+
+            val viewModel = createVaultItemListingViewModel()
+            mutableVaultDataStateFlow.value = dataState
+
+            viewModel.eventFlow.test {
+                assertEquals(
+                    VaultItemListingEvent.CompleteFido2GetCredentialsRequest(
+                        result = GetFido2CredentialsResult.Success(
+                            userId = "mockUserId-1",
+                            option = mockBeginGetPublicKeyCredentialOption,
+                            credentials = emptyList(),
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `Fido2GetCredentialsRequest should display error dialog when request is invalid`() =
+        runTest {
+            setupMockUri()
+            val mockGetCredentialsRequest = createMockFido2GetCredentialsRequest(number = 1)
+            val mockFido2CredentialsList = createMockSdkFido2CredentialList(number = 1)
+            val mockCipherView = createMockCipherView(
+                number = 1,
+                fido2Credentials = mockFido2CredentialsList,
+            )
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2GetCredentials(
+                    mockGetCredentialsRequest,
+                )
+
+            every {
+                vaultRepository
+                    .ciphersStateFlow
+                    .value
+                    .data
+            } returns listOf(mockCipherView)
+            every {
+                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(any())
+            } returns mockk(relaxed = true)
+            every {
+                mockBeginGetCredentialRequest.beginGetCredentialOptions
+            } returns emptyList()
+
+            val dataState = DataState.Loaded(
+                data = VaultData(
+                    cipherViewList = listOf(mockCipherView),
+                    folderViewList = listOf(createMockFolderView(number = 1)),
+                    collectionViewList = listOf(createMockCollectionView(number = 1)),
+                    sendViewList = listOf(createMockSendView(number = 1)),
+                ),
+            )
+
+            val viewModel = createVaultItemListingViewModel()
+            mutableVaultDataStateFlow.value = dataState
+
+            assertEquals(
+                VaultItemListingState.DialogState.Fido2OperationFail(
+                    title = R.string.an_error_has_occurred.asText(),
+                    message =
+                        R.string.passkey_operation_failed_because_the_request_is_invalid.asText(),
+                ),
+                viewModel.stateFlow.value.dialogState,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Fido2GetCredentialsRequest should display error dialog when relyingParty cannot be identified`() =
+        runTest {
+            setupMockUri()
+            val mockGetCredentialsRequest = createMockFido2GetCredentialsRequest(number = 1)
+            val mockFido2CredentialsList = createMockSdkFido2CredentialList(number = 1)
+            val mockCipherView = createMockCipherView(
+                number = 1,
+                fido2Credentials = mockFido2CredentialsList,
+            )
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2GetCredentials(
+                    mockGetCredentialsRequest,
+                )
+
+            every {
+                vaultRepository
+                    .ciphersStateFlow
+                    .value
+                    .data
+            } returns listOf(mockCipherView)
+            every {
+                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(any())
+            } returns mockk(relaxed = true) {
+                every { relyingPartyId } returns null
+            }
+
+            val dataState = DataState.Loaded(
+                data = VaultData(
+                    cipherViewList = listOf(mockCipherView),
+                    folderViewList = listOf(createMockFolderView(number = 1)),
+                    collectionViewList = listOf(createMockCollectionView(number = 1)),
+                    sendViewList = listOf(createMockSendView(number = 1)),
+                ),
+            )
+
+            val viewModel = createVaultItemListingViewModel()
+            mutableVaultDataStateFlow.value = dataState
+
+            assertEquals(
+                VaultItemListingState.DialogState.Fido2OperationFail(
+                    title = R.string.an_error_has_occurred.asText(),
+                    message =
+                        R.string.passkey_operation_failed_because_relying_party_cannot_be_identified
+                            .asText(),
+                ),
+                viewModel.stateFlow.value.dialogState,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Fido2GetCredentialsRequest should display error dialog when callingApp cannot be verified`() =
+        runTest {
+            setupMockUri()
+            val mockGetCredentialsRequest = createMockFido2GetCredentialsRequest(number = 1)
+            val mockFido2CredentialsList = createMockSdkFido2CredentialList(number = 1)
+            val mockCipherView = createMockCipherView(
+                number = 1,
+                fido2Credentials = mockFido2CredentialsList,
+            )
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2GetCredentials(
+                    mockGetCredentialsRequest,
+                )
+
+            every {
+                vaultRepository
+                    .ciphersStateFlow
+                    .value
+                    .data
+            } returns listOf(mockCipherView)
+            every {
+                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(any())
+            } returns mockk(relaxed = true)
+            every {
+                mockBeginGetCredentialRequest.callingAppInfo
+            } returns null
+
+            val dataState = DataState.Loaded(
+                data = VaultData(
+                    cipherViewList = listOf(mockCipherView),
+                    folderViewList = listOf(createMockFolderView(number = 1)),
+                    collectionViewList = listOf(createMockCollectionView(number = 1)),
+                    sendViewList = listOf(createMockSendView(number = 1)),
+                ),
+            )
+
+            val viewModel = createVaultItemListingViewModel()
+            mutableVaultDataStateFlow.value = dataState
+
+            assertEquals(
+                VaultItemListingState.DialogState.Fido2OperationFail(
+                    title = R.string.an_error_has_occurred.asText(),
+                    message =
+                        R.string.passkey_operation_failed_because_app_could_not_be_verified
+                            .asText(),
+                ),
+                viewModel.stateFlow.value.dialogState,
+            )
+        }
+
+    @Test
+    fun `Fido2GetCredentialsRequest should display error dialog when origin validation fails`() =
+        runTest {
+            setupMockUri()
+            val mockGetCredentialsRequest = createMockFido2GetCredentialsRequest(number = 1)
+            val mockFido2CredentialsList = createMockSdkFido2CredentialList(number = 1)
+            val mockCipherView = createMockCipherView(
+                number = 1,
+                fido2Credentials = mockFido2CredentialsList,
+            )
+            specialCircumstanceManager.specialCircumstance =
+                SpecialCircumstance.Fido2GetCredentials(
+                    mockGetCredentialsRequest,
+                )
+            every {
+                fido2CredentialManager.getPasskeyAssertionOptionsOrNull(any())
+            } returns mockk(relaxed = true)
+            coEvery {
+                fido2OriginManager.validateOrigin(
+                    callingAppInfo = any(),
+                    relyingPartyId = any(),
+                )
+            } returns Fido2ValidateOriginResult.Error.Unknown
+
+            val dataState = DataState.Loaded(
+                data = VaultData(
+                    cipherViewList = listOf(mockCipherView),
+                    folderViewList = listOf(createMockFolderView(number = 1)),
+                    collectionViewList = listOf(createMockCollectionView(number = 1)),
+                    sendViewList = listOf(createMockSendView(number = 1)),
+                ),
+            )
+
+            val viewModel = createVaultItemListingViewModel()
+            mutableVaultDataStateFlow.value = dataState
+
+            assertEquals(
+                VaultItemListingState.DialogState.Fido2OperationFail(
+                    title = R.string.an_error_has_occurred.asText(),
+                    message = R.string.generic_error_message.asText(),
                 ),
                 viewModel.stateFlow.value.dialogState,
             )
@@ -3645,6 +3929,28 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     VaultItemListingEvent.CompleteFido2Registration(
                         result = RegisterFido2CredentialResult.Cancelled,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `UserVerificationCancelled should clear dialog state, set isUserVerified to false, and emit CompleteFido2Assertion with cancelled result`() =
+        runTest {
+            specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Assertion(
+                createMockFido2CredentialAssertionRequest(number = 1),
+            )
+            val viewModel = createVaultItemListingViewModel()
+            viewModel.trySendAction(VaultItemListingsAction.UserVerificationCancelled)
+
+            verify { fido2CredentialManager.isUserVerified = false }
+            assertNull(viewModel.stateFlow.value.dialogState)
+            viewModel.eventFlow.test {
+                assertEquals(
+                    VaultItemListingEvent.CompleteFido2Assertion(
+                        result = AssertFido2CredentialResult.Cancelled,
                     ),
                     awaitItem(),
                 )
@@ -4510,6 +4816,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 viewModel.stateFlow.value.dialogState,
             )
         }
+
+    //endregion FIDO2 process handling
 
     @Test
     fun `InternetConnectionErrorReceived should show network error if no internet connection`() =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
@@ -887,6 +887,7 @@ class VaultItemListingDataExtensionsTest {
                 autofillSelectionData = null,
                 fido2CreationData = Fido2CreateCredentialRequest(
                     userId = "userId",
+                    isUserPreVerified = false,
                     requestData = bundleOf(),
                 ),
                 fido2CredentialAutofillViews = null,


### PR DESCRIPTION
## 🎟️ Tracking

PM-20127

## 📔 Objective

Prevent user verification from prompting twice when single-tap passkey processing is enabled.

- Added `isUserPreVerified` property to `Fido2CreateCredentialRequest` and `Fido2CredentialAssertionRequest` to indicate if the user has been verified by the OS biometric prompt.
- Updated `Fido2IntentUtils` to extract the OS biometric prompt result from request data and include it in `isUserPreVerified`.
- Updated `MainViewModel` to set the user's verification status based on `isUserPreVerified` when a new FIDO 2 request is received.
- Updated FIDO2 logic in `VaultItemListingViewModel` and `VaultAddEditViewModel` to support new `Fido2GetCredentialsRequest`.
- Removed some redundant methods from `Fido2CredentialManagerImpl`.
- Added tests for `Fido2GetCredentialsRequest` handling in `VaultItemListingViewModel`.
- Updated tests to use new `isUserPreVerified` in `Fido2CreateCredentialRequest`.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
