### PR TITLE
Use explicit timezone in tests

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModelTest.kt
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.Year
-import java.time.ZoneId
+import java.time.ZoneOffset
 
 class AboutViewModelTest : BaseViewModelTest() {
 
@@ -235,7 +235,7 @@ class AboutViewModelTest : BaseViewModelTest() {
 
 private val FIXED_CLOCK = Clock.fixed(
     Instant.parse("2024-01-25T10:15:30.00Z"),
-    ZoneId.systemDefault(),
+    ZoneOffset.UTC,
 )
 private val DEFAULT_ABOUT_STATE: AboutState = AboutState(
     version = "Version: <version_name> (<version_code>)".asText(),


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This is addresses a minor bug in the `AboutViewModelTests` where the test was using the system default timezone. This can cause discrepancies between output of a time based on the timezone of the dev machine and the CI machine. Currently it is not an issue because this class has no tests like that but this will avoid a future headache if someone were to add more featues/tests.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
