### PR TITLE
[PM-20194] Migrate FolderService and related models to network module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/di/VaultNetworkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/datasource/network/di/VaultNetworkModule.kt
@@ -1,12 +1,12 @@
 package com.x8bit.bitwarden.data.vault.datasource.network.di
 
+import com.bitwarden.network.service.FolderService
+import com.bitwarden.network.service.FolderServiceImpl
 import com.x8bit.bitwarden.data.platform.datasource.network.retrofit.Retrofits
 import com.x8bit.bitwarden.data.vault.datasource.network.service.CiphersService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.CiphersServiceImpl
 import com.x8bit.bitwarden.data.vault.datasource.network.service.DownloadService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.DownloadServiceImpl
-import com.x8bit.bitwarden.data.vault.datasource.network.service.FolderService
-import com.x8bit.bitwarden.data.vault.datasource.network.service.FolderServiceImpl
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SendsService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SendsServiceImpl
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SyncService

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -17,6 +17,8 @@ import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.exporters.ExportFormat
 import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.network.model.UpdateFolderResponseJson
+import com.bitwarden.network.service.FolderService
 import com.bitwarden.network.util.isNoConnectionError
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.send.Send
@@ -49,10 +51,8 @@ import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAn
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateFileSendResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateSendJsonResponse
-import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateSendResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.service.CiphersService
-import com.x8bit.bitwarden.data.vault.datasource.network.service.FolderService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SendsService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SyncService
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.vault.repository.di
 
 import com.bitwarden.data.manager.DispatcherManager
+import com.bitwarden.network.service.FolderService
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
@@ -9,7 +10,6 @@ import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.network.service.CiphersService
-import com.x8bit.bitwarden.data.vault.datasource.network.service.FolderService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SendsService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SyncService
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -18,6 +18,7 @@ import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SendTypeJson
 import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.network.model.UpdateFolderResponseJson
 import com.bitwarden.network.model.createMockCipher
 import com.bitwarden.network.model.createMockCollection
 import com.bitwarden.network.model.createMockDomains
@@ -30,6 +31,7 @@ import com.bitwarden.network.model.createMockProfile
 import com.bitwarden.network.model.createMockSend
 import com.bitwarden.network.model.createMockSendJsonRequest
 import com.bitwarden.network.model.createMockSyncResponse
+import com.bitwarden.network.service.FolderService
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.send.SendType
 import com.bitwarden.send.SendView
@@ -60,10 +62,8 @@ import com.x8bit.bitwarden.data.platform.manager.model.SyncSendUpsertData
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateFileSendResponse
 import com.x8bit.bitwarden.data.vault.datasource.network.model.CreateSendJsonResponse
-import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateSendResponseJson
 import com.x8bit.bitwarden.data.vault.datasource.network.service.CiphersService
-import com.x8bit.bitwarden.data.vault.datasource.network.service.FolderService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SendsService
 import com.x8bit.bitwarden.data.vault.datasource.network.service.SyncService
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource

--- a/network/src/main/kotlin/com/bitwarden/network/model/UpdateFolderResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/UpdateFolderResponseJson.kt
@@ -1,6 +1,5 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.model
+package com.bitwarden.network.model
 
-import com.bitwarden.network.model.SyncResponseJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/network/src/main/kotlin/com/bitwarden/network/service/FolderService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/FolderService.kt
@@ -1,8 +1,8 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.service
+package com.bitwarden.network.service
 
 import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SyncResponseJson
-import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
+import com.bitwarden.network.model.UpdateFolderResponseJson
 
 /**
  * Provides an API for querying folder endpoints.

--- a/network/src/main/kotlin/com/bitwarden/network/service/FolderServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/FolderServiceImpl.kt
@@ -1,13 +1,13 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.service
+package com.bitwarden.network.service
 
 import com.bitwarden.network.api.FoldersApi
 import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.network.model.UpdateFolderResponseJson
 import com.bitwarden.network.model.toBitwardenError
 import com.bitwarden.network.util.NetworkErrorCode
 import com.bitwarden.network.util.parseErrorBodyOrNull
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
 import kotlinx.serialization.json.Json
 
 class FolderServiceImpl(

--- a/network/src/test/kotlin/com/bitwarden/network/service/FoldersServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/FoldersServiceTest.kt
@@ -1,10 +1,10 @@
-package com.x8bit.bitwarden.data.vault.datasource.network.service
+package com.bitwarden.network.service
 
 import com.bitwarden.network.api.FoldersApi
 import com.bitwarden.network.base.BaseServiceTest
 import com.bitwarden.network.model.FolderJsonRequest
 import com.bitwarden.network.model.SyncResponseJson
-import com.x8bit.bitwarden.data.vault.datasource.network.model.UpdateFolderResponseJson
+import com.bitwarden.network.model.UpdateFolderResponseJson
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals


### PR DESCRIPTION
Moved `FolderService`, `FolderServiceImpl`, and `UpdateFolderResponseJson` to the `network` module. This change removes these components from the `app` module, including their associated test files. Updated all usages to use the new implementation in `network`.

## 🎟️ Tracking

PM-20194

## 📔 Objective

Moved `FolderService`, `FolderServiceImpl`, and `UpdateFolderResponseJson` to the `network` module. This change removes these components from the `app` module, including their associated test files. Updated all usages to use the new implementation in `network`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
