### PR TITLE
[PM-14846] Improve IP Address and Port Handling in StringExtensions

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/util/StringExtensionsTest.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.platform.util.getWebHostFromAndroidUriOrNull
 import com.x8bit.bitwarden.data.platform.util.hasHttpProtocol
 import com.x8bit.bitwarden.data.platform.util.hasPort
 import com.x8bit.bitwarden.data.platform.util.isAndroidApp
+import com.x8bit.bitwarden.data.platform.util.isIpAddress
 import com.x8bit.bitwarden.data.platform.util.parseDomainOrNull
 import com.x8bit.bitwarden.data.platform.util.toUriOrNull
 import io.mockk.every
@@ -201,6 +202,12 @@ class StringExtensionsTest {
     }
 
     @Test
+    fun `hasPort returns true when URI is IP address and port`() {
+        val uriString = "192.168.1.1:8080"
+        assertTrue(uriString.hasPort())
+    }
+
+    @Test
     fun `getHostWithPortOrNull should return host with port when present`() {
         val uriString = "www.google.com:8080"
         assertEquals("www.google.com:8080", uriString.getHostWithPortOrNull())
@@ -223,4 +230,48 @@ class StringExtensionsTest {
         val uriString = "androidapp://www.google.com:8080"
         assertEquals("www.google.com:8080", uriString.getHostWithPortOrNull())
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getHostWithPortOrNull should return host with port when URI is IP address with port and scheme`() {
+        val uriString = "https://192.168.1.1:8080"
+        assertEquals("192.168.1.1:8080", uriString.getHostWithPortOrNull())
+    }
+
+    @Test
+    fun `isIpAddress should return correct value for various IP addresses`() {
+        testIpAddresses.forEach { (ipAddress, expected) ->
+            assertEquals(expected, ipAddress.isIpAddress()) { "Failed for $ipAddress" }
+        }
+    }
+
+    private val testIpAddresses = listOf(
+        "192.168.1.1" to true,
+        "10.0.0.5:8080" to true,
+        "255.255.255.0:9000" to true,
+        "0.0.0.0" to true,
+        "256.1.1.1" to false,
+        "10.1.1" to false,
+        "10.1.1.1:abc" to false,
+        "10.1.1.1:-1" to false,
+        "10.1.1.1:" to false,
+        "10.1.1.1:0" to true,
+        "1.1.1.1:123" to true,
+        "1.1.1.1:65535" to true,
+        "1.1.1.1:65536" to false,
+        "1.1.1.1:99999" to false,
+        ":1234" to false,
+        "255.255.255.255:65535" to true,
+        "255.255.255.255:0" to true,
+        "255.255.255.255:" to false,
+        "255.255.255.255:-1" to false,
+        "http://192.168.1.1" to true,
+        "https://10.0.0.5:8080" to true,
+        "http://255.255.255.0:9000" to true,
+        "https://0.0.0.0" to true,
+        "http://256.1.1.1" to false,
+        "https://10.1.1" to false,
+        "http://10.1.1.1:abc" to false,
+        "https://10.1.1.1:-1" to false,
+    )
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-14846
PM-20513
Relates to #5084 

## 📔 Objective

Correct parsing of IP addresses with and without scheme and port. `URI` cannot parse an IP address with a port when it does not also include the scheme (http, https), so autofill matching triggered from the Quick Tile was not working properly.

-   **New Function:** Added `isIpAddress()` to check if a string is a valid IPv4 address, optionally with a port and scheme.
-   **Regex Update:** Added the `IP_ADDRESS_WITH_OPTIONAL_PORT` regex. It validates IPv4 addresses with or without ports (0-65535 range), with an optional `http://` or `https://` prefix.
-   **URI Parsing:** Modified `toUriOrNull()` to handle IP addresses without schemes by adding a default "https://" scheme before parsing.
- **Tests update**: Added new tests for `isIpAddress` function.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
