### PR TITLE
PM-20400: Display snackbar confirming log deletion

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
@@ -46,6 +46,9 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialo
 import com.x8bit.bitwarden.ui.platform.components.model.CardStyle
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
+import com.x8bit.bitwarden.ui.platform.components.snackbar.rememberBitwardenSnackbarHostState
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
@@ -64,11 +67,18 @@ fun RecordedLogsScreen(
     intentManager: IntentManager = LocalIntentManager.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
+    val snackbarHostState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel) { event ->
         when (event) {
             RecordedLogsEvent.NavigateBack -> onNavigateBack()
             is RecordedLogsEvent.ShareLog -> {
                 intentManager.shareFile(fileUri = event.uri.toUri())
+            }
+
+            is RecordedLogsEvent.ShowSnackbar -> {
+                snackbarHostState.showSnackbar(
+                    snackbarData = BitwardenSnackbarData(message = event.text),
+                )
             }
         }
     }
@@ -104,6 +114,7 @@ fun RecordedLogsScreen(
                 },
             )
         },
+        snackbarHost = { BitwardenSnackbarHost(bitwardenHostState = snackbarHostState) },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
     ) {
         when (val viewState = state.viewState) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsViewModel.kt
@@ -74,6 +74,7 @@ class RecordedLogsViewModel @Inject constructor(
 
     private fun handleDeleteAllClick() {
         settingsRepository.deleteAllLogs()
+        sendEvent(RecordedLogsEvent.ShowSnackbar(text = R.string.all_logs_deleted.asText()))
     }
 
     private fun handleDeleteClick(action: RecordedLogsAction.DeleteClick) {
@@ -81,7 +82,10 @@ class RecordedLogsViewModel @Inject constructor(
             .flightRecorderData
             .data
             .find { it.id == action.item.id }
-            ?.let { settingsRepository.deleteLog(data = it) }
+            ?.let {
+                settingsRepository.deleteLog(data = it)
+                sendEvent(RecordedLogsEvent.ShowSnackbar(text = R.string.log_deleted.asText()))
+            }
     }
 
     private fun handleShareAllClick() {
@@ -256,6 +260,11 @@ sealed class RecordedLogsEvent {
      * Shares the logs are the given [uri].
      */
     data class ShareLog(val uri: String) : RecordedLogsEvent()
+
+    /**
+     * Displays a snackbar with the given [text].
+     */
+    data class ShowSnackbar(val text: Text) : RecordedLogsEvent()
 }
 
 /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1256,4 +1256,6 @@ Do you want to switch to this account?</string>
   <string name="flight_recorder_banner_title">Flight recorder on</string>
   <string name="flight_recorder_banner_message">Flight recorder will be active until %1$s at %2$s. Return to settings to deactivate now.</string>
   <string name="go_to_settings">Go to settings</string>
+  <string name="all_logs_deleted">All logs deleted</string>
+  <string name="log_deleted">Log deleted</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
@@ -82,6 +82,16 @@ class RecordedLogsScreenTest : BaseComposeTest() {
     }
 
     @Test
+    fun `on ShowSnackbar event should display the snackbar with the correct message`() {
+        val message = "Test Snackbar Message"
+        mutableEventFlow.tryEmit(RecordedLogsEvent.ShowSnackbar(text = message.asText()))
+
+        composeTestRule
+            .onNodeWithText(text = message)
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun `on ShareLog event should invoke shareFile on intent manager`() {
         val stringUri = "/logs"
         mutableEventFlow.tryEmit(RecordedLogsEvent.ShareLog(uri = stringUri))

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
@@ -257,16 +257,22 @@ class RecordedLogsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `on DeleteAllClick action should call deleteAllLogs`() {
+    fun `on DeleteAllClick action should call deleteAllLogs`() = runTest {
         val viewModel = createViewModel()
-        viewModel.trySendAction(RecordedLogsAction.DeleteAllClick)
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(RecordedLogsAction.DeleteAllClick)
+            assertEquals(
+                RecordedLogsEvent.ShowSnackbar(R.string.all_logs_deleted.asText()),
+                awaitItem(),
+            )
+        }
         verify(exactly = 1) {
             settingsRepository.deleteAllLogs()
         }
     }
 
     @Test
-    fun `on DeleteClick action should call deleteLog`() {
+    fun `on DeleteClick action should call deleteLog`() = runTest {
         val data = mockk<FlightRecorderDataSet.FlightRecorderData> {
             every { id } returns "50"
         }
@@ -276,7 +282,13 @@ class RecordedLogsViewModelTest : BaseViewModelTest() {
         val item = mockk<RecordedLogsState.DisplayItem> {
             every { id } returns "50"
         }
-        viewModel.trySendAction(RecordedLogsAction.DeleteClick(item = item))
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(RecordedLogsAction.DeleteClick(item = item))
+            assertEquals(
+                RecordedLogsEvent.ShowSnackbar(R.string.log_deleted.asText()),
+                awaitItem(),
+            )
+        }
         verify(exactly = 1) {
             settingsRepository.deleteLog(data = data)
         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20400](https://bitwarden.atlassian.net/browse/PM-20400)

## 📔 Objective

This PR adds a confirmation Snackbar after deleting flight recorder logs.

## 📸 Screenshots

| Single Log Deleted | All Logs Deleted |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5d94963d-7c2d-4402-af82-551ba7c23980" width="300" /> | <img src="https://github.com/user-attachments/assets/aac5344f-9471-4490-85b1-c4ff506eaa73" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20400]: https://bitwarden.atlassian.net/browse/PM-20400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ