### PR TITLE
PM-20552: Ensure userState does not emit while the active user is unlocking

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -283,6 +283,7 @@ class AuthRepositoryImpl(
         merge(
             mutableHasPendingAccountDeletionStateFlow,
             mutableUserStateTransactionCountStateFlow,
+            vaultRepository.isActiveUserUnlockingFlow,
         ),
     ) { array ->
         val userStateJson = array[0] as UserStateJson?
@@ -306,8 +307,11 @@ class AuthRepositoryImpl(
             firstTimeState = firstTimeState,
         )
     }
-        .filterNot { mutableHasPendingAccountDeletionStateFlow.value }
-        .filterNot { mutableUserStateTransactionCountStateFlow.value > 0 }
+        .filterNot {
+            mutableHasPendingAccountDeletionStateFlow.value ||
+                mutableUserStateTransactionCountStateFlow.value > 0 ||
+                vaultRepository.isActiveUserUnlockingFlow.value
+        }
         .stateIn(
             scope = unconfinedScope,
             started = SharingStarted.Eagerly,

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManager.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.vault.manager
 
 import com.bitwarden.core.InitUserCryptoMethod
 import com.bitwarden.crypto.Kdf
+import com.bitwarden.sdk.AuthClient
 import com.x8bit.bitwarden.data.vault.manager.model.VaultStateEvent
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
@@ -16,6 +17,11 @@ interface VaultLockManager {
      * Flow that represents the current vault lock state for each user.
      */
     val vaultUnlockDataStateFlow: StateFlow<List<VaultUnlockData>>
+
+    /**
+     * Flow that indicates whether the active user is actively unlocking the vault.
+     */
+    val isActiveUserUnlockingFlow: StateFlow<Boolean>
 
     /**
      * Flow that emits whenever any vault is locked or unlocked.

--- a/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -19,6 +19,7 @@ import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
+import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokens
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
@@ -41,9 +42,11 @@ import com.x8bit.bitwarden.data.vault.repository.util.update
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -56,8 +59,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
@@ -98,6 +103,26 @@ class VaultLockManagerImpl(
 
     override val vaultUnlockDataStateFlow: StateFlow<List<VaultUnlockData>>
         get() = mutableVaultUnlockDataStateFlow.asStateFlow()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override val isActiveUserUnlockingFlow: StateFlow<Boolean>
+        get() = authDiskSource
+            .activeUserIdChangesFlow
+            .flatMapLatest { activeUserId ->
+                vaultUnlockDataStateFlow.map { vaultUnlockData ->
+                    vaultUnlockData.any {
+                        it.userId == activeUserId && it.status == VaultUnlockData.Status.UNLOCKING
+                    }
+                }
+            }
+            .distinctUntilChanged()
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Lazily,
+                initialValue = mutableVaultUnlockDataStateFlow.value.any {
+                    it.userId == activeUserId && it.status == VaultUnlockData.Status.UNLOCKING
+                },
+            )
 
     override val vaultStateEventFlow: Flow<VaultStateEvent>
         get() = mutableVaultStateEventSharedFlow.asSharedFlow()
@@ -144,7 +169,7 @@ class VaultLockManagerImpl(
         privateKey: String,
         initUserCryptoMethod: InitUserCryptoMethod,
         organizationKeys: Map<String, String>?,
-    ): VaultUnlockResult =
+    ): VaultUnlockResult = withContext(context = NonCancellable) {
         flow {
             setVaultToUnlocking(userId = userId)
             emit(
@@ -202,10 +227,9 @@ class VaultLockManagerImpl(
                                 .also {
                                     if (it is VaultUnlockResult.Success) {
                                         clearInvalidUnlockCount(userId = userId)
-                                        setVaultToUnlocked(userId = userId)
-                                        trustedDeviceManager.trustThisDeviceIfNecessary(
-                                            userId = userId,
-                                        )
+                                        trustedDeviceManager
+                                            .trustThisDeviceIfNecessary(userId = userId)
+                                            .also { setVaultToUnlocked(userId = userId) }
                                     } else {
                                         incrementInvalidUnlockCount(userId = userId)
                                     }
@@ -216,6 +240,7 @@ class VaultLockManagerImpl(
         }
             .onCompletion { setVaultToNotUnlocking(userId = userId) }
             .first()
+    }
 
     override suspend fun waitUntilUnlocked(userId: String) {
         vaultUnlockDataStateFlow

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -170,9 +170,11 @@ class AuthRepositoryTest {
     private val haveIBeenPwnedService: HaveIBeenPwnedService = mockk()
     private val organizationService: OrganizationService = mockk()
     private val mutableVaultUnlockDataStateFlow = MutableStateFlow(VAULT_UNLOCK_DATA)
+    private val mutableIsActiveUserUnlockingFlow = MutableStateFlow(false)
     private val vaultRepository: VaultRepository = mockk {
         every { vaultUnlockDataStateFlow } returns mutableVaultUnlockDataStateFlow
         every { deleteVaultData(any()) } just runs
+        every { isActiveUserUnlockingFlow } returns mutableIsActiveUserUnlockingFlow
     }
     private val fakeAuthDiskSource = FakeAuthDiskSource()
     private val fakeEnvironmentRepository =


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20552](https://bitwarden.atlassian.net/browse/PM-20966)

## 📔 Objective

This PR Fixes a TDE bug caused by a race condition that occurs when logging in.

When logging in with TDE and trusting the device, 3 distinct flags will be set that can cause the `userState` to emit and the `RootNavScreen` to change it's target destination:
* `shouldTrustDevice`
* `isTdeLoginComplete`
* `isVaultUnlocked`

We want these 3 properties to all update together as a single transaction in order to ensure the app does not navigate prematurely. This premature navigation can cause the user to be logged-out or cancel the trusted device process. To fix this, I am ensuring that the userState does not emit while the active user is unlocking their vault and as soon as the entire process is complete, it updates at that time. The other thing I have done is make the `unlockVault` function non-cancellable.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20552]: https://bitwarden.atlassian.net/browse/PM-20552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ