### PR TITLE
[PM-20186] Migrate AuthRequestsService to the network module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/di/AuthNetworkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/datasource/network/di/AuthNetworkModule.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.data.auth.datasource.network.di
 
+import com.bitwarden.network.service.AuthRequestsService
+import com.bitwarden.network.service.AuthRequestsServiceImpl
 import com.x8bit.bitwarden.data.auth.datasource.network.service.AccountsService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.AccountsServiceImpl
-import com.x8bit.bitwarden.data.auth.datasource.network.service.AuthRequestsService
-import com.x8bit.bitwarden.data.auth.datasource.network.service.AuthRequestsServiceImpl
 import com.x8bit.bitwarden.data.auth.datasource.network.service.DevicesService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.DevicesServiceImpl
 import com.x8bit.bitwarden.data.auth.datasource.network.service.HaveIBeenPwnedService

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerImpl.kt
@@ -5,9 +5,9 @@ import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.core.data.util.flatMap
 import com.bitwarden.network.model.AuthRequestTypeJson
+import com.bitwarden.network.service.AuthRequestsService
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.PendingAuthRequestJson
-import com.x8bit.bitwarden.data.auth.datasource.network.service.AuthRequestsService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.NewAuthRequestService
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequest

--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
@@ -2,9 +2,9 @@ package com.x8bit.bitwarden.data.auth.manager.di
 
 import android.content.Context
 import com.bitwarden.data.manager.DispatcherManager
+import com.bitwarden.network.service.AuthRequestsService
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.network.service.AccountsService
-import com.x8bit.bitwarden.data.auth.datasource.network.service.AuthRequestsService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.DevicesService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.NewAuthRequestService
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/manager/AuthRequestManagerTest.kt
@@ -7,12 +7,12 @@ import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.network.model.AuthRequestTypeJson
 import com.bitwarden.network.model.AuthRequestsResponseJson
 import com.bitwarden.network.model.KdfTypeJson
+import com.bitwarden.network.service.AuthRequestsService
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.PendingAuthRequestJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
-import com.x8bit.bitwarden.data.auth.datasource.network.service.AuthRequestsService
 import com.x8bit.bitwarden.data.auth.datasource.network.service.NewAuthRequestService
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequest

--- a/network/src/main/kotlin/com/bitwarden/network/service/AuthRequestsService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/AuthRequestsService.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.service
+package com.bitwarden.network.service
 
 import com.bitwarden.network.model.AuthRequestsResponseJson
 

--- a/network/src/main/kotlin/com/bitwarden/network/service/AuthRequestsServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/AuthRequestsServiceImpl.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.service
+package com.bitwarden.network.service
 
 import com.bitwarden.network.api.AuthenticatedAuthRequestsApi
 import com.bitwarden.network.model.AuthRequestUpdateRequestJson

--- a/network/src/test/kotlin/com/bitwarden/network/service/AuthRequestsServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/AuthRequestsServiceTest.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.auth.datasource.network.service
+package com.bitwarden.network.service
 
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.network.api.AuthenticatedAuthRequestsApi


### PR DESCRIPTION
## 🎟️ Tracking

PM-20186

## 📔 Objective

Moved `AuthRequestsService` and `AuthRequestsServiceImpl` from the `app` module to the `network` module. Updated all usages of `AuthRequestsService` and related tests to use the new implementation in `network`. Removed the service and its implementation from the `app` module. Added `AuthRequestsService` and `AuthRequestsServiceImpl` to `network`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
