### PR TITLE
Drop all tables when performing destructive migration in Authenticator

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/di/AuthenticatorDiskModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/datasource/disk/di/AuthenticatorDiskModule.kt
@@ -30,7 +30,7 @@ object AuthenticatorDiskModule {
                 klass = AuthenticatorDatabase::class.java,
                 name = "authenticator_database",
             )
-            .fallbackToDestructiveMigration()
+            .fallbackToDestructiveMigration(dropAllTables = true)
             .addTypeConverter(AuthenticatorItemTypeConverter())
             .addTypeConverter(AuthenticatorItemAlgorithmConverter())
             .build()


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Updated the `AuthenticatorDatabase` setup to use `fallbackToDestructiveMigration(dropAllTables = true)` instead of the deprecated `fallbackToDestructiveMigration()`. This ensures that all tables are dropped and recreated during a destructive migration.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
