### PR TITLE
[PM-20373] Migrate Digital Asset Link API to `network` module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/datasource/network/di/Fido2NetworkModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/datasource/network/di/Fido2NetworkModule.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.autofill.fido2.datasource.network.di
 
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkServiceImpl
+import com.bitwarden.network.service.DigitalAssetLinkService
+import com.bitwarden.network.service.DigitalAssetLinkServiceImpl
 import com.x8bit.bitwarden.data.platform.datasource.network.retrofit.Retrofits
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/di/Fido2ProviderModule.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.bitwarden.data.manager.DispatcherManager
+import com.bitwarden.network.service.DigitalAssetLinkService
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManager
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2CredentialManagerImpl
 import com.x8bit.bitwarden.data.autofill.fido2.manager.Fido2OriginManager

--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManagerImpl.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.autofill.fido2.manager
 
 import androidx.credentials.provider.CallingAppInfo
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
+import com.bitwarden.network.model.DigitalAssetLinkResponseJson
+import com.bitwarden.network.service.DigitalAssetLinkService
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.platform.manager.AssetManager
 import com.x8bit.bitwarden.data.platform.util.getSignatureFingerprintAsHexString

--- a/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2OriginManagerTest.kt
@@ -5,8 +5,8 @@ import android.util.Base64
 import androidx.credentials.provider.CallingAppInfo
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service.DigitalAssetLinkService
+import com.bitwarden.network.model.DigitalAssetLinkResponseJson
+import com.bitwarden.network.service.DigitalAssetLinkService
 import com.x8bit.bitwarden.data.autofill.fido2.model.Fido2ValidateOriginResult
 import com.x8bit.bitwarden.data.platform.manager.AssetManager
 import io.mockk.coEvery

--- a/network/src/main/kotlin/com/bitwarden/network/api/DigitalAssetLinkApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/DigitalAssetLinkApi.kt
@@ -1,7 +1,7 @@
-package com.x8bit.bitwarden.data.autofill.fido2.datasource.network.api
+package com.bitwarden.network.api
 
+import com.bitwarden.network.model.DigitalAssetLinkResponseJson
 import com.bitwarden.network.model.NetworkResult
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
 import retrofit2.http.GET
 import retrofit2.http.Url
 

--- a/network/src/main/kotlin/com/bitwarden/network/model/DigitalAssetLinkResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/DigitalAssetLinkResponseJson.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model
+package com.bitwarden.network.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/network/src/main/kotlin/com/bitwarden/network/service/DigitalAssetLinkService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/DigitalAssetLinkService.kt
@@ -1,6 +1,6 @@
-package com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service
+package com.bitwarden.network.service
 
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
+import com.bitwarden.network.model.DigitalAssetLinkResponseJson
 
 /**
  * Provides an API for querying digital asset links.

--- a/network/src/main/kotlin/com/bitwarden/network/service/DigitalAssetLinkServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/DigitalAssetLinkServiceImpl.kt
@@ -1,8 +1,8 @@
-package com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service
+package com.bitwarden.network.service
 
+import com.bitwarden.network.api.DigitalAssetLinkApi
+import com.bitwarden.network.model.DigitalAssetLinkResponseJson
 import com.bitwarden.network.util.toResult
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.api.DigitalAssetLinkApi
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
 
 /**
  * Primary implementation of [DigitalAssetLinkService].

--- a/network/src/test/kotlin/com/bitwarden/network/service/DigitalAssetLinkServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/DigitalAssetLinkServiceTest.kt
@@ -1,8 +1,8 @@
-package com.x8bit.bitwarden.data.autofill.fido2.datasource.network.service
+package com.bitwarden.network.service
 
+import com.bitwarden.network.api.DigitalAssetLinkApi
 import com.bitwarden.network.base.BaseServiceTest
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.api.DigitalAssetLinkApi
-import com.x8bit.bitwarden.data.autofill.fido2.datasource.network.model.DigitalAssetLinkResponseJson
+import com.bitwarden.network.model.DigitalAssetLinkResponseJson
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals


### PR DESCRIPTION
## 🎟️ Tracking

PM-20373

## 📔 Objective

Moved the Digital Asset Link API components from the `app` module to the `network` module. This includes:

-   `DigitalAssetLinkApi` interface.
-   `DigitalAssetLinkResponseJson` data model.
-   `DigitalAssetLinkService` interface.
-   `DigitalAssetLinkServiceImpl` implementation.
-   Related unit tests.

Updated all usages to reference the new `network` module location.
Removed the redundant implementations from `app` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
