### PR TITLE
PM-19593: Display all flight recorder logs

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/model/FlightRecorderDataSet.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/disk/model/FlightRecorderDataSet.kt
@@ -42,5 +42,8 @@ data class FlightRecorderDataSet(
 
         @SerialName("isActive")
         val isActive: Boolean,
+
+        @SerialName("expirationTime")
+        val expirationTimeMs: Long? = null,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/FileExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/FileExtensions.kt
@@ -1,0 +1,10 @@
+package com.x8bit.bitwarden.data.platform.util
+
+import com.bitwarden.core.annotation.OmitFromCoverage
+import java.io.File
+
+/**
+ * A helper function for creating a file from a path.
+ */
+@OmitFromCoverage
+fun fileOf(path: String): File = File(path)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
@@ -1,25 +1,48 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
+import com.x8bit.bitwarden.ui.platform.base.util.cardStyle
+import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.x8bit.bitwarden.ui.platform.base.util.toListItemCardStyle
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
+import com.x8bit.bitwarden.ui.platform.components.appbar.action.BitwardenOverflowActionItem
+import com.x8bit.bitwarden.ui.platform.components.appbar.action.OverflowMenuItemData
 import com.x8bit.bitwarden.ui.platform.components.content.BitwardenEmptyContent
 import com.x8bit.bitwarden.ui.platform.components.content.BitwardenLoadingContent
+import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
+import kotlinx.collections.immutable.persistentListOf
 
 /**
  * Displays the flight recorder recorded logs screen.
@@ -47,13 +70,32 @@ fun RecordedLogsScreen(
                     { viewModel.trySendAction(RecordedLogsAction.BackClick) }
                 },
                 scrollBehavior = scrollBehavior,
+                actions = {
+                    RecordedLogsOverflowMenu(
+                        isOverflowEnabled = state.viewState.isOverflowEnabled,
+                        onDeleteAllClick = remember(viewModel) {
+                            { viewModel.trySendAction(RecordedLogsAction.DeleteAllClick) }
+                        },
+                        onShareAllClick = remember(viewModel) {
+                            { viewModel.trySendAction(RecordedLogsAction.ShareAllClick) }
+                        },
+                    )
+                },
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
     ) {
-        when (state.viewState) {
-            RecordedLogsState.ViewState.Content -> {
-                // TODO: PM-19593 Create the flight recorder UI.
+        when (val viewState = state.viewState) {
+            is RecordedLogsState.ViewState.Content -> {
+                RecordedLogsContent(
+                    viewState = viewState,
+                    onShareItemClick = remember(viewModel) {
+                        { viewModel.trySendAction(RecordedLogsAction.ShareClick(it)) }
+                    },
+                    onDeleteItemClick = remember(viewModel) {
+                        { viewModel.trySendAction(RecordedLogsAction.DeleteClick(it)) }
+                    },
+                )
             }
 
             RecordedLogsState.ViewState.Empty -> {
@@ -68,5 +110,138 @@ fun RecordedLogsScreen(
                 BitwardenLoadingContent(modifier = Modifier.fillMaxSize())
             }
         }
+    }
+}
+
+@Composable
+private fun RecordedLogsOverflowMenu(
+    isOverflowEnabled: Boolean,
+    onDeleteAllClick: () -> Unit,
+    onShareAllClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BitwardenOverflowActionItem(
+        modifier = modifier,
+        menuItemDataList = persistentListOf(
+            OverflowMenuItemData(
+                text = stringResource(id = R.string.share_all),
+                onClick = onShareAllClick,
+                isEnabled = isOverflowEnabled,
+            ),
+            OverflowMenuItemData(
+                text = stringResource(id = R.string.delete_all),
+                onClick = onDeleteAllClick,
+                isEnabled = isOverflowEnabled,
+                color = BitwardenTheme.colorScheme.status.error,
+            ),
+        ),
+    )
+}
+
+@Composable
+private fun RecordedLogsContent(
+    viewState: RecordedLogsState.ViewState.Content,
+    onDeleteItemClick: (RecordedLogsState.DisplayItem) -> Unit,
+    onShareItemClick: (RecordedLogsState.DisplayItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier) {
+        item(key = "top_spacer") {
+            Spacer(modifier = Modifier.height(height = 12.dp))
+        }
+
+        itemsIndexed(
+            items = viewState.items,
+            key = { _, item -> item.toString() },
+        ) { index, item ->
+            LogRow(
+                displayableItem = item,
+                cardStyle = viewState.items.toListItemCardStyle(index = index),
+                onDeleteItemClick = onDeleteItemClick,
+                onShareItemClick = onShareItemClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+        }
+
+        item(key = "bottom_spacer") {
+            Spacer(modifier = Modifier.height(height = 16.dp))
+            Spacer(modifier = Modifier.navigationBarsPadding())
+        }
+    }
+}
+
+@Suppress("LongMethod")
+@Composable
+private fun LogRow(
+    displayableItem: RecordedLogsState.DisplayItem,
+    onDeleteItemClick: (RecordedLogsState.DisplayItem) -> Unit,
+    onShareItemClick: (RecordedLogsState.DisplayItem) -> Unit,
+    cardStyle: CardStyle,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .defaultMinSize(minHeight = 60.dp)
+            .cardStyle(
+                cardStyle = cardStyle,
+                paddingTop = 12.dp,
+                paddingBottom = 12.dp,
+                paddingStart = 16.dp,
+                paddingEnd = 4.dp,
+            ),
+    ) {
+        Column(modifier = Modifier.weight(weight = 1f)) {
+            Text(
+                text = displayableItem.title(),
+                style = BitwardenTheme.typography.bodyLarge,
+                color = BitwardenTheme.colorScheme.text.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(height = 2.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = displayableItem.subtextStart(),
+                    style = BitwardenTheme.typography.bodyMedium,
+                    color = BitwardenTheme.colorScheme.text.secondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(weight = 1f),
+                )
+                displayableItem.subtextEnd?.let {
+                    Spacer(modifier = Modifier.width(width = 4.dp))
+                    Text(
+                        text = it(),
+                        style = BitwardenTheme.typography.bodyMedium,
+                        color = BitwardenTheme.colorScheme.text.secondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.End,
+                        modifier = Modifier.weight(weight = 1f),
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.width(width = 12.dp))
+        BitwardenOverflowActionItem(
+            menuItemDataList = persistentListOf(
+                OverflowMenuItemData(
+                    text = stringResource(id = R.string.share),
+                    onClick = { onShareItemClick(displayableItem) },
+                ),
+                OverflowMenuItemData(
+                    text = stringResource(id = R.string.delete),
+                    onClick = { onDeleteItemClick(displayableItem) },
+                    color = BitwardenTheme.colorScheme.status.error,
+                    isEnabled = displayableItem.isDeletedEnabled,
+                ),
+            ),
+            vectorIconRes = R.drawable.ic_ellipsis_horizontal,
+            testTag = "Options",
+        )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsViewModel.kt
@@ -1,8 +1,20 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.bitwarden.ui.util.Text
+import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.vault.manager.FileManager
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.util.toViewState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import java.time.Clock
 import javax.inject.Inject
 
 private const val KEY_STATE = "state"
@@ -12,22 +24,80 @@ private const val KEY_STATE = "state"
  */
 @HiltViewModel
 class RecordedLogsViewModel @Inject constructor(
+    private val clock: Clock,
+    private val settingsRepository: SettingsRepository,
+    fileManager: FileManager,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<RecordedLogsState, RecordedLogsEvent, RecordedLogsAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
         ?: RecordedLogsState(
             viewState = RecordedLogsState.ViewState.Loading,
+            logsFolder = fileManager.logsDirectory,
         ),
 ) {
+    init {
+        settingsRepository
+            .flightRecorderDataFlow
+            .map { RecordedLogsAction.Internal.OnReceiveFlightRecorderData(it) }
+            .onEach(::sendAction)
+            .launchIn(scope = viewModelScope)
+    }
+
     override fun handleAction(action: RecordedLogsAction) {
         when (action) {
             RecordedLogsAction.BackClick -> handleBackClick()
+            RecordedLogsAction.DeleteAllClick -> handleDeleteAllClick()
+            is RecordedLogsAction.DeleteClick -> handleDeleteClick(action)
+            is RecordedLogsAction.ShareClick -> handleShareClick(action)
+            RecordedLogsAction.ShareAllClick -> handleShareAllClick()
+            is RecordedLogsAction.Internal -> handleInternalAction(action)
         }
     }
 
     private fun handleBackClick() {
         sendEvent(RecordedLogsEvent.NavigateBack)
+    }
+
+    private fun handleDeleteAllClick() {
+        settingsRepository.deleteAllLogs()
+    }
+
+    private fun handleDeleteClick(action: RecordedLogsAction.DeleteClick) {
+        settingsRepository
+            .flightRecorderData
+            .data
+            .find { it.id == action.item.id }
+            ?.let { settingsRepository.deleteLog(data = it) }
+    }
+
+    private fun handleShareAllClick() {
+        // TODO: PM-19622 Add logic for sharing the logs
+    }
+
+    private fun handleShareClick(action: RecordedLogsAction.ShareClick) {
+        // TODO: PM-19622 Add logic for sharing the logs
+    }
+
+    private fun handleInternalAction(action: RecordedLogsAction.Internal) {
+        when (action) {
+            is RecordedLogsAction.Internal.OnReceiveFlightRecorderData -> {
+                handleOnReceiveFlightRecorderData(action)
+            }
+        }
+    }
+
+    private fun handleOnReceiveFlightRecorderData(
+        action: RecordedLogsAction.Internal.OnReceiveFlightRecorderData,
+    ) {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = action.flightRecorderData.toViewState(
+                    clock = clock,
+                    logsFolder = state.logsFolder,
+                ),
+            )
+        }
     }
 }
 
@@ -36,26 +106,51 @@ class RecordedLogsViewModel @Inject constructor(
  */
 data class RecordedLogsState(
     val viewState: ViewState,
+    val logsFolder: String,
 ) {
     /**
      * View states for the [RecordedLogsViewModel].
      */
     sealed class ViewState {
         /**
+         * Indicates if the overflow items should be enabled.
+         */
+        abstract val isOverflowEnabled: Boolean
+
+        /**
          * Represents the loading state for the [RecordedLogsViewModel].
          */
-        data object Loading : ViewState()
+        data object Loading : ViewState() {
+            override val isOverflowEnabled: Boolean get() = false
+        }
 
         /**
          * Represents the empty state for the [RecordedLogsViewModel].
          */
-        data object Empty : ViewState()
+        data object Empty : ViewState() {
+            override val isOverflowEnabled: Boolean get() = false
+        }
 
         /**
          * Represents the content state for the [RecordedLogsViewModel].
          */
-        data object Content : ViewState()
+        data class Content(
+            val items: ImmutableList<DisplayItem>,
+        ) : ViewState() {
+            override val isOverflowEnabled: Boolean get() = true
+        }
     }
+
+    /**
+     * Wrapper class for all displayable data in a row.
+     */
+    data class DisplayItem(
+        val id: String,
+        val title: Text,
+        val subtextStart: Text,
+        val subtextEnd: Text?,
+        val isDeletedEnabled: Boolean,
+    )
 }
 
 /**
@@ -76,4 +171,40 @@ sealed class RecordedLogsAction {
      * Indicates that the user clicked the close button.
      */
     data object BackClick : RecordedLogsAction()
+
+    /**
+     * Indicates that the user clicked the delete all button.
+     */
+    data object DeleteAllClick : RecordedLogsAction()
+
+    /**
+     * Indicates that the user clicked the delete button for a specific item.
+     */
+    data class DeleteClick(
+        val item: RecordedLogsState.DisplayItem,
+    ) : RecordedLogsAction()
+
+    /**
+     * Indicates that the user clicked the share all button.
+     */
+    data object ShareAllClick : RecordedLogsAction()
+
+    /**
+     * Indicates that the user clicked the share button for a specific item.
+     */
+    data class ShareClick(
+        val item: RecordedLogsState.DisplayItem,
+    ) : RecordedLogsAction()
+
+    /**
+     * Actions for internal use by the ViewModel.
+     */
+    sealed class Internal : RecordedLogsAction() {
+        /**
+         * Indicates that the log data has changed.
+         */
+        data class OnReceiveFlightRecorderData(
+            val flightRecorderData: FlightRecorderDataSet,
+        ) : Internal()
+    }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/util/FlightRecorderDataSetExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/util/FlightRecorderDataSetExtensions.kt
@@ -1,0 +1,87 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.util
+
+import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
+import com.x8bit.bitwarden.data.platform.util.fileOf
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
+import com.x8bit.bitwarden.ui.platform.util.formatBytes
+import com.x8bit.bitwarden.ui.platform.util.toFormattedPattern
+import kotlinx.collections.immutable.toImmutableList
+import java.time.Clock
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Converts a set of [FlightRecorderDataSet] to a [RecordedLogsState.ViewState].
+ */
+fun FlightRecorderDataSet.toViewState(
+    clock: Clock,
+    logsFolder: String,
+): RecordedLogsState.ViewState =
+    if (this.data.isEmpty()) {
+        RecordedLogsState.ViewState.Empty
+    } else {
+        RecordedLogsState.ViewState.Content(
+            items = this
+                .data
+                .sortedByDescending { it.startTimeMs }
+                .map { it.toDisplayItem(clock = clock, logsFolder = logsFolder) }
+                .toImmutableList(),
+        )
+    }
+
+private fun FlightRecorderDataSet.FlightRecorderData.toDisplayItem(
+    clock: Clock,
+    logsFolder: String,
+): RecordedLogsState.DisplayItem =
+    RecordedLogsState.DisplayItem(
+        id = this.id,
+        title = this.title(clock = clock).asText(),
+        subtextStart = this.getFileSize(logsFolder = logsFolder).asText(),
+        subtextEnd = this.expiresIn(clock = clock),
+        isDeletedEnabled = !this.isActive,
+    )
+
+private fun FlightRecorderDataSet.FlightRecorderData.title(clock: Clock): String {
+    val pattern = "yyyy-MM-dd'T'HH:mm:ss"
+    val formattedStartTime = Instant
+        .ofEpochMilli(this.startTimeMs)
+        .toFormattedPattern(pattern = pattern, clock = clock)
+    val formattedEndTime = Instant
+        .ofEpochMilli(this.startTimeMs + this.durationMs)
+        .toFormattedPattern(pattern = pattern, clock = clock)
+    return "$formattedStartTime – $formattedEndTime"
+}
+
+private fun FlightRecorderDataSet.FlightRecorderData.expiresIn(clock: Clock): Text? {
+    val expirationTime = this.expirationTimeMs?.let { Instant.ofEpochMilli(it) } ?: return null
+    val now = clock.instant()
+    val dayBeforeExpiration = expirationTime.minus(1, ChronoUnit.DAYS).atZone(clock.zone)
+    return if (this.isActive) {
+        // If the log is active, then the expiration time should be null but we check here anyways.
+        null
+    } else if (now.isAfter(expirationTime)) {
+        // We have passed expiration. This should never happen since the data should be deleted.
+        R.string.expired.asText()
+    } else if (now.isAfter(expirationTime.minus(1, ChronoUnit.DAYS))) {
+        // We are within 24 hours of expiration, so show the specific time.
+        val expirationTime = expirationTime.toFormattedPattern(pattern = "h:mm a", clock = clock)
+        R.string.expires_at.asText(expirationTime)
+    } else if (dayBeforeExpiration.dayOfYear == now.atZone(clock.zone).dayOfYear) {
+        // We expire tomorrow based on the day of year.
+        R.string.expires_tomorrow.asText()
+    } else {
+        // Let them know how many days they have left.
+        val millisRemaining = expirationTime.minusMillis(now.toEpochMilli()).toEpochMilli()
+        R.string.expires_in_days.asText(millisRemaining.milliseconds.inWholeDays)
+    }
+}
+
+private fun FlightRecorderDataSet.FlightRecorderData.getFileSize(
+    logsFolder: String,
+): String = fileOf("$logsFolder/${this.fileName}")
+    .length()
+    .formatBytes()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/LongExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/LongExtensions.kt
@@ -1,0 +1,22 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+private const val BASE_DATA_SIZE: Long = 1024L
+private val DATA_SIZE_UNITS = arrayOf("B", "KB", "MB", "GB", "TB")
+
+/**
+ * Formats the a long, representing size in bytes, into a human readable string.
+ *
+ * Note: This uses base-2 to determine the size of the file but uses base-10 units.
+ */
+fun Long.formatBytes(): String {
+    if (this < BASE_DATA_SIZE) return "$this ${DATA_SIZE_UNITS[0]}"
+
+    var value = this.toDouble()
+    var unitIndex = 0
+    while (value >= BASE_DATA_SIZE && unitIndex < DATA_SIZE_UNITS.lastIndex) {
+        value /= BASE_DATA_SIZE
+        unitIndex++
+    }
+
+    return String.format(locale = null, format = "%.2f ${DATA_SIZE_UNITS[unitIndex]}", value)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -620,6 +620,9 @@ Scanning will happen automatically.</string>
   <string name="deletion_date_info">The Send will be permanently deleted on the specified date and time.</string>
   <string name="pending_delete">Pending deletion</string>
   <string name="expired">Expired</string>
+  <string name="expires_at">Expires at %s</string>
+  <string name="expires_tomorrow">Expires tomorrow</string>
+  <string name="expires_in_days">Expires in %s days</string>
   <string name="stops_logging_on">Stops logging on %1$s at %2$s</string>
   <string name="maximum_access_count">Maximum access count</string>
   <string name="maximum_access_count_info">If set, users will no longer be able to access this Send once the maximum access count is reached.</string>
@@ -1236,4 +1239,6 @@ Do you want to switch to this account?</string>
   <string name="flight_recorder_eight_hours">8 hours</string>
   <string name="flight_recorder_twenty_four_hours">24 hours</string>
   <string name="flight_recorder_one_week">1 week</string>
+  <string name="delete_all">Delete all</string>
+  <string name="share_all">Share all</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerTest.kt
@@ -27,6 +27,7 @@ import java.io.File
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class FlightRecorderManagerTest {
@@ -143,6 +144,7 @@ class FlightRecorderManagerTest {
                     startTimeMs = FIXED_CLOCK_TIME,
                     durationMs = 60L,
                     isActive = true,
+                    expirationTimeMs = null,
                 ),
                 FlightRecorderDataSet.FlightRecorderData(
                     id = "50",
@@ -150,6 +152,7 @@ class FlightRecorderManagerTest {
                     startTimeMs = FIXED_CLOCK_TIME,
                     durationMs = 60L,
                     isActive = false,
+                    expirationTimeMs = null,
                 ),
             ),
         )
@@ -166,6 +169,10 @@ class FlightRecorderManagerTest {
                         startTimeMs = FIXED_CLOCK_TIME,
                         durationMs = 60L,
                         isActive = false,
+                        expirationTimeMs = FIXED_CLOCK
+                            .instant()
+                            .plus(30, ChronoUnit.DAYS)
+                            .toEpochMilli(),
                     ),
                     FlightRecorderDataSet.FlightRecorderData(
                         id = "50",
@@ -173,6 +180,10 @@ class FlightRecorderManagerTest {
                         startTimeMs = FIXED_CLOCK_TIME,
                         durationMs = 60L,
                         isActive = false,
+                        expirationTimeMs = FIXED_CLOCK
+                            .instant()
+                            .plus(30, ChronoUnit.DAYS)
+                            .toEpochMilli(),
                     ),
                 ),
             ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
@@ -2,10 +2,18 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recorded
 
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onSiblings
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.ui.util.asText
+import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsAction
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsEvent
@@ -16,6 +24,7 @@ import com.x8bit.bitwarden.ui.util.isProgressBar
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import org.junit.Assert.assertTrue
@@ -67,12 +76,174 @@ class RecordedLogsScreenTest : BaseComposeTest() {
         mutableStateFlow.update { it.copy(viewState = RecordedLogsState.ViewState.Empty) }
         composeTestRule.onNodeWithText(text = "No logs recorded").assertIsDisplayed()
 
-        mutableStateFlow.update { it.copy(viewState = RecordedLogsState.ViewState.Content) }
-        // TODO: PM-19593 Assert content is displayed
+        mutableStateFlow.update {
+            it.copy(
+                viewState = RecordedLogsState.ViewState.Content(
+                    items = persistentListOf(
+                        RecordedLogsState.DisplayItem(
+                            id = "50",
+                            title = "2025-04-12T03:15:52 – 2025-04-12T04:15:52".asText(),
+                            subtextStart = "1.00 KB".asText(),
+                            subtextEnd = null,
+                            isDeletedEnabled = false,
+                        ),
+                        RecordedLogsState.DisplayItem(
+                            id = "52",
+                            title = "2025-04-12T03:15:00 – 2025-04-12T04:15:00".asText(),
+                            subtextStart = "1.00 KB".asText(),
+                            subtextEnd = R.string.expires_in_days.asText("30"),
+                            isDeletedEnabled = true,
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = "2025-04-12T03:15:52 – 2025-04-12T04:15:52")
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(text = "2025-04-12T03:15:00 – 2025-04-12T04:15:00")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `on Share All click should emit ShareAllClick`() {
+        mutableStateFlow.update {
+            it.copy(viewState = RecordedLogsState.ViewState.Content(items = persistentListOf()))
+        }
+        composeTestRule.onNodeWithContentDescription(label = "More").performClick()
+        composeTestRule.onNodeWithText(text = "Share all").performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(RecordedLogsAction.ShareAllClick)
+        }
+    }
+
+    @Test
+    fun `on Delete All click should emit DeleteAllClick`() {
+        mutableStateFlow.update {
+            it.copy(viewState = RecordedLogsState.ViewState.Content(items = persistentListOf()))
+        }
+        composeTestRule.onNodeWithContentDescription(label = "More").performClick()
+        composeTestRule.onNodeWithText(text = "Delete all").performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(RecordedLogsAction.DeleteAllClick)
+        }
+    }
+
+    @Test
+    fun `individual delete button should be enabled based on state`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = RecordedLogsState.ViewState.Content(
+                    items = persistentListOf(
+                        RecordedLogsState.DisplayItem(
+                            id = "50",
+                            title = "title".asText(),
+                            subtextStart = "1.00 KB".asText(),
+                            subtextEnd = null,
+                            isDeletedEnabled = true,
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = "title")
+            .performScrollTo()
+            .onSiblings()
+            .filterToOne(matcher = hasContentDescription(value = "More"))
+            .performClick()
+        composeTestRule.onNodeWithText(text = "Delete").assertIsEnabled()
+
+        mutableStateFlow.update {
+            it.copy(
+                viewState = RecordedLogsState.ViewState.Content(
+                    items = persistentListOf(
+                        RecordedLogsState.DisplayItem(
+                            id = "50",
+                            title = "title".asText(),
+                            subtextStart = "1.00 KB".asText(),
+                            subtextEnd = null,
+                            isDeletedEnabled = false,
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = "title")
+            .performScrollTo()
+            .onSiblings()
+            .filterToOne(matcher = hasContentDescription(value = "More"))
+            .performClick()
+        composeTestRule.onNodeWithText(text = "Delete").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `on individual Share click should emit ShareClick`() {
+        val displayItem = RecordedLogsState.DisplayItem(
+            id = "50",
+            title = "title".asText(),
+            subtextStart = "1.00 KB".asText(),
+            subtextEnd = null,
+            isDeletedEnabled = true,
+        )
+        mutableStateFlow.update {
+            it.copy(
+                viewState = RecordedLogsState.ViewState.Content(
+                    items = persistentListOf(displayItem),
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = "title")
+            .performScrollTo()
+            .onSiblings()
+            .filterToOne(matcher = hasContentDescription(value = "More"))
+            .performClick()
+        composeTestRule.onNodeWithText(text = "Share").performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(RecordedLogsAction.ShareClick(displayItem))
+        }
+    }
+
+    @Test
+    fun `on individual Delete click should emit DeleteClick`() {
+        val displayItem = RecordedLogsState.DisplayItem(
+            id = "50",
+            title = "title".asText(),
+            subtextStart = "1.00 KB".asText(),
+            subtextEnd = null,
+            isDeletedEnabled = true,
+        )
+        mutableStateFlow.update {
+            it.copy(
+                viewState = RecordedLogsState.ViewState.Content(
+                    items = persistentListOf(displayItem),
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = "title")
+            .performScrollTo()
+            .onSiblings()
+            .filterToOne(matcher = hasContentDescription(value = "More"))
+            .performClick()
+        composeTestRule.onNodeWithText(text = "Delete").performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(RecordedLogsAction.DeleteClick(displayItem))
+        }
     }
 }
 
 private val DEFAULT_STATE: RecordedLogsState =
     RecordedLogsState(
         viewState = RecordedLogsState.ViewState.Loading,
+        logsFolder = "/logs",
     )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
@@ -2,21 +2,75 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recorded
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.vault.manager.FileManager
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsAction
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsEvent
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsViewModel
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.util.toViewState
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 class RecordedLogsViewModelTest : BaseViewModelTest() {
+
+    private val fileManager = mockk<FileManager> {
+        every { logsDirectory } returns "/logs"
+    }
+    private val mutableFlightRecorderDataFlow = MutableStateFlow(FlightRecorderDataSet(emptySet()))
+    private val settingsRepository = mockk<SettingsRepository> {
+        every { flightRecorderDataFlow } returns mutableFlightRecorderDataFlow
+        every { deleteAllLogs() } just runs
+        every { deleteLog(data = any()) } just runs
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(FlightRecorderDataSet::toViewState)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(FlightRecorderDataSet::toViewState)
+    }
 
     @Test
     fun `initial state should be correct`() = runTest {
         val viewModel = createViewModel()
         assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
+    }
+
+    @Test
+    fun `on flightRecorderDataFlow emission should update the viewState`() {
+        val viewState = RecordedLogsState.ViewState.Content(items = persistentListOf())
+        val dataset = mockk<FlightRecorderDataSet> {
+            every { toViewState(clock = FIXED_CLOCK, logsFolder = "/logs") } returns viewState
+        }
+        val viewModel = createViewModel()
+
+        mutableFlightRecorderDataFlow.value = dataset
+
+        verify(exactly = 1) {
+            dataset.toViewState(clock = FIXED_CLOCK, logsFolder = "/logs")
+        }
+        assertEquals(DEFAULT_STATE.copy(viewState = viewState), viewModel.stateFlow.value)
     }
 
     @Test
@@ -28,10 +82,52 @@ class RecordedLogsViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Test
+    fun `on ShareAllClick action should do nothing`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(RecordedLogsAction.ShareAllClick)
+    }
+
+    @Test
+    fun `on ShareClick action should do nothing`() {
+        val viewModel = createViewModel()
+        val item = mockk<RecordedLogsState.DisplayItem>()
+        viewModel.trySendAction(RecordedLogsAction.ShareClick(item = item))
+    }
+
+    @Test
+    fun `on DeleteAllClick action should call deleteAllLogs`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(RecordedLogsAction.DeleteAllClick)
+        verify(exactly = 1) {
+            settingsRepository.deleteAllLogs()
+        }
+    }
+
+    @Test
+    fun `on DeleteClick action should call deleteLog`() {
+        val data = mockk<FlightRecorderDataSet.FlightRecorderData> {
+            every { id } returns "50"
+        }
+        val dataset = FlightRecorderDataSet(data = setOf(data))
+        every { settingsRepository.flightRecorderData } returns dataset
+        val viewModel = createViewModel()
+        val item = mockk<RecordedLogsState.DisplayItem> {
+            every { id } returns "50"
+        }
+        viewModel.trySendAction(RecordedLogsAction.DeleteClick(item = item))
+        verify(exactly = 1) {
+            settingsRepository.deleteLog(data = data)
+        }
+    }
+
     private fun createViewModel(
         state: RecordedLogsState? = null,
     ): RecordedLogsViewModel =
         RecordedLogsViewModel(
+            clock = FIXED_CLOCK,
+            fileManager = fileManager,
+            settingsRepository = settingsRepository,
             savedStateHandle = SavedStateHandle().apply {
                 set("state", state)
             },
@@ -40,5 +136,11 @@ class RecordedLogsViewModelTest : BaseViewModelTest() {
 
 private val DEFAULT_STATE: RecordedLogsState =
     RecordedLogsState(
-        viewState = RecordedLogsState.ViewState.Loading,
+        viewState = RecordedLogsState.ViewState.Empty,
+        logsFolder = "/logs",
     )
+
+private val FIXED_CLOCK: Clock = Clock.fixed(
+    Instant.parse("2023-10-27T12:00:00Z"),
+    ZoneOffset.UTC,
+)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/util/FlightRecorderDataSetExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/util/FlightRecorderDataSetExtensionsTest.kt
@@ -1,0 +1,147 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedlogs.util
+
+import com.bitwarden.ui.util.asText
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
+import com.x8bit.bitwarden.data.platform.util.fileOf
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
+import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.util.toViewState
+import com.x8bit.bitwarden.ui.platform.util.formatBytes
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+
+class FlightRecorderDataSetExtensionsTest {
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(
+            ::fileOf,
+            Long::formatBytes,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(
+            ::fileOf,
+            Long::formatBytes,
+        )
+    }
+
+    @Test
+    fun `toViewState with empty data should return empty state`() {
+        val dataset = FlightRecorderDataSet(data = emptySet())
+
+        val result = dataset.toViewState(clock = FIXED_CLOCK, logsFolder = "/logs")
+
+        assertEquals(RecordedLogsState.ViewState.Empty, result)
+    }
+
+    @Test
+    fun `toViewState with data data should return content state`() {
+        every { fileOf(path = any()).length() } returns 1024L
+        every { 1024L.formatBytes() } returns "1.00 KB"
+        val dataset = FlightRecorderDataSet(
+            data = setOf(
+                // Active
+                FlightRecorderDataSet.FlightRecorderData(
+                    id = "50",
+                    fileName = "flight_recorder_2025-04-03_14-22-40",
+                    startTimeMs = 1_744_445_752_855L,
+                    durationMs = 3_600_000L,
+                    isActive = true,
+                    expirationTimeMs = null,
+                ),
+                // Expires in 30 days
+                FlightRecorderDataSet.FlightRecorderData(
+                    id = "52",
+                    fileName = "flight_recorder_2025-04-03_14-52-00",
+                    startTimeMs = 1_744_445_700_000L,
+                    durationMs = 3_600_000L,
+                    isActive = false,
+                    expirationTimeMs = FIXED_CLOCK
+                        .instant()
+                        .plus(30, ChronoUnit.DAYS)
+                        .toEpochMilli(),
+                ),
+                // Expires in less than 24 hours
+                FlightRecorderDataSet.FlightRecorderData(
+                    id = "51",
+                    fileName = "flight_recorder_2025-04-03_14-52-00",
+                    startTimeMs = 1_444_445_752_000L,
+                    durationMs = 3_600_000L,
+                    isActive = false,
+                    expirationTimeMs = FIXED_CLOCK
+                        .instant()
+                        .plus(12, ChronoUnit.HOURS)
+                        .toEpochMilli(),
+                ),
+                // Expires tomorrow
+                FlightRecorderDataSet.FlightRecorderData(
+                    id = "53",
+                    fileName = "flight_recorder_2025-04-03_14-52-00",
+                    startTimeMs = 1_444_445_752_000L,
+                    durationMs = 3_600_000L,
+                    isActive = false,
+                    expirationTimeMs = FIXED_CLOCK
+                        .instant()
+                        .plus(26, ChronoUnit.HOURS)
+                        .toEpochMilli(),
+                ),
+            ),
+        )
+
+        val result = dataset.toViewState(clock = FIXED_CLOCK, logsFolder = "/logs")
+
+        assertEquals(
+            RecordedLogsState.ViewState.Content(
+                items = persistentListOf(
+                    RecordedLogsState.DisplayItem(
+                        id = "50",
+                        title = "2025-04-12T08:15:52 – 2025-04-12T09:15:52".asText(),
+                        subtextStart = "1.00 KB".asText(),
+                        subtextEnd = null,
+                        isDeletedEnabled = false,
+                    ),
+                    RecordedLogsState.DisplayItem(
+                        id = "52",
+                        title = "2025-04-12T08:15:00 – 2025-04-12T09:15:00".asText(),
+                        subtextStart = "1.00 KB".asText(),
+                        subtextEnd = R.string.expires_in_days.asText(30L),
+                        isDeletedEnabled = true,
+                    ),
+                    RecordedLogsState.DisplayItem(
+                        id = "51",
+                        title = "2015-10-10T02:55:52 – 2015-10-10T03:55:52".asText(),
+                        subtextStart = "1.00 KB".asText(),
+                        subtextEnd = R.string.expires_at.asText("10:15 PM"),
+                        isDeletedEnabled = true,
+                    ),
+                    RecordedLogsState.DisplayItem(
+                        id = "53",
+                        title = "2015-10-10T02:55:52 – 2015-10-10T03:55:52".asText(),
+                        subtextStart = "1.00 KB".asText(),
+                        subtextEnd = R.string.expires_tomorrow.asText(),
+                        isDeletedEnabled = true,
+                    ),
+                ),
+            ),
+            result,
+        )
+    }
+}
+
+private val FIXED_CLOCK = Clock.fixed(
+    Instant.parse("2025-04-11T10:15:30.00Z"),
+    ZoneOffset.UTC,
+)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/util/FlightRecorderDurationTests.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/util/FlightRecorderDurationTests.kt
@@ -1,0 +1,23 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.util
+
+import com.bitwarden.ui.util.asText
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FlightRecorderDurationTests {
+    @Test
+    fun `displayText should return appropriate text`() {
+        mapOf(
+            FlightRecorderDuration.ONE_HOUR to R.string.flight_recorder_one_hour.asText(),
+            FlightRecorderDuration.EIGHT_HOURS to R.string.flight_recorder_eight_hours.asText(),
+            FlightRecorderDuration.TWENTY_FOUR_HOURS to
+                R.string.flight_recorder_twenty_four_hours.asText(),
+            FlightRecorderDuration.ONE_WEEK to R.string.flight_recorder_one_week.asText(),
+        )
+            .forEach {
+                assertEquals(it.value, it.key.displayText)
+            }
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/LongExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/util/LongExtensionsTest.kt
@@ -1,0 +1,30 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class LongExtensionsTest {
+    @Test
+    fun `formatBytes should return string in appropriate format`() {
+        // Bytes
+        assertEquals("0 B", 0L.formatBytes())
+        assertEquals("500 B", 500L.formatBytes())
+        assertEquals("1023 B", 1_023L.formatBytes())
+        // Kibibytes
+        assertEquals("1.00 KB", 1_024L.formatBytes())
+        assertEquals("21.51 KB", 22_024L.formatBytes())
+        assertEquals("591.82 KB", 606_024L.formatBytes())
+        // Mebibytes
+        assertEquals("1.00 MB", 1_048_576L.formatBytes())
+        assertEquals("3.27 MB", 3_425_346L.formatBytes())
+        assertEquals("477.24 MB", 500_425_346L.formatBytes())
+        // Gibibytes
+        assertEquals("1.00 GB", 1_073_741_824L.formatBytes())
+        assertEquals("1.07 GB", 1_151_461_496L.formatBytes())
+        assertEquals("52.08 GB", 55_917_186_986L.formatBytes())
+        // Tebibytes
+        assertEquals("1.00 TB", 1_099_511_627_776L.formatBytes())
+        assertEquals("12.49 TB", 13_732_900_230_922L.formatBytes())
+        assertEquals("2000.00 TB", 2_199_023_255_552_000L.formatBytes())
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19593](https://bitwarden.atlassian.net/browse/PM-19593)

## 📔 Objective

This PR updates the `FlightRecorderManager` to store the expiration date when a log becomes inactive and adds the recorded logs UI.

## 📸 Screenshots

<img src="https://github.com/user-attachments/assets/160e01b4-b1d7-4136-8f8d-6519542b842c" width="350" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19593]: https://bitwarden.atlassian.net/browse/PM-19593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ