### PR TITLE
PM-20385: Delete confirmation dialog should dismiss on confirmation

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
@@ -150,7 +150,10 @@ private fun RecordedLogsOverflowMenu(
             dismissButtonText = stringResource(id = R.string.cancel),
             onDismissRequest = { showDeletionDialog = false },
             onDismissClick = { showDeletionDialog = false },
-            onConfirmClick = onDeleteAllClick,
+            onConfirmClick = {
+                onDeleteAllClick()
+                showDeletionDialog = false
+            },
         )
     }
     BitwardenOverflowActionItem(
@@ -242,7 +245,10 @@ private fun LogRow(
             dismissButtonText = stringResource(id = R.string.cancel),
             onDismissRequest = { showDeletionDialog = false },
             onDismissClick = { showDeletionDialog = false },
-            onConfirmClick = { onDeleteItemClick(displayableItem) },
+            onConfirmClick = {
+                onDeleteItemClick(displayableItem)
+                showDeletionDialog = false
+            },
         )
     }
     Row(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
@@ -159,6 +159,7 @@ class RecordedLogsScreenTest : BaseComposeTest() {
             .onAllNodesWithText(text = "Yes")
             .filterToOne(matcher = hasAnyAncestor(isDialog()))
             .performClick()
+        composeTestRule.assertNoDialogExists()
 
         verify(exactly = 1) {
             viewModel.trySendAction(RecordedLogsAction.DeleteAllClick)
@@ -274,6 +275,7 @@ class RecordedLogsScreenTest : BaseComposeTest() {
             .onAllNodesWithText(text = "Yes")
             .filterToOne(matcher = hasAnyAncestor(isDialog()))
             .performClick()
+        composeTestRule.assertNoDialogExists()
 
         verify(exactly = 1) {
             viewModel.trySendAction(RecordedLogsAction.DeleteClick(displayItem))


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20385](https://bitwarden.atlassian.net/browse/PM-20385)

## 📔 Objective

This PR ensures that the delete log confirmation dialog is removed after the user clicks "yes".

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20385]: https://bitwarden.atlassian.net/browse/PM-20385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ