### PR TITLE
PM-20172: Display errors from WebAuthN results

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/WebAuthUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/util/WebAuthUtils.kt
@@ -27,7 +27,7 @@ fun Intent.getWebAuthResultOrNull(): WebAuthResult? {
         localData
             .getQueryParameter("data")
             ?.let { WebAuthResult.Success(token = it) }
-            ?: WebAuthResult.Failure
+            ?: WebAuthResult.Failure(message = localData.getQueryParameter("error"))
     } else {
         null
     }
@@ -74,5 +74,5 @@ sealed class WebAuthResult {
     /**
      * Represents a failure in the web auth callback.
      */
-    data object Failure : WebAuthResult()
+    data class Failure(val message: String?) : WebAuthResult()
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -404,11 +404,12 @@ class TwoFactorLoginViewModel @Inject constructor(
         action: TwoFactorLoginAction.Internal.ReceiveWebAuthResult,
     ) {
         when (val result = action.webAuthResult) {
-            WebAuthResult.Failure -> {
+            is WebAuthResult.Failure -> {
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
-                            message = R.string.generic_error_message.asText(),
+                            message = result.message?.asText()
+                                ?: R.string.generic_error_message.asText(),
                         ),
                     )
                 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/WebAuthUtilsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/util/WebAuthUtilsTest.kt
@@ -54,13 +54,15 @@ class WebAuthUtilsTest : BaseComposeTest() {
 
     @Test
     fun `getWebAuthResultOrNull should return Failure with missing data parameter`() {
+        val message = "An Error!"
         val intent = mockk<Intent> {
             every { data?.getQueryParameter("data") } returns null
+            every { data?.getQueryParameter("error") } returns message
             every { action } returns Intent.ACTION_VIEW
             every { data?.host } returns "webauthn-callback"
         }
         val result = intent.getWebAuthResultOrNull()
-        assertEquals(WebAuthResult.Failure, result)
+        assertEquals(WebAuthResult.Failure(message = message), result)
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -176,14 +176,30 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `webAuthResultFlow update with failure should display error dialog`() {
+    fun `webAuthResultFlow failure without message should display generic error dialog`() {
         val initialState = DEFAULT_STATE.copy(authMethod = TwoFactorAuthMethod.WEB_AUTH)
         val viewModel = createViewModel(state = initialState)
-        mutableWebAuthResultFlow.tryEmit(WebAuthResult.Failure)
+        mutableWebAuthResultFlow.tryEmit(WebAuthResult.Failure(message = null))
         assertEquals(
             initialState.copy(
                 dialogState = TwoFactorLoginState.DialogState.Error(
                     message = R.string.generic_error_message.asText(),
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `webAuthResultFlow failure with message should display error dialog with message`() {
+        val initialState = DEFAULT_STATE.copy(authMethod = TwoFactorAuthMethod.WEB_AUTH)
+        val viewModel = createViewModel(state = initialState)
+        val errorMessage = "An error"
+        mutableWebAuthResultFlow.tryEmit(WebAuthResult.Failure(message = errorMessage))
+        assertEquals(
+            initialState.copy(
+                dialogState = TwoFactorLoginState.DialogState.Error(
+                    message = errorMessage.asText(),
                 ),
             ),
             viewModel.stateFlow.value,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20172](https://bitwarden.atlassian.net/browse/PM-20172)

## 📔 Objective

This PR displays the error message from webAuthN responses to the user.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/eb685098-2fb0-4674-b366-c08a99bc9b36" width="300" /> | <img src="https://github.com/user-attachments/assets/e43c0290-4b28-41ec-9a28-97beb63cb7b9" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20172]: https://bitwarden.atlassian.net/browse/PM-20172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ