### PR TITLE
PM-20375: Events to use their own scope

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -47,6 +48,7 @@ import com.x8bit.bitwarden.ui.platform.composition.LocalKeyChainManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.keychain.KeyChainManager
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.launch
 
 /**
  * Displays the about self-hosted/custom environment screen.
@@ -69,6 +71,7 @@ fun EnvironmentScreen(
             )
         }
     }
+    val scope = rememberCoroutineScope()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             is EnvironmentEvent.NavigateBack -> onNavigateBack.invoke()
@@ -83,13 +86,14 @@ fun EnvironmentScreen(
             }
 
             is EnvironmentEvent.ShowSystemCertificateSelectionDialog -> {
-                viewModel.trySendAction(
-                    EnvironmentAction.SystemCertificateSelectionResultReceive(
-                        keyChainManager.choosePrivateKeyAlias(
-                            currentServerUrl = event.serverUrl?.takeUnless { it.isEmpty() },
-                        ),
-                    ),
-                )
+                scope.launch {
+                    val result = keyChainManager.choosePrivateKeyAlias(
+                        currentServerUrl = event.serverUrl?.takeUnless { it.isEmpty() },
+                    )
+                    viewModel.trySendAction(
+                        action = EnvironmentAction.SystemCertificateSelectionResultReceive(result),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -50,6 +51,7 @@ import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.model.WindowSize
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.ui.platform.util.rememberWindowSize
+import kotlinx.coroutines.launch
 
 /**
  * The custom horizontal margin that is specific to this screen.
@@ -68,11 +70,12 @@ fun WelcomeScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val pagerState = rememberPagerState(pageCount = { state.pages.size })
+    val scope = rememberCoroutineScope()
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             is WelcomeEvent.UpdatePager -> {
-                pagerState.animateScrollToPage(event.index)
+                scope.launch { pagerState.animateScrollToPage(event.index) }
             }
 
             WelcomeEvent.NavigateToCreateAccount -> onNavigateToCreateAccount()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/EventsEffect.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/EventsEffect.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.onEach
 fun <E> EventsEffect(
     viewModel: BaseViewModel<*, E, *>,
     lifecycleOwner: Lifecycle = LocalLifecycleOwner.current.lifecycle,
-    handler: suspend (E) -> Unit,
+    handler: (E) -> Unit,
 ) {
     LaunchedEffect(key1 = Unit) {
         viewModel.eventFlow

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -149,6 +149,7 @@ fun GeneratorScreen(
     LaunchedEffect(key1 = coachMarkState.isVisible.value) {
         onDimNavBarRequest(coachMarkState.isVisible.value)
     }
+    val scope = rememberCoroutineScope()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             GeneratorEvent.NavigateToPasswordHistory -> onNavigateToPasswordHistory()
@@ -168,7 +169,9 @@ fun GeneratorScreen(
 
             GeneratorEvent.NavigateBack -> onNavigateBack.invoke()
             GeneratorEvent.StartCoachMarkTour -> {
-                coachMarkState.showCoachMark(ExploreGeneratorCoachMark.PASSWORD_MODE)
+                scope.launch {
+                    coachMarkState.showCoachMark(ExploreGeneratorCoachMark.PASSWORD_MODE)
+                }
             }
         }
     }
@@ -193,23 +196,14 @@ fun GeneratorScreen(
             }
         }
 
-    val scope = rememberCoroutineScope()
     val onShowNextCoachMark: () -> Unit = remember {
-        {
-            scope.launch { coachMarkState.showNextCoachMark() }
-        }
+        { scope.launch { coachMarkState.showNextCoachMark() } }
     }
-
     val onShowPreviousCoachMark: () -> Unit = remember {
-        {
-            scope.launch { coachMarkState.showPreviousCoachMark() }
-        }
+        { scope.launch { coachMarkState.showPreviousCoachMark() } }
     }
-
     val onDismissCoachMark: () -> Unit = remember {
-        {
-            scope.launch { lazyListState.animateScrollToItem(index = 0) }
-        }
+        { scope.launch { lazyListState.animateScrollToItem(index = 0) } }
     }
 
     val passwordHandlers = rememberPasswordHandlers(viewModel)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -121,6 +121,7 @@ fun VaultAddEditScreen(
         lazyListState = lazyListState,
         orderedList = AddEditItemCoachMark.entries,
     )
+    val scope = rememberCoroutineScope()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             is VaultAddEditEvent.NavigateToQrCodeScan -> {
@@ -180,9 +181,11 @@ fun VaultAddEditScreen(
             }
 
             VaultAddEditEvent.StartAddLoginItemCoachMarkTour -> {
-                coachMarkState.showCoachMark(
-                    coachMarkToShow = AddEditItemCoachMark.GENERATE_PASSWORD,
-                )
+                scope.launch {
+                    coachMarkState.showCoachMark(
+                        coachMarkToShow = AddEditItemCoachMark.GENERATE_PASSWORD,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20375](https://bitwarden.atlassian.net/browse/PM-20375)

## 📔 Objective

This PR updates the way `EventsEffect` works to force users to provide their own scope so that nothing blocks other events.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20375]: https://bitwarden.atlassian.net/browse/PM-20375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ