### PR TITLE
[PM-17686] Allow overwriting TLS certificates

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/CertificateManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/CertificateManager.kt
@@ -10,6 +10,11 @@ import com.x8bit.bitwarden.data.platform.manager.model.ImportPrivateKeyResult
 interface CertificateManager : CertificateProvider {
 
     /**
+     * Returns a list of aliases for all mTLS keys stored in the application KeyStore.
+     */
+    fun getMutualTlsKeyAliases(): List<String>
+
+    /**
      * Import a private key into the application KeyStore.
      *
      * @param key The private key to be saved.

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/CertificateManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/CertificateManagerImpl.kt
@@ -28,6 +28,7 @@ import java.security.cert.X509Certificate
 /**
  * Default implementation of [CertificateManager].
  */
+@Suppress("TooManyFunctions")
 class CertificateManagerImpl(
     private val context: Context,
     private val environmentRepository: EnvironmentRepository,
@@ -60,6 +61,8 @@ class CertificateManagerImpl(
                 host = host,
             )
         }
+
+    override fun getMutualTlsKeyAliases(): List<String> = androidKeyStore.aliases().toList()
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     @WorkerThread
@@ -130,10 +133,6 @@ class CertificateManagerImpl(
         // Step 4: Store the private key and X.509 certificate in the AndroidKeyStore if the alias
         // does not exists.
         with(androidKeyStore) {
-            if (containsAlias(alias)) {
-                return ImportPrivateKeyResult.Error.DuplicateAlias
-            }
-
             try {
                 setKeyEntry(alias, privateKey, null, certChain)
             } catch (e: KeyStoreException) {

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/ImportPrivateKeyResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/ImportPrivateKeyResult.kt
@@ -36,13 +36,6 @@ sealed class ImportPrivateKeyResult {
         ) : Error()
 
         /**
-         * Indicates that the specified alias is already in use.
-         */
-        data object DuplicateAlias : Error() {
-            override val throwable: Throwable? = null
-        }
-
-        /**
          * Indicates that an error occurred during the key store operation.
          */
         data class KeyStoreOperationFailed(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
@@ -104,8 +104,9 @@ fun EnvironmentScreen(
                 title = stringResource(id = R.string.an_error_has_occurred),
                 message = dialog.message(),
                 onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.ErrorDialogDismiss) }
+                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
                 },
+                throwable = dialog.throwable,
             )
         }
 
@@ -145,10 +146,34 @@ fun EnvironmentScreen(
                 },
                 dismissButtonText = stringResource(R.string.cancel),
                 onDismissClick = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.ErrorDialogDismiss) }
+                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
                 },
                 onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.ErrorDialogDismiss) }
+                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
+                },
+            )
+        }
+
+        is EnvironmentState.DialogState.ConfirmOverwriteAlias -> {
+            BitwardenTwoButtonDialog(
+                title = dialog.title(),
+                message = dialog.message(),
+                confirmButtonText = stringResource(R.string.replace_certificate),
+                dismissButtonText = stringResource(R.string.cancel),
+                onConfirmClick = remember(viewModel) {
+                    {
+                        viewModel.trySendAction(
+                            EnvironmentAction.ConfirmOverwriteCertificateClick(
+                                triggeringAction = dialog.triggeringAction,
+                            ),
+                        )
+                    }
+                },
+                onDismissClick = remember(viewModel) {
+                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
+                },
+                onDismissRequest = remember(viewModel) {
+                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
                 },
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1259,4 +1259,8 @@ Do you want to switch to this account?</string>
     <string name="all_logs_deleted">All logs deleted</string>
     <string name="log_deleted">Log deleted</string>
     <string name="app_settings">App settings</string>
+    <string name="replace_existing_certificate">Replace existing certificate?</string>
+    <string name="a_certificate_with_the_alias_x_already_exists_do_you_want_to_replace_it">A certificate with this alias \"%s\" already exists. Do you want to replace it?\nReplace the certificate may impact your connection to any environments currently using it.</string>
+    <string name="replace_certificate">Replace certificate</string>
+    <string name="unable_to_read_certificate">Unable to read certificate.</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
@@ -124,7 +124,7 @@ class EnvironmentScreenTest : BaseComposeTest() {
             .onAllNodesWithText("Ok")
             .filterToOne(hasAnyAncestor(isDialog()))
             .performClick()
-        verify { viewModel.trySendAction(EnvironmentAction.ErrorDialogDismiss) }
+        verify { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
     }
 
     @Test
@@ -308,6 +308,111 @@ class EnvironmentScreenTest : BaseComposeTest() {
         verify {
             viewModel.trySendAction(
                 EnvironmentAction.IconsServerUrlChange(iconsServerUrl = "updated-icons-url"),
+            )
+        }
+    }
+
+    @Test
+    fun `ConfirmOverwriteCertificate dialog should display based on state`() {
+        composeTestRule.onNode(isDialog()).assertDoesNotExist()
+
+        mutableStateFlow.update {
+            it.copy(
+                dialog = DialogState.ConfirmOverwriteAlias(
+                    title = "Confirm overwrite".asText(),
+                    message = "Overwrite existing certificate?".asText(),
+                    triggeringAction = EnvironmentAction.SetCertificateInfoResultReceive(
+                        certificateFileData = mockk(),
+                        alias = "mockAlias",
+                        password = "mockPassword",
+                    ),
+                ),
+            )
+        }
+
+        composeTestRule.onNode(isDialog()).assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("Confirm overwrite")
+            .assert(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("Overwrite existing certificate?")
+            .assert(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("Cancel")
+            .assert(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("Replace certificate")
+            .assert(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ConfirmOverwriteCertificate dialog Replace certificate click should send ConfirmOverwriteCertificate action`() {
+        val mockFileData = mockk<IntentManager.FileData>()
+        mutableStateFlow.update {
+            it.copy(
+                dialog = DialogState.ConfirmOverwriteAlias(
+                    title = "Confirm overwrite".asText(),
+                    message = "Overwrite existing certificate?".asText(),
+                    triggeringAction = EnvironmentAction.SetCertificateInfoResultReceive(
+                        certificateFileData = mockFileData,
+                        alias = "mockAlias",
+                        password = "mockPassword",
+                    ),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onAllNodesWithText("Replace certificate")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                EnvironmentAction.ConfirmOverwriteCertificateClick(
+                    EnvironmentAction.SetCertificateInfoResultReceive(
+                        certificateFileData = mockFileData,
+                        alias = "mockAlias",
+                        password = "mockPassword",
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `ConfirmOverwriteCertificate dialog Cancel click should send DismissDialog action`() {
+        mutableStateFlow.update {
+            it.copy(
+                dialog = DialogState.ConfirmOverwriteAlias(
+                    title = "Confirm overwrite".asText(),
+                    message = "Overwrite existing certificate?".asText(),
+                    triggeringAction = EnvironmentAction.SetCertificateInfoResultReceive(
+                        certificateFileData = mockk(),
+                        alias = "mockAlias",
+                        password = "mockPassword",
+                    ),
+                ),
+            )
+        }
+
+        composeTestRule
+            .onAllNodesWithText("Cancel")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                EnvironmentAction.DialogDismiss,
             )
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

PM-17686

## 📔 Objective

When a certificate alias already exists, the app now displays a confirmation dialog to allow the user to overwrite the existing certificate.

## 📸 Screenshots

<img width="413" alt="image" src="https://github.com/user-attachments/assets/f16da68f-902f-442d-b3a6-3c6538d2a0fd" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
