### PR TITLE
PM-19622: Add ability to share flight recorder logs

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerImpl.kt
@@ -82,7 +82,7 @@ internal class FlightRecorderManagerImpl(
                     add(
                         element = FlightRecorderDataSet.FlightRecorderData(
                             id = UUID.randomUUID().toString(),
-                            fileName = "flight_recorder_$formattedTime",
+                            fileName = "flight_recorder_$formattedTime.txt",
                             startTimeMs = startTime.toEpochMilli(),
                             durationMs = duration.milliseconds,
                             isActive = true,

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/FileManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/FileManager.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.vault.manager
 import android.net.Uri
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.data.vault.manager.model.DownloadResult
+import com.x8bit.bitwarden.data.vault.manager.model.ZipFileResult
 import java.io.File
 
 /**
@@ -48,6 +49,12 @@ interface FileManager {
      * Reads the [fileUri] into memory. A successful result will contain the raw [ByteArray].
      */
     suspend fun uriToByteArray(fileUri: Uri): Result<ByteArray>
+
+    /**
+     * Reads the file or folder on disk from the [uri] and creates a temporary zip file. A
+     * successful result will contain the zip [File] reference.
+     */
+    suspend fun zipUriToCache(uri: Uri): ZipFileResult
 
     /**
      * Reads the [fileUri] into a file on disk. A successful result will contain the [File]

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/model/ZipFileResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/model/ZipFileResult.kt
@@ -1,0 +1,23 @@
+package com.x8bit.bitwarden.data.vault.manager.model
+
+import java.io.File
+
+/**
+ * Represents a result from zipping a raw file or folder.
+ */
+sealed class ZipFileResult {
+    /**
+     * The zip was a success, and was saved to the temporary [file].
+     */
+    data class Success(val file: File) : ZipFileResult()
+
+    /**
+     * There was no file or folder to zip.
+     */
+    data object NothingToZip : ZipFileResult()
+
+    /**
+     * The zip failed in some generic manner.
+     */
+    data class Failure(val error: Throwable) : ZipFileResult()
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -69,6 +69,11 @@ interface IntentManager {
     ): ManagedActivityResultLauncher<Intent, ActivityResult>
 
     /**
+     * Launches the share sheet with the given [title] and file.
+     */
+    fun shareFile(title: String? = null, fileUri: Uri)
+
+    /**
      * Launches the share sheet with the given [text].
      */
     fun shareText(text: String)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -175,6 +175,20 @@ class IntentManagerImpl(
         }
     }
 
+    override fun shareFile(title: String?, fileUri: Uri) {
+        val providedFile = FileProvider.getUriForFile(
+            context,
+            FILE_PROVIDER_AUTHORITY,
+            File(fileUri.toString()),
+        )
+        val sendIntent: Intent = Intent(Intent.ACTION_SEND).apply {
+            putExtra(Intent.EXTRA_TEXT, title)
+            putExtra(Intent.EXTRA_STREAM, providedFile)
+            type = "application/zip"
+        }
+        startActivity(Intent.createChooser(sendIntent, null))
+    }
+
     override fun shareText(text: String) {
         val sendIntent: Intent = Intent(Intent.ACTION_SEND).apply {
             putExtra(Intent.EXTRA_TEXT, text)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1241,4 +1241,11 @@ Do you want to switch to this account?</string>
   <string name="flight_recorder_one_week">1 week</string>
   <string name="delete_all">Delete all</string>
   <string name="share_all">Share all</string>
+  <string name="unable_to_share">Unable to share</string>
+  <string name="please_try_again_or_select_a_different_log">Please try again or select a different log.</string>
+  <string name="the_log_file_you_are_trying_to_share_has_been_removed">The log file you are trying to share has been removed.</string>
+  <string name="delete_log">Delete log</string>
+  <string name="do_you_really_want_to_delete_this_log">Do you really want to delete this log?</string>
+  <string name="delete_logs">Delete logs</string>
+  <string name="do_you_really_want_to_delete_all_recorded_logs">Do you really want to delete all recorded logs?</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerTest.kt
@@ -123,7 +123,7 @@ class FlightRecorderManagerTest {
                 data = setOf(
                     FlightRecorderDataSet.FlightRecorderData(
                         id = "mockUUID",
-                        fileName = "flight_recorder_2023-10-27_12-00-00",
+                        fileName = "flight_recorder_2023-10-27_12-00-00.txt",
                         startTimeMs = FIXED_CLOCK_TIME,
                         durationMs = FlightRecorderDuration.ONE_HOUR.milliseconds,
                         isActive = true,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
@@ -1,16 +1,22 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedlogs
 
+import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.ui.util.asText
+import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.manager.FileManager
+import com.x8bit.bitwarden.data.vault.manager.model.ZipFileResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsAction
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsEvent
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsViewModel
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.util.toViewState
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -25,6 +31,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.io.File
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -37,18 +44,27 @@ class RecordedLogsViewModelTest : BaseViewModelTest() {
     private val mutableFlightRecorderDataFlow = MutableStateFlow(FlightRecorderDataSet(emptySet()))
     private val settingsRepository = mockk<SettingsRepository> {
         every { flightRecorderDataFlow } returns mutableFlightRecorderDataFlow
+        every { flightRecorderData } returns FlightRecorderDataSet(emptySet())
         every { deleteAllLogs() } just runs
         every { deleteLog(data = any()) } just runs
     }
 
     @BeforeEach
     fun setup() {
-        mockkStatic(FlightRecorderDataSet::toViewState)
+        mockkStatic(
+            FlightRecorderDataSet::toViewState,
+            File::toURI,
+            Uri::parse,
+        )
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(FlightRecorderDataSet::toViewState)
+        unmockkStatic(
+            FlightRecorderDataSet::toViewState,
+            File::toURI,
+            Uri::parse,
+        )
     }
 
     @Test
@@ -83,16 +99,161 @@ class RecordedLogsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `on ShareAllClick action should do nothing`() {
-        val viewModel = createViewModel()
+    fun `on ShareAllClick action with zipUriToCache Success should send ShareLog event`() =
+        runTest {
+            val uri = setupMockUri("/logs")
+            val zipFile = mockk<File>()
+            coEvery { fileManager.zipUriToCache(uri = uri) } returns ZipFileResult.Success(zipFile)
+            val viewModel = createViewModel()
+
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(RecordedLogsAction.ShareAllClick)
+                assertEquals(RecordedLogsEvent.ShareLog(uri = zipFile.toString()), awaitItem())
+            }
+
+            coVerify(exactly = 1) {
+                fileManager.zipUriToCache(uri = uri)
+            }
+        }
+
+    @Test
+    fun `on ShareAllClick action with zipUriToCache Failure should display error dialog`() {
+        val uri = setupMockUri("/logs")
+        val error = Throwable("Fail!")
+        coEvery { fileManager.zipUriToCache(uri = uri) } returns ZipFileResult.Failure(error)
+        val viewModel = createViewModel(DEFAULT_STATE)
+
         viewModel.trySendAction(RecordedLogsAction.ShareAllClick)
+
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialogState = RecordedLogsState.DialogState.Error(
+                    title = R.string.unable_to_share.asText(),
+                    message = R.string.please_try_again_or_select_a_different_log.asText(),
+                    error = error,
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+        coVerify(exactly = 1) {
+            fileManager.zipUriToCache(uri = uri)
+        }
     }
 
     @Test
-    fun `on ShareClick action should do nothing`() {
+    fun `on ShareAllClick action with zipUriToCache NothingToZip should display error dialog`() {
+        val uri = setupMockUri("/logs")
+        coEvery { fileManager.zipUriToCache(uri = uri) } returns ZipFileResult.NothingToZip
+        val viewModel = createViewModel(DEFAULT_STATE)
+
+        viewModel.trySendAction(RecordedLogsAction.ShareAllClick)
+
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialogState = RecordedLogsState.DialogState.Error(
+                    title = R.string.unable_to_share.asText(),
+                    message = R.string.the_log_file_you_are_trying_to_share_has_been_removed
+                        .asText(),
+                    error = null,
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+        coVerify(exactly = 1) {
+            fileManager.zipUriToCache(uri = uri)
+        }
+    }
+
+    @Test
+    fun `on ShareClick action with zipUriToCache Success should send ShareLog event`() =
+        runTest {
+            val viewModel = createViewModel()
+            val data = mockk<FlightRecorderDataSet.FlightRecorderData> {
+                every { id } returns "50"
+                every { fileName } returns "filename"
+            }
+            val dataset = FlightRecorderDataSet(data = setOf(data))
+            every { settingsRepository.flightRecorderData } returns dataset
+            val item = mockk<RecordedLogsState.DisplayItem> {
+                every { id } returns "50"
+            }
+            val zipFile = mockk<File>()
+            coEvery {
+                fileManager.zipUriToCache(uri = any())
+            } returns ZipFileResult.Success(zipFile)
+
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(RecordedLogsAction.ShareClick(item))
+                assertEquals(RecordedLogsEvent.ShareLog(uri = zipFile.toString()), awaitItem())
+            }
+
+            coVerify(exactly = 1) {
+                fileManager.zipUriToCache(uri = any())
+            }
+        }
+
+    @Test
+    fun `on ShareClick action with zipUriToCache Failure should display an error dialog`() {
         val viewModel = createViewModel()
-        val item = mockk<RecordedLogsState.DisplayItem>()
-        viewModel.trySendAction(RecordedLogsAction.ShareClick(item = item))
+        val data = mockk<FlightRecorderDataSet.FlightRecorderData> {
+            every { id } returns "50"
+            every { fileName } returns "filename"
+        }
+        val dataset = FlightRecorderDataSet(data = setOf(data))
+        every { settingsRepository.flightRecorderData } returns dataset
+        val item = mockk<RecordedLogsState.DisplayItem> {
+            every { id } returns "50"
+        }
+        val error = Throwable("Fail!")
+        coEvery { fileManager.zipUriToCache(uri = any()) } returns ZipFileResult.Failure(error)
+
+        viewModel.trySendAction(RecordedLogsAction.ShareClick(item))
+
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialogState = RecordedLogsState.DialogState.Error(
+                    title = R.string.unable_to_share.asText(),
+                    message = R.string.please_try_again_or_select_a_different_log.asText(),
+                    error = error,
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+        coVerify(exactly = 1) {
+            fileManager.zipUriToCache(uri = any())
+        }
+    }
+
+    @Test
+    fun `on ShareClick action with zipUriToCache NothingToZip should display an error dialog`() {
+        val viewModel = createViewModel()
+        val data = mockk<FlightRecorderDataSet.FlightRecorderData> {
+            every { id } returns "50"
+            every { fileName } returns "filename"
+        }
+        val dataset = FlightRecorderDataSet(data = setOf(data))
+        every { settingsRepository.flightRecorderData } returns dataset
+        val item = mockk<RecordedLogsState.DisplayItem> {
+            every { id } returns "50"
+        }
+        coEvery { fileManager.zipUriToCache(uri = any()) } returns ZipFileResult.NothingToZip
+
+        viewModel.trySendAction(RecordedLogsAction.ShareClick(item))
+
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialogState = RecordedLogsState.DialogState.Error(
+                    title = R.string.unable_to_share.asText(),
+                    message = R.string.the_log_file_you_are_trying_to_share_has_been_removed
+                        .asText(),
+                    error = null,
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+        coVerify(exactly = 1) {
+            fileManager.zipUriToCache(uri = any())
+        }
     }
 
     @Test
@@ -121,6 +282,23 @@ class RecordedLogsViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Test
+    fun `on DismissDialog action should clear the dialog state`() = runTest {
+        val initialState = DEFAULT_STATE.copy(
+            dialogState = RecordedLogsState.DialogState.Error(
+                title = "title".asText(),
+                message = "message".asText(),
+                error = null,
+            ),
+        )
+        val viewModel = createViewModel(state = initialState)
+        viewModel.stateFlow.test {
+            assertEquals(initialState, awaitItem())
+            viewModel.trySendAction(RecordedLogsAction.DismissDialog)
+            assertEquals(initialState.copy(dialogState = null), awaitItem())
+        }
+    }
+
     private fun createViewModel(
         state: RecordedLogsState? = null,
     ): RecordedLogsViewModel =
@@ -132,11 +310,20 @@ class RecordedLogsViewModelTest : BaseViewModelTest() {
                 set("state", state)
             },
         )
+
+    private fun setupMockUri(
+        url: String,
+    ): Uri {
+        val mockUri = mockk<Uri>()
+        every { Uri.parse(url) } returns mockUri
+        return mockUri
+    }
 }
 
 private val DEFAULT_STATE: RecordedLogsState =
     RecordedLogsState(
         viewState = RecordedLogsState.ViewState.Empty,
+        dialogState = null,
         logsFolder = "/logs",
     )
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19622](https://bitwarden.atlassian.net/browse/PM-19622)

## 📔 Objective

This PR adds the ability to share flight recorder logs.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/499b212c-c0dc-4390-9180-73f65169ddc1" width="350" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19622]: https://bitwarden.atlassian.net/browse/PM-19622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ