### PR TITLE
[PM-20508] Centralize passkey credential entry creation

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
@@ -16,6 +16,8 @@ import com.x8bit.bitwarden.data.autofill.fido2.processor.Fido2ProviderProcessorI
 import com.x8bit.bitwarden.data.platform.manager.AssetManager
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
@@ -41,8 +43,6 @@ object Fido2ProviderModule {
     fun provideCredentialProviderProcessor(
         @ApplicationContext context: Context,
         authRepository: AuthRepository,
-        vaultRepository: VaultRepository,
-        fido2CredentialStore: Fido2CredentialStore,
         fido2CredentialManager: Fido2CredentialManager,
         dispatcherManager: DispatcherManager,
         intentManager: IntentManager,
@@ -53,8 +53,6 @@ object Fido2ProviderModule {
         Fido2ProviderProcessorImpl(
             context,
             authRepository,
-            vaultRepository,
-            fido2CredentialStore,
             fido2CredentialManager,
             intentManager,
             clock,
@@ -66,14 +64,29 @@ object Fido2ProviderModule {
     @Provides
     @Singleton
     fun provideFido2CredentialManager(
+        @ApplicationContext context: Context,
+        intentManager: IntentManager,
+        featureFlagManager: FeatureFlagManager,
+        biometricsEncryptionManager: BiometricsEncryptionManager,
         vaultSdkSource: VaultSdkSource,
         fido2CredentialStore: Fido2CredentialStore,
         json: Json,
+        environmentRepository: EnvironmentRepository,
+        settingsRepository: SettingsRepository,
+        vaultRepository: VaultRepository,
+        dispatcherManager: DispatcherManager,
     ): Fido2CredentialManager =
         Fido2CredentialManagerImpl(
+            context = context,
             vaultSdkSource = vaultSdkSource,
             fido2CredentialStore = fido2CredentialStore,
+            intentManager = intentManager,
+            featureFlagManager = featureFlagManager,
+            biometricsEncryptionManager = biometricsEncryptionManager,
             json = json,
+            environmentRepository = environmentRepository,
+            vaultRepository = vaultRepository,
+            dispatcherManager = dispatcherManager,
         )
 
     @Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManager.kt
@@ -2,7 +2,9 @@ package com.x8bit.bitwarden.data.autofill.fido2.manager
 
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
 import androidx.credentials.provider.CallingAppInfo
+import androidx.credentials.provider.CredentialEntry
 import androidx.credentials.provider.ProviderGetCredentialRequest
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
@@ -94,4 +96,13 @@ interface Fido2CredentialManager {
         request: CreatePublicKeyCredentialRequest,
         fallbackRequirement: UserVerificationRequirement = UserVerificationRequirement.REQUIRED,
     ): UserVerificationRequirement
+
+    /**
+     * Retrieve a list of [CredentialEntry] objects representing vault items matching the given
+     * request [option].
+     */
+    suspend fun getPublicKeyCredentialEntries(
+        userId: String,
+        option: BeginGetPublicKeyCredentialOption,
+    ): Result<List<CredentialEntry>>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
@@ -1,42 +1,91 @@
 package com.x8bit.bitwarden.data.autofill.fido2.manager
 
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.annotation.WorkerThread
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.graphics.drawable.IconCompat
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.exceptions.GetCredentialUnknownException
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
+import androidx.credentials.provider.BiometricPromptData
 import androidx.credentials.provider.CallingAppInfo
+import androidx.credentials.provider.CredentialEntry
 import androidx.credentials.provider.ProviderGetCredentialRequest
+import androidx.credentials.provider.PublicKeyCredentialEntry
+import com.bitwarden.core.annotation.OmitFromCoverage
+import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.core.data.repository.util.takeUntilLoaded
+import com.bitwarden.core.data.util.asFailure
+import com.bitwarden.core.data.util.asSuccess
+import com.bitwarden.data.manager.DispatcherManager
+import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.fido.ClientData
+import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.fido.Origin
 import com.bitwarden.fido.UnverifiedAssetLink
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.vault.CipherView
+import com.bumptech.glide.Glide
+import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
+import com.x8bit.bitwarden.data.autofill.fido2.processor.GET_PASSKEY_INTENT
+import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
+import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.util.getAppOrigin
 import com.x8bit.bitwarden.data.platform.util.getAppSigningSignatureFingerprint
 import com.x8bit.bitwarden.data.platform.util.getSignatureFingerprintAsHexString
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.AuthenticateFido2CredentialRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.RegisterFido2CredentialRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.util.toAndroidAttestationResponse
 import com.x8bit.bitwarden.data.vault.datasource.sdk.util.toAndroidFido2PublicKeyCredential
+import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.data.vault.repository.model.DecryptFido2CredentialAutofillViewResult
 import com.x8bit.bitwarden.ui.platform.base.util.prefixHttpsIfNecessaryOrNull
+import com.x8bit.bitwarden.ui.platform.components.model.IconData
+import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.x8bit.bitwarden.ui.vault.feature.vault.util.toLoginIconData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import timber.log.Timber
+import java.util.concurrent.ExecutionException
+import javax.crypto.Cipher
+import kotlin.random.Random
 
 /**
  * Primary implementation of [Fido2CredentialManager].
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 class Fido2CredentialManagerImpl(
+    private val context: Context,
     private val vaultSdkSource: VaultSdkSource,
     private val fido2CredentialStore: Fido2CredentialStore,
+    private val intentManager: IntentManager,
+    private val featureFlagManager: FeatureFlagManager,
+    private val biometricsEncryptionManager: BiometricsEncryptionManager,
     private val json: Json,
+    private val vaultRepository: VaultRepository,
+    private val environmentRepository: EnvironmentRepository,
+    dispatcherManager: DispatcherManager,
 ) : Fido2CredentialManager,
     Fido2CredentialStore by fido2CredentialStore {
+
+    private val ioScope = CoroutineScope(dispatcherManager.io)
 
     override var isUserVerified: Boolean = false
 
@@ -167,6 +216,168 @@ class Fido2CredentialManagerImpl(
         ?.authenticatorSelection
         ?.userVerification
         ?: fallbackRequirement
+
+    override suspend fun getPublicKeyCredentialEntries(
+        userId: String,
+        option: BeginGetPublicKeyCredentialOption,
+    ): Result<List<CredentialEntry>> = withContext(ioScope.coroutineContext) {
+        val options = getPasskeyAssertionOptionsOrNull(option.requestJson)
+            ?: return@withContext GetCredentialUnknownException("Invalid data.").asFailure()
+        val relyingPartyId = options.relyingPartyId
+            ?: return@withContext GetCredentialUnknownException("Invalid data.").asFailure()
+
+        val cipherViews = vaultRepository
+            .ciphersStateFlow
+            .takeUntilLoaded()
+            .fold(initial = emptyList<CipherView>()) { initial, dataState ->
+                when (dataState) {
+                    is DataState.Loaded -> {
+                        dataState.data.filter { it.isActiveWithFido2Credentials }
+                    }
+
+                    else -> emptyList()
+                }
+            }
+
+        if (cipherViews.isEmpty()) {
+            return@withContext emptyList<CredentialEntry>().asSuccess()
+        }
+
+        val decryptResult = vaultRepository
+            .getDecryptedFido2CredentialAutofillViews(cipherViews)
+        when (decryptResult) {
+            is DecryptFido2CredentialAutofillViewResult.Error -> {
+                GetCredentialUnknownException("Error decrypting credentials.")
+                    .asFailure()
+            }
+
+            is DecryptFido2CredentialAutofillViewResult.Success -> {
+                val baseIconUrl = environmentRepository
+                    .environment
+                    .environmentUrlData
+                    .baseIconUrl
+                val autofillViews = decryptResult.fido2CredentialAutofillViews
+                    .filter { it.rpId == relyingPartyId }
+                if (autofillViews.isEmpty()) {
+                    return@withContext emptyList<CredentialEntry>().asSuccess()
+                }
+                val cipherIdsToMatch = autofillViews
+                    .map { it.cipherId }
+                    .toSet()
+
+                cipherViews
+                    .filter { cipherView -> cipherView.id in cipherIdsToMatch }
+                    .associateWith { cipherView ->
+                        autofillViews.first { it.cipherId == cipherView.id }
+                    }
+                    .toPublicKeyCredentialEntryList(
+                        baseIconUrl = baseIconUrl,
+                        userId = userId,
+                        option = option,
+                    )
+                    .asSuccess()
+            }
+        }
+    }
+
+    private suspend fun Map<CipherView, Fido2CredentialAutofillView>.toPublicKeyCredentialEntryList(
+        baseIconUrl: String,
+        userId: String,
+        option: BeginGetPublicKeyCredentialOption,
+    ): List<PublicKeyCredentialEntry> = this.map { (cipherView, autofillView) ->
+        val loginIconData = cipherView.login
+            ?.uris
+            .toLoginIconData(
+                // TODO: [PM-20176] Enable web icons in passkey credential entries
+                // Leave web icons disabled until CredentialManager TransactionTooLargeExceptions
+                // are addressed. See https://issuetracker.google.com/issues/355141766 for details.
+                isIconLoadingDisabled = true,
+                baseIconUrl = baseIconUrl,
+                usePasskeyDefaultIcon = true,
+            )
+        val iconCompat = when (loginIconData) {
+            is IconData.Local -> {
+                IconCompat.createWithResource(context, loginIconData.iconRes)
+            }
+
+            is IconData.Network -> {
+                loginIconData.toIconCompat()
+            }
+        }
+
+        val pkEntryBuilder = PublicKeyCredentialEntry
+            .Builder(
+                context = context,
+                username = autofillView.userNameForUi
+                    ?: context.getString(R.string.no_username),
+                pendingIntent = intentManager
+                    .createFido2GetCredentialPendingIntent(
+                        action = GET_PASSKEY_INTENT,
+                        userId = userId,
+                        credentialId = autofillView.credentialId.toString(),
+                        cipherId = autofillView.cipherId,
+                        isUserVerified = isUserVerified,
+                        requestCode = Random.nextInt(),
+                    ),
+                beginGetPublicKeyCredentialOption = option,
+            )
+            .setIcon(iconCompat.toIcon(context))
+
+        if (featureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)) {
+            biometricsEncryptionManager
+                .getOrCreateCipher(userId)
+                ?.let { cipher ->
+                    pkEntryBuilder
+                        .setBiometricPromptDataIfSupported(cipher = cipher)
+                }
+        }
+
+        pkEntryBuilder.build()
+    }
+
+    private fun PublicKeyCredentialEntry.Builder.setBiometricPromptDataIfSupported(
+        cipher: Cipher,
+    ): PublicKeyCredentialEntry.Builder =
+        if (isBuildVersionBelow(Build.VERSION_CODES.VANILLA_ICE_CREAM)) {
+            this
+        } else {
+            setBiometricPromptData(
+                biometricPromptData = buildPromptDataWithCipher(cipher),
+            )
+        }
+
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    private fun buildPromptDataWithCipher(
+        cipher: Cipher,
+    ): BiometricPromptData = BiometricPromptData.Builder()
+        .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+        .setCryptoObject(BiometricPrompt.CryptoObject(cipher))
+        .build()
+
+    /**
+     * Converts a network icon to an [IconCompat]. Performs a blocking network request to fetch the
+     * icon, so only call this method from a background thread or coroutine.
+     */
+    @OmitFromCoverage
+    @WorkerThread
+    private suspend fun IconData.Network.toIconCompat(): IconCompat = try {
+        val futureTargetBitmap = Glide
+            .with(context)
+            .asBitmap()
+            .load(this.uri)
+            .placeholder(R.drawable.ic_bw_passkey)
+            .submit()
+
+        IconCompat.createWithBitmap(futureTargetBitmap.get())
+    } catch (_: ExecutionException) {
+        null
+    } catch (_: InterruptedException) {
+        null
+    }
+        ?: IconCompat.createWithResource(
+            context,
+            this.fallbackIconRes,
+        )
 
     private suspend fun registerFido2CredentialForUnprivilegedApp(
         userId: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/processor/Fido2ProviderProcessorImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/processor/Fido2ProviderProcessorImpl.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.data.autofill.fido2.processor
 
 import android.content.Context
-import android.graphics.drawable.Icon
 import android.os.Build
 import android.os.CancellationSignal
 import android.os.OutcomeReceiver
@@ -28,27 +27,18 @@ import androidx.credentials.provider.BiometricPromptData
 import androidx.credentials.provider.CreateEntry
 import androidx.credentials.provider.CredentialEntry
 import androidx.credentials.provider.ProviderClearCredentialStateRequest
-import androidx.credentials.provider.PublicKeyCredentialEntry
-import com.bitwarden.core.data.repository.model.DataState
-import com.bitwarden.core.data.repository.util.takeUntilLoaded
+import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.data.manager.DispatcherManager
-import com.bitwarden.fido.Fido2CredentialAutofillView
-import com.bitwarden.sdk.Fido2CredentialStore
-import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
-import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
-import com.x8bit.bitwarden.data.vault.repository.VaultRepository
-import com.x8bit.bitwarden.data.vault.repository.model.DecryptFido2CredentialAutofillViewResult
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.launch
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
@@ -67,8 +57,6 @@ const val UNLOCK_ACCOUNT_INTENT = "com.x8bit.bitwarden.fido2.ACTION_UNLOCK_ACCOU
 class Fido2ProviderProcessorImpl(
     private val context: Context,
     private val authRepository: AuthRepository,
-    private val vaultRepository: VaultRepository,
-    private val fido2CredentialStore: Fido2CredentialStore,
     private val fido2CredentialManager: Fido2CredentialManager,
     private val intentManager: IntentManager,
     private val clock: Clock,
@@ -78,7 +66,7 @@ class Fido2ProviderProcessorImpl(
 ) : Fido2ProviderProcessor {
 
     private val requestCode = AtomicInteger()
-    private val scope = CoroutineScope(dispatcherManager.unconfined)
+    private val ioScope = CoroutineScope(dispatcherManager.io)
 
     override fun processCreateCredentialRequest(
         request: BeginCreateCredentialRequest,
@@ -91,7 +79,7 @@ class Fido2ProviderProcessorImpl(
             return
         }
 
-        val createCredentialJob = scope.launch {
+        val createCredentialJob = ioScope.launch {
             processCreateCredentialRequest(request = request)
                 ?.let { callback.onResult(it) }
                 ?: callback.onError(CreateCredentialUnknownException())
@@ -136,21 +124,17 @@ class Fido2ProviderProcessorImpl(
         }
 
         // Otherwise, find all matching credentials from the current vault.
-        val getCredentialJob = scope.launch {
-            try {
-                val credentialEntries = getMatchingFido2CredentialEntries(
-                    userId = userState.activeUserId,
-                    request = request,
-                )
-
-                callback.onResult(
-                    BeginGetCredentialResponse(
-                        credentialEntries = credentialEntries,
-                    ),
-                )
-            } catch (e: GetCredentialException) {
-                callback.onError(e)
-            }
+        val getCredentialJob = ioScope.launch {
+            getMatchingFido2CredentialEntries(
+                userId = userState.activeUserId,
+                request = request,
+            )
+                .onSuccess {
+                    callback.onResult(
+                        BeginGetCredentialResponse(credentialEntries = it),
+                    )
+                }
+                .onFailure { callback.onError(GetCredentialUnknownException(it.message)) }
         }
         cancellationSignal.setOnCancelListener {
             callback.onError(GetCredentialCancellationException())
@@ -230,109 +214,21 @@ class Fido2ProviderProcessorImpl(
         return entryBuilder.build()
     }
 
-    @Throws(GetCredentialUnsupportedException::class)
     private suspend fun getMatchingFido2CredentialEntries(
         userId: String,
         request: BeginGetCredentialRequest,
-    ): List<CredentialEntry> =
+    ): Result<List<CredentialEntry>> =
         request
             .beginGetCredentialOptions
-            .flatMap { option ->
-                if (option is BeginGetPublicKeyCredentialOption) {
-                    val relyingPartyId = fido2CredentialManager
-                        .getPasskeyAssertionOptionsOrNull(requestJson = option.requestJson)
-                        ?.relyingPartyId
-                        ?: throw GetCredentialUnknownException("Invalid data.")
-                    buildCredentialEntries(userId, relyingPartyId, option)
-                } else {
-                    throw GetCredentialUnsupportedException("Unsupported option.")
-                }
-            }
-
-    private suspend fun buildCredentialEntries(
-        userId: String,
-        relyingPartyId: String,
-        option: BeginGetPublicKeyCredentialOption,
-    ): List<CredentialEntry> {
-        val cipherViews = vaultRepository
-            .ciphersStateFlow
-            .takeUntilLoaded()
-            .fold(emptyList<CipherView>()) { _, dataState ->
-                when (dataState) {
-                    is DataState.Loaded -> dataState.data.filter { it.isActiveWithFido2Credentials }
-
-                    else -> emptyList()
-                }
-            }
-        val result = vaultRepository
-            .getDecryptedFido2CredentialAutofillViews(cipherViews)
-        return when (result) {
-            is DecryptFido2CredentialAutofillViewResult.Error -> {
-                throw GetCredentialUnknownException("Error decrypting credentials.")
-            }
-
-            is DecryptFido2CredentialAutofillViewResult.Success -> {
-                result
-                    .fido2CredentialAutofillViews
-                    .filter { it.rpId == relyingPartyId }
-                    .toCredentialEntries(
+            .firstNotNullOfOrNull { it as? BeginGetPublicKeyCredentialOption }
+            ?.let {
+                fido2CredentialManager
+                    .getPublicKeyCredentialEntries(
                         userId = userId,
-                        option = option,
+                        option = it,
                     )
             }
-        }
-    }
-
-    private fun List<Fido2CredentialAutofillView>.toCredentialEntries(
-        userId: String,
-        option: BeginGetPublicKeyCredentialOption,
-    ): List<CredentialEntry> =
-        this
-            .map {
-                val publicKeyEntryBuilder = PublicKeyCredentialEntry
-                    .Builder(
-                        context = context,
-                        username = it.userNameForUi ?: context.getString(R.string.no_username),
-                        pendingIntent = intentManager.createFido2GetCredentialPendingIntent(
-                            action = GET_PASSKEY_INTENT,
-                            userId = userId,
-                            credentialId = it.credentialId.toString(),
-                            cipherId = it.cipherId,
-                            requestCode = requestCode.getAndIncrement(),
-                        ),
-                        beginGetPublicKeyCredentialOption = option,
-                    )
-                    .setIcon(
-                        Icon.createWithResource(
-                            context,
-                            R.drawable.ic_bw_passkey,
-                        ),
-                    )
-
-                if (featureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)) {
-                    biometricsEncryptionManager
-                        .getOrCreateCipher(userId)
-                        ?.let {
-                            publicKeyEntryBuilder
-                                .setBiometricPromptDataIfSupported(cipher = it)
-                        }
-                }
-                publicKeyEntryBuilder.build()
-            }
-
-    private fun PublicKeyCredentialEntry.Builder.setBiometricPromptDataIfSupported(
-        cipher: Cipher,
-    ): PublicKeyCredentialEntry.Builder {
-        return if (isBuildVersionBelow(Build.VERSION_CODES.VANILLA_ICE_CREAM)) {
-            this
-        } else {
-            setBiometricPromptData(
-                biometricPromptData = BiometricPromptData
-                    .Builder()
-                    .buildPromptDataWithCipher(cipher),
-            )
-        }
-    }
+            ?: GetCredentialUnsupportedException("Unsupported option.").asFailure()
 
     private fun CreateEntry.Builder.setBiometricPromptDataIfSupported(
         cipher: Cipher,
@@ -341,15 +237,13 @@ class Fido2ProviderProcessorImpl(
             this
         } else {
             setBiometricPromptData(
-                biometricPromptData = BiometricPromptData
-                    .Builder()
-                    .buildPromptDataWithCipher(cipher),
+                biometricPromptData = buildPromptDataWithCipher(cipher),
             )
         }
     }
 
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
-    private fun BiometricPromptData.Builder.buildPromptDataWithCipher(
+    private fun buildPromptDataWithCipher(
         cipher: Cipher,
     ): BiometricPromptData = BiometricPromptData.Builder()
         .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtils.kt
@@ -13,6 +13,7 @@ import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_CIPHER_ID
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_CREDENTIAL_ID
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_USER_ID
+import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK
 
 /**
  * Checks if this [Intent] contains a [Fido2CreateCredentialRequest] related to an ongoing FIDO 2
@@ -28,11 +29,11 @@ fun Intent.getFido2CreateCredentialRequestOrNull(): Fido2CreateCredentialRequest
         ?: return null
 
     // Extract the OS biometric prompt result from the request data because it is not included in
-    // the bundle returned by `ProviderGetCredentialRequest.asBundle()`.
+    // the bundle returned by `ProviderCreateCredentialRequest.asBundle()`.
     val isUserPreVerified = systemRequest
         .biometricPromptResult
         ?.isSuccessful
-        ?: false
+        ?: getBooleanExtra(EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK, false)
 
     return Fido2CreateCredentialRequest(
         userId = userId,
@@ -66,7 +67,7 @@ fun Intent.getFido2AssertionRequestOrNull(): Fido2CredentialAssertionRequest? {
     val isUserPreVerified = systemRequest
         .biometricPromptResult
         ?.isSuccessful
-        ?: false
+        ?: getBooleanExtra(EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK, false)
 
     return Fido2CredentialAssertionRequest(
         userId = userId,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/model/GetFido2CredentialsResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/autofill/fido2/manager/model/GetFido2CredentialsResult.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.ui.autofill.fido2.manager.model
 
 import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
-import com.bitwarden.fido.Fido2CredentialAutofillView
+import androidx.credentials.provider.CredentialEntry
 import com.bitwarden.ui.util.Text
 
 /**
@@ -14,7 +14,7 @@ sealed class GetFido2CredentialsResult {
      * option, and associated user ID.
      */
     data class Success(
-        val credentials: List<Fido2CredentialAutofillView>,
+        val credentialEntries: List<CredentialEntry>,
         val option: BeginGetPublicKeyCredentialOption,
         val userId: String,
     ) : GetFido2CredentialsResult()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
@@ -76,7 +76,7 @@ private fun createFido2CompletionManager(
     if (isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
         Fido2CompletionManagerUnsupportedApiImpl
     } else {
-        Fido2CompletionManagerImpl(activity, intentManager)
+        Fido2CompletionManagerImpl(activity)
     }
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -128,11 +128,13 @@ interface IntentManager {
      * Creates a pending intent to use when providing
      * [androidx.credentials.provider.CredentialEntry] instances for FIDO 2 credential filling.
      */
+    @Suppress("LongParameterList")
     fun createFido2GetCredentialPendingIntent(
         action: String,
         userId: String,
         credentialId: String,
         cipherId: String,
+        isUserVerified: Boolean,
         requestCode: Int,
     ): PendingIntent
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -73,6 +73,11 @@ const val EXTRA_KEY_CREDENTIAL_ID: String = "credential_id"
 const val EXTRA_KEY_CIPHER_ID: String = "cipher_id"
 
 /**
+ * Key for the user verification performed during vault unlock while processing a FIDO 2 request.
+ */
+const val EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK: String = "uv_performed_during_unlock"
+
+/**
  * The default implementation of the [IntentManager] for simplifying the handling of Android
  * Intents within a given context.
  */
@@ -310,6 +315,7 @@ class IntentManagerImpl(
         userId: String,
         credentialId: String,
         cipherId: String,
+        isUserVerified: Boolean,
         requestCode: Int,
     ): PendingIntent {
         val intent = Intent(action)
@@ -317,6 +323,7 @@ class IntentManagerImpl(
             .putExtra(EXTRA_KEY_USER_ID, userId)
             .putExtra(EXTRA_KEY_CREDENTIAL_ID, credentialId)
             .putExtra(EXTRA_KEY_CIPHER_ID, cipherId)
+            .putExtra(EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK, isUserVerified)
 
         return PendingIntent.getActivity(
             /* context = */ context,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1583,7 +1583,7 @@ class VaultItemListingViewModel @Inject constructor(
         updateStateWithVaultData(vaultData = vaultData.data, clearDialogState = true)
 
         state.fido2GetCredentialsRequest
-            ?.let { handleFido2GetCredentialsRequest(it, vaultData.data) }
+            ?.let { handleFido2GetCredentialsRequest(it) }
             ?: state.fido2CredentialAssertionRequest
                 ?.let { request ->
                     trySendAction(
@@ -1701,9 +1701,9 @@ class VaultItemListingViewModel @Inject constructor(
         )
     }
 
+    @Suppress("LongMethod")
     private fun handleFido2GetCredentialsRequest(
         request: Fido2GetCredentialsRequest,
-        vaultData: VaultData,
     ) {
         val beginGetCredentialOption = request
             .beginGetPublicKeyCredentialOption
@@ -1743,10 +1743,13 @@ class VaultItemListingViewModel @Inject constructor(
                             GetFido2CredentialsResult.Success(
                                 userId = request.userId,
                                 option = beginGetCredentialOption,
-                                credentials = vaultData
-                                    .toFido2CredentialAutofillViews()
-                                    .orEmpty()
-                                    .filter { it.rpId == relyingPartyId },
+                                credentialEntries = fido2CredentialManager
+                                    .getPublicKeyCredentialEntries(
+                                        userId = request.userId,
+                                        option = beginGetCredentialOption,
+                                    )
+                                    .getOrNull()
+                                    .orEmpty(),
                             ),
                         ),
                     )

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerTest.kt
@@ -1,18 +1,29 @@
 package com.x8bit.bitwarden.data.autofill.fido2.manager
 
+import android.content.Context
 import android.content.pm.Signature
 import android.content.pm.SigningInfo
+import android.graphics.drawable.Icon
+import android.net.Uri
 import android.util.Base64
+import androidx.core.graphics.drawable.IconCompat
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.exceptions.GetCredentialUnknownException
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
 import androidx.credentials.provider.CallingAppInfo
+import androidx.credentials.provider.CredentialEntry
 import androidx.credentials.provider.ProviderGetCredentialRequest
+import androidx.credentials.provider.PublicKeyCredentialEntry
+import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.core.data.util.decodeFromStringOrNull
+import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
 import com.bitwarden.fido.ClientData
 import com.bitwarden.fido.Origin
 import com.bitwarden.fido.PublicKeyCredentialAuthenticatorAssertionResponse
 import com.bitwarden.fido.UnverifiedAssetLink
+import com.bitwarden.sdk.BitwardenException
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2AttestationResponse
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
@@ -21,24 +32,39 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResu
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
+import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
+import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.platform.util.getAppSigningSignatureFingerprint
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
+import com.x8bit.bitwarden.data.util.mockBuilder
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.AuthenticateFido2CredentialRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.RegisterFido2CredentialRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFido2CredentialAutofillView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockLoginView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPublicKeyAssertionResponse
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPublicKeyAttestationResponse
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFido2CredentialList
 import com.x8bit.bitwarden.data.vault.datasource.sdk.util.toAndroidFido2PublicKeyCredential
+import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.data.vault.repository.model.DecryptFido2CredentialAutofillViewResult
+import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAssertionOptions
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAttestationOptions
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkConstructor
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -96,6 +122,11 @@ class Fido2CredentialManagerTest {
     }
     private val mockVaultSdkSource = mockk<VaultSdkSource>()
     private val mockFido2CredentialStore = mockk<Fido2CredentialStore>()
+    private val mockIntentManager = mockk<IntentManager>()
+    private val mockVaultRepository = mockk<VaultRepository>()
+    private val mockFeatureFlagManager = mockk<FeatureFlagManager>()
+    private val mockBiometricsEncryptionManager = mockk<BiometricsEncryptionManager>()
+    private val fakeEnvironmentRepository = FakeEnvironmentRepository()
 
     @BeforeEach
     fun setUp() {
@@ -107,22 +138,33 @@ class Fido2CredentialManagerTest {
         every { Base64.encodeToString(any(), any()) } returns DEFAULT_APP_SIGNATURE
 
         fido2CredentialManager = Fido2CredentialManagerImpl(
+            context = mockk(relaxed = true),
             vaultSdkSource = mockVaultSdkSource,
             fido2CredentialStore = mockFido2CredentialStore,
             json = json,
+            intentManager = mockIntentManager,
+            dispatcherManager = FakeDispatcherManager(),
+            vaultRepository = mockVaultRepository,
+            featureFlagManager = mockFeatureFlagManager,
+            biometricsEncryptionManager = mockBiometricsEncryptionManager,
+            environmentRepository = fakeEnvironmentRepository,
         )
     }
 
     @AfterEach
     fun tearDown() {
         unmockkStatic(
-            MessageDigest::class,
             Base64::class,
+            IconCompat::class,
+            MessageDigest::class,
+            Uri::class,
         )
         unmockkStatic(
             PublicKeyCredentialAuthenticatorAssertionResponse::toAndroidFido2PublicKeyCredential,
             CallingAppInfo::getAppSigningSignatureFingerprint,
+            ::isBuildVersionBelow,
         )
+        unmockkConstructor(PublicKeyCredentialEntry.Builder::class)
     }
 
     @Test
@@ -901,6 +943,203 @@ class Fido2CredentialManagerTest {
                 ),
             )
         }
+
+    @Test
+    fun `getPublicKeyCredentialEntries should return empty list when cipherViews are empty`() =
+        runTest {
+            val mockBeginGetPublicKeyCredentialOption = mockk<BeginGetPublicKeyCredentialOption>()
+            every {
+                mockBeginGetPublicKeyCredentialOption.requestJson
+            } returns DEFAULT_FIDO2_AUTH_REQUEST_JSON
+            every {
+                mockVaultRepository.ciphersStateFlow
+            } returns MutableStateFlow(DataState.Loaded(emptyList()))
+            val result = fido2CredentialManager.getPublicKeyCredentialEntries(
+                "mockUserId",
+                mockBeginGetPublicKeyCredentialOption,
+            )
+            assertEquals(emptyList<CredentialEntry>(), result.getOrNull())
+        }
+
+    @Test
+    fun `getPublicKeyCredentialEntries should return error when decryption fails`() = runTest {
+        val mockBeginGetPublicKeyCredentialOption = mockk<BeginGetPublicKeyCredentialOption>()
+        every {
+            mockBeginGetPublicKeyCredentialOption.requestJson
+        } returns DEFAULT_FIDO2_AUTH_REQUEST_JSON
+        every {
+            mockVaultRepository.ciphersStateFlow
+        } returns MutableStateFlow(
+            DataState.Loaded(
+                listOf(
+                    createMockCipherView(
+                        number = 1,
+                        fido2Credentials = createMockSdkFido2CredentialList(number = 1),
+                    ),
+                ),
+            ),
+        )
+        coEvery {
+            mockVaultRepository.getDecryptedFido2CredentialAutofillViews(any())
+        } returns DecryptFido2CredentialAutofillViewResult.Error(
+            BitwardenException.E("Error decrypting credentials."),
+        )
+        val result = fido2CredentialManager.getPublicKeyCredentialEntries(
+            "mockUserId",
+            mockBeginGetPublicKeyCredentialOption,
+        )
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is GetCredentialUnknownException)
+    }
+
+    @Test
+    fun `getPublicKeyCredentialEntries should return error when assertion options are null`() =
+        runTest {
+            val mockRequest = mockk<BeginGetPublicKeyCredentialOption> {
+                every { requestJson } returns ""
+            }
+            every {
+                json.decodeFromString<PasskeyAssertionOptions>(any())
+            } throws SerializationException()
+            val result = fido2CredentialManager.getPublicKeyCredentialEntries(
+                "mockUserId",
+                mockRequest,
+            )
+            assertTrue(
+                result.exceptionOrNull() is GetCredentialUnknownException,
+            )
+        }
+
+    @Test
+    fun `getPublicKeyCredentialEntries should return error when relyingPartyId is null`() =
+        runTest {
+            val mockRequest = mockk<BeginGetPublicKeyCredentialOption> {
+                every { requestJson } returns ""
+            }
+            every {
+                json.decodeFromString<PasskeyAssertionOptions>(any())
+            } returns createMockPasskeyAssertionOptions(number = 1, relyingPartyId = null)
+            val result = fido2CredentialManager.getPublicKeyCredentialEntries(
+                "mockUserId",
+                mockRequest,
+            )
+            assertTrue(
+                result.exceptionOrNull() is GetCredentialUnknownException,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getPublicKeyCredentialEntries should return list of PublicKeyCredentialEntry when decryption succeeds`() =
+        runTest {
+            setupMockUri()
+            mockkStatic(IconCompat::class)
+            mockkStatic(::isBuildVersionBelow)
+            mockkConstructor(PublicKeyCredentialEntry.Builder::class)
+            every {
+                anyConstructed<PublicKeyCredentialEntry.Builder>().build()
+            } returns mockk()
+            val mockBeginGetPublicKeyCredentialOption = mockk<BeginGetPublicKeyCredentialOption>()
+            every {
+                mockBeginGetPublicKeyCredentialOption.requestJson
+            } returns DEFAULT_FIDO2_AUTH_REQUEST_JSON
+            every {
+                mockVaultRepository.ciphersStateFlow
+            } returns MutableStateFlow(
+                DataState.Loaded(
+                    listOf(
+                        createMockCipherView(
+                            number = 1,
+                            login = createMockLoginView(number = 1, hasUris = false),
+                            fido2Credentials = createMockSdkFido2CredentialList(number = 1),
+                        ),
+                    ),
+                ),
+            )
+            coEvery {
+                mockVaultRepository.getDecryptedFido2CredentialAutofillViews(any())
+            } returns DecryptFido2CredentialAutofillViewResult.Success(
+                listOf(
+                    createMockFido2CredentialAutofillView(
+                        number = 1,
+                        cipherId = "mockId-1",
+                        rpId = "mockRelyingPartyId-1",
+                    ),
+                ),
+            )
+            val mockIcon = mockk<Icon>()
+            every {
+                IconCompat.createWithResource(any<Context>(), any<Int>())
+            } returns mockk {
+                every { toIcon(any()) } returns mockIcon
+            }
+            every {
+                mockIntentManager.createFido2GetCredentialPendingIntent(
+                    action = "com.x8bit.bitwarden.fido2.ACTION_GET_PASSKEY",
+                    userId = "mockUserId",
+                    credentialId = any(),
+                    cipherId = "mockId-1",
+                    isUserVerified = false,
+                    requestCode = any(),
+                )
+            } returns mockk()
+            every {
+                mockBiometricsEncryptionManager.getOrCreateCipher("mockUserId")
+            } returns mockk()
+            every {
+                mockFeatureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)
+            } returns false
+            mockBuilder<PublicKeyCredentialEntry.Builder> { it.setIcon(mockIcon) }
+            mockBuilder<PublicKeyCredentialEntry.Builder> { it.setBiometricPromptData(any()) }
+            val result = fido2CredentialManager.getPublicKeyCredentialEntries(
+                "mockUserId",
+                mockBeginGetPublicKeyCredentialOption,
+            )
+            assertTrue(result.isSuccess)
+            assertEquals(1, result.getOrNull()?.size)
+            assertTrue(result.getOrNull()?.first() is PublicKeyCredentialEntry)
+            verify {
+                anyConstructed<PublicKeyCredentialEntry.Builder>().setIcon(mockIcon)
+            }
+            verify(exactly = 0) {
+                anyConstructed<PublicKeyCredentialEntry.Builder>().setBiometricPromptData(any())
+            }
+
+            // Verify biometric prompt data IS NOT set when single tap feature flag is enabled and
+            // build version is < 35
+            every {
+                mockFeatureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)
+            } returns true
+            every { isBuildVersionBelow(35) } returns true
+            fido2CredentialManager.getPublicKeyCredentialEntries(
+                "mockUserId",
+                mockBeginGetPublicKeyCredentialOption,
+            )
+            verify(exactly = 0) {
+                anyConstructed<PublicKeyCredentialEntry.Builder>().setBiometricPromptData(any())
+            }
+
+            // Verify biometric prompt data IS set when single tap feature flag is enabled and build
+            // version is 35+
+            every {
+                mockFeatureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)
+            } returns true
+            every { isBuildVersionBelow(35) } returns false
+            fido2CredentialManager.getPublicKeyCredentialEntries(
+                "mockUserId",
+                mockBeginGetPublicKeyCredentialOption,
+            )
+            verify {
+                anyConstructed<PublicKeyCredentialEntry.Builder>().setBiometricPromptData(any())
+            }
+        }
+
+    private fun setupMockUri() {
+        mockkStatic(Uri::class)
+        val uriMock = mockk<Uri>()
+        every { Uri.parse(any()) } returns uriMock
+        every { uriMock.host } returns "www.mockuri.com"
+    }
 }
 
 private const val DEFAULT_PACKAGE_NAME = "com.x8bit.bitwarden"

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtilsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/util/Fido2IntentUtilsTest.kt
@@ -11,6 +11,7 @@ import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_CIPHER_ID
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_CREDENTIAL_ID
 import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_USER_ID
+import com.x8bit.bitwarden.ui.platform.manager.intent.EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -100,8 +102,18 @@ class Fido2IntentUtilsTest {
         createRequest = intent.getFido2CreateCredentialRequestOrNull()
         assert(createRequest!!.isUserPreVerified)
 
-        // Verify false is returned when biometric prompt result is null
+        // Verify true is returned when biometric prompt result is null and intent extra is true
         every { mockProviderCreateCredentialRequest.biometricPromptResult } returns null
+        every {
+            intent.getBooleanExtra(EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK, false)
+        } returns true
+        createRequest = intent.getFido2CreateCredentialRequestOrNull()
+        assertTrue(createRequest!!.isUserPreVerified)
+
+        // Verify false is returned when biometric prompt result is null and intent extra is false
+        every {
+            intent.getBooleanExtra(EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK, false)
+        } returns false
         createRequest = intent.getFido2CreateCredentialRequestOrNull()
         assertFalse(createRequest!!.isUserPreVerified)
     }
@@ -169,6 +181,9 @@ class Fido2IntentUtilsTest {
             every { getStringExtra(EXTRA_KEY_USER_ID) } returns "mockUserId"
             every { getStringExtra(EXTRA_KEY_CIPHER_ID) } returns "mockCipherId"
             every { getStringExtra(EXTRA_KEY_CREDENTIAL_ID) } returns "mockCredentialId"
+            every {
+                getBooleanExtra(EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK, false)
+            } returns false
         }
         val mockBiometricPromptResult = mockk<BiometricPromptResult>(relaxed = true) {
             every { isSuccessful } returns false

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherViewUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherViewUtil.kt
@@ -50,6 +50,12 @@ fun createMockCipherView(
     clock: Clock = FIXED_CLOCK,
     fido2Credentials: List<Fido2Credential>? = null,
     sshKey: SshKeyView? = createMockSshKeyView(number = number),
+    login: LoginView? = createMockLoginView(
+        number = number,
+        totp = totp,
+        clock = clock,
+        fido2Credentials = fido2Credentials,
+    ),
 ): CipherView =
     CipherView(
         id = "mockId-$number",
@@ -60,13 +66,7 @@ fun createMockCipherView(
         name = "mockName-$number",
         notes = "mockNotes-$number",
         type = cipherType,
-        login = createMockLoginView(
-            number = number,
-            totp = totp,
-            clock = clock,
-            fido2Credentials = fido2Credentials,
-        )
-            .takeIf { cipherType == CipherType.LOGIN },
+        login = login.takeIf { cipherType == CipherType.LOGIN },
         creationDate = clock.instant(),
         deletedDate = if (isDeleted) {
             clock.instant()
@@ -98,6 +98,7 @@ fun createMockLoginView(
     number: Int,
     totp: String? = "mockTotp-$number",
     clock: Clock = FIXED_CLOCK,
+    hasUris: Boolean = true,
     fido2Credentials: List<Fido2Credential>? = createMockSdkFido2CredentialList(number, clock),
 ): LoginView =
     LoginView(
@@ -105,7 +106,7 @@ fun createMockLoginView(
         password = "mockPassword-$number",
         passwordRevisionDate = clock.instant(),
         autofillOnPageLoad = false,
-        uris = listOf(createMockUriView(number = number)),
+        uris = listOf(createMockUriView(number = number)).takeIf { hasUris },
         totp = totp,
         fido2Credentials = fido2Credentials,
     )
@@ -116,13 +117,14 @@ fun createMockLoginView(
 fun createMockSdkFido2CredentialList(
     number: Int,
     clock: Clock = FIXED_CLOCK,
-): List<Fido2Credential> = listOf(createMockSdkFido2Credential(number, clock))
+): List<Fido2Credential> = listOf(createMockSdkFido2Credential(number = number, clock = clock))
 
 /**
  * Create a mock [Fido2Credential] with a given [number].
  */
 fun createMockSdkFido2Credential(
     number: Int,
+    rpId: String = "mockRpId-$number",
     clock: Clock = FIXED_CLOCK,
 ): Fido2Credential = Fido2Credential(
     credentialId = "mockCredentialId-$number",
@@ -130,7 +132,7 @@ fun createMockSdkFido2Credential(
     keyAlgorithm = "mockKeyAlgorithm-$number",
     keyCurve = "mockKeyCurve-$number",
     keyValue = "mockKeyValue-$number",
-    rpId = "mockRpId-$number",
+    rpId = rpId,
     userHandle = "mockUserHandle-$number",
     userName = "mockUserName-$number",
     counter = "mockCounter-$number",
@@ -146,11 +148,12 @@ fun createMockSdkFido2Credential(
 fun createMockFido2CredentialAutofillView(
     number: Int,
     cipherId: String? = null,
+    rpId: String = "mockRpId-$number",
 ): Fido2CredentialAutofillView =
     Fido2CredentialAutofillView(
         credentialId = "mockCredentialId-$number".encodeToByteArray(),
         cipherId = cipherId ?: "mockCipherId-$number",
-        rpId = "mockRpId-$number",
+        rpId = rpId,
         userNameForUi = "mockUserNameForUi-$number",
         userHandle = "mockUserHandle-$number".encodeToByteArray(),
     )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -1275,8 +1275,11 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `on ReceiveVaultUnlockResult should set FIDO 2 user verification state to verified when result is Success`() {
-        val viewModel = createViewModel()
-
+        val viewModel = createViewModel(
+            state = DEFAULT_STATE.copy(
+                fido2GetCredentialsRequest = mockk(relaxed = true),
+            ),
+        )
         viewModel.trySendAction(
             VaultUnlockAction.Internal.ReceiveVaultUnlockResult(
                 userId = "activeUserId",

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -1926,7 +1926,7 @@ class VaultItemListingScreenTest : BaseComposeTest() {
         val result = GetFido2CredentialsResult.Success(
             userId = "mockUserId",
             option = mockk(),
-            credentials = mockk(),
+            credentialEntries = mockk(),
         )
         mutableEventFlow.tryEmit(VaultItemListingEvent.CompleteFido2GetCredentialsRequest(result))
         verify {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -8,9 +8,11 @@ import androidx.credentials.provider.BeginGetCredentialRequest
 import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
 import androidx.credentials.provider.ProviderCreateCredentialRequest
 import androidx.credentials.provider.ProviderGetCredentialRequest
+import androidx.credentials.provider.PublicKeyCredentialEntry
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseIconUrl
@@ -39,6 +41,7 @@ import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CreateCredentialReques
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
+import com.x8bit.bitwarden.data.autofill.fido2.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.autofill.fido2.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CreateCredentialRequest
 import com.x8bit.bitwarden.data.autofill.fido2.model.createMockFido2CredentialAssertionRequest
@@ -3030,13 +3033,20 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 number = 1,
                 fido2Credentials = mockFido2CredentialsList,
             )
+            val mockPasskeyAssertionOptions = mockk<PasskeyAssertionOptions>(relaxed = true)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.Fido2GetCredentials(
                     mockGetCredentialsRequest,
                 )
             every {
                 fido2CredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns mockk(relaxed = true)
+            } returns mockPasskeyAssertionOptions
+            coEvery {
+                fido2CredentialManager.getPublicKeyCredentialEntries(
+                    userId = "mockUserId-1",
+                    option = mockBeginGetPublicKeyCredentialOption,
+                )
+            } returns emptyList<PublicKeyCredentialEntry>().asSuccess()
             coEvery {
                 fido2OriginManager.validateOrigin(
                     callingAppInfo = any(),
@@ -3068,7 +3078,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         result = GetFido2CredentialsResult.Success(
                             userId = "mockUserId-1",
                             option = mockBeginGetPublicKeyCredentialOption,
-                            credentials = emptyList(),
+                            credentialEntries = emptyList(),
                         ),
                     ),
                     awaitItem(),


### PR DESCRIPTION
## 🎟️ Tracking

Resolves PM-20176
Resolves PM-20127

## 📔 Objective

Move the responsibility of building credential entries from `Fido2ProviderProcessor` to `Fido2CredentialManager`. This change centralizes the credential handling and simplifies the code in `Fido2ProviderProcessor` by delegating this task.

Key changes:

- **Fido2CredentialManager:**
    - Implemented `getCredentialEntries()` to handle the retrieval and creation of `CredentialEntry` objects.
    - Now uses the `VaultRepository` to fetch and decrypt credential data.
    - Uses `EnvironmentRepository` to get base icon url.
    - Now uses Glide for network image loading (currently disabled).
    - Includes logic to handle biometric prompts.
- **Fido2ProviderProcessor:**
    - Removed the logic for building `CredentialEntry`.
    - Now relies on `Fido2CredentialManager` to provide the credential entries.
    - Updated logic in `handleFido2GetCredentialsRequest` to delegate credential retrieval to manager.
- **Fido2CompletionManager:**
    - Updated to use `CredentialEntry`.
    - Updated logic to use new `GetFido2CredentialsResult`.
- **VaultItemListingViewModel:**
    - Updated logic in `handleFido2GetCredentialsRequest` to delegate credential retrieval to manager.
- **Tests:**
    - Updated unit tests to reflect the changes in `Fido2ProviderProcessor`, `VaultItemListingScreenTest`, and `Fido2CompletionManager`.
- **Dependencies:**
    - Removed redundant dependencies.
- **Cleanup:**
    - Removed unnecessary code and comments.
- **Module dependency:**
    - Added dispatcher and environment modules dependencies to Fido2Provider module.
- **LocalManagerProvider:**
   - `Fido2CompletionManager` doesn't need `IntentManager` anymore.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
