### PR TITLE
Limit network logs in production

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/retrofit/RetrofitsImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/datasource/network/retrofit/RetrofitsImpl.kt
@@ -8,6 +8,7 @@ import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.BaseUrlI
 import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.BaseUrlInterceptors
 import com.x8bit.bitwarden.data.platform.datasource.network.interceptor.HeadersInterceptor
 import com.x8bit.bitwarden.data.platform.datasource.network.ssl.SslManager
+import com.x8bit.bitwarden.data.platform.util.isDevBuild
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -88,7 +89,11 @@ class RetrofitsImpl(
         HttpLoggingInterceptor { message -> Timber.tag("BitwardenNetworkClient").d(message) }
             .apply {
                 redactHeader(name = HEADER_KEY_AUTHORIZATION)
-                setLevel(HttpLoggingInterceptor.Level.BODY)
+                setLevel(
+                    level = HttpLoggingInterceptor.Level.BODY
+                        .takeIf { isDevBuild }
+                        ?: HttpLoggingInterceptor.Level.BASIC,
+                )
             }
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/util/BuildConfigUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/util/BuildConfigUtils.kt
@@ -10,6 +10,12 @@ val isFdroid: Boolean
     get() = BuildConfig.FLAVOR == "fdroid"
 
 /**
+ * A boolean property that indicates whether the current build is a dev build.
+ */
+val isDevBuild: Boolean
+    get() = BuildConfig.BUILD_TYPE == "debug"
+
+/**
  * A string that represents a displayable app version.
  */
 val versionData: String


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20260](https://bitwarden.atlassian.net/browse/PM-20260)

## 📔 Objective

This PR limits the network logs in production to just the urls being hit and the response codes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20260]: https://bitwarden.atlassian.net/browse/PM-20260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ