### PR TITLE
PM-21156: Fix ConfigService retrofit instance

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -18,7 +18,6 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.model.Ch
 import com.x8bit.bitwarden.ui.platform.util.persistentListOfNotNull
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -58,7 +57,9 @@ class AutoFillViewModel @Inject constructor(
                 defaultUriMatchType = settingsRepository.defaultUriMatchType,
                 showAutofillActionCard = false,
                 activeUserId = userId,
-                chromeAutofillSettingsOptions = persistentListOf(),
+                chromeAutofillSettingsOptions = chromeThirdPartyAutofillEnabledManager
+                    .chromeThirdPartyAutofillStatus
+                    .toChromeAutoFillSettingsOptions(),
             )
         },
 ) {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -50,6 +50,7 @@ class AutoFillViewModelTest : BaseViewModelTest() {
     private val chromeThirdPartyAutofillEnabledManager =
         mockk<ChromeThirdPartyAutofillEnabledManager> {
             every { chromeThirdPartyAutofillStatusFlow } returns mutableChromeAutofillStatusFlow
+            every { chromeThirdPartyAutofillStatus } returns DEFAULT_AUTOFILL_STATUS
         }
 
     private val settingsRepository: SettingsRepository = mockk {
@@ -79,7 +80,6 @@ class AutoFillViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `initial state should be correct when not set`() {
-        mockkStatic(::isBuildVersionBelow)
         every { isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE) } returns false
 
         val viewModel = createViewModel(state = null)
@@ -90,7 +90,6 @@ class AutoFillViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `initial state should be correct when set`() {
-        mockkStatic(::isBuildVersionBelow)
         every { isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE) } returns false
 
         mutableIsAutofillEnabledStateFlow.value = true
@@ -106,7 +105,6 @@ class AutoFillViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `initial state should be correct when sdk is below min`() {
-        mockkStatic(::isBuildVersionBelow)
         every { isBuildVersionBelow(Build.VERSION_CODES.UPSIDE_DOWN_CAKE) } returns true
 
         val expected = DEFAULT_STATE.copy(

--- a/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClientImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClientImpl.kt
@@ -118,7 +118,7 @@ internal class BitwardenServiceClientImpl(
 
     override val configService: ConfigService by lazy {
         ConfigServiceImpl(
-            configApi = retrofits.createStaticRetrofit().create(),
+            configApi = retrofits.unauthenticatedApiRetrofit.create(),
         )
     }
 

--- a/network/src/main/kotlin/com/bitwarden/network/service/ConfigServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/ConfigServiceImpl.kt
@@ -7,7 +7,6 @@ import com.bitwarden.network.util.toResult
 /**
  * Default implementation of [ConfigService] for querying app configurations.
  */
-// TODO [PM-19846] Make internal when dependents are migrated.
 internal class ConfigServiceImpl(private val configApi: ConfigApi) : ConfigService {
     override suspend fun getConfig(): Result<ConfigResponseJson> = configApi.getConfig().toResult()
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21156](https://bitwarden.atlassian.net/browse/PM-21156)

## 📔 Objective

This PR fixes the retrofit instance used by the `ConfigService` to ensure configurations are pulled from the correct environment.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21156]: https://bitwarden.atlassian.net/browse/PM-21156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ