### PR TITLE
[PM-20037] Remove native-carousel-flow feature flag

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -116,7 +116,6 @@ import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.util.getActivePolicies
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -380,8 +379,7 @@ class AuthRepositoryImpl(
         get() = activeUserId?.let { authDiskSource.getOrganizations(it) }.orEmpty()
 
     override val showWelcomeCarousel: Boolean
-        get() = !settingsRepository.hasUserLoggedInOrCreatedAccount &&
-            featureFlagManager.getFeatureFlag(FlagKey.OnboardingCarousel)
+        get() = !settingsRepository.hasUserLoggedInOrCreatedAccount
 
     init {
         combine(

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -29,7 +29,6 @@ sealed class FlagKey<out T : Any> {
                 AuthenticatorSync,
                 EmailVerification,
                 OnboardingFlow,
-                OnboardingCarousel,
                 ImportLoginsFlow,
                 VerifiedSsoDomainEndpoint,
                 CredentialExchangeProtocolImport,
@@ -82,15 +81,6 @@ sealed class FlagKey<out T : Any> {
         override val keyName: String = "enable-pm-flight-recorder"
         override val defaultValue: Boolean = false
         override val isRemotelyConfigured: Boolean = false
-    }
-
-    /**
-     * Data object holding the feature flag key for the Onboarding Carousel feature.
-     */
-    data object OnboardingCarousel : FlagKey<Boolean>() {
-        override val keyName: String = "native-carousel-flow"
-        override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -101,8 +101,6 @@ fun DebugMenuScreen(
             Spacer(Modifier.height(height = 16.dp))
             // Pulled these into variable to avoid over-nested formatting in the composable call.
             val isRestartOnboardingEnabled = state.featureFlags[FlagKey.OnboardingFlow] as? Boolean
-            val isRestartOnboardingCarouselEnabled = state
-                .featureFlags[FlagKey.OnboardingCarousel] as? Boolean
             OnboardingOverrideContent(
                 isRestartOnboardingEnabled = isRestartOnboardingEnabled == true,
                 onStartOnboarding = remember(viewModel) {
@@ -110,7 +108,6 @@ fun DebugMenuScreen(
                         viewModel.trySendAction(DebugMenuAction.RestartOnboarding)
                     }
                 },
-                isCarouselOverrideEnabled = isRestartOnboardingCarouselEnabled == true,
                 onStartOnboardingCarousel = remember(viewModel) {
                     {
                         viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel)
@@ -183,7 +180,6 @@ private fun FeatureFlagContent(
 private fun OnboardingOverrideContent(
     isRestartOnboardingEnabled: Boolean,
     onStartOnboarding: () -> Unit,
-    isCarouselOverrideEnabled: Boolean,
     onStartOnboardingCarousel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -217,7 +213,6 @@ private fun OnboardingOverrideContent(
         BitwardenFilledButton(
             label = stringResource(R.string.restart_onboarding_carousel),
             onClick = onStartOnboardingCarousel,
-            isEnabled = isCarouselOverrideEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
@@ -242,7 +237,6 @@ private fun FeatureFlagContent_preview() {
         FeatureFlagContent(
             featureFlagMap = persistentMapOf(
                 FlagKey.EmailVerification to true,
-                FlagKey.OnboardingCarousel to true,
                 FlagKey.OnboardingFlow to false,
             ),
             onValueChange = { _, _ -> },
@@ -259,7 +253,6 @@ private fun OnboardingOverrideContent_preview() {
             onStartOnboarding = {},
             isRestartOnboardingEnabled = true,
             onStartOnboardingCarousel = {},
-            isCarouselOverrideEnabled = true,
         )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -27,7 +27,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
 
     FlagKey.AuthenticatorSync,
     FlagKey.EmailVerification,
-    FlagKey.OnboardingCarousel,
     FlagKey.OnboardingFlow,
     FlagKey.ImportLoginsFlow,
     FlagKey.VerifiedSsoDomainEndpoint,
@@ -87,7 +86,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
 
     FlagKey.AuthenticatorSync -> stringResource(R.string.authenticator_sync)
     FlagKey.EmailVerification -> stringResource(R.string.email_verification)
-    FlagKey.OnboardingCarousel -> stringResource(R.string.onboarding_carousel)
     FlagKey.OnboardingFlow -> stringResource(R.string.onboarding_flow)
     FlagKey.ImportLoginsFlow -> stringResource(R.string.import_logins_flow)
     FlagKey.VerifiedSsoDomainEndpoint -> stringResource(R.string.verified_sso_domain_verified)

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -9,7 +9,6 @@
 
     <!-- Debug Menu -->
     <string name="email_verification">Email Verification</string>
-    <string name="onboarding_carousel">Onboarding Carousel</string>
     <string name="onboarding_flow">Onboarding Flow</string>
     <string name="import_logins_flow">Import Logins Flow</string>
     <string name="feature_flags">Feature Flags:</string>

--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -5497,17 +5497,11 @@ class AuthRepositoryTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `showWelcomeCarousel should return value from settings repository and feature flag manager`() {
+    fun `showWelcomeCarousel should return value from settings repository`() {
         every { settingsRepository.hasUserLoggedInOrCreatedAccount } returns false
-        every { featureFlagManager.getFeatureFlag(FlagKey.OnboardingCarousel) } returns true
         assertTrue(repository.showWelcomeCarousel)
 
         every { settingsRepository.hasUserLoggedInOrCreatedAccount } returns true
-        every { featureFlagManager.getFeatureFlag(FlagKey.OnboardingCarousel) } returns true
-        assertFalse(repository.showWelcomeCarousel)
-
-        every { settingsRepository.hasUserLoggedInOrCreatedAccount } returns true
-        every { featureFlagManager.getFeatureFlag(FlagKey.OnboardingCarousel) } returns false
         assertFalse(repository.showWelcomeCarousel)
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -18,10 +18,6 @@ class FlagKeyTest {
             "email-verification",
         )
         assertEquals(
-            FlagKey.OnboardingCarousel.keyName,
-            "native-carousel-flow",
-        )
-        assertEquals(
             FlagKey.OnboardingFlow.keyName,
             "native-create-account-flow",
         )
@@ -89,7 +85,6 @@ class FlagKeyTest {
             listOf(
                 FlagKey.AuthenticatorSync,
                 FlagKey.EmailVerification,
-                FlagKey.OnboardingCarousel,
                 FlagKey.OnboardingFlow,
                 FlagKey.ImportLoginsFlow,
                 FlagKey.VerifiedSsoDomainEndpoint,
@@ -116,7 +111,6 @@ class FlagKeyTest {
             listOf(
                 FlagKey.AuthenticatorSync,
                 FlagKey.EmailVerification,
-                FlagKey.OnboardingCarousel,
                 FlagKey.OnboardingFlow,
                 FlagKey.ImportLoginsFlow,
                 FlagKey.VerifiedSsoDomainEndpoint,

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
@@ -105,10 +105,6 @@ class DebugMenuRepositoryTest {
                     FlagKey.EmailVerification.defaultValue,
                 )
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
-                    FlagKey.OnboardingCarousel,
-                    FlagKey.OnboardingCarousel.defaultValue,
-                )
-                mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
                     FlagKey.OnboardingFlow,
                     FlagKey.OnboardingFlow.defaultValue,
                 )
@@ -127,7 +123,6 @@ class DebugMenuRepositoryTest {
             val mockServerData = mockk<ConfigResponseJson>(relaxed = true) {
                 every { featureStates } returns mapOf(
                     FlagKey.EmailVerification.keyName to JsonPrimitive(true),
-                    FlagKey.OnboardingCarousel.keyName to JsonPrimitive(true),
                     FlagKey.OnboardingFlow.keyName to JsonPrimitive(true),
                 )
             }
@@ -139,13 +134,8 @@ class DebugMenuRepositoryTest {
             debugMenuRepository.resetFeatureFlagOverrides()
 
             assertTrue(FlagKey.EmailVerification.isRemotelyConfigured)
-            assertTrue(FlagKey.OnboardingCarousel.isRemotelyConfigured)
             verify(exactly = 1) {
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(FlagKey.EmailVerification, true)
-                mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
-                    FlagKey.OnboardingCarousel,
-                    true,
-                )
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
                     FlagKey.OnboardingFlow,
                     true,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
@@ -151,13 +151,6 @@ class DebugMenuScreenTest : BaseComposeTest() {
 
     @Test
     fun `Show onboarding carousel should send action when enabled and clicked`() {
-        mutableStateFlow.tryEmit(
-            DebugMenuState(
-                featureFlags = persistentMapOf(
-                    FlagKey.OnboardingCarousel to true,
-                ),
-            ),
-        )
         composeTestRule
             .onNodeWithText("Show Onboarding Carousel", ignoreCase = true)
             .performScrollTo()
@@ -165,25 +158,6 @@ class DebugMenuScreenTest : BaseComposeTest() {
             .performClick()
 
         verify(exactly = 1) { viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel) }
-    }
-
-    @Test
-    fun `show onboarding carousel should not send action when not enabled`() {
-        mutableStateFlow.tryEmit(
-            DebugMenuState(
-                featureFlags = persistentMapOf(
-                    FlagKey.OnboardingCarousel to false,
-                ),
-            ),
-        )
-
-        composeTestRule
-            .onNodeWithText("Show Onboarding Carousel", ignoreCase = true)
-            .performScrollTo()
-            .assertIsNotEnabled()
-            .performClick()
-
-        verify(exactly = 0) { viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel) }
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -122,7 +122,6 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
 private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf(
     FlagKey.AuthenticatorSync to true,
     FlagKey.EmailVerification to true,
-    FlagKey.OnboardingCarousel to true,
     FlagKey.OnboardingFlow to true,
     FlagKey.ImportLoginsFlow to true,
     FlagKey.VerifiedSsoDomainEndpoint to true,
@@ -143,7 +142,6 @@ private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
 private val UPDATED_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf(
     FlagKey.AuthenticatorSync to false,
     FlagKey.EmailVerification to false,
-    FlagKey.OnboardingCarousel to true,
     FlagKey.OnboardingFlow to false,
     FlagKey.ImportLoginsFlow to false,
     FlagKey.VerifiedSsoDomainEndpoint to false,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-20037

## 📔 Objective

Remove the Onboarding Carousel flag, keeping the DebugMenu button to restart the Onboarding Carousel

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
