### PR TITLE
Update user-agent header in Authenticator app

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/network/util/HeaderUtils.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/network/util/HeaderUtils.kt
@@ -8,7 +8,7 @@ import com.bitwarden.authenticator.BuildConfig
  */
 @Suppress("MaxLineLength")
 val HEADER_VALUE_USER_AGENT: String =
-    "Bitwarden_Mobile/${BuildConfig.VERSION_NAME} (${BuildConfig.BUILD_TYPE}) (Android ${Build.VERSION.RELEASE}; SDK ${Build.VERSION.SDK_INT}; Model ${Build.MODEL})"
+    "Bitwarden_Authenticator_Mobile/${BuildConfig.VERSION_NAME} (${BuildConfig.BUILD_TYPE}) (Android ${Build.VERSION.RELEASE}; SDK ${Build.VERSION.SDK_INT}; Model ${Build.MODEL})"
 
 /**
  * The value used for the 'bitwarden-client-name' headers.


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

Updated the user-agent header value in the `authenticator` module to include "Bitwarden_Authenticator_Mobile" instead of "Bitwarden_Mobile".

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
