### PR TITLE
[PM-20127] Prevent double UV prompt during FIDO 2 operations

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/autofill/fido2/manager/Fido2CredentialManagerImpl.kt
@@ -321,7 +321,9 @@ class Fido2CredentialManagerImpl(
             )
             .setIcon(iconCompat.toIcon(context))
 
-        if (featureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)) {
+        if (featureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication) &&
+            !isUserVerified
+        ) {
             biometricsEncryptionManager
                 .getOrCreateCipher(userId)
                 ?.let { cipher ->


### PR DESCRIPTION
## 🎟️ Tracking

PM-20127

## 📔 Objective

The logic for single tap passkey authentication has been updated to prevent user verification when user is already verified.

## 📸 Screenshots

https://github.com/user-attachments/assets/ce534184-7752-479b-b53a-ffa07584612b

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
