### PR TITLE
[PM-20072] Migrate SendsApi to `network` module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SendsServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SendsServiceImpl.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.vault.datasource.network.service
 
 import androidx.core.net.toUri
 import com.bitwarden.network.api.AzureApi
+import com.bitwarden.network.api.SendsApi
 import com.bitwarden.network.model.CreateFileSendResponseJson
 import com.bitwarden.network.model.FileUploadType
 import com.bitwarden.network.model.SendJsonRequest
@@ -10,7 +11,6 @@ import com.bitwarden.network.model.toBitwardenError
 import com.bitwarden.network.util.NetworkErrorCode
 import com.bitwarden.network.util.parseErrorBodyOrNull
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.vault.datasource.network.api.SendsApi
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateFileSendResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateSendJsonResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateSendResponseJson

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SendsServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SendsServiceTest.kt
@@ -2,12 +2,12 @@ package com.x8bit.bitwarden.data.vault.datasource.network.service
 
 import android.net.Uri
 import com.bitwarden.network.api.AzureApi
+import com.bitwarden.network.api.SendsApi
 import com.bitwarden.network.base.BaseServiceTest
 import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.network.model.createMockFileSendResponseJson
 import com.bitwarden.network.model.createMockSend
 import com.bitwarden.network.model.createMockSendJsonRequest
-import com.x8bit.bitwarden.data.vault.datasource.network.api.SendsApi
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateFileSendResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateSendJsonResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateSendResponseJson

--- a/network/src/main/kotlin/com/bitwarden/network/api/SendsApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/SendsApi.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.api
+package com.bitwarden.network.api
 
 import androidx.annotation.Keep
 import com.bitwarden.network.model.CreateFileSendResponseJson


### PR DESCRIPTION
## 🎟️ Tracking

PM-20072

## 📔 Objective

The `SendsApi` interface has been moved from the `app` module to the `network` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
