### PR TITLE
PM-19593: Update expiration string to be 'Expires on <date>'

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/util/FlightRecorderDataSetExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/util/FlightRecorderDataSetExtensions.kt
@@ -12,7 +12,6 @@ import kotlinx.collections.immutable.toImmutableList
 import java.time.Clock
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Converts a set of [FlightRecorderDataSet] to a [RecordedLogsState.ViewState].
@@ -74,9 +73,9 @@ private fun FlightRecorderDataSet.FlightRecorderData.expiresIn(clock: Clock): Te
         // We expire tomorrow based on the day of year.
         R.string.expires_tomorrow.asText()
     } else {
-        // Let them know how many days they have left.
-        val millisRemaining = expirationTime.minusMillis(now.toEpochMilli()).toEpochMilli()
-        R.string.expires_in_days.asText(millisRemaining.milliseconds.inWholeDays)
+        // Let them know the date it expires.
+        val expirationDate = expirationTime.toFormattedPattern(pattern = "M/d/yy", clock = clock)
+        R.string.expires_on.asText(expirationDate)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -622,7 +622,7 @@ Scanning will happen automatically.</string>
   <string name="expired">Expired</string>
   <string name="expires_at">Expires at %s</string>
   <string name="expires_tomorrow">Expires tomorrow</string>
-  <string name="expires_in_days">Expires in %s days</string>
+  <string name="expires_on">Expires on %s</string>
   <string name="stops_logging_on">Stops logging on %1$s at %2$s</string>
   <string name="maximum_access_count">Maximum access count</string>
   <string name="maximum_access_count_info">If set, users will no longer be able to access this Send once the maximum access count is reached.</string>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
@@ -114,7 +114,7 @@ class RecordedLogsScreenTest : BaseComposeTest() {
                             id = "52",
                             title = "2025-04-12T03:15:00 – 2025-04-12T04:15:00".asText(),
                             subtextStart = "1.00 KB".asText(),
-                            subtextEnd = R.string.expires_in_days.asText("30"),
+                            subtextEnd = R.string.expires_on.asText("4/12/25"),
                             isDeletedEnabled = true,
                         ),
                     ),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/util/FlightRecorderDataSetExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/util/FlightRecorderDataSetExtensionsTest.kt
@@ -117,7 +117,7 @@ class FlightRecorderDataSetExtensionsTest {
                         id = "52",
                         title = "2025-04-12T08:15:00 – 2025-04-12T09:15:00".asText(),
                         subtextStart = "1.00 KB".asText(),
-                        subtextEnd = R.string.expires_in_days.asText(30L),
+                        subtextEnd = R.string.expires_on.asText("5/11/25"),
                         isDeletedEnabled = true,
                     ),
                     RecordedLogsState.DisplayItem(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19593](https://bitwarden.atlassian.net/browse/PM-19593)

## 📔 Objective

This PR updates the expiration string to specify the date instead of the number of days for extra clarity.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/4506f728-bfd4-4781-a21d-f0b489c3a89e" width="300" /> | <img src="https://github.com/user-attachments/assets/899c8fbd-b513-4b1a-a0e5-d448c1bb44f3" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19593]: https://bitwarden.atlassian.net/browse/PM-19593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ