### PR TITLE
[PM-20073] Migrate SyncApi to the network module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceImpl.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
+import com.bitwarden.network.api.SyncApi
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.vault.datasource.network.api.SyncApi
 
 class SyncServiceImpl(
     private val syncApi: SyncApi,

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/network/service/SyncServiceTest.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.service
 
+import com.bitwarden.network.api.SyncApi
 import com.bitwarden.network.base.BaseServiceTest
 import com.bitwarden.network.model.createMockSyncResponse
-import com.x8bit.bitwarden.data.vault.datasource.network.api.SyncApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/network/src/main/kotlin/com/bitwarden/network/api/SyncApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/SyncApi.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.api
+package com.bitwarden.network.api
 
 import com.bitwarden.network.model.NetworkResult
 import com.bitwarden.network.model.SyncResponseJson


### PR DESCRIPTION
## 🎟️ Tracking

PM-20073

## 📔 Objective

Moved `SyncApi` from the `app` module to the `network` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
