### PR TITLE
PM-21255: Implement type-safe navigation

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillNavigation.kt
@@ -6,65 +6,82 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import com.x8bit.bitwarden.ui.platform.util.toObjectRoute
+import kotlinx.serialization.Serializable
 
 /**
- * Route constant for navigating to the [SetupAutoFillScreen].
+ * The type-safe route for the setup autofill screen.
  */
-private const val SETUP_AUTO_FILL_PREFIX = "setup_auto_fill"
-private const val SETUP_AUTO_FILL_AS_ROOT_PREFIX = "${SETUP_AUTO_FILL_PREFIX}_as_root"
-private const val SETUP_AUTO_FILL_NAV_ARG = "isInitialSetup"
-private const val SETUP_AUTO_FILL_ROUTE = "$SETUP_AUTO_FILL_PREFIX/{$SETUP_AUTO_FILL_NAV_ARG}"
-const val SETUP_AUTO_FILL_AS_ROOT_ROUTE =
-    "$SETUP_AUTO_FILL_AS_ROOT_PREFIX/{$SETUP_AUTO_FILL_NAV_ARG}"
+sealed class SetupAutofillRoute {
+    /**
+     * The [isInitialSetup] value used in the setup autofill screen.
+     */
+    abstract val isInitialSetup: Boolean
+
+    /**
+     * The type-safe route for the standard setup autofill screen.
+     */
+    @Serializable
+    data object Standard : SetupAutofillRoute() {
+        override val isInitialSetup: Boolean get() = false
+    }
+
+    /**
+     * The type-safe route for the root setup autofill screen.
+     */
+    @Serializable
+    data object AsRoot : SetupAutofillRoute() {
+        override val isInitialSetup: Boolean get() = true
+    }
+}
 
 /**
  * Arguments for the [SetupAutoFillScreen] using [SavedStateHandle].
  */
-data class SetupAutoFillScreenArgs(val isInitialSetup: Boolean) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        isInitialSetup = requireNotNull(savedStateHandle[SETUP_AUTO_FILL_NAV_ARG]),
-    )
+data class SetupAutoFillScreenArgs(val isInitialSetup: Boolean)
+
+/**
+ * Constructs a [SetupAutoFillScreenArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toSetupAutoFillArgs(): SetupAutoFillScreenArgs {
+    val route = (this.toObjectRoute<SetupAutofillRoute.AsRoot>()
+        ?: this.toObjectRoute<SetupAutofillRoute.Standard>())
+    return route
+        ?.let { SetupAutoFillScreenArgs(isInitialSetup = it.isInitialSetup) }
+        ?: throw IllegalStateException("Missing correct route for SetupAutofillScreen")
 }
 
 /**
- * Navigate to the setup auto-fill screen.
+ * Navigate to the setup autofill screen.
  */
 fun NavController.navigateToSetupAutoFillScreen(navOptions: NavOptions? = null) {
-    this.navigate("$SETUP_AUTO_FILL_PREFIX/false", navOptions)
+    this.navigate(route = SetupAutofillRoute.Standard, navOptions = navOptions)
 }
 
 /**
- * Navigate to the setup auto-fill screen as the root.
+ * Navigate to the setup autofill screen as the root.
  */
 fun NavController.navigateToSetupAutoFillAsRootScreen(navOptions: NavOptions? = null) {
-    this.navigate("$SETUP_AUTO_FILL_AS_ROOT_PREFIX/true", navOptions)
+    this.navigate(route = SetupAutofillRoute.AsRoot, navOptions = navOptions)
 }
 
 /**
- * Add the setup auto-fil screen to the nav graph.
+ * Add the setup autofill screen to the nav graph.
  */
 fun NavGraphBuilder.setupAutoFillDestination(onNavigateBack: () -> Unit) {
-    composableWithSlideTransitions(
-        route = SETUP_AUTO_FILL_ROUTE,
-        arguments = setupAutofillNavArgs,
-    ) {
+    composableWithSlideTransitions<SetupAutofillRoute.Standard> {
         SetupAutoFillScreen(onNavigateBack = onNavigateBack)
     }
 }
 
 /**
- * Add the setup autofil screen to the root nav graph.
+ * Add the setup autofill screen to the root nav graph.
  */
 fun NavGraphBuilder.setupAutoFillDestinationAsRoot() {
-    composableWithPushTransitions(
-        route = SETUP_AUTO_FILL_AS_ROOT_ROUTE,
-        arguments = setupAutofillNavArgs,
-    ) {
+    composableWithPushTransitions<SetupAutofillRoute.AsRoot> {
         SetupAutoFillScreen(
             onNavigateBack = {
                 // No-Op
@@ -72,9 +89,3 @@ fun NavGraphBuilder.setupAutoFillDestinationAsRoot() {
         )
     }
 }
-
-private val setupAutofillNavArgs = listOf(
-    navArgument(SETUP_AUTO_FILL_NAV_ARG) {
-        type = NavType.BoolType
-    },
-)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModel.kt
@@ -32,7 +32,7 @@ class SetupAutoFillViewModel @Inject constructor(
         // We load the state from the savedStateHandle for testing purposes.
         initialState = savedStateHandle[KEY_STATE] ?: run {
             val userId = requireNotNull(authRepository.userStateFlow.value).activeUserId
-            val isInitialSetup = SetupAutoFillScreenArgs(savedStateHandle).isInitialSetup
+            val isInitialSetup = savedStateHandle.toSetupAutoFillArgs().isInitialSetup
             SetupAutoFillState(
                 userId = userId,
                 dialogState = null,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteNavigation.kt
@@ -7,26 +7,26 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import kotlinx.serialization.Serializable
 
 /**
- * Route name for [SetupCompleteScreen].
+ * The type-safe route for the setup complete screen.
  */
-const val SETUP_COMPLETE_ROUTE = "setup_complete"
+@Serializable
+data object SetupCompleteRoute
 
 /**
  * Navigate to the setup complete screen.
  */
 fun NavController.navigateToSetupCompleteScreen(navOptions: NavOptions? = null) {
-    this.navigate(SETUP_COMPLETE_ROUTE, navOptions)
+    this.navigate(route = SetupCompleteRoute, navOptions = navOptions)
 }
 
 /**
  * Add the setup complete screen to the nav graph.
  */
 fun NavGraphBuilder.setupCompleteDestination() {
-    composableWithPushTransitions(
-        route = SETUP_COMPLETE_ROUTE,
-    ) {
+    composableWithPushTransitions<SetupCompleteRoute> {
         SetupCompleteScreen()
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModel.kt
@@ -43,7 +43,7 @@ class SetupUnlockViewModel @Inject constructor(
             cipher = biometricsEncryptionManager.getOrCreateCipher(userId = userId),
         )
         // whether or not the user has completed the initial setup prior to this.
-        val isInitialSetup = SetupUnlockArgs(savedStateHandle).isInitialSetup
+        val isInitialSetup = savedStateHandle.toSetupUnlockArgs().isInitialSetup
         SetupUnlockState(
             userId = userId,
             isUnlockWithPasswordEnabled = authRepository

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
@@ -21,7 +21,7 @@ import com.x8bit.bitwarden.ui.auth.feature.enterprisesignon.navigateToEnterprise
 import com.x8bit.bitwarden.ui.auth.feature.environment.environmentDestination
 import com.x8bit.bitwarden.ui.auth.feature.environment.navigateToEnvironment
 import com.x8bit.bitwarden.ui.auth.feature.expiredregistrationlink.expiredRegistrationLinkDestination
-import com.x8bit.bitwarden.ui.auth.feature.landing.LANDING_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.landing.LandingRoute
 import com.x8bit.bitwarden.ui.auth.feature.landing.landingDestination
 import com.x8bit.bitwarden.ui.auth.feature.landing.navigateToLanding
 import com.x8bit.bitwarden.ui.auth.feature.login.loginDestination
@@ -46,8 +46,13 @@ import com.x8bit.bitwarden.ui.auth.feature.twofactorlogin.twoFactorLoginDestinat
 import com.x8bit.bitwarden.ui.auth.feature.welcome.welcomeDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.navigateToPreAuthSettings
 import com.x8bit.bitwarden.ui.platform.feature.settings.preAuthSettingsDestinations
+import kotlinx.serialization.Serializable
 
-const val AUTH_GRAPH_ROUTE: String = "auth_graph"
+/**
+ * The type-safe route for the auth graph.
+ */
+@Serializable
+data object AuthGraphRoute
 
 /**
  * Add auth destinations to the nav graph.
@@ -56,9 +61,8 @@ const val AUTH_GRAPH_ROUTE: String = "auth_graph"
 fun NavGraphBuilder.authGraph(
     navController: NavHostController,
 ) {
-    navigation(
-        startDestination = LANDING_ROUTE,
-        route = AUTH_GRAPH_ROUTE,
+    navigation<AuthGraphRoute>(
+        startDestination = LandingRoute,
     ) {
         createAccountDestination(
             onNavigateBack = { navController.popBackStack() },
@@ -67,7 +71,7 @@ fun NavGraphBuilder.authGraph(
                     emailAddress = emailAddress,
                     captchaToken = captchaToken,
                     navOptions = navOptions {
-                        popUpTo(LANDING_ROUTE)
+                        popUpTo(route = LandingRoute)
                     },
                 )
             },
@@ -82,7 +86,7 @@ fun NavGraphBuilder.authGraph(
                 )
             },
             onNavigateToCheckEmail = { emailAddress ->
-                navController.navigateToCheckEmail(emailAddress)
+                navController.navigateToCheckEmail(emailAddress = emailAddress)
             },
             onNavigateToEnvironment = { navController.navigateToEnvironment() },
         )
@@ -102,7 +106,7 @@ fun NavGraphBuilder.authGraph(
                     emailAddress = emailAddress,
                     captchaToken = captchaToken,
                     navOptions = navOptions {
-                        popUpTo(LANDING_ROUTE)
+                        popUpTo(route = LandingRoute)
                     },
                 )
             },
@@ -203,14 +207,14 @@ fun NavGraphBuilder.authGraph(
             onNavigateToStartRegistration = {
                 navController.navigateToStartRegistration(
                     navOptions = navOptions {
-                        popUpTo(LANDING_ROUTE)
+                        popUpTo(route = LandingRoute)
                     },
                 )
             },
             onNavigateToLogin = {
                 navController.navigateToLanding(
                     navOptions = navOptions {
-                        popUpTo(LANDING_ROUTE)
+                        popUpTo(route = LandingRoute)
                     },
                 )
             },
@@ -226,5 +230,5 @@ fun NavGraphBuilder.authGraph(
 fun NavController.navigateToAuthGraph(
     navOptions: NavOptions? = null,
 ) {
-    navigate(AUTH_GRAPH_ROUTE, navOptions)
+    navigate(route = AuthGraphRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailNavigation.kt
@@ -6,19 +6,24 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val EMAIL: String = "email"
-private const val CHECK_EMAIL_ROUTE: String = "check_email/{$EMAIL}"
+/**
+ * The type-safe route for the check email screen.
+ */
+@Serializable
+data class CheckEmailRoute(
+    val emailAddress: String,
+)
 
 /**
  * Navigate to the check email screen.
  */
 fun NavController.navigateToCheckEmail(emailAddress: String, navOptions: NavOptions? = null) {
-    this.navigate("check_email/$emailAddress", navOptions)
+    this.navigate(route = CheckEmailRoute(emailAddress = emailAddress), navOptions = navOptions)
 }
 
 /**
@@ -26,10 +31,14 @@ fun NavController.navigateToCheckEmail(emailAddress: String, navOptions: NavOpti
  */
 data class CheckEmailArgs(
     val emailAddress: String,
-) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        emailAddress = checkNotNull(savedStateHandle.get<String>(EMAIL)),
-    )
+)
+
+/**
+ * Constructs a [CheckEmailArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toCheckEmailArgs(): CheckEmailArgs {
+    val route = this.toRoute<CheckEmailRoute>()
+    return CheckEmailArgs(emailAddress = route.emailAddress)
 }
 
 /**
@@ -38,12 +47,7 @@ data class CheckEmailArgs(
 fun NavGraphBuilder.checkEmailDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = CHECK_EMAIL_ROUTE,
-        arguments = listOf(
-            navArgument(EMAIL) { type = NavType.StringType },
-        ),
-    ) {
+    composableWithSlideTransitions<CheckEmailRoute> {
         CheckEmailScreen(
             onNavigateBack = onNavigateBack,
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailViewModel.kt
@@ -21,7 +21,7 @@ class CheckEmailViewModel @Inject constructor(
 ) : BaseViewModel<CheckEmailState, CheckEmailEvent, CheckEmailAction>(
     initialState = savedStateHandle[KEY_STATE]
         ?: CheckEmailState(
-            email = CheckEmailArgs(savedStateHandle).emailAddress,
+            email = savedStateHandle.toCheckEmailArgs().emailAddress,
         ),
 ) {
     init {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModel.kt
@@ -57,7 +57,7 @@ class CompleteRegistrationViewModel @Inject constructor(
     private val specialCircumstanceManager: SpecialCircumstanceManager,
 ) : BaseViewModel<CompleteRegistrationState, CompleteRegistrationEvent, CompleteRegistrationAction>(
     initialState = savedStateHandle[KEY_STATE] ?: run {
-        val args = CompleteRegistrationArgs(savedStateHandle)
+        val args = savedStateHandle.toCompleteRegistrationArgs()
         CompleteRegistrationState(
             userEmail = args.emailAddress,
             emailVerificationToken = args.verificationToken,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val CREATE_ACCOUNT_ROUTE = "create_account"
+/**
+ * The type-safe route for the create account screen.
+ */
+@Serializable
+data object CreateAccountRoute
 
 /**
  * Navigate to the create account screen.
  */
 fun NavController.navigateToCreateAccount(navOptions: NavOptions? = null) {
-    this.navigate(CREATE_ACCOUNT_ROUTE, navOptions)
+    this.navigate(route = CreateAccountRoute, navOptions = navOptions)
 }
 
 /**
@@ -24,9 +29,7 @@ fun NavGraphBuilder.createAccountDestination(
     onNavigateBack: () -> Unit,
     onNavigateToLogin: (emailAddress: String, captchaToken: String) -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = CREATE_ACCOUNT_ROUTE,
-    ) {
+    composableWithSlideTransitions<CreateAccountRoute> {
         CreateAccountScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToLogin = onNavigateToLogin,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnNavigation.kt
@@ -6,22 +6,30 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val ENTERPRISE_SIGN_ON_PREFIX = "enterprise_sign_on "
-private const val EMAIL_ADDRESS: String = "email_address"
-private const val ENTERPRISE_SIGN_ON_ROUTE = "$ENTERPRISE_SIGN_ON_PREFIX/{$EMAIL_ADDRESS}"
+/**
+ * The type-safe route for the enterprise sign-on screen.
+ */
+@Serializable
+data class EnterpriseSignOnRoute(
+    val emailAddress: String,
+)
 
 /**
  * Class to retrieve login arguments from the [SavedStateHandle].
  */
-data class EnterpriseSignOnArgs(val emailAddress: String) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        checkNotNull(savedStateHandle[EMAIL_ADDRESS]) as String,
-    )
+data class EnterpriseSignOnArgs(val emailAddress: String)
+
+/**
+ * Constructs a [EnterpriseSignOnArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toEnterpriseSignOnArgs(): EnterpriseSignOnArgs {
+    val route = this.toRoute<EnterpriseSignOnRoute>()
+    return EnterpriseSignOnArgs(emailAddress = route.emailAddress)
 }
 
 /**
@@ -31,7 +39,10 @@ fun NavController.navigateToEnterpriseSignOn(
     emailAddress: String,
     navOptions: NavOptions? = null,
 ) {
-    this.navigate("$ENTERPRISE_SIGN_ON_PREFIX/$emailAddress", navOptions)
+    this.navigate(
+        route = EnterpriseSignOnRoute(emailAddress = emailAddress),
+        navOptions = navOptions,
+    )
 }
 
 /**
@@ -42,12 +53,7 @@ fun NavGraphBuilder.enterpriseSignOnDestination(
     onNavigateToSetPassword: () -> Unit,
     onNavigateToTwoFactorLogin: (emailAddress: String, orgIdentifier: String) -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = ENTERPRISE_SIGN_ON_ROUTE,
-        arguments = listOf(
-            navArgument(EMAIL_ADDRESS) { type = NavType.StringType },
-        ),
-    ) {
+    composableWithSlideTransitions<EnterpriseSignOnRoute> {
         EnterpriseSignOnScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToSetPassword = onNavigateToSetPassword,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModel.kt
@@ -191,7 +191,7 @@ class EnterpriseSignOnViewModel @Inject constructor(
                 mutableStateFlow.update { it.copy(dialogState = null) }
                 sendEvent(
                     EnterpriseSignOnEvent.NavigateToTwoFactorLogin(
-                        emailAddress = EnterpriseSignOnArgs(savedStateHandle).emailAddress,
+                        emailAddress = savedStateHandle.toEnterpriseSignOnArgs().emailAddress,
                         orgIdentifier = state.orgIdentifierInput,
                     ),
                 )
@@ -434,7 +434,7 @@ class EnterpriseSignOnViewModel @Inject constructor(
                     viewModelScope.launch {
                         val result = authRepository
                             .login(
-                                email = EnterpriseSignOnArgs(savedStateHandle).emailAddress,
+                                email = savedStateHandle.toEnterpriseSignOnArgs().emailAddress,
                                 ssoCode = ssoCallbackResult.code,
                                 ssoCodeVerifier = ssoData.codeVerifier,
                                 ssoRedirectUri = SSO_URI,
@@ -459,7 +459,7 @@ class EnterpriseSignOnViewModel @Inject constructor(
         viewModelScope.launch {
             if (featureFlagManager.getFeatureFlag(key = FlagKey.VerifiedSsoDomainEndpoint)) {
                 val result = authRepository.getVerifiedOrganizationDomainSsoDetails(
-                    email = EnterpriseSignOnArgs(savedStateHandle).emailAddress,
+                    email = savedStateHandle.toEnterpriseSignOnArgs().emailAddress,
                 )
                 sendAction(
                     EnterpriseSignOnAction.Internal.OnVerifiedOrganizationDomainSsoDetailsReceive(
@@ -468,7 +468,7 @@ class EnterpriseSignOnViewModel @Inject constructor(
                 )
             } else {
                 val result = authRepository.getOrganizationDomainSsoDetails(
-                    email = EnterpriseSignOnArgs(savedStateHandle).emailAddress,
+                    email = savedStateHandle.toEnterpriseSignOnArgs().emailAddress,
                 )
                 sendAction(
                     EnterpriseSignOnAction.Internal.OnOrganizationDomainSsoDetailsReceive(result),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentNavigation.kt
@@ -7,25 +7,28 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
-
-private const val ENVIRONMENT_ROUTE = "environment"
+import kotlinx.serialization.Serializable
 
 /**
- * Add settings destinations to the nav graph.
+ * The type-safe route for the environment screen.
+ */
+@Serializable
+data object EnvironmentRoute
+
+/**
+ * Add the environment destination to the nav graph.
  */
 fun NavGraphBuilder.environmentDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = ENVIRONMENT_ROUTE,
-    ) {
+    composableWithSlideTransitions<EnvironmentRoute> {
         EnvironmentScreen(onNavigateBack = onNavigateBack)
     }
 }
 
 /**
- * Navigate to the about screen.
+ * Navigate to the environment screen.
  */
 fun NavController.navigateToEnvironment(navOptions: NavOptions? = null) {
-    navigate(ENVIRONMENT_ROUTE, navOptions)
+    this.navigate(route = EnvironmentRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/expiredregistrationlink/ExpiredRegistrationLinkNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/expiredregistrationlink/ExpiredRegistrationLinkNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import kotlinx.serialization.Serializable
 
-private const val EXPIRED_REGISTRATION_LINK_ROUTE = "expired_registration_link"
+/**
+ * The type-safe route for the expired registration link screen.
+ */
+@Serializable
+data object ExpiredRegistrationLinkRoute
 
 /**
  * Navigate to the expired registration link screen.
  */
 fun NavController.navigateToExpiredRegistrationLinkScreen(navOptions: NavOptions? = null) {
-    this.navigate(route = EXPIRED_REGISTRATION_LINK_ROUTE, navOptions = navOptions)
+    this.navigate(route = ExpiredRegistrationLinkRoute, navOptions = navOptions)
 }
 
 /**
@@ -25,9 +30,7 @@ fun NavGraphBuilder.expiredRegistrationLinkDestination(
     onNavigateToStartRegistration: () -> Unit,
     onNavigateToLogin: () -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = EXPIRED_REGISTRATION_LINK_ROUTE,
-    ) {
+    composableWithPushTransitions<ExpiredRegistrationLinkRoute> {
         ExpiredRegistrationLinkScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToStartRegistration = onNavigateToStartRegistration,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/landing/LandingNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithStayTransitions
+import kotlinx.serialization.Serializable
 
-const val LANDING_ROUTE: String = "landing"
+/**
+ * The type-safe route for the landing screen.
+ */
+@Serializable
+data object LandingRoute
 
 /**
  * Navigate to the landing screen.
  */
 fun NavController.navigateToLanding(navOptions: NavOptions? = null) {
-    this.navigate(LANDING_ROUTE, navOptions)
+    this.navigate(route = LandingRoute, navOptions = navOptions)
 }
 
 /**
@@ -27,9 +32,7 @@ fun NavGraphBuilder.landingDestination(
     onNavigateToStartRegistration: () -> Unit,
     onNavigateToPreAuthSettings: () -> Unit,
 ) {
-    composableWithStayTransitions(
-        route = LANDING_ROUTE,
-    ) {
+    composableWithStayTransitions<LandingRoute> {
         LandingScreen(
             onNavigateToCreateAccount = onNavigateToCreateAccount,
             onNavigateToLogin = onNavigateToLogin,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.KnownDeviceResult
@@ -16,8 +18,6 @@ import com.x8bit.bitwarden.data.auth.repository.util.generateUriForCaptcha
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
-import com.bitwarden.ui.util.Text
-import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.toAccountSummaries
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -43,16 +43,23 @@ class LoginViewModel @Inject constructor(
 ) : BaseViewModel<LoginState, LoginEvent, LoginAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
-        ?: LoginState(
-            emailAddress = LoginArgs(savedStateHandle).emailAddress,
-            isLoginButtonEnabled = false,
-            passwordInput = "",
-            environmentLabel = environmentRepository.environment.label,
-            dialogState = LoginState.DialogState.Loading(R.string.loading.asText()),
-            captchaToken = LoginArgs(savedStateHandle).captchaToken,
-            accountSummaries = authRepository.userStateFlow.value?.toAccountSummaries().orEmpty(),
-            shouldShowLoginWithDevice = false,
-        ),
+        ?: run {
+            val args = savedStateHandle.toLoginArgs()
+            LoginState(
+                emailAddress = args.emailAddress,
+                isLoginButtonEnabled = false,
+                passwordInput = "",
+                environmentLabel = environmentRepository.environment.label,
+                dialogState = LoginState.DialogState.Loading(R.string.loading.asText()),
+                captchaToken = args.captchaToken,
+                accountSummaries = authRepository
+                    .userStateFlow
+                    .value
+                    ?.toAccountSummaries()
+                    .orEmpty(),
+                shouldShowLoginWithDevice = false,
+            )
+        },
 ) {
 
     init {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceNavigation.kt
@@ -6,17 +6,20 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.auth.feature.loginwithdevice.model.LoginWithDeviceType
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val EMAIL_ADDRESS: String = "email_address"
-private const val LOGIN_WITH_DEVICE_PREFIX = "login_with_device"
-private const val LOGIN_TYPE: String = "login_type"
-private const val LOGIN_WITH_DEVICE_ROUTE =
-    "$LOGIN_WITH_DEVICE_PREFIX/{$EMAIL_ADDRESS}/{$LOGIN_TYPE}"
+/**
+ * The type-safe route for the login with device screen.
+ */
+@Serializable
+data class LoginWithDeviceRoute(
+    val emailAddress: String,
+    val loginType: LoginWithDeviceType,
+)
 
 /**
  * Class to retrieve login with device arguments from the [SavedStateHandle].
@@ -24,11 +27,14 @@ private const val LOGIN_WITH_DEVICE_ROUTE =
 data class LoginWithDeviceArgs(
     val emailAddress: String,
     val loginType: LoginWithDeviceType,
-) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        emailAddress = checkNotNull(savedStateHandle.get<String>(EMAIL_ADDRESS)),
-        loginType = checkNotNull(savedStateHandle.get<LoginWithDeviceType>(LOGIN_TYPE)),
-    )
+)
+
+/**
+ * Constructs a [LoginWithDeviceArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toLoginWithDeviceArgs(): LoginWithDeviceArgs {
+    val route = this.toRoute<LoginWithDeviceRoute>()
+    return LoginWithDeviceArgs(emailAddress = route.emailAddress, loginType = route.loginType)
 }
 
 /**
@@ -40,7 +46,10 @@ fun NavController.navigateToLoginWithDevice(
     navOptions: NavOptions? = null,
 ) {
     this.navigate(
-        route = "$LOGIN_WITH_DEVICE_PREFIX/$emailAddress/$loginType",
+        route = LoginWithDeviceRoute(
+            emailAddress = emailAddress,
+            loginType = loginType,
+        ),
         navOptions = navOptions,
     )
 }
@@ -52,13 +61,7 @@ fun NavGraphBuilder.loginWithDeviceDestination(
     onNavigateBack: () -> Unit,
     onNavigateToTwoFactorLogin: (emailAddress: String) -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = LOGIN_WITH_DEVICE_ROUTE,
-        arguments = listOf(
-            navArgument(EMAIL_ADDRESS) { type = NavType.StringType },
-            navArgument(LOGIN_TYPE) { type = NavType.EnumType(LoginWithDeviceType::class.java) },
-        ),
-    ) {
+    composableWithSlideTransitions<LoginWithDeviceRoute> {
         LoginWithDeviceScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToTwoFactorLogin = onNavigateToTwoFactorLogin,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
@@ -4,6 +4,8 @@ import android.net.Uri
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.manager.model.CreateAuthRequestResult
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -14,8 +16,6 @@ import com.x8bit.bitwarden.ui.auth.feature.loginwithdevice.model.LoginWithDevice
 import com.x8bit.bitwarden.ui.auth.feature.loginwithdevice.util.toAuthRequestType
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.ui.platform.base.util.BackgroundEvent
-import com.bitwarden.ui.util.Text
-import com.bitwarden.ui.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
@@ -39,7 +39,7 @@ class LoginWithDeviceViewModel @Inject constructor(
 ) : BaseViewModel<LoginWithDeviceState, LoginWithDeviceEvent, LoginWithDeviceAction>(
     initialState = savedStateHandle[KEY_STATE]
         ?: run {
-            val args = LoginWithDeviceArgs(savedStateHandle)
+            val args = savedStateHandle.toLoginWithDeviceArgs()
             LoginWithDeviceState(
                 loginWithDeviceType = args.loginType,
                 emailAddress = args.emailAddress,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val MASTER_PASSWORD_GENERATOR = "master_password_generator"
+/**
+ * The type-safe route for the master password generator screen.
+ */
+@Serializable
+data object MasterPasswordGeneratorRoute
 
 /**
  * Navigate to master password generator  screen.
  */
 fun NavController.navigateToMasterPasswordGenerator(navOptions: NavOptions? = null) {
-    this.navigate(MASTER_PASSWORD_GENERATOR, navOptions)
+    this.navigate(route = MasterPasswordGeneratorRoute, navOptions = navOptions)
 }
 
 /**
@@ -25,9 +30,7 @@ fun NavGraphBuilder.masterPasswordGeneratorDestination(
     onNavigateToPreventLockout: () -> Unit,
     onNavigateBackWithPassword: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = MASTER_PASSWORD_GENERATOR,
-    ) {
+    composableWithSlideTransitions<MasterPasswordGeneratorRoute> {
         MasterPasswordGeneratorScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToPreventLockout = onNavigateToPreventLockout,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val MASTER_PASSWORD_GUIDANCE = "master_password_guidance"
+/**
+ * The type-safe route for the master password guidance screen.
+ */
+@Serializable
+data object MasterPasswordGuidanceRoute
 
 /**
  * Navigate to the master password guidance screen.
  */
 fun NavController.navigateToMasterPasswordGuidance(navOptions: NavOptions? = null) {
-    this.navigate(MASTER_PASSWORD_GUIDANCE, navOptions)
+    this.navigate(route = MasterPasswordGuidanceRoute, navOptions = navOptions)
 }
 
 /**
@@ -24,9 +29,7 @@ fun NavGraphBuilder.masterPasswordGuidanceDestination(
     onNavigateBack: () -> Unit,
     onNavigateToGeneratePassword: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = MASTER_PASSWORD_GUIDANCE,
-    ) {
+    composableWithSlideTransitions<MasterPasswordGuidanceRoute> {
         MasterPasswordGuidanceScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToGeneratePassword = onNavigateToGeneratePassword,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintNavigation.kt
@@ -6,21 +6,30 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val EMAIL_ADDRESS: String = "email_address"
-private const val MASTER_PASSWORD_HINT_ROUTE: String = "master_password_hint/{$EMAIL_ADDRESS}"
+/**
+ * The type-safe route for the master password hint screen.
+ */
+@Serializable
+data class MasterPasswordHintRoute(
+    val emailAddress: String,
+)
 
 /**
  * Class to retrieve login arguments from the [SavedStateHandle].
  */
-data class MasterPasswordHintArgs(val emailAddress: String) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        checkNotNull(savedStateHandle[EMAIL_ADDRESS]) as String,
-    )
+data class MasterPasswordHintArgs(val emailAddress: String)
+
+/**
+ * Constructs a [MasterPasswordHintArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toMasterPasswordHintArgs(): MasterPasswordHintArgs {
+    val route = this.toRoute<MasterPasswordHintRoute>()
+    return MasterPasswordHintArgs(emailAddress = route.emailAddress)
 }
 
 /**
@@ -30,7 +39,10 @@ fun NavController.navigateToMasterPasswordHint(
     emailAddress: String,
     navOptions: NavOptions? = null,
 ) {
-    this.navigate("master_password_hint/$emailAddress", navOptions)
+    this.navigate(
+        route = MasterPasswordHintRoute(emailAddress = emailAddress),
+        navOptions = navOptions,
+    )
 }
 
 /**
@@ -39,12 +51,7 @@ fun NavController.navigateToMasterPasswordHint(
 fun NavGraphBuilder.masterPasswordHintDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = MASTER_PASSWORD_HINT_ROUTE,
-        arguments = listOf(
-            navArgument(EMAIL_ADDRESS) { type = NavType.StringType },
-        ),
-    ) {
+    composableWithSlideTransitions<MasterPasswordHintRoute> {
         MasterPasswordHintScreen(onNavigateBack = onNavigateBack)
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintViewModel.kt
@@ -3,13 +3,13 @@ package com.x8bit.bitwarden.ui.auth.feature.masterpasswordhint
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.PasswordHintResult
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
-import com.bitwarden.ui.util.Text
-import com.bitwarden.ui.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -31,7 +31,7 @@ class MasterPasswordHintViewModel @Inject constructor(
 ) : BaseViewModel<MasterPasswordHintState, MasterPasswordHintEvent, MasterPasswordHintAction>(
     initialState = savedStateHandle[KEY_STATE]
         ?: MasterPasswordHintState(
-            emailInput = MasterPasswordHintArgs(savedStateHandle).emailAddress,
+            emailInput = savedStateHandle.toMasterPasswordHintArgs().emailAddress,
         ),
 ) {
     init {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/preventaccountlockout/PreventAccountLockoutNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/preventaccountlockout/PreventAccountLockoutNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val PREVENT_ACCOUNT_LOCKOUT = "prevent_account_lockout"
+/**
+ * The type-safe route for the prevent account lockout screen.
+ */
+@Serializable
+data object PreventAccountLockoutRoute
 
 /**
  * Navigate to prevent account lockout screen.
  */
 fun NavController.navigateToPreventAccountLockout(navOptions: NavOptions? = null) {
-    this.navigate(PREVENT_ACCOUNT_LOCKOUT, navOptions)
+    this.navigate(route = PreventAccountLockoutRoute, navOptions = navOptions)
 }
 
 /**
@@ -23,9 +28,7 @@ fun NavController.navigateToPreventAccountLockout(navOptions: NavOptions? = null
 fun NavGraphBuilder.preventAccountLockoutDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = PREVENT_ACCOUNT_LOCKOUT,
-    ) {
+    composableWithSlideTransitions<PreventAccountLockoutRoute> {
         PreventAccountLockoutScreen(
             onNavigateBack = onNavigateBack,
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordNavigation.kt
@@ -7,19 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.bitwarden.core.annotation.OmitFromCoverage
+import kotlinx.serialization.Serializable
 
 /**
- * The route for navigating to the [RemovePasswordScreen].
+ * The type-safe route for the remove password screen.
  */
-const val REMOVE_PASSWORD_ROUTE: String = "remove_password"
+@Serializable
+data object RemovePasswordRoute
 
 /**
  * Add the Remove Password screen to the nav graph.
  */
 fun NavGraphBuilder.removePasswordDestination() {
-    composable(
-        route = REMOVE_PASSWORD_ROUTE,
-    ) {
+    composable<RemovePasswordRoute> {
         RemovePasswordScreen()
     }
 }
@@ -30,5 +30,5 @@ fun NavGraphBuilder.removePasswordDestination() {
 fun NavController.navigateToRemovePassword(
     navOptions: NavOptions? = null,
 ) {
-    this.navigate(REMOVE_PASSWORD_ROUTE, navOptions)
+    this.navigate(route = RemovePasswordRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.bitwarden.core.annotation.OmitFromCoverage
+import kotlinx.serialization.Serializable
 
-const val RESET_PASSWORD_ROUTE: String = "reset_password"
+/**
+ * The type-safe route for the reset password screen.
+ */
+@Serializable
+data object ResetPasswordRoute
 
 /**
  * Add the Reset Password screen to the nav graph.
@@ -16,9 +21,7 @@ const val RESET_PASSWORD_ROUTE: String = "reset_password"
 fun NavGraphBuilder.resetPasswordDestination(
     onNavigateToPreventAccountLockOut: () -> Unit,
 ) {
-    composable(
-        route = RESET_PASSWORD_ROUTE,
-    ) {
+    composable<ResetPasswordRoute> {
         ResetPasswordScreen(onNavigateToPreventAccountLockOut = onNavigateToPreventAccountLockOut)
     }
 }
@@ -29,5 +32,5 @@ fun NavGraphBuilder.resetPasswordDestination(
 fun NavController.navigateToResetPasswordScreen(
     navOptions: NavOptions? = null,
 ) {
-    this.navigate(RESET_PASSWORD_ROUTE, navOptions)
+    this.navigate(route = ResetPasswordRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordNavigation.kt
@@ -7,16 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.bitwarden.core.annotation.OmitFromCoverage
+import kotlinx.serialization.Serializable
 
-const val SET_PASSWORD_ROUTE: String = "set_password"
+/**
+ * The type-safe route for the set password screen.
+ */
+@Serializable
+data object SetPasswordRoute
 
 /**
  * Add the Set Password screen to the nav graph.
  */
 fun NavGraphBuilder.setPasswordDestination() {
-    composable(
-        route = SET_PASSWORD_ROUTE,
-    ) {
+    composable<SetPasswordRoute> {
         SetPasswordScreen()
     }
 }
@@ -27,5 +30,5 @@ fun NavGraphBuilder.setPasswordDestination() {
 fun NavController.navigateToSetPassword(
     navOptions: NavOptions? = null,
 ) {
-    this.navigate(SET_PASSWORD_ROUTE, navOptions)
+    this.navigate(route = SetPasswordRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val START_REGISTRATION_ROUTE = "start_registration"
+/**
+ * The type-safe route for the start registration screen.
+ */
+@Serializable
+data object StartRegistrationRoute
 
 /**
  * Navigate to the start registration screen.
  */
 fun NavController.navigateToStartRegistration(navOptions: NavOptions? = null) {
-    this.navigate(START_REGISTRATION_ROUTE, navOptions)
+    this.navigate(route = StartRegistrationRoute, navOptions = navOptions)
 }
 
 /**
@@ -29,9 +34,7 @@ fun NavGraphBuilder.startRegistrationDestination(
     onNavigateToCheckEmail: (email: String) -> Unit,
     onNavigateToEnvironment: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = START_REGISTRATION_ROUTE,
-    ) {
+    composableWithSlideTransitions<StartRegistrationRoute> {
         StartRegistrationScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToCompleteRegistration = onNavigateToCompleteRegistration,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceEncryptionNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceEncryptionNavigation.kt
@@ -15,16 +15,20 @@ import com.x8bit.bitwarden.ui.auth.feature.twofactorlogin.navigateToTwoFactorLog
 import com.x8bit.bitwarden.ui.auth.feature.twofactorlogin.twoFactorLoginDestination
 import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.navigateToTdeVaultUnlock
 import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.tdeVaultUnlockDestination
+import kotlinx.serialization.Serializable
 
-const val TRUSTED_DEVICE_GRAPH_ROUTE: String = "trusted_device_graph"
+/**
+ * The type-safe route for the trusted device graph.
+ */
+@Serializable
+data object TrustedDeviceGraphRoute
 
 /**
  * Add trusted device destinations to the nav graph.
  */
 fun NavGraphBuilder.trustedDeviceGraph(navController: NavHostController) {
-    navigation(
-        startDestination = TRUSTED_DEVICE_ROUTE,
-        route = TRUSTED_DEVICE_GRAPH_ROUTE,
+    navigation<TrustedDeviceGraphRoute>(
+        startDestination = TrustedDeviceRoute,
     ) {
         loginWithDeviceDestination(
             onNavigateBack = { navController.popBackStack() },
@@ -66,5 +70,5 @@ fun NavGraphBuilder.trustedDeviceGraph(navController: NavHostController) {
 fun NavController.navigateToTrustedDeviceGraph(
     navOptions: NavOptions? = null,
 ) {
-    navigate(TRUSTED_DEVICE_GRAPH_ROUTE, navOptions)
+    navigate(route = TrustedDeviceGraphRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceNavigation.kt
@@ -7,11 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
 /**
- * The route for navigating to the [TrustedDeviceScreen].
+ * The type-safe route for the trusted device screen.
  */
-const val TRUSTED_DEVICE_ROUTE: String = "trusted_device"
+@Serializable
+data object TrustedDeviceRoute
 
 /**
  * Add the Trusted Device Screen to the nav graph.
@@ -21,9 +23,7 @@ fun NavGraphBuilder.trustedDeviceDestination(
     onNavigateToLoginWithOtherDevice: (emailAddress: String) -> Unit,
     onNavigateToLock: (emailAddress: String) -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = TRUSTED_DEVICE_ROUTE,
-    ) {
+    composableWithSlideTransitions<TrustedDeviceRoute> {
         TrustedDeviceScreen(
             onNavigateToAdminApproval = onNavigateToAdminApproval,
             onNavigateToLoginWithOtherDevice = onNavigateToLoginWithOtherDevice,
@@ -38,5 +38,5 @@ fun NavGraphBuilder.trustedDeviceDestination(
 fun NavController.navigateToTrustedDevice(
     navOptions: NavOptions? = null,
 ) {
-    this.navigate(TRUSTED_DEVICE_ROUTE, navOptions)
+    this.navigate(route = TrustedDeviceRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -57,7 +57,7 @@ class TwoFactorLoginViewModel @Inject constructor(
 ) : BaseViewModel<TwoFactorLoginState, TwoFactorLoginEvent, TwoFactorLoginAction>(
     initialState = savedStateHandle[KEY_STATE]
         ?: run {
-            val args = TwoFactorLoginArgs(savedStateHandle)
+            val args = savedStateHandle.toTwoFactorLoginArgs()
             TwoFactorLoginState(
                 authMethod = authRepository.twoFactorResponse.preferredAuthMethod,
                 availableAuthMethods = authRepository.twoFactorResponse.availableAuthMethods,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -86,7 +86,7 @@ class VaultUnlockViewModel @Inject constructor(
         val specialCircumstance = specialCircumstanceManager.specialCircumstance
 
         val showAccountMenu =
-            VaultUnlockArgs(savedStateHandle).unlockType == UnlockType.STANDARD &&
+            savedStateHandle.toVaultUnlockArgs().unlockType == UnlockType.STANDARD &&
                 (specialCircumstance !is SpecialCircumstance.Fido2GetCredentials &&
                     specialCircumstance !is SpecialCircumstance.Fido2Assertion)
         VaultUnlockState(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithStayTransitions
+import kotlinx.serialization.Serializable
 
-private const val WELCOME_ROUTE: String = "welcome"
+/**
+ * The type-safe route for the welcome screen.
+ */
+@Serializable
+data object WelcomeRoute
 
 /**
  * Navigate to the welcome screen.
  */
 fun NavController.navigateToWelcome(navOptions: NavOptions? = null) {
-    this.navigate(WELCOME_ROUTE, navOptions)
+    this.navigate(route = WelcomeRoute, navOptions = navOptions)
 }
 
 /**
@@ -25,9 +30,7 @@ fun NavGraphBuilder.welcomeDestination(
     onNavigateToLogin: () -> Unit,
     onNavigateToStartRegistration: () -> Unit,
 ) {
-    composableWithStayTransitions(
-        route = WELCOME_ROUTE,
-    ) {
+    composableWithStayTransitions<WelcomeRoute> {
         WelcomeScreen(
             onNavigateToCreateAccount = onNavigateToCreateAccount,
             onNavigateToLogin = onNavigateToLogin,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/NavGraphBuilderExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/NavGraphBuilderExtensions.kt
@@ -1,28 +1,28 @@
+@file:OmitFromCoverage
+
 package com.x8bit.bitwarden.ui.platform.base.util
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.runtime.Composable
-import androidx.navigation.NamedNavArgument
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.theme.TransitionProviders
+import kotlin.reflect.KType
 
 /**
  * A wrapper around [NavGraphBuilder.composable] that supplies slide up/down transitions.
  */
-@OmitFromCoverage
-fun NavGraphBuilder.composableWithSlideTransitions(
-    route: String,
-    arguments: List<NamedNavArgument> = emptyList(),
+inline fun <reified T : Any> NavGraphBuilder.composableWithSlideTransitions(
+    typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
-    content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
-    this.composable(
-        route = route,
-        arguments = arguments,
+    this.composable<T>(
+        typeMap = typeMap,
         deepLinks = deepLinks,
         enterTransition = TransitionProviders.Enter.slideUp,
         exitTransition = TransitionProviders.Exit.stay,
@@ -35,21 +35,19 @@ fun NavGraphBuilder.composableWithSlideTransitions(
 /**
  * A wrapper around [NavGraphBuilder.composable] that supplies "stay" transitions.
  */
-@OmitFromCoverage
-fun NavGraphBuilder.composableWithStayTransitions(
-    route: String,
-    arguments: List<NamedNavArgument> = emptyList(),
+inline fun <reified T : Any> NavGraphBuilder.composableWithStayTransitions(
+    typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
-    content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
-    this.composable(
-        route = route,
-        arguments = arguments,
+    this.composable<T>(
+        typeMap = typeMap,
         deepLinks = deepLinks,
         enterTransition = TransitionProviders.Enter.stay,
         exitTransition = TransitionProviders.Exit.stay,
         popEnterTransition = TransitionProviders.Enter.stay,
         popExitTransition = TransitionProviders.Exit.stay,
+        sizeTransform = null,
         content = content,
     )
 }
@@ -60,21 +58,19 @@ fun NavGraphBuilder.composableWithStayTransitions(
  * This is suitable for screens deeper within a hierarchy that uses push transitions; the root
  * screen of such a hierarchy should use [composableWithRootPushTransitions].
  */
-@OmitFromCoverage
-fun NavGraphBuilder.composableWithPushTransitions(
-    route: String,
-    arguments: List<NamedNavArgument> = emptyList(),
+inline fun <reified T : Any> NavGraphBuilder.composableWithPushTransitions(
+    typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
-    content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
-    this.composable(
-        route = route,
-        arguments = arguments,
+    this.composable<T>(
+        typeMap = typeMap,
         deepLinks = deepLinks,
         enterTransition = TransitionProviders.Enter.pushLeft,
         exitTransition = TransitionProviders.Exit.stay,
         popEnterTransition = TransitionProviders.Enter.stay,
         popExitTransition = TransitionProviders.Exit.pushRight,
+        sizeTransform = null,
         content = content,
     )
 }
@@ -83,21 +79,19 @@ fun NavGraphBuilder.composableWithPushTransitions(
  * A wrapper around [NavGraphBuilder.composable] that supplies push transitions to the root screen
  * in a nested graph that uses push transitions.
  */
-@OmitFromCoverage
-fun NavGraphBuilder.composableWithRootPushTransitions(
-    route: String,
-    arguments: List<NamedNavArgument> = emptyList(),
+inline fun <reified T : Any> NavGraphBuilder.composableWithRootPushTransitions(
+    typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
-    content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
-    this.composable(
-        route = route,
-        arguments = arguments,
+    this.composable<T>(
+        typeMap = typeMap,
         deepLinks = deepLinks,
         enterTransition = TransitionProviders.Enter.stay,
         exitTransition = TransitionProviders.Exit.pushLeft,
         popEnterTransition = TransitionProviders.Enter.pushRight,
         popExitTransition = TransitionProviders.Exit.fadeOut,
+        sizeTransform = null,
         content = content,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuNavigation.kt
@@ -6,14 +6,19 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import kotlinx.serialization.Serializable
 
-private const val DEBUG_MENU = "debug_menu"
+/**
+ * The type-safe route for the debug screen.
+ */
+@Serializable
+data object DebugRoute
 
 /**
  * Navigate to the setup unlock screen.
  */
 fun NavController.navigateToDebugMenuScreen() {
-    this.navigate(DEBUG_MENU) {
+    this.navigate(route = DebugRoute) {
         launchSingleTop = true
     }
 }
@@ -25,9 +30,7 @@ fun NavGraphBuilder.debugMenuDestination(
     onNavigateBack: () -> Unit,
     onSplashScreenRemoved: () -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = DEBUG_MENU,
-    ) {
+    composableWithPushTransitions<DebugRoute> {
         DebugMenuScreen(onNavigateBack = onNavigateBack)
         // If we are displaying the debug screen, then we can just hide the splash screen.
         onSplashScreenRemoved()

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -17,48 +17,49 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
-import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_AUTO_FILL_AS_ROOT_ROUTE
-import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_COMPLETE_ROUTE
-import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SETUP_UNLOCK_AS_ROOT_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupAutofillRoute
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupCompleteRoute
+import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupUnlockRoute
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupAutoFillAsRootScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupCompleteScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupUnlockScreenAsRoot
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupAutoFillDestinationAsRoot
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupCompleteDestination
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupUnlockDestinationAsRoot
-import com.x8bit.bitwarden.ui.auth.feature.auth.AUTH_GRAPH_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.auth.AuthGraphRoute
 import com.x8bit.bitwarden.ui.auth.feature.auth.authGraph
 import com.x8bit.bitwarden.ui.auth.feature.auth.navigateToAuthGraph
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.navigateToCompleteRegistration
 import com.x8bit.bitwarden.ui.auth.feature.expiredregistrationlink.navigateToExpiredRegistrationLinkScreen
 import com.x8bit.bitwarden.ui.auth.feature.preventaccountlockout.navigateToPreventAccountLockout
-import com.x8bit.bitwarden.ui.auth.feature.removepassword.REMOVE_PASSWORD_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.removepassword.RemovePasswordRoute
 import com.x8bit.bitwarden.ui.auth.feature.removepassword.navigateToRemovePassword
 import com.x8bit.bitwarden.ui.auth.feature.removepassword.removePasswordDestination
-import com.x8bit.bitwarden.ui.auth.feature.resetpassword.RESET_PASSWORD_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.resetpassword.ResetPasswordRoute
 import com.x8bit.bitwarden.ui.auth.feature.resetpassword.navigateToResetPasswordScreen
 import com.x8bit.bitwarden.ui.auth.feature.resetpassword.resetPasswordDestination
-import com.x8bit.bitwarden.ui.auth.feature.setpassword.SET_PASSWORD_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.setpassword.SetPasswordRoute
 import com.x8bit.bitwarden.ui.auth.feature.setpassword.navigateToSetPassword
-import com.x8bit.bitwarden.ui.auth.feature.trusteddevice.TRUSTED_DEVICE_GRAPH_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.trusteddevice.TrustedDeviceGraphRoute
 import com.x8bit.bitwarden.ui.auth.feature.trusteddevice.navigateToTrustedDeviceGraph
 import com.x8bit.bitwarden.ui.auth.feature.trusteddevice.trustedDeviceGraph
-import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.VAULT_UNLOCK_ROUTE
+import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.VaultUnlockRoute
 import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.navigateToVaultUnlock
 import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.vaultUnlockDestination
 import com.x8bit.bitwarden.ui.auth.feature.welcome.navigateToWelcome
 import com.x8bit.bitwarden.ui.platform.components.util.rememberBitwardenNavController
 import com.x8bit.bitwarden.ui.platform.feature.rootnav.util.toVaultItemListingType
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.loginapproval.navigateToLoginApproval
-import com.x8bit.bitwarden.ui.platform.feature.splash.SPLASH_ROUTE
+import com.x8bit.bitwarden.ui.platform.feature.splash.SplashRoute
 import com.x8bit.bitwarden.ui.platform.feature.splash.navigateToSplash
 import com.x8bit.bitwarden.ui.platform.feature.splash.splashDestination
-import com.x8bit.bitwarden.ui.platform.feature.vaultunlocked.VAULT_UNLOCKED_GRAPH_ROUTE
+import com.x8bit.bitwarden.ui.platform.feature.vaultunlocked.VaultUnlockedGraphRoute
 import com.x8bit.bitwarden.ui.platform.feature.vaultunlocked.navigateToVaultUnlockedGraph
 import com.x8bit.bitwarden.ui.platform.feature.vaultunlocked.vaultUnlockedGraph
 import com.x8bit.bitwarden.ui.platform.theme.NonNullEnterTransitionProvider
 import com.x8bit.bitwarden.ui.platform.theme.NonNullExitTransitionProvider
 import com.x8bit.bitwarden.ui.platform.theme.RootTransitionProviders
+import com.x8bit.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.model.AddSendType
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.navigateToAddSend
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
@@ -89,7 +90,7 @@ fun RootNavScreen(
 
     NavHost(
         navController = navController,
-        startDestination = SPLASH_ROUTE,
+        startDestination = SplashRoute,
         enterTransition = { toEnterTransition()(this) },
         exitTransition = { toExitTransition()(this) },
         popEnterTransition = { toEnterTransition()(this) },
@@ -116,14 +117,14 @@ fun RootNavScreen(
         is RootNavState.CompleteOngoingRegistration,
         RootNavState.AuthWithWelcome,
         RootNavState.ExpiredRegistrationLink,
-            -> AUTH_GRAPH_ROUTE
+            -> AuthGraphRoute
 
-        RootNavState.ResetPassword -> RESET_PASSWORD_ROUTE
-        RootNavState.SetPassword -> SET_PASSWORD_ROUTE
-        RootNavState.RemovePassword -> REMOVE_PASSWORD_ROUTE
-        RootNavState.Splash -> SPLASH_ROUTE
-        RootNavState.TrustedDevice -> TRUSTED_DEVICE_GRAPH_ROUTE
-        RootNavState.VaultLocked -> VAULT_UNLOCK_ROUTE
+        RootNavState.ResetPassword -> ResetPasswordRoute
+        RootNavState.SetPassword -> SetPasswordRoute
+        RootNavState.RemovePassword -> RemovePasswordRoute
+        RootNavState.Splash -> SplashRoute
+        RootNavState.TrustedDevice -> TrustedDeviceGraphRoute
+        RootNavState.VaultLocked -> VaultUnlockRoute.Standard
         is RootNavState.VaultUnlocked,
         is RootNavState.VaultUnlockedForAutofillSave,
         is RootNavState.VaultUnlockedForAutofillSelection,
@@ -133,11 +134,11 @@ fun RootNavScreen(
         is RootNavState.VaultUnlockedForFido2Save,
         is RootNavState.VaultUnlockedForFido2Assertion,
         is RootNavState.VaultUnlockedForFido2GetCredentials,
-            -> VAULT_UNLOCKED_GRAPH_ROUTE
+            -> VaultUnlockedGraphRoute
 
-        RootNavState.OnboardingAccountLockSetup -> SETUP_UNLOCK_AS_ROOT_ROUTE
-        RootNavState.OnboardingAutoFillSetup -> SETUP_AUTO_FILL_AS_ROOT_ROUTE
-        RootNavState.OnboardingStepsComplete -> SETUP_COMPLETE_ROUTE
+        RootNavState.OnboardingAccountLockSetup -> SetupUnlockRoute.AsRoot
+        RootNavState.OnboardingAutoFillSetup -> SetupAutofillRoute.AsRoot
+        RootNavState.OnboardingStepsComplete -> SetupCompleteRoute
     }
     val currentRoute = navController.currentDestination?.rootLevelRoute()
 
@@ -145,7 +146,9 @@ fun RootNavScreen(
     // death. In this case, the NavHost already restores state, so we don't have to navigate.
     // However, if the route is correct but the underlying state is different, we should still
     // proceed in order to get a fresh version of that route.
-    if (currentRoute == targetRoute && previousStateReference.get() == state) {
+    if (currentRoute == targetRoute.toObjectNavigationRoute() &&
+        previousStateReference.get() == state
+    ) {
         previousStateReference.set(state)
         return
     }
@@ -291,13 +294,13 @@ private fun NavDestination?.rootLevelRoute(): String? {
 @Suppress("MaxLineLength")
 private fun AnimatedContentTransitionScope<NavBackStackEntry>.toEnterTransition(): NonNullEnterTransitionProvider =
     when (targetState.destination.rootLevelRoute()) {
-        RESET_PASSWORD_ROUTE -> RootTransitionProviders.Enter.slideUp
+        ResetPasswordRoute.toObjectNavigationRoute() -> RootTransitionProviders.Enter.slideUp
         else -> when (initialState.destination.rootLevelRoute()) {
             // Disable transitions when coming from the splash screen
-            SPLASH_ROUTE -> RootTransitionProviders.Enter.none
+            SplashRoute.toObjectNavigationRoute() -> RootTransitionProviders.Enter.none
             // The RESET_PASSWORD_ROUTE animation should be stay but due to an issue when combining
             // certain animations, we are just using a fadeIn instead.
-            RESET_PASSWORD_ROUTE -> RootTransitionProviders.Enter.fadeIn
+            ResetPasswordRoute.toObjectNavigationRoute() -> RootTransitionProviders.Enter.fadeIn
             else -> RootTransitionProviders.Enter.fadeIn
         }
     }
@@ -306,13 +309,14 @@ private fun AnimatedContentTransitionScope<NavBackStackEntry>.toEnterTransition(
  * Define the exit transition for each route.
  */
 @Suppress("MaxLineLength")
-private fun AnimatedContentTransitionScope<NavBackStackEntry>.toExitTransition(): NonNullExitTransitionProvider =
-    when (initialState.destination.rootLevelRoute()) {
+private fun AnimatedContentTransitionScope<NavBackStackEntry>.toExitTransition(): NonNullExitTransitionProvider {
+    return when (initialState.destination.rootLevelRoute()) {
         // Disable transitions when coming from the splash screen
-        SPLASH_ROUTE -> RootTransitionProviders.Exit.none
-        RESET_PASSWORD_ROUTE -> RootTransitionProviders.Exit.slideDown
+        SplashRoute.toObjectNavigationRoute() -> RootTransitionProviders.Exit.none
+        ResetPasswordRoute.toObjectNavigationRoute() -> RootTransitionProviders.Exit.slideDown
         else -> when (targetState.destination.rootLevelRoute()) {
-            RESET_PASSWORD_ROUTE -> RootTransitionProviders.Exit.stay
+            ResetPasswordRoute.toObjectNavigationRoute() -> RootTransitionProviders.Exit.stay
             else -> RootTransitionProviders.Exit.fadeOut
         }
     }
+}

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -87,7 +87,7 @@ class SearchViewModel @Inject constructor(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
         ?: run {
-            val searchType = SearchArgs(savedStateHandle).type
+            val searchType = savedStateHandle.toSearchArgs().type
             val userState = requireNotNull(authRepo.userStateFlow.value)
             val specialCircumstance = specialCircumstanceManager.specialCircumstance
             val searchTerm = (specialCircumstance as? SpecialCircumstance.SearchShortcut)

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
@@ -31,7 +31,7 @@ class SettingsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<SettingsState, SettingsEvent, SettingsAction>(
     initialState = SettingsState(
-        isPreAuth = SettingsArgs(savedStateHandle = savedStateHandle).isPreAuth,
+        isPreAuth = savedStateHandle.toSettingsArgs().isPreAuth,
         securityCount = firstTimeActionManager.allSecuritySettingsBadgeCountFlow.value,
         autoFillCount = firstTimeActionManager.allAutofillSettingsBadgeCountFlow.value,
         vaultCount = firstTimeActionManager.allVaultSettingsBadgeCountFlow.value,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutNavigation.kt
@@ -7,9 +7,25 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import kotlinx.serialization.Serializable
 
-private const val PRE_AUTH_ABOUT_ROUTE = "pre_auth_settings_about"
-private const val ABOUT_ROUTE = "settings_about"
+/**
+ * The type-safe route for the settings about screen.
+ */
+@Serializable
+sealed class SettingsAboutRoute {
+    /**
+     * The type-safe route for the settings about screen.
+     */
+    @Serializable
+    data object Standard : SettingsAboutRoute()
+
+    /**
+     * The type-safe route for the pre-auth settings about screen.
+     */
+    @Serializable
+    data object PreAuth : SettingsAboutRoute()
+}
 
 /**
  * Add settings destinations to the nav graph.
@@ -20,14 +36,22 @@ fun NavGraphBuilder.aboutDestination(
     onNavigateToFlightRecorder: () -> Unit,
     onNavigateToRecordedLogs: () -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = getRoute(isPreAuth = isPreAuth),
-    ) {
-        AboutScreen(
-            onNavigateBack = onNavigateBack,
-            onNavigateToFlightRecorder = onNavigateToFlightRecorder,
-            onNavigateToRecordedLogs = onNavigateToRecordedLogs,
-        )
+    if (isPreAuth) {
+        composableWithPushTransitions<SettingsAboutRoute.PreAuth> {
+            AboutScreen(
+                onNavigateBack = onNavigateBack,
+                onNavigateToFlightRecorder = onNavigateToFlightRecorder,
+                onNavigateToRecordedLogs = onNavigateToRecordedLogs,
+            )
+        }
+    } else {
+        composableWithPushTransitions<SettingsAboutRoute.Standard> {
+            AboutScreen(
+                onNavigateBack = onNavigateBack,
+                onNavigateToFlightRecorder = onNavigateToFlightRecorder,
+                onNavigateToRecordedLogs = onNavigateToRecordedLogs,
+            )
+        }
     }
 }
 
@@ -38,9 +62,8 @@ fun NavController.navigateToAbout(
     isPreAuth: Boolean,
     navOptions: NavOptions? = null,
 ) {
-    navigate(route = getRoute(isPreAuth = isPreAuth), navOptions = navOptions)
+    navigate(
+        route = if (isPreAuth) SettingsAboutRoute.PreAuth else SettingsAboutRoute.Standard,
+        navOptions = navOptions,
+    )
 }
-
-private fun getRoute(
-    isPreAuth: Boolean,
-): String = if (isPreAuth) PRE_AUTH_ABOUT_ROUTE else ABOUT_ROUTE

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import kotlinx.serialization.Serializable
 
-private const val ACCOUNT_SECURITY_ROUTE = "settings_account_security"
+/**
+ * The type-safe route for the account security screen.
+ */
+@Serializable
+data object AccountSecurityRoute
 
 /**
  * Add settings destinations to the nav graph.
@@ -19,9 +24,7 @@ fun NavGraphBuilder.accountSecurityDestination(
     onNavigateToPendingRequests: () -> Unit,
     onNavigateToSetupUnlockScreen: () -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = ACCOUNT_SECURITY_ROUTE,
-    ) {
+    composableWithPushTransitions<AccountSecurityRoute> {
         AccountSecurityScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToDeleteAccount = onNavigateToDeleteAccount,
@@ -35,5 +38,5 @@ fun NavGraphBuilder.accountSecurityDestination(
  * Navigate to the account security screen.
  */
 fun NavController.navigateToAccountSecurity(navOptions: NavOptions? = null) {
-    navigate(ACCOUNT_SECURITY_ROUTE, navOptions)
+    this.navigate(route = AccountSecurityRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val DELETE_ACCOUNT_ROUTE = "delete_account"
+/**
+ * The type-safe route for the delete account screen.
+ */
+@Serializable
+data object DeleteAccountRoute
 
 /**
  * Add delete account destinations to the nav graph.
@@ -17,9 +22,7 @@ fun NavGraphBuilder.deleteAccountDestination(
     onNavigateBack: () -> Unit,
     onNavigateToDeleteAccountConfirmation: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = DELETE_ACCOUNT_ROUTE,
-    ) {
+    composableWithSlideTransitions<DeleteAccountRoute> {
         DeleteAccountScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToDeleteAccountConfirmation = onNavigateToDeleteAccountConfirmation,
@@ -31,5 +34,5 @@ fun NavGraphBuilder.deleteAccountDestination(
  * Navigate to the delete account screen.
  */
 fun NavController.navigateToDeleteAccount(navOptions: NavOptions? = null) {
-    navigate(DELETE_ACCOUNT_ROUTE, navOptions)
+    this.navigate(route = DeleteAccountRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val DELETE_ACCOUNT_CONFIRMATION_ROUTE = "delete_account_confirmation"
+/**
+ * The type-safe route for the delete account confirmation screen.
+ */
+@Serializable
+data object DeleteAccountConfirmationRoute
 
 /**
  * Add delete account confirmation destinations to the nav graph.
@@ -16,9 +21,7 @@ private const val DELETE_ACCOUNT_CONFIRMATION_ROUTE = "delete_account_confirmati
 fun NavGraphBuilder.deleteAccountConfirmationDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = DELETE_ACCOUNT_CONFIRMATION_ROUTE,
-    ) {
+    composableWithSlideTransitions<DeleteAccountConfirmationRoute> {
         DeleteAccountConfirmationScreen(
             onNavigateBack = onNavigateBack,
         )
@@ -29,5 +32,5 @@ fun NavGraphBuilder.deleteAccountConfirmationDestination(
  * Navigate to the [DeleteAccountConfirmationScreen].
  */
 fun NavController.navigateToDeleteAccountConfirmation(navOptions: NavOptions? = null) {
-    navigate(DELETE_ACCOUNT_CONFIRMATION_ROUTE, navOptions)
+    this.navigate(route = DeleteAccountConfirmationRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalNavigation.kt
@@ -6,22 +6,30 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val FINGERPRINT: String = "fingerprint"
-private const val LOGIN_APPROVAL_PREFIX = "login_approval"
-private const val LOGIN_APPROVAL_ROUTE = "$LOGIN_APPROVAL_PREFIX?$FINGERPRINT={$FINGERPRINT}"
+/**
+ * The type-safe route for the login approval screen.
+ */
+@Serializable
+data class LoginApprovalRoute(
+    val fingerprint: String?,
+)
 
 /**
  * Class to retrieve login approval arguments from the [SavedStateHandle].
  */
-data class LoginApprovalArgs(val fingerprint: String?) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        fingerprint = savedStateHandle.get<String>(FINGERPRINT),
-    )
+data class LoginApprovalArgs(val fingerprint: String?)
+
+/**
+ * Constructs a [LoginApprovalArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toLoginApprovalArgs(): LoginApprovalArgs {
+    val route = this.toRoute<LoginApprovalRoute>()
+    return LoginApprovalArgs(fingerprint = route.fingerprint)
 }
 
 /**
@@ -30,16 +38,7 @@ data class LoginApprovalArgs(val fingerprint: String?) {
 fun NavGraphBuilder.loginApprovalDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = LOGIN_APPROVAL_ROUTE,
-        arguments = listOf(
-            navArgument(FINGERPRINT) {
-                type = NavType.StringType
-                nullable = true
-                defaultValue = null
-            },
-        ),
-    ) {
+    composableWithSlideTransitions<LoginApprovalRoute> {
         LoginApprovalScreen(
             onNavigateBack = onNavigateBack,
         )
@@ -53,5 +52,5 @@ fun NavController.navigateToLoginApproval(
     fingerprint: String?,
     navOptions: NavOptions? = null,
 ) {
-    navigate("$LOGIN_APPROVAL_PREFIX?$FINGERPRINT=$fingerprint", navOptions)
+    this.navigate(route = LoginApprovalRoute(fingerprint = fingerprint), navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
@@ -5,6 +5,8 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.loginap
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequestResult
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequestUpdatesResult
@@ -12,8 +14,6 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
-import com.bitwarden.ui.util.Text
-import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.platform.util.toFormattedPattern
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
@@ -45,7 +45,7 @@ class LoginApprovalViewModel @Inject constructor(
                 specialCircumstance = specialCircumstance,
                 fingerprint = specialCircumstance
                     ?.let { "" }
-                    ?: requireNotNull(LoginApprovalArgs(savedStateHandle).fingerprint),
+                    ?: requireNotNull(savedStateHandle.toLoginApprovalArgs().fingerprint),
                 masterPasswordHash = null,
                 publicKey = "",
                 requestId = "",

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val PENDING_REQUESTS_ROUTE = "pending_requests"
+/**
+ * The type-safe route for the pending requests screen.
+ */
+@Serializable
+data object PendingRequestsRoute
 
 /**
  * Add pending requests destinations to the nav graph.
@@ -17,9 +22,7 @@ fun NavGraphBuilder.pendingRequestsDestination(
     onNavigateBack: () -> Unit,
     onNavigateToLoginApproval: (fingerprintPhrase: String) -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = PENDING_REQUESTS_ROUTE,
-    ) {
+    composableWithSlideTransitions<PendingRequestsRoute> {
         PendingRequestsScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToLoginApproval = onNavigateToLoginApproval,
@@ -31,5 +34,5 @@ fun NavGraphBuilder.pendingRequestsDestination(
  * Navigate to the Pending Login Requests screen.
  */
 fun NavController.navigateToPendingRequests(navOptions: NavOptions? = null) {
-    navigate(PENDING_REQUESTS_ROUTE, navOptions)
+    this.navigate(route = PendingRequestsRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceNavigation.kt
@@ -7,9 +7,25 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import kotlinx.serialization.Serializable
 
-private const val PRE_AUTH_APPEARANCE_ROUTE = "pre_auth_settings_appearance"
-private const val APPEARANCE_ROUTE = "settings_appearance"
+/**
+ * The type-safe route for the settings appearance screen.
+ */
+@Serializable
+sealed class SettingsAppearanceRoute {
+    /**
+     * The type-safe route for the settings appearance screen.
+     */
+    @Serializable
+    data object Standard : SettingsAppearanceRoute()
+
+    /**
+     * The type-safe route for the pre-auth settings appearance screen.
+     */
+    @Serializable
+    data object PreAuth : SettingsAppearanceRoute()
+}
 
 /**
  * Add settings destinations to the nav graph.
@@ -18,10 +34,14 @@ fun NavGraphBuilder.appearanceDestination(
     isPreAuth: Boolean,
     onNavigateBack: () -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = getRoute(isPreAuth = isPreAuth),
-    ) {
-        AppearanceScreen(onNavigateBack = onNavigateBack)
+    if (isPreAuth) {
+        composableWithPushTransitions<SettingsAppearanceRoute.PreAuth> {
+            AppearanceScreen(onNavigateBack = onNavigateBack)
+        }
+    } else {
+        composableWithPushTransitions<SettingsAppearanceRoute.Standard> {
+            AppearanceScreen(onNavigateBack = onNavigateBack)
+        }
     }
 }
 
@@ -32,9 +52,12 @@ fun NavController.navigateToAppearance(
     isPreAuth: Boolean,
     navOptions: NavOptions? = null,
 ) {
-    navigate(route = getRoute(isPreAuth = isPreAuth), navOptions = navOptions)
+    this.navigate(
+        route = if (isPreAuth) {
+            SettingsAppearanceRoute.PreAuth
+        } else {
+            SettingsAppearanceRoute.Standard
+        },
+        navOptions = navOptions,
+    )
 }
-
-private fun getRoute(
-    isPreAuth: Boolean,
-): String = if (isPreAuth) PRE_AUTH_APPEARANCE_ROUTE else APPEARANCE_ROUTE

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import kotlinx.serialization.Serializable
 
-private const val AUTO_FILL_ROUTE = "settings_auto_fill"
+/**
+ * The type-safe route for the autofill screen.
+ */
+@Serializable
+data object AutofillRoute
 
 /**
  * Add settings destinations to the nav graph.
@@ -18,9 +23,7 @@ fun NavGraphBuilder.autoFillDestination(
     onNavigateToBlockAutoFillScreen: () -> Unit,
     onNavigateToSetupAutofill: () -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = AUTO_FILL_ROUTE,
-    ) {
+    composableWithPushTransitions<AutofillRoute> {
         AutoFillScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToBlockAutoFillScreen = onNavigateToBlockAutoFillScreen,
@@ -33,5 +36,5 @@ fun NavGraphBuilder.autoFillDestination(
  * Navigate to the auto-fill screen.
  */
 fun NavController.navigateToAutoFill(navOptions: NavOptions? = null) {
-    navigate(AUTO_FILL_ROUTE, navOptions)
+    this.navigate(route = AutofillRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/BlockAutoFillNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/BlockAutoFillNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
+import kotlinx.serialization.Serializable
 
-private const val BLOCK_AUTO_FILL_ROUTE = "settings_block_auto_fill"
+/**
+ * The type-safe route for the block autofill settings screen.
+ */
+@Serializable
+data object BlockAutofillSettingsRoute
 
 /**
  * Add block auto-fill destination to the nav graph.
@@ -16,9 +21,7 @@ private const val BLOCK_AUTO_FILL_ROUTE = "settings_block_auto_fill"
 fun NavGraphBuilder.blockAutoFillDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = BLOCK_AUTO_FILL_ROUTE,
-    ) {
+    composableWithPushTransitions<BlockAutofillSettingsRoute> {
         BlockAutoFillScreen(onNavigateBack = onNavigateBack)
     }
 }
@@ -27,5 +30,5 @@ fun NavGraphBuilder.blockAutoFillDestination(
  * Navigate to the block auto-fill screen.
  */
 fun NavController.navigateToBlockAutoFillScreen(navOptions: NavOptions? = null) {
-    navigate(BLOCK_AUTO_FILL_ROUTE, navOptions)
+    this.navigate(route = BlockAutofillSettingsRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val EXPORT_VAULT_ROUTE = "export_vault"
+/**
+ * The type-safe route for the pending requests screen.
+ */
+@Serializable
+data object ExportVaultRoute
 
 /**
  * Add the Export Vault screen to the nav graph.
@@ -16,9 +21,7 @@ private const val EXPORT_VAULT_ROUTE = "export_vault"
 fun NavGraphBuilder.exportVaultDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = EXPORT_VAULT_ROUTE,
-    ) {
+    composableWithSlideTransitions<ExportVaultRoute> {
         ExportVaultScreen(
             onNavigateBack = onNavigateBack,
         )
@@ -29,5 +32,5 @@ fun NavGraphBuilder.exportVaultDestination(
  * Navigate to the Export Vault screen.
  */
 fun NavController.navigateToExportVault(navOptions: NavOptions? = null) {
-    this.navigate(EXPORT_VAULT_ROUTE, navOptions)
+    this.navigate(route = ExportVaultRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderNavigation.kt
@@ -7,9 +7,25 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val PRE_AUTH_FLIGHT_RECORDER_ROUTE = "pre_auth_flight_recorder_config"
-private const val FLIGHT_RECORDER_ROUTE = "flight_recorder_config"
+/**
+ * The type-safe route for the flight recorder screen.
+ */
+@Serializable
+sealed class FlightRecorderRoute {
+    /**
+     * The type-safe route for the flight recorder screen.
+     */
+    @Serializable
+    data object Standard : FlightRecorderRoute()
+
+    /**
+     * The type-safe route for the pre-auth flight recorder screen.
+     */
+    @Serializable
+    data object PreAuth : FlightRecorderRoute()
+}
 
 /**
  * Add flight recorder destination to the nav graph.
@@ -18,12 +34,18 @@ fun NavGraphBuilder.flightRecorderDestination(
     isPreAuth: Boolean,
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = getRoute(isPreAuth = isPreAuth),
-    ) {
-        FlightRecorderScreen(
-            onNavigateBack = onNavigateBack,
-        )
+    if (isPreAuth) {
+        composableWithSlideTransitions<FlightRecorderRoute.PreAuth> {
+            FlightRecorderScreen(
+                onNavigateBack = onNavigateBack,
+            )
+        }
+    } else {
+        composableWithSlideTransitions<FlightRecorderRoute.Standard> {
+            FlightRecorderScreen(
+                onNavigateBack = onNavigateBack,
+            )
+        }
     }
 }
 
@@ -34,9 +56,8 @@ fun NavController.navigateToFlightRecorder(
     isPreAuth: Boolean,
     navOptions: NavOptions? = null,
 ) {
-    navigate(route = getRoute(isPreAuth = isPreAuth), navOptions = navOptions)
+    navigate(
+        route = if (isPreAuth) FlightRecorderRoute.PreAuth else FlightRecorderRoute.Standard,
+        navOptions = navOptions,
+    )
 }
-
-private fun getRoute(
-    isPreAuth: Boolean,
-): String = if (isPreAuth) PRE_AUTH_FLIGHT_RECORDER_ROUTE else FLIGHT_RECORDER_ROUTE

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsNavigation.kt
@@ -7,10 +7,25 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val PRE_AUTH_FLIGHT_RECORDER_RECORDED_LOGS_ROUTE =
-    "pre_auth_flight_recorder_recorded_logs"
-private const val FLIGHT_RECORDER_RECORDED_LOGS_ROUTE = "flight_recorder_recorded_logs"
+/**
+ * The type-safe route for the recorded logs screen.
+ */
+@Serializable
+sealed class RecordedLogsRoute {
+    /**
+     * The type-safe route for the recorded logs screen.
+     */
+    @Serializable
+    data object Standard : RecordedLogsRoute()
+
+    /**
+     * The type-safe route for the pre-auth recorded logs screen.
+     */
+    @Serializable
+    data object PreAuth : RecordedLogsRoute()
+}
 
 /**
  * Add recorded logs destination to the nav graph.
@@ -19,12 +34,18 @@ fun NavGraphBuilder.recordedLogsDestination(
     isPreAuth: Boolean,
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = getRoute(isPreAuth = isPreAuth),
-    ) {
-        RecordedLogsScreen(
-            onNavigateBack = onNavigateBack,
-        )
+    if (isPreAuth) {
+        composableWithSlideTransitions<RecordedLogsRoute.PreAuth> {
+            RecordedLogsScreen(
+                onNavigateBack = onNavigateBack,
+            )
+        }
+    } else {
+        composableWithSlideTransitions<RecordedLogsRoute.Standard> {
+            RecordedLogsScreen(
+                onNavigateBack = onNavigateBack,
+            )
+        }
     }
 }
 
@@ -35,14 +56,8 @@ fun NavController.navigateToRecordedLogs(
     isPreAuth: Boolean,
     navOptions: NavOptions? = null,
 ) {
-    navigate(route = getRoute(isPreAuth = isPreAuth), navOptions = navOptions)
+    navigate(
+        route = if (isPreAuth) RecordedLogsRoute.PreAuth else RecordedLogsRoute.Standard,
+        navOptions = navOptions,
+    )
 }
-
-private fun getRoute(
-    isPreAuth: Boolean,
-): String =
-    if (isPreAuth) {
-        PRE_AUTH_FLIGHT_RECORDER_RECORDED_LOGS_ROUTE
-    } else {
-        FLIGHT_RECORDER_RECORDED_LOGS_ROUTE
-    }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val FOLDERS_ROUTE = "settings_folders"
+/**
+ * The type-safe route for the folders screen.
+ */
+@Serializable
+data object FoldersRoute
 
 /**
  * Add folders destinations to the nav graph.
@@ -18,9 +23,7 @@ fun NavGraphBuilder.foldersDestination(
     onNavigateToAddFolderScreen: () -> Unit,
     onNavigateToEditFolderScreen: (folderId: String) -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = FOLDERS_ROUTE,
-    ) {
+    composableWithSlideTransitions<FoldersRoute> {
         FoldersScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
@@ -33,5 +36,5 @@ fun NavGraphBuilder.foldersDestination(
  * Navigate to the folders screen.
  */
 fun NavController.navigateToFolders(navOptions: NavOptions? = null) {
-    navigate(FOLDERS_ROUTE, navOptions)
+    this.navigate(route = FoldersRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditViewModel.kt
@@ -39,7 +39,7 @@ class FolderAddEditViewModel @Inject constructor(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
         ?: run {
-            val folderAddEditArgs = FolderAddEditArgs(savedStateHandle)
+            val folderAddEditArgs = savedStateHandle.toFolderAddEditArgs()
             FolderAddEditState(
                 folderAddEditType = folderAddEditArgs.folderAddEditType,
                 viewState = when (folderAddEditArgs.folderAddEditType) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherViewModel.kt
@@ -40,7 +40,7 @@ class OtherViewModel @Inject constructor(
 ) : BaseViewModel<OtherState, OtherEvent, OtherAction>(
     initialState = savedStateHandle[KEY_STATE]
         ?: OtherState(
-            isPreAuth = OtherArgs(savedStateHandle = savedStateHandle).isPreAuth,
+            isPreAuth = savedStateHandle.toOtherArgs().isPreAuth,
             allowScreenCapture = settingsRepo.isScreenCaptureAllowed,
             allowSyncOnRefresh = settingsRepo.getPullToRefreshEnabledFlow().value,
             clearClipboardFrequency = settingsRepo.clearClipboardFrequency,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsNavigation.kt
@@ -8,8 +8,13 @@ import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
+import kotlinx.serialization.Serializable
 
-private const val VAULT_SETTINGS_ROUTE = "vault_settings"
+/**
+ * The type-safe route for the vault settings screen.
+ */
+@Serializable
+data object VaultSettingsRoute
 
 /**
  * Add Vault Settings destinations to the nav graph.
@@ -20,9 +25,7 @@ fun NavGraphBuilder.vaultSettingsDestination(
     onNavigateToFolders: () -> Unit,
     onNavigateToImportLogins: (SnackbarRelay) -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = VAULT_SETTINGS_ROUTE,
-    ) {
+    composableWithPushTransitions<VaultSettingsRoute> {
         VaultSettingsScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToExportVault = onNavigateToExportVault,
@@ -36,5 +39,5 @@ fun NavGraphBuilder.vaultSettingsDestination(
  * Navigate to the Vault Settings screen.
  */
 fun NavController.navigateToVaultSettings(navOptions: NavOptions? = null) {
-    navigate(VAULT_SETTINGS_ROUTE, navOptions)
+    this.navigate(route = VaultSettingsRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/splash/SplashNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/splash/SplashNavigation.kt
@@ -7,14 +7,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.bitwarden.core.annotation.OmitFromCoverage
+import kotlinx.serialization.Serializable
 
-const val SPLASH_ROUTE: String = "splash"
+/**
+ * The type-safe route for the splash screen.
+ */
+@Serializable
+data object SplashRoute
 
 /**
  * Add splash destinations to the nav graph.
  */
 fun NavGraphBuilder.splashDestination() {
-    composable(SPLASH_ROUTE) { SplashScreen() }
+    composable<SplashRoute> { SplashScreen() }
 }
 
 /**
@@ -23,5 +28,5 @@ fun NavGraphBuilder.splashDestination() {
 fun NavController.navigateToSplash(
     navOptions: NavOptions? = null,
 ) {
-    navigate(SPLASH_ROUTE, navOptions)
+    navigate(SplashRoute, navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -32,7 +32,7 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.folders.addedit.navigate
 import com.x8bit.bitwarden.ui.platform.feature.settings.folders.foldersDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.folders.model.FolderAddEditType
 import com.x8bit.bitwarden.ui.platform.feature.settings.folders.navigateToFolders
-import com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.VAULT_UNLOCKED_NAV_BAR_ROUTE
+import com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.VaultUnlockedNavbarRoute
 import com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.vaultUnlockedNavBarDestination
 import com.x8bit.bitwarden.ui.tools.feature.generator.generatorModalDestination
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorPasswordHistoryMode
@@ -57,14 +57,19 @@ import com.x8bit.bitwarden.ui.vault.feature.movetoorganization.navigateToVaultMo
 import com.x8bit.bitwarden.ui.vault.feature.movetoorganization.vaultMoveToOrganizationDestination
 import com.x8bit.bitwarden.ui.vault.feature.qrcodescan.navigateToQrCodeScanScreen
 import com.x8bit.bitwarden.ui.vault.feature.qrcodescan.vaultQrCodeScanDestination
+import kotlinx.serialization.Serializable
 
-const val VAULT_UNLOCKED_GRAPH_ROUTE: String = "vault_unlocked_graph"
+/**
+ * The type-safe route for the vault unlocked graph.
+ */
+@Serializable
+data object VaultUnlockedGraphRoute
 
 /**
  * Navigate to the vault unlocked screen.
  */
 fun NavController.navigateToVaultUnlockedGraph(navOptions: NavOptions? = null) {
-    navigate(VAULT_UNLOCKED_GRAPH_ROUTE, navOptions)
+    navigate(route = VaultUnlockedGraphRoute, navOptions = navOptions)
 }
 
 /**
@@ -74,9 +79,8 @@ fun NavController.navigateToVaultUnlockedGraph(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.vaultUnlockedGraph(
     navController: NavController,
 ) {
-    navigation(
-        startDestination = VAULT_UNLOCKED_NAV_BAR_ROUTE,
-        route = VAULT_UNLOCKED_GRAPH_ROUTE,
+    navigation<VaultUnlockedGraphRoute>(
+        startDestination = VaultUnlockedNavbarRoute,
     ) {
         vaultItemListingDestinationAsRoot(
             onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
@@ -11,17 +11,19 @@ import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
 import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
+import kotlinx.serialization.Serializable
 
 /**
- * The functions below pertain to entry into the [VaultUnlockedNavBarScreen].
+ * The type-safe route for the vault unlocked navbar screen.
  */
-const val VAULT_UNLOCKED_NAV_BAR_ROUTE: String = "VaultUnlockedNavBar"
+@Serializable
+data object VaultUnlockedNavbarRoute
 
 /**
  * Navigate to the [VaultUnlockedNavBarScreen].
  */
 fun NavController.navigateToVaultUnlockedNavBar(navOptions: NavOptions? = null) {
-    navigate(VAULT_UNLOCKED_NAV_BAR_ROUTE, navOptions)
+    navigate(route = VaultUnlockedNavbarRoute, navOptions = navOptions)
 }
 
 /**
@@ -48,9 +50,7 @@ fun NavGraphBuilder.vaultUnlockedNavBarDestination(
     onNavigateToImportLogins: (SnackbarRelay) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderName: String?) -> Unit,
 ) {
-    composableWithStayTransitions(
-        route = VAULT_UNLOCKED_NAV_BAR_ROUTE,
-    ) {
+    composableWithStayTransitions<VaultUnlockedNavbarRoute> {
         VaultUnlockedNavBarScreen(
             onNavigateToVaultAddItem = onNavigateToVaultAddItem,
             onNavigateToVaultItem = onNavigateToVaultItem,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -42,7 +42,7 @@ import com.x8bit.bitwarden.ui.tools.feature.send.navigateToSendGraph
 import com.x8bit.bitwarden.ui.tools.feature.send.sendGraph
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
 import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
-import com.x8bit.bitwarden.ui.vault.feature.vault.VAULT_GRAPH_ROUTE
+import com.x8bit.bitwarden.ui.vault.feature.vault.VaultGraphRoute
 import com.x8bit.bitwarden.ui.vault.feature.vault.navigateToVaultGraph
 import com.x8bit.bitwarden.ui.vault.feature.vault.vaultGraph
 import kotlinx.collections.immutable.persistentListOf
@@ -220,7 +220,7 @@ private fun VaultUnlockedNavBarScaffold(
         // - consume the IME insets.
         NavHost(
             navController = navController,
-            startDestination = VAULT_GRAPH_ROUTE,
+            startDestination = VaultGraphRoute,
             enterTransition = RootTransitionProviders.Enter.fadeIn,
             exitTransition = RootTransitionProviders.Exit.fadeOut,
             popEnterTransition = RootTransitionProviders.Enter.fadeIn,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
@@ -3,14 +3,15 @@ package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.model
 import android.os.Parcelable
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.model.NavigationItem
-import com.x8bit.bitwarden.ui.platform.feature.settings.SETTINGS_GRAPH_ROUTE
-import com.x8bit.bitwarden.ui.platform.feature.settings.SETTINGS_ROUTE
-import com.x8bit.bitwarden.ui.tools.feature.generator.GENERATOR_GRAPH_ROUTE
-import com.x8bit.bitwarden.ui.tools.feature.generator.GENERATOR_ROUTE
-import com.x8bit.bitwarden.ui.tools.feature.send.SEND_GRAPH_ROUTE
-import com.x8bit.bitwarden.ui.tools.feature.send.SEND_ROUTE
-import com.x8bit.bitwarden.ui.vault.feature.vault.VAULT_GRAPH_ROUTE
-import com.x8bit.bitwarden.ui.vault.feature.vault.VAULT_ROUTE
+import com.x8bit.bitwarden.ui.platform.feature.settings.SettingsGraphRoute
+import com.x8bit.bitwarden.ui.platform.feature.settings.SettingsRoute
+import com.x8bit.bitwarden.ui.platform.util.toObjectNavigationRoute
+import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorGraphRoute
+import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorRoute
+import com.x8bit.bitwarden.ui.tools.feature.send.SendGraphRoute
+import com.x8bit.bitwarden.ui.tools.feature.send.SendRoute
+import com.x8bit.bitwarden.ui.vault.feature.vault.VaultGraphRoute
+import com.x8bit.bitwarden.ui.vault.feature.vault.VaultRoute
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -33,8 +34,8 @@ sealed class VaultUnlockedNavBarTab : NavigationItem, Parcelable {
         override val iconRes get() = R.drawable.ic_generator
         override val labelRes get() = R.string.generator
         override val contentDescriptionRes get() = R.string.generator
-        override val graphRoute: String get() = GENERATOR_GRAPH_ROUTE
-        override val startDestinationRoute get() = GENERATOR_ROUTE
+        override val graphRoute get() = GeneratorGraphRoute.toObjectNavigationRoute()
+        override val startDestinationRoute get() = GeneratorRoute.Standard.toObjectNavigationRoute()
         override val testTag get() = "GeneratorTab"
         override val notificationCount get() = 0
     }
@@ -48,8 +49,8 @@ sealed class VaultUnlockedNavBarTab : NavigationItem, Parcelable {
         override val iconRes get() = R.drawable.ic_send
         override val labelRes get() = R.string.send
         override val contentDescriptionRes get() = R.string.send
-        override val graphRoute: String get() = SEND_GRAPH_ROUTE
-        override val startDestinationRoute get() = SEND_ROUTE
+        override val graphRoute get() = SendGraphRoute.toObjectNavigationRoute()
+        override val startDestinationRoute get() = SendRoute.toObjectNavigationRoute()
         override val testTag get() = "SendTab"
         override val notificationCount get() = 0
     }
@@ -64,8 +65,8 @@ sealed class VaultUnlockedNavBarTab : NavigationItem, Parcelable {
     ) : VaultUnlockedNavBarTab() {
         override val iconResSelected get() = R.drawable.ic_vault_filled
         override val iconRes get() = R.drawable.ic_vault
-        override val graphRoute: String get() = VAULT_GRAPH_ROUTE
-        override val startDestinationRoute get() = VAULT_ROUTE
+        override val graphRoute get() = VaultGraphRoute.toObjectNavigationRoute()
+        override val startDestinationRoute get() = VaultRoute.toObjectNavigationRoute()
         override val testTag get() = "VaultTab"
         override val notificationCount get() = 0
     }
@@ -81,8 +82,8 @@ sealed class VaultUnlockedNavBarTab : NavigationItem, Parcelable {
         override val iconRes get() = R.drawable.ic_settings
         override val labelRes get() = R.string.settings
         override val contentDescriptionRes get() = R.string.settings
-        override val graphRoute: String get() = SETTINGS_GRAPH_ROUTE
-        override val startDestinationRoute get() = SETTINGS_ROUTE
+        override val graphRoute get() = SettingsGraphRoute.toObjectNavigationRoute()
+        override val startDestinationRoute get() = SettingsRoute.Standard.toObjectNavigationRoute()
         override val testTag get() = "SettingsTab"
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelay.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelay.kt
@@ -1,11 +1,13 @@
 package com.x8bit.bitwarden.ui.platform.manager.snackbar
 
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
+import kotlinx.serialization.Serializable
 
 /**
  * Models a relay key to be mapped to an instance of [BitwardenSnackbarData] being sent
  * between producers and consumers of the data.
  */
+@Serializable
 enum class SnackbarRelay {
     VAULT_SETTINGS_RELAY,
     MY_VAULT_RELAY,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/RouteUtil.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/RouteUtil.kt
@@ -1,0 +1,18 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.serializer
+import kotlin.reflect.KClass
+
+/**
+ * Gets the route string for an object.
+ */
+@OptIn(InternalSerializationApi::class)
+fun <T : Any> T.toObjectNavigationRoute(): String = this::class.toObjectKClassNavigationRoute()
+
+/**
+ * Gets the route string for a [KClass] of an object.
+ */
+@OptIn(InternalSerializationApi::class)
+fun <T : Any> KClass<T>.toObjectKClassNavigationRoute(): String =
+    this.serializer().descriptor.serialName

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/SavedStateHandleExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/SavedStateHandleExtensions.kt
@@ -1,0 +1,24 @@
+package com.x8bit.bitwarden.ui.platform.util
+
+import android.content.Intent
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
+import androidx.navigation.toRoute
+
+/**
+ * Determines if the [SavedStateHandle] contains a route for the specified object class.
+ *
+ * This will return the object instance if the route is correct, `null` otherwise.
+ */
+inline fun <reified T : Any> SavedStateHandle.toObjectRoute(): T? =
+    this
+        .get<Intent>(key = NavController.KEY_DEEP_LINK_INTENT)
+        ?.data
+        ?.pathSegments
+        .orEmpty()
+        .takeIf { segments -> segments.any { it == T::class.toObjectKClassNavigationRoute() } }
+        ?.let { _ ->
+            // This will get the instance for us. We only do this after the checks above as it
+            // will always return the object instance even if it is not the correct one.
+            this.toRoute<T>()
+        }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorGraphNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorGraphNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.navigation
 import com.bitwarden.core.annotation.OmitFromCoverage
+import kotlinx.serialization.Serializable
 
-const val GENERATOR_GRAPH_ROUTE: String = "generator_graph"
+/**
+ * The type-safe route for the generator graph.
+ */
+@Serializable
+data object GeneratorGraphRoute
 
 /**
  * Add generator destination to the root nav graph.
@@ -17,9 +22,8 @@ fun NavGraphBuilder.generatorGraph(
     onNavigateToPasswordHistory: () -> Unit,
     onDimNavBarRequest: (Boolean) -> Unit,
 ) {
-    navigation(
-        route = GENERATOR_GRAPH_ROUTE,
-        startDestination = GENERATOR_ROUTE,
+    navigation<GeneratorGraphRoute>(
+        startDestination = GeneratorRoute.Standard,
     ) {
         generatorDestination(
             onNavigateToPasswordHistory = onNavigateToPasswordHistory,
@@ -32,5 +36,5 @@ fun NavGraphBuilder.generatorGraph(
  * Navigate to the generator graph.
  */
 fun NavController.navigateToGeneratorGraph(navOptions: NavOptions? = null) {
-    navigate(GENERATOR_GRAPH_ROUTE, navOptions)
+    this.navigate(route = GeneratorGraphRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorViewModel.kt
@@ -86,7 +86,7 @@ class GeneratorViewModel @Inject constructor(
     private val featureFlagManager: FeatureFlagManager,
 ) : BaseViewModel<GeneratorState, GeneratorEvent, GeneratorAction>(
     initialState = savedStateHandle[KEY_STATE] ?: run {
-        val generatorMode = GeneratorArgs(savedStateHandle).type
+        val generatorMode = savedStateHandle.toGeneratorArgs().type
         GeneratorState(
             generatedText = NO_GENERATED_TEXT,
             selectedType = when (generatorMode) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModel.kt
@@ -44,7 +44,7 @@ class PasswordHistoryViewModel @Inject constructor(
     initialState = savedStateHandle[KEY_STATE]
         ?: run {
             PasswordHistoryState(
-                passwordHistoryMode = PasswordHistoryArgs(savedStateHandle).passwordHistoryMode,
+                passwordHistoryMode = savedStateHandle.toPasswordHistoryArgs().passwordHistoryMode,
                 viewState = PasswordHistoryState.ViewState.Loading,
             )
         },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendGraphNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendGraphNavigation.kt
@@ -11,8 +11,13 @@ import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.navigateToSendItemListing
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.sendItemListingDestination
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
+import kotlinx.serialization.Serializable
 
-const val SEND_GRAPH_ROUTE: String = "send_graph"
+/**
+ * The type-safe route for the send graph.
+ */
+@Serializable
+data object SendGraphRoute
 
 /**
  * Add send destination to the nav graph.
@@ -23,9 +28,8 @@ fun NavGraphBuilder.sendGraph(
     onNavigateToEditSend: (sendItemId: String) -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
 ) {
-    navigation(
-        startDestination = SEND_ROUTE,
-        route = SEND_GRAPH_ROUTE,
+    navigation<SendGraphRoute>(
+        startDestination = SendRoute,
     ) {
         sendDestination(
             onNavigateToAddSend = onNavigateToAddSend,
@@ -52,5 +56,5 @@ fun NavGraphBuilder.sendGraph(
  * via [sendGraph].
  */
 fun NavController.navigateToSendGraph(navOptions: NavOptions? = null) {
-    navigate(SEND_GRAPH_ROUTE, navOptions)
+    navigate(route = SendGraphRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendNavigation.kt
@@ -8,8 +8,13 @@ import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithRootPushTransitions
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
+import kotlinx.serialization.Serializable
 
-const val SEND_ROUTE: String = "send"
+/**
+ * The type-safe route for the send screen.
+ */
+@Serializable
+data object SendRoute
 
 /**
  * Add send destination to the nav graph.
@@ -21,9 +26,7 @@ fun NavGraphBuilder.sendDestination(
     onNavigateToSendTextList: () -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
 ) {
-    composableWithRootPushTransitions(
-        route = SEND_ROUTE,
-    ) {
+    composableWithRootPushTransitions<SendRoute> {
         SendScreen(
             onNavigateToAddSend = onNavigateToAddSend,
             onNavigateToEditSend = onNavigateToEditSend,
@@ -39,5 +42,5 @@ fun NavGraphBuilder.sendDestination(
  * via [sendDestination].
  */
 fun NavController.navigateToSend(navOptions: NavOptions? = null) {
-    navigate(SEND_ROUTE, navOptions)
+    navigate(route = SendRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
@@ -78,7 +78,7 @@ class AddSendViewModel @Inject constructor(
         // Check to see if we are navigating here from an external source
         val specialCircumstance = specialCircumstanceManager.specialCircumstance
         val shareSendType = specialCircumstance.toSendType()
-        val sendAddType = AddSendArgs(savedStateHandle).sendAddType
+        val sendAddType = savedStateHandle.toAddSendArgs().sendAddType
         AddSendState(
             shouldFinishOnComplete = specialCircumstance.shouldFinishOnComplete(),
             isShared = shareSendType != null,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditNavigation.kt
@@ -6,38 +6,35 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import kotlinx.serialization.Serializable
 
-private const val ADD_TYPE: String = "add"
-private const val EDIT_TYPE: String = "edit"
-private const val CLONE_TYPE: String = "clone"
-private const val EDIT_ITEM_ID: String = "vault_edit_id"
+/**
+ * The type-safe route for the vault add/edit screen.
+ */
+@Serializable
+data class VaultAddEditRoute(
+    val vaultAddEditMode: VaultAddEditMode,
+    val vaultItemId: String?,
+    val vaultItemCipherType: VaultItemCipherType,
+    val selectedFolderId: String? = null,
+    val selectedCollectionId: String? = null,
+)
 
-private const val LOGIN: String = "login"
-private const val CARD: String = "card"
-private const val IDENTITY: String = "identity"
-private const val SECURE_NOTE: String = "secure_note"
-private const val SSH_KEY: String = "ssh_key"
-private const val CIPHER_TYPE: String = "vault_item_type"
-
-private const val ADD_EDIT_ITEM_PREFIX: String = "vault_add_edit_item"
-private const val ADD_EDIT_ITEM_TYPE: String = "vault_add_edit_type"
-private const val ADD_SELECTED_FOLDER_ID: String = "vault_add_selected_folder_id"
-private const val ADD_SELECTED_COLLECTION_ID: String = "vault_add_selected_collection_id"
-
-private const val ADD_EDIT_ITEM_ROUTE: String =
-    ADD_EDIT_ITEM_PREFIX +
-        "/{$ADD_EDIT_ITEM_TYPE}" +
-        "?$EDIT_ITEM_ID={$EDIT_ITEM_ID}" +
-        "?$CIPHER_TYPE={$CIPHER_TYPE}" +
-        "?$ADD_SELECTED_FOLDER_ID={$ADD_SELECTED_FOLDER_ID}" +
-        "?$ADD_SELECTED_COLLECTION_ID={$ADD_SELECTED_COLLECTION_ID}"
+/**
+ * The mode in which the vault add/edit screen should be displayed.
+ */
+@Serializable
+enum class VaultAddEditMode {
+    ADD,
+    EDIT,
+    CLONE,
+}
 
 /**
  * Class to retrieve vault add & edit arguments from the [SavedStateHandle].
@@ -47,24 +44,27 @@ data class VaultAddEditArgs(
     val vaultItemCipherType: VaultItemCipherType,
     val selectedFolderId: String? = null,
     val selectedCollectionId: String? = null,
-) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        vaultAddEditType = when (requireNotNull(savedStateHandle[ADD_EDIT_ITEM_TYPE])) {
-            ADD_TYPE -> VaultAddEditType.AddItem
-            EDIT_TYPE -> VaultAddEditType.EditItem(
-                vaultItemId = requireNotNull(savedStateHandle[EDIT_ITEM_ID]),
-            )
+)
 
-            CLONE_TYPE -> VaultAddEditType.CloneItem(
-                vaultItemId = requireNotNull(savedStateHandle[EDIT_ITEM_ID]),
-            )
+/**
+ * Constructs a [VaultAddEditArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toVaultAddEditArgs(): VaultAddEditArgs {
+    val route = this.toRoute<VaultAddEditRoute>()
+    return VaultAddEditArgs(
+        vaultAddEditType = when (route.vaultAddEditMode) {
+            VaultAddEditMode.ADD -> VaultAddEditType.AddItem
+            VaultAddEditMode.EDIT -> {
+                VaultAddEditType.EditItem(vaultItemId = requireNotNull(route.vaultItemId))
+            }
 
-            else -> throw IllegalStateException("Unknown VaultAddEditType.")
+            VaultAddEditMode.CLONE -> {
+                VaultAddEditType.CloneItem(vaultItemId = requireNotNull(route.vaultItemId))
+            }
         },
-        vaultItemCipherType = requireNotNull(savedStateHandle.get<String>(CIPHER_TYPE))
-            .toVaultItemCipherType(),
-        selectedFolderId = savedStateHandle[ADD_SELECTED_FOLDER_ID],
-        selectedCollectionId = savedStateHandle[ADD_SELECTED_COLLECTION_ID],
+        vaultItemCipherType = route.vaultItemCipherType,
+        selectedFolderId = route.selectedFolderId,
+        selectedCollectionId = route.selectedCollectionId,
     )
 }
 
@@ -80,25 +80,7 @@ fun NavGraphBuilder.vaultAddEditDestination(
     onNavigateToAttachments: (cipherId: String) -> Unit,
     onNavigateToMoveToOrganization: (cipherId: String, showOnlyCollections: Boolean) -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = ADD_EDIT_ITEM_ROUTE,
-        arguments = listOf(
-            navArgument(ADD_EDIT_ITEM_TYPE) { type = NavType.StringType },
-            navArgument(CIPHER_TYPE) { type = NavType.StringType },
-            navArgument(ADD_SELECTED_FOLDER_ID) {
-                type = NavType.StringType
-                nullable = true
-            },
-            navArgument(ADD_SELECTED_COLLECTION_ID) {
-                type = NavType.StringType
-                nullable = true
-            },
-            navArgument(ADD_SELECTED_COLLECTION_ID) {
-                type = NavType.StringType
-                nullable = true
-            },
-        ),
-    ) {
+    composableWithSlideTransitions<VaultAddEditRoute> {
         VaultAddEditScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToManualCodeEntryScreen = onNavigateToManualCodeEntryScreen,
@@ -118,46 +100,17 @@ fun NavController.navigateToVaultAddEdit(
     navOptions: NavOptions? = null,
 ) {
     navigate(
-        route = "$ADD_EDIT_ITEM_PREFIX/${args.vaultAddEditType.toTypeString()}" +
-            "?$EDIT_ITEM_ID=${args.vaultAddEditType.toIdOrNull()}" +
-            "?$CIPHER_TYPE=${args.vaultItemCipherType.toTypeString()}" +
-            "?$ADD_SELECTED_FOLDER_ID=${args.selectedFolderId}" +
-            "?$ADD_SELECTED_COLLECTION_ID=${args.selectedCollectionId}",
+        route = VaultAddEditRoute(
+            vaultAddEditMode = when (args.vaultAddEditType) {
+                VaultAddEditType.AddItem -> VaultAddEditMode.ADD
+                is VaultAddEditType.CloneItem -> VaultAddEditMode.CLONE
+                is VaultAddEditType.EditItem -> VaultAddEditMode.EDIT
+            },
+            vaultItemId = args.vaultAddEditType.vaultItemId,
+            vaultItemCipherType = args.vaultItemCipherType,
+            selectedFolderId = args.selectedFolderId,
+            selectedCollectionId = args.selectedFolderId,
+        ),
         navOptions = navOptions,
     )
 }
-
-private fun VaultAddEditType.toTypeString(): String =
-    when (this) {
-        is VaultAddEditType.AddItem -> ADD_TYPE
-        is VaultAddEditType.EditItem -> EDIT_TYPE
-        is VaultAddEditType.CloneItem -> CLONE_TYPE
-    }
-
-private fun VaultAddEditType.toIdOrNull(): String? =
-    when (this) {
-        is VaultAddEditType.AddItem -> null
-        is VaultAddEditType.CloneItem -> vaultItemId
-        is VaultAddEditType.EditItem -> vaultItemId
-    }
-
-private fun VaultItemCipherType.toTypeString(): String =
-    when (this) {
-        VaultItemCipherType.LOGIN -> LOGIN
-        VaultItemCipherType.CARD -> CARD
-        VaultItemCipherType.IDENTITY -> IDENTITY
-        VaultItemCipherType.SECURE_NOTE -> SECURE_NOTE
-        VaultItemCipherType.SSH_KEY -> SSH_KEY
-    }
-
-private fun String.toVaultItemCipherType(): VaultItemCipherType =
-    when (this) {
-        LOGIN -> VaultItemCipherType.LOGIN
-        CARD -> VaultItemCipherType.CARD
-        IDENTITY -> VaultItemCipherType.IDENTITY
-        SECURE_NOTE -> VaultItemCipherType.SECURE_NOTE
-        SSH_KEY -> VaultItemCipherType.SSH_KEY
-        else -> throw IllegalStateException(
-            "Edit Item string arguments for VaultAddEditNavigation must match!",
-        )
-    }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -126,7 +126,7 @@ class VaultAddEditViewModel @Inject constructor(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
         ?: run {
-            val args = VaultAddEditArgs(savedStateHandle = savedStateHandle)
+            val args = savedStateHandle.toVaultAddEditArgs()
             val vaultAddEditType = args.vaultAddEditType
             val vaultCipherType = args.vaultItemCipherType
             val selectedFolderId = args.selectedFolderId

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsNavigation.kt
@@ -6,22 +6,30 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val ATTACHMENTS_CIPHER_ID = "cipher_id"
-private const val ATTACHMENTS_ROUTE_PREFIX = "attachments"
-private const val ATTACHMENTS_ROUTE = "$ATTACHMENTS_ROUTE_PREFIX/{$ATTACHMENTS_CIPHER_ID}"
+/**
+ * The type-safe route for the attachments screen.
+ */
+@Serializable
+data class AttachmentsRoute(
+    val cipherId: String,
+)
 
 /**
  * Class to retrieve arguments from the [SavedStateHandle].
  */
-data class AttachmentsArgs(val cipherId: String) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        cipherId = checkNotNull(savedStateHandle.get<String>(ATTACHMENTS_CIPHER_ID)),
-    )
+data class AttachmentsArgs(val cipherId: String)
+
+/**
+ * Constructs a [AttachmentsArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toAttachmentsArgs(): AttachmentsArgs {
+    val route = this.toRoute<AttachmentsRoute>()
+    return AttachmentsArgs(cipherId = route.cipherId)
 }
 
 /**
@@ -30,12 +38,7 @@ data class AttachmentsArgs(val cipherId: String) {
 fun NavGraphBuilder.attachmentDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = ATTACHMENTS_ROUTE,
-        arguments = listOf(
-            navArgument(ATTACHMENTS_CIPHER_ID) { type = NavType.StringType },
-        ),
-    ) {
+    composableWithSlideTransitions<AttachmentsRoute> {
         AttachmentsScreen(
             onNavigateBack = onNavigateBack,
         )
@@ -50,7 +53,7 @@ fun NavController.navigateToAttachment(
     navOptions: NavOptions? = null,
 ) {
     navigate(
-        route = "$ATTACHMENTS_ROUTE_PREFIX/$cipherId",
+        route = AttachmentsRoute(cipherId = cipherId),
         navOptions = navOptions,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
@@ -50,7 +50,7 @@ class AttachmentsViewModel @Inject constructor(
         ?: run {
             val isPremiumUser = authRepo.userStateFlow.value?.activeAccount?.isPremium == true
             AttachmentsState(
-                cipherId = AttachmentsArgs(savedStateHandle).cipherId,
+                cipherId = savedStateHandle.toAttachmentsArgs().cipherId,
                 viewState = AttachmentsState.ViewState.Loading,
                 dialogState = AttachmentsState.DialogState.Error(
                     title = null,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsNavigation.kt
@@ -6,25 +6,31 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
+import kotlinx.serialization.Serializable
 
-private const val IMPORT_LOGINS_PREFIX = "import-logins"
-private const val IMPORT_LOGINS_NAV_ARG = "snackbarRelay"
-private const val IMPORT_LOGINS_ROUTE = "$IMPORT_LOGINS_PREFIX/{$IMPORT_LOGINS_NAV_ARG}"
+/**
+ * The type-safe route for the import logins screen.
+ */
+@Serializable
+data class ImportLoginsRoute(
+    val snackbarRelay: SnackbarRelay,
+)
 
 /**
  * Arguments for the [ImportLoginsScreen] using [SavedStateHandle].
  */
-data class ImportLoginsArgs(val snackBarRelay: SnackbarRelay) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        snackBarRelay = SnackbarRelay.valueOf(
-            requireNotNull(savedStateHandle[IMPORT_LOGINS_NAV_ARG]),
-        ),
-    )
+data class ImportLoginsArgs(val snackBarRelay: SnackbarRelay)
+
+/**
+ * Constructs a [ImportLoginsArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toImportLoginsArgs(): ImportLoginsArgs {
+    val route = this.toRoute<ImportLoginsRoute>()
+    return ImportLoginsArgs(snackBarRelay = route.snackbarRelay)
 }
 
 /**
@@ -34,7 +40,7 @@ fun NavController.navigateToImportLoginsScreen(
     snackbarRelay: SnackbarRelay,
     navOptions: NavOptions? = null,
 ) {
-    navigate(route = "$IMPORT_LOGINS_PREFIX/$snackbarRelay", navOptions = navOptions)
+    navigate(route = ImportLoginsRoute(snackbarRelay = snackbarRelay), navOptions = navOptions)
 }
 
 /**
@@ -43,15 +49,7 @@ fun NavController.navigateToImportLoginsScreen(
 fun NavGraphBuilder.importLoginsScreenDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = IMPORT_LOGINS_ROUTE,
-        arguments = listOf(
-            navArgument(IMPORT_LOGINS_NAV_ARG) {
-                type = NavType.StringType
-                nullable = false
-            },
-        ),
-    ) {
+    composableWithSlideTransitions<ImportLoginsRoute> {
         ImportLoginsScreen(
             onNavigateBack = onNavigateBack,
         )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
@@ -41,7 +41,7 @@ class ImportLoginsViewModel @Inject constructor(
                 showBottomSheet = false,
                 // attempt to trim the scheme of the vault url
                 currentWebVaultUrl = vaultUrl.toUriOrNull()?.host ?: vaultUrl,
-                snackbarRelay = ImportLoginsArgs(savedStateHandle).snackBarRelay,
+                snackbarRelay = savedStateHandle.toImportLoginsArgs().snackBarRelay,
             )
         },
     ) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -76,7 +76,7 @@ class VaultItemViewModel @Inject constructor(
 ) : BaseViewModel<VaultItemState, VaultItemEvent, VaultItemAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE] ?: run {
-        val args = VaultItemArgs(savedStateHandle)
+        val args = savedStateHandle.toVaultItemArgs()
         VaultItemState(
             vaultItemId = args.vaultItemId,
             cipherType = args.cipherType,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -133,7 +133,8 @@ class VaultItemListingViewModel @Inject constructor(
         val fido2GetCredentialsRequest = specialCircumstance?.toFido2GetCredentialsRequestOrNull()
         val fido2AssertCredentialRequest = specialCircumstance?.toFido2AssertionRequestOrNull()
         VaultItemListingState(
-            itemListingType = VaultItemListingArgs(savedStateHandle = savedStateHandle)
+            itemListingType = savedStateHandle
+                .toVaultItemListingArgs()
                 .vaultItemListingType
                 .toItemListingType(),
             activeAccountSummary = activeAccountSummary,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val MANUAL_CODE_ENTRY_ROUTE: String = "manual_code_entry"
+/**
+ * The type-safe route for the manual code entry screen.
+ */
+@Serializable
+data object ManualCodeEntryRoute
 
 /**
  * Add the manual code entry screen to the nav graph.
@@ -17,9 +22,7 @@ fun NavGraphBuilder.vaultManualCodeEntryDestination(
     onNavigateBack: () -> Unit,
     onNavigateToQrCodeScreen: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = MANUAL_CODE_ENTRY_ROUTE,
-    ) {
+    composableWithSlideTransitions<ManualCodeEntryRoute> {
         ManualCodeEntryScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToQrCodeScreen = onNavigateToQrCodeScreen,
@@ -33,5 +36,5 @@ fun NavGraphBuilder.vaultManualCodeEntryDestination(
 fun NavController.navigateToManualCodeEntryScreen(
     navOptions: NavOptions? = null,
 ) {
-    this.navigate(MANUAL_CODE_ENTRY_ROUTE, navOptions)
+    this.navigate(route = ManualCodeEntryRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationNavigation.kt
@@ -6,19 +6,19 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val VAULT_MOVE_TO_ORGANIZATION_PREFIX = "vault_move_to_organization"
-private const val VAULT_MOVE_TO_ORGANIZATION_ID = "vault_move_to_organization_id"
-private const val VAULT_MOVE_TO_ORGANIZATION_ONLY_COLLECTIONS =
-    "vault_move_to_organization_only_collections"
-private const val VAULT_MOVE_TO_ORGANIZATION_ROUTE =
-    VAULT_MOVE_TO_ORGANIZATION_PREFIX +
-        "/{$VAULT_MOVE_TO_ORGANIZATION_ID}" +
-        "/{$VAULT_MOVE_TO_ORGANIZATION_ONLY_COLLECTIONS}"
+/**
+ * The type-safe route for the vault move to organization screen.
+ */
+@Serializable
+data class VaultMoveToOrganizationRoute(
+    val vaultItemId: String,
+    val showOnlyCollections: Boolean,
+)
 
 /**
  * Class to retrieve vault move to organization arguments from the [SavedStateHandle].
@@ -26,12 +26,16 @@ private const val VAULT_MOVE_TO_ORGANIZATION_ROUTE =
 data class VaultMoveToOrganizationArgs(
     val vaultItemId: String,
     val showOnlyCollections: Boolean,
-) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        vaultItemId = checkNotNull(savedStateHandle[VAULT_MOVE_TO_ORGANIZATION_ID]) as String,
-        showOnlyCollections =
-            (checkNotNull(savedStateHandle[VAULT_MOVE_TO_ORGANIZATION_ONLY_COLLECTIONS]) as String)
-                .toBoolean(),
+)
+
+/**
+ * Constructs a [VaultMoveToOrganizationArgs] from the [SavedStateHandle] and internal route data.
+ */
+fun SavedStateHandle.toVaultMoveToOrganizationArgs(): VaultMoveToOrganizationArgs {
+    val route = this.toRoute<VaultMoveToOrganizationRoute>()
+    return VaultMoveToOrganizationArgs(
+        vaultItemId = route.vaultItemId,
+        showOnlyCollections = route.showOnlyCollections,
     )
 }
 
@@ -41,15 +45,7 @@ data class VaultMoveToOrganizationArgs(
 fun NavGraphBuilder.vaultMoveToOrganizationDestination(
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = VAULT_MOVE_TO_ORGANIZATION_ROUTE,
-        arguments = listOf(
-            navArgument(VAULT_MOVE_TO_ORGANIZATION_ID) { type = NavType.StringType },
-            navArgument(VAULT_MOVE_TO_ORGANIZATION_ONLY_COLLECTIONS) {
-                type = NavType.StringType
-            },
-        ),
-    ) {
+    composableWithSlideTransitions<VaultMoveToOrganizationRoute> {
         VaultMoveToOrganizationScreen(
             onNavigateBack = onNavigateBack,
         )
@@ -64,8 +60,11 @@ fun NavController.navigateToVaultMoveToOrganization(
     showOnlyCollections: Boolean,
     navOptions: NavOptions? = null,
 ) {
-    navigate(
-        route = "$VAULT_MOVE_TO_ORGANIZATION_PREFIX/$vaultItemId/$showOnlyCollections",
+    this.navigate(
+        route = VaultMoveToOrganizationRoute(
+            vaultItemId = vaultItemId,
+            showOnlyCollections = showOnlyCollections,
+        ),
         navOptions = navOptions,
     )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.combineDataStates
+import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
+import com.bitwarden.ui.util.concat
 import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.CollectionView
 import com.x8bit.bitwarden.R
@@ -13,9 +16,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.ShareCipherResult
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModel
-import com.bitwarden.ui.util.Text
-import com.bitwarden.ui.util.asText
-import com.bitwarden.ui.util.concat
 import com.x8bit.bitwarden.ui.vault.feature.movetoorganization.util.toViewState
 import com.x8bit.bitwarden.ui.vault.model.VaultCollection
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -42,9 +42,10 @@ class VaultMoveToOrganizationViewModel @Inject constructor(
 ) : BaseViewModel<VaultMoveToOrganizationState, VaultMoveToOrganizationEvent, VaultMoveToOrganizationAction>(
     initialState = savedStateHandle[KEY_STATE]
         ?: run {
+            val args = savedStateHandle.toVaultMoveToOrganizationArgs()
             VaultMoveToOrganizationState(
-                vaultItemId = VaultMoveToOrganizationArgs(savedStateHandle).vaultItemId,
-                onlyShowCollections = VaultMoveToOrganizationArgs(savedStateHandle).showOnlyCollections,
+                vaultItemId = args.vaultItemId,
+                onlyShowCollections = args.showOnlyCollections,
                 viewState = VaultMoveToOrganizationState.ViewState.Loading,
                 dialogState = null,
             )

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanNavigation.kt
@@ -7,8 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
 
-private const val QR_CODE_SCAN_ROUTE: String = "qr_code_scan"
+/**
+ * The type-safe route for the QR code scan screen.
+ */
+@Serializable
+data object QrCodeScanRoute
 
 /**
  * Add the QR code scan screen to the nav graph.
@@ -17,9 +22,7 @@ fun NavGraphBuilder.vaultQrCodeScanDestination(
     onNavigateBack: () -> Unit,
     onNavigateToManualCodeEntryScreen: () -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = QR_CODE_SCAN_ROUTE,
-    ) {
+    composableWithSlideTransitions<QrCodeScanRoute> {
         QrCodeScanScreen(
             onNavigateToManualCodeEntryScreen = onNavigateToManualCodeEntryScreen,
             onNavigateBack = onNavigateBack,
@@ -33,5 +36,5 @@ fun NavGraphBuilder.vaultQrCodeScanDestination(
 fun NavController.navigateToQrCodeScanScreen(
     navOptions: NavOptions? = null,
 ) {
-    this.navigate(QR_CODE_SCAN_ROUTE, navOptions)
+    this.navigate(route = QrCodeScanRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultGraphNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultGraphNavigation.kt
@@ -15,8 +15,13 @@ import com.x8bit.bitwarden.ui.vault.feature.itemlisting.navigateToVaultItemListi
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.vaultItemListingDestination
 import com.x8bit.bitwarden.ui.vault.feature.verificationcode.navigateToVerificationCodeScreen
 import com.x8bit.bitwarden.ui.vault.feature.verificationcode.vaultVerificationCodeDestination
+import kotlinx.serialization.Serializable
 
-const val VAULT_GRAPH_ROUTE: String = "vault_graph"
+/**
+ * The type-safe route for the vault graph.
+ */
+@Serializable
+data object VaultGraphRoute
 
 /**
  * Add vault destinations to the nav graph.
@@ -33,9 +38,8 @@ fun NavGraphBuilder.vaultGraph(
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToAboutScreen: () -> Unit,
 ) {
-    navigation(
-        route = VAULT_GRAPH_ROUTE,
-        startDestination = VAULT_ROUTE,
+    navigation<VaultGraphRoute>(
+        startDestination = VaultRoute,
     ) {
         vaultDestination(
             onNavigateToVaultAddItemScreen = { onNavigateToVaultAddItemScreen(it) },
@@ -75,5 +79,5 @@ fun NavGraphBuilder.vaultGraph(
  * Navigate to the vault graph.
  */
 fun NavController.navigateToVaultGraph(navOptions: NavOptions? = null) {
-    navigate(VAULT_GRAPH_ROUTE, navOptions)
+    this.navigate(route = VaultGraphRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/vault/VaultNavigation.kt
@@ -12,8 +12,13 @@ import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
 import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
+import kotlinx.serialization.Serializable
 
-const val VAULT_ROUTE: String = "vault"
+/**
+ * The type-safe route for the vault screen.
+ */
+@Serializable
+data object VaultRoute
 
 /**
  * Add vault destination to the nav graph.
@@ -31,9 +36,7 @@ fun NavGraphBuilder.vaultDestination(
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToAboutScreen: () -> Unit,
 ) {
-    composableWithRootPushTransitions(
-        route = VAULT_ROUTE,
-    ) {
+    composableWithRootPushTransitions<VaultRoute> {
         VaultScreen(
             onNavigateToVaultAddItemScreen = onNavigateToVaultAddItemScreen,
             onNavigateToVaultItemScreen = onNavigateToVaultItemScreen,
@@ -53,5 +56,5 @@ fun NavGraphBuilder.vaultDestination(
  * Navigate to the [VaultScreen].
  */
 fun NavController.navigateToVault(navOptions: NavOptions? = null) {
-    navigate(VAULT_ROUTE, navOptions)
+    this.navigate(route = VaultRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeNavigation.kt
@@ -8,8 +8,13 @@ import androidx.navigation.NavOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.platform.base.util.composableWithPushTransitions
 import com.x8bit.bitwarden.ui.vault.feature.item.VaultItemArgs
+import kotlinx.serialization.Serializable
 
-private const val VERIFICATION_CODE_ROUTE: String = "verification_code"
+/**
+ * The type-safe route for the verification code screen.
+ */
+@Serializable
+data object VerificationCodeRoute
 
 /**
  * Add the verification code screen to the nav graph.
@@ -19,9 +24,7 @@ fun NavGraphBuilder.vaultVerificationCodeDestination(
     onNavigateToSearchVault: () -> Unit,
     onNavigateToVaultItemScreen: (args: VaultItemArgs) -> Unit,
 ) {
-    composableWithPushTransitions(
-        route = VERIFICATION_CODE_ROUTE,
-    ) {
+    composableWithPushTransitions<VerificationCodeRoute> {
         VerificationCodeScreen(
             onNavigateToVaultItemScreen = onNavigateToVaultItemScreen,
             onNavigateToSearch = onNavigateToSearchVault,
@@ -36,5 +39,5 @@ fun NavGraphBuilder.vaultVerificationCodeDestination(
 fun NavController.navigateToVerificationCodeScreen(
     navOptions: NavOptions? = null,
 ) {
-    this.navigate(VERIFICATION_CODE_ROUTE, navOptions)
+    this.navigate(route = VerificationCodeRoute, navOptions = navOptions)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/model/VaultItemCipherType.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/model/VaultItemCipherType.kt
@@ -1,8 +1,11 @@
 package com.x8bit.bitwarden.ui.vault.model
 
+import kotlinx.serialization.Serializable
+
 /**
  * Represents different types of ciphers that can be added/viewed.
  */
+@Serializable
 enum class VaultItemCipherType {
 
     /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutoFillViewModelTest.kt
@@ -12,14 +12,18 @@ import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class SetupAutoFillViewModelTest : BaseViewModelTest() {
@@ -43,6 +47,16 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
     private val authRepository: AuthRepository = mockk {
         every { userStateFlow } returns mutableUserStateFlow
         every { setOnboardingStatus(any()) } just runs
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toSetupAutoFillArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toSetupAutoFillArgs)
     }
 
     @Test
@@ -183,12 +197,10 @@ class SetupAutoFillViewModelTest : BaseViewModelTest() {
     private fun createViewModel(
         initialState: SetupAutoFillState? = null,
     ) = SetupAutoFillViewModel(
-        savedStateHandle = SavedStateHandle(
-            mapOf(
-                "state" to initialState,
-                "isInitialSetup" to true,
-            ),
-        ),
+        savedStateHandle = SavedStateHandle().apply {
+            set(key = "state", value = initialState)
+            every { toSetupAutoFillArgs() } returns SetupAutoFillScreenArgs(isInitialSetup = true)
+        },
         settingsRepository = settingsRepository,
         authRepository = authRepository,
         firstTimeActionManager = firstTimeActionManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockViewModelTest.kt
@@ -20,12 +20,16 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.crypto.Cipher
 
@@ -54,6 +58,16 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
             isBiometricIntegrityValid(userId = DEFAULT_USER_ID, cipher = CIPHER)
         } returns false
         every { createCipherOrNull(DEFAULT_USER_ID) } returns CIPHER
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toSetupUnlockArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toSetupUnlockArgs)
     }
 
     @Test
@@ -373,12 +387,10 @@ class SetupUnlockViewModelTest : BaseViewModelTest() {
         state: SetupUnlockState? = null,
     ): SetupUnlockViewModel =
         SetupUnlockViewModel(
-            savedStateHandle = SavedStateHandle(
-                mapOf(
-                    "state" to state,
-                    "isInitialSetup" to true,
-                ),
-            ),
+            savedStateHandle = SavedStateHandle().apply {
+                set(key = "state", value = state)
+                every { toSetupUnlockArgs() } returns SetupUnlockArgs(isInitialSetup = true)
+            },
             authRepository = authRepository,
             settingsRepository = settingsRepository,
             biometricsEncryptionManager = biometricsEncryptionManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailViewModelTest.kt
@@ -2,21 +2,26 @@ package com.x8bit.bitwarden.ui.auth.feature.checkemail
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
-import io.mockk.mockk
-import kotlinx.coroutines.flow.MutableStateFlow
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class CheckEmailViewModelTest : BaseViewModelTest() {
-    private val mutableFeatureFlagFlow = MutableStateFlow(false)
-    private val featureFlagManager = mockk<FeatureFlagManager>(relaxed = true) {
-        every { getFeatureFlag(FlagKey.OnboardingFlow) } returns false
-        every { getFeatureFlagFlow(FlagKey.OnboardingFlow) } returns mutableFeatureFlagFlow
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toCheckEmailArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toCheckEmailArgs)
     }
 
     @Test
@@ -76,16 +81,14 @@ class CheckEmailViewModelTest : BaseViewModelTest() {
 
     private fun createViewModel(state: CheckEmailState? = null): CheckEmailViewModel =
         CheckEmailViewModel(
-            savedStateHandle = SavedStateHandle().also {
-                it["email"] = EMAIL
-                it["state"] = state
+            savedStateHandle = SavedStateHandle().apply {
+                set(key = "state", value = state)
+                every { toCheckEmailArgs() } returns CheckEmailArgs(emailAddress = EMAIL)
             },
         )
-
-    companion object {
-        private const val EMAIL = "test@gmail.com"
-        private val DEFAULT_STATE = CheckEmailState(
-            email = EMAIL,
-        )
-    }
 }
+
+private const val EMAIL = "test@gmail.com"
+private val DEFAULT_STATE = CheckEmailState(
+    email = EMAIL,
+)

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationViewModelTest.kt
@@ -108,12 +108,18 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
     @BeforeEach
     fun setUp() {
         specialCircumstanceManager.specialCircumstance = mockCompleteRegistrationCircumstance
-        mockkStatic(::generateUriForCaptcha)
+        mockkStatic(
+            SavedStateHandle::toCompleteRegistrationArgs,
+            ::generateUriForCaptcha,
+        )
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(::generateUriForCaptcha)
+        unmockkStatic(
+            SavedStateHandle::toCompleteRegistrationArgs,
+            ::generateUriForCaptcha,
+        )
     }
 
     @Test
@@ -668,11 +674,14 @@ class CompleteRegistrationViewModelTest : BaseViewModelTest() {
     private fun createCompleteRegistrationViewModel(
         completeRegistrationState: CompleteRegistrationState? = DEFAULT_STATE,
     ): CompleteRegistrationViewModel = CompleteRegistrationViewModel(
-        savedStateHandle = SavedStateHandle(
-            mapOf(
-                "state" to completeRegistrationState,
-            ),
-        ),
+        savedStateHandle = SavedStateHandle().apply {
+            set(key = "state", value = completeRegistrationState)
+            every { toCompleteRegistrationArgs() } returns CompleteRegistrationArgs(
+                emailAddress = completeRegistrationState?.userEmail ?: EMAIL,
+                verificationToken = completeRegistrationState?.emailVerificationToken ?: TOKEN,
+                fromEmail = completeRegistrationState?.fromEmail ?: false,
+            )
+        },
         authRepository = mockAuthRepository,
         environmentRepository = fakeEnvironmentRepository,
         specialCircumstanceManager = specialCircumstanceManager,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
@@ -68,14 +68,20 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
 
     @BeforeEach
     fun setUp() {
-        mockkStatic(::generateUriForSso)
-        mockkStatic(Uri::parse)
+        mockkStatic(
+            SavedStateHandle::toEnterpriseSignOnArgs,
+            ::generateUriForSso,
+            Uri::parse,
+        )
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(::generateUriForSso)
-        unmockkStatic(Uri::parse)
+        unmockkStatic(
+            SavedStateHandle::toEnterpriseSignOnArgs,
+            ::generateUriForSso,
+            Uri::parse,
+        )
     }
 
     @Test
@@ -1172,14 +1178,14 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
         initialState: EnterpriseSignOnState? = null,
         ssoData: SsoResponseData? = null,
         ssoCallbackResult: SsoCallbackResult? = null,
-        savedStateHandle: SavedStateHandle = SavedStateHandle(
-            initialState = mapOf(
-                "state" to initialState,
-                "email_address" to DEFAULT_EMAIL,
-                "ssoData" to ssoData,
-                "ssoCallbackResult" to ssoCallbackResult,
-            ),
-        ),
+        savedStateHandle: SavedStateHandle = SavedStateHandle().apply {
+            set(key = "state", value = initialState)
+            set(key = "ssoData", value = ssoData)
+            set(key = "ssoCallbackResult", value = ssoCallbackResult)
+            every {
+                toEnterpriseSignOnArgs()
+            } returns EnterpriseSignOnArgs(emailAddress = DEFAULT_EMAIL)
+        },
         isNetworkConnected: Boolean = true,
         dismissInitialDialog: Boolean = true,
     ): EnterpriseSignOnViewModel = EnterpriseSignOnViewModel(

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModelTest.kt
@@ -58,12 +58,18 @@ class LoginViewModelTest : BaseViewModelTest() {
 
     @BeforeEach
     fun setUp() {
-        mockkStatic(::generateUriForCaptcha)
+        mockkStatic(
+            ::generateUriForCaptcha,
+            SavedStateHandle::toLoginArgs,
+        )
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(::generateUriForCaptcha)
+        unmockkStatic(
+            ::generateUriForCaptcha,
+            SavedStateHandle::toLoginArgs,
+        )
     }
 
     @Test
@@ -617,9 +623,9 @@ class LoginViewModelTest : BaseViewModelTest() {
             authRepository = authRepository,
             environmentRepository = fakeEnvironmentRepository,
             vaultRepository = vaultRepository,
-            savedStateHandle = SavedStateHandle().also {
-                it["email_address"] = EMAIL
-                it["state"] = state
+            savedStateHandle = SavedStateHandle().apply {
+                set(key = "state", value = state)
+                every { toLoginArgs() } returns LoginArgs(emailAddress = EMAIL, captchaToken = null)
             },
         )
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
@@ -16,11 +16,16 @@ import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.awaits
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 
@@ -36,6 +41,16 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
             createAuthRequestWithUpdates(email = EMAIL, authRequestType = any())
         } returns mutableCreateAuthRequestWithUpdatesFlow
         coEvery { captchaTokenResultFlow } returns mutableCaptchaTokenResultFlow
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toLoginWithDeviceArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toLoginWithDeviceArgs)
     }
 
     @Test
@@ -728,8 +743,10 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
             authRepository = authRepository,
             savedStateHandle = SavedStateHandle().apply {
                 set("state", state)
-                set("email_address", state?.emailAddress ?: EMAIL)
-                set("login_type", state?.loginWithDeviceType ?: LoginWithDeviceType.OTHER_DEVICE)
+                every { toLoginWithDeviceArgs() } returns LoginWithDeviceArgs(
+                    emailAddress = state?.emailAddress ?: EMAIL,
+                    loginType = state?.loginWithDeviceType ?: LoginWithDeviceType.OTHER_DEVICE,
+                )
             },
         )
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -36,14 +36,18 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.crypto.Cipher
 
@@ -95,6 +99,16 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
 
     private val vaultLockManager: VaultLockManager = mockk(relaxed = true) {
         every { isFromLockFlow } returns false
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toVaultUnlockArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toVaultUnlockArgs)
     }
 
     @Test
@@ -1347,7 +1361,7 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
     ): VaultUnlockViewModel = VaultUnlockViewModel(
         savedStateHandle = SavedStateHandle().apply {
             set("state", state)
-            set("unlock_type", unlockType)
+            every { toVaultUnlockArgs() } returns VaultUnlockArgs(unlockType = unlockType)
         },
         authRepository = authRepository,
         vaultRepo = vaultRepo,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/FakeNavHostController.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/FakeNavHostController.kt
@@ -79,8 +79,14 @@ class FakeNavHostController : NavHostController(context = mockk()) {
             every { id } returns graphId
             every { startDestinationId } returns graphId
             every {
-                findNode(graphId)
+                findNode(resId = graphId)
             } returns mockk { every { id } returns graphId }
+            every {
+                findNodeComprehensive(resId = any(), lastVisited = any(), searchChildren = any())
+            } returns mockk {
+                every { id } returns graphId
+                every { arguments } returns emptyMap()
+            }
         }
 
     override var graph: NavGraph

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -49,6 +49,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.platform.feature.search.util.createMockDisplayItemForCipher
 import com.x8bit.bitwarden.ui.platform.feature.search.util.filterAndOrganize
 import com.x8bit.bitwarden.ui.platform.feature.search.util.toViewState
@@ -130,6 +131,7 @@ class SearchViewModelTest : BaseViewModelTest() {
     @BeforeEach
     fun setup() {
         mockkStatic(
+            SavedStateHandle::toSearchArgs,
             List<CipherView>::toViewState,
             List<CipherView>::filterAndOrganize,
             List<CipherView>::toFilteredList,
@@ -139,6 +141,7 @@ class SearchViewModelTest : BaseViewModelTest() {
     @AfterEach
     fun tearDown() {
         unmockkStatic(
+            SavedStateHandle::toSearchArgs,
             List<CipherView>::toViewState,
             List<CipherView>::filterAndOrganize,
             List<CipherView>::toFilteredList,
@@ -1518,44 +1521,31 @@ class SearchViewModelTest : BaseViewModelTest() {
     ): SearchViewModel = SearchViewModel(
         SavedStateHandle().apply {
             set("state", initialState)
-            set(
-                "search_type",
-                when (initialState?.searchType) {
-                    SearchTypeData.Sends.All -> "search_type_sends_all"
-                    SearchTypeData.Sends.Files -> "search_type_sends_file"
-                    SearchTypeData.Sends.Texts -> "search_type_sends_text"
-                    SearchTypeData.Vault.All -> "search_type_vault_all"
-                    SearchTypeData.Vault.Cards -> "search_type_vault_cards"
-                    SearchTypeData.Vault.SshKeys -> "search_type_vault_ssh_keys"
-                    is SearchTypeData.Vault.Collection -> "search_type_vault_collection"
-                    is SearchTypeData.Vault.Folder -> "search_type_vault_folder"
-                    SearchTypeData.Vault.Identities -> "search_type_vault_identities"
-                    SearchTypeData.Vault.Logins -> "search_type_vault_logins"
-                    SearchTypeData.Vault.NoFolder -> "search_type_vault_no_folder"
-                    SearchTypeData.Vault.SecureNotes -> "search_type_vault_secure_notes"
-                    SearchTypeData.Vault.VerificationCodes -> "search_type_vault_verification_codes"
-                    SearchTypeData.Vault.Trash -> "search_type_vault_trash"
-                    null -> "search_type_vault_all"
-                },
-            )
-            set(
-                "search_type_id",
-                when (val searchType = initialState?.searchType) {
-                    SearchTypeData.Sends.All -> null
-                    SearchTypeData.Sends.Files -> null
-                    SearchTypeData.Sends.Texts -> null
-                    SearchTypeData.Vault.All -> null
-                    SearchTypeData.Vault.Cards -> null
-                    SearchTypeData.Vault.SshKeys -> null
-                    is SearchTypeData.Vault.Collection -> searchType.collectionId
-                    is SearchTypeData.Vault.Folder -> searchType.folderId
-                    SearchTypeData.Vault.Identities -> null
-                    SearchTypeData.Vault.Logins -> null
-                    SearchTypeData.Vault.NoFolder -> null
-                    SearchTypeData.Vault.SecureNotes -> null
-                    SearchTypeData.Vault.VerificationCodes -> null
-                    SearchTypeData.Vault.Trash -> null
-                    null -> null
+            every {
+                toSearchArgs()
+            } returns SearchArgs(
+                type = when (val searchType = initialState?.searchType) {
+                    SearchTypeData.Sends.All -> SearchType.Sends.All
+                    SearchTypeData.Sends.Files -> SearchType.Sends.Files
+                    SearchTypeData.Sends.Texts -> SearchType.Sends.Texts
+                    SearchTypeData.Vault.All -> SearchType.Vault.All
+                    SearchTypeData.Vault.Cards -> SearchType.Vault.Cards
+                    is SearchTypeData.Vault.Collection -> SearchType.Vault.Collection(
+                        collectionId = searchType.collectionId,
+                    )
+
+                    is SearchTypeData.Vault.Folder -> SearchType.Vault.Folder(
+                        folderId = searchType.folderId,
+                    )
+
+                    SearchTypeData.Vault.Identities -> SearchType.Vault.Identities
+                    SearchTypeData.Vault.Logins -> SearchType.Vault.Logins
+                    SearchTypeData.Vault.NoFolder -> SearchType.Vault.NoFolder
+                    SearchTypeData.Vault.SecureNotes -> SearchType.Vault.SecureNotes
+                    SearchTypeData.Vault.SshKeys -> SearchType.Vault.SshKeys
+                    SearchTypeData.Vault.Trash -> SearchType.Vault.Trash
+                    SearchTypeData.Vault.VerificationCodes -> SearchType.Vault.VerificationCodes
+                    null -> SearchType.Vault.All
                 },
             )
         },

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -9,12 +9,16 @@ import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class SettingsViewModelTest : BaseViewModelTest() {
@@ -29,6 +33,16 @@ class SettingsViewModelTest : BaseViewModelTest() {
     }
     private val specialCircumstanceManager: SpecialCircumstanceManager = mockk {
         every { specialCircumstance } returns null
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toSettingsArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toSettingsArgs)
     }
 
     @Test
@@ -175,7 +189,7 @@ class SettingsViewModelTest : BaseViewModelTest() {
         firstTimeActionManager = firstTimeManager,
         specialCircumstanceManager = specialCircumstanceManager,
         savedStateHandle = SavedStateHandle().apply {
-            set("isPreAuth", isPreAuth)
+            every { toSettingsArgs() } returns SettingsArgs(isPreAuth = isPreAuth)
         },
     )
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModelTest.kt
@@ -22,10 +22,14 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
@@ -50,6 +54,16 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
         } returns mutableAuthRequestSharedFlow
         coEvery { getAuthRequestByIdFlow(REQUEST_ID) } returns mutableAuthRequestSharedFlow
         every { userStateFlow } returns mutableUserStateFlow
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toLoginApprovalArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toLoginApprovalArgs)
     }
 
     @Test
@@ -415,9 +429,10 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
         clock = fixedClock,
         authRepository = mockAuthRepository,
         specialCircumstanceManager = mockSpecialCircumstanceManager,
-        savedStateHandle = SavedStateHandle()
-            .also { it["fingerprint"] = FINGERPRINT }
-            .apply { set("state", state) },
+        savedStateHandle = SavedStateHandle().apply {
+            set("state", state)
+            every { toLoginApprovalArgs() } returns LoginApprovalArgs(fingerprint = FINGERPRINT)
+        },
     )
 }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherViewModelTest.kt
@@ -12,11 +12,15 @@ import com.x8bit.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
@@ -45,6 +49,16 @@ class OtherViewModelTest : BaseViewModelTest() {
     private val vaultRepository = mockk<VaultRepository>()
     private val networkConnectionManager = mockk<NetworkConnectionManager> {
         every { isNetworkConnected } returns true
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toOtherArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toOtherArgs)
     }
 
     @Test
@@ -211,7 +225,7 @@ class OtherViewModelTest : BaseViewModelTest() {
         vaultRepo = vaultRepository,
         savedStateHandle = SavedStateHandle().apply {
             set("state", state)
-            set("isPreAuth", state?.isPreAuth == true)
+            every { toOtherArgs() } returns OtherArgs(isPreAuth = state?.isPreAuth == true)
         },
         networkConnectionManager = networkConnectionManager,
     )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModelTest.kt
@@ -93,6 +93,7 @@ class AddSendViewModelTest : BaseViewModelTest() {
     @BeforeEach
     fun setup() {
         mockkStatic(
+            SavedStateHandle::toAddSendArgs,
             AddSendState.ViewState.Content::toSendView,
             SendView::toSendUrl,
             SendView::toViewState,
@@ -102,6 +103,7 @@ class AddSendViewModelTest : BaseViewModelTest() {
     @AfterEach
     fun tearDown() {
         unmockkStatic(
+            SavedStateHandle::toAddSendArgs,
             AddSendState.ViewState.Content::toSendView,
             SendView::toSendUrl,
             SendView::toViewState,
@@ -1016,15 +1018,8 @@ class AddSendViewModelTest : BaseViewModelTest() {
     ): AddSendViewModel = AddSendViewModel(
         savedStateHandle = SavedStateHandle().apply {
             set("state", state?.copy(addSendType = addSendType))
-            set(
-                "add_send_item_type",
-                when (addSendType) {
-                    AddSendType.AddItem -> "add"
-                    is AddSendType.EditItem -> "edit"
-                },
-            )
-            set("edit_send_id", (addSendType as? AddSendType.EditItem)?.sendItemId)
             set("activityToken", activityToken)
+            every { toAddSendArgs() } returns AddSendArgs(sendAddType = addSendType)
         },
         authRepo = authRepository,
         environmentRepo = environmentRepository,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -136,11 +136,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     private val loginInitialState = createVaultAddItemState(
         typeContentViewState = createLoginTypeContentViewState(),
     )
-    private val loginInitialSavedStateHandle = createSavedStateHandleWithState(
-        state = loginInitialState,
-        vaultAddEditType = VaultAddEditType.AddItem,
-        vaultItemCipherType = VaultItemCipherType.LOGIN,
-    )
+    private val loginInitialSavedStateHandle
+        get() = createSavedStateHandleWithState(
+            state = loginInitialState,
+            vaultAddEditType = VaultAddEditType.AddItem,
+            vaultItemCipherType = VaultItemCipherType.LOGIN,
+        )
 
     private val totpTestCodeFlow: MutableSharedFlow<TotpCodeResult> = bufferedMutableSharedFlow()
 
@@ -199,16 +200,22 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @BeforeEach
     fun setup() {
-        mockkStatic(CipherView::toViewState)
-        mockkStatic(UUID::randomUUID)
+        mockkStatic(
+            SavedStateHandle::toVaultAddEditArgs,
+            CipherView::toViewState,
+            UUID::randomUUID,
+        )
         mockkObject(ProviderCreateCredentialRequest.Companion)
         every { UUID.randomUUID().toString() } returns TEST_ID
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(CipherView::toViewState)
-        unmockkStatic(UUID::randomUUID)
+        unmockkStatic(
+            SavedStateHandle::toVaultAddEditArgs,
+            CipherView::toViewState,
+            UUID::randomUUID,
+        )
         unmockkObject(ProviderCreateCredentialRequest.Companion)
     }
 
@@ -4691,24 +4698,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         vaultItemCipherType: VaultItemCipherType,
     ): SavedStateHandle = SavedStateHandle().apply {
         set("state", state)
-        set(
-            "vault_add_edit_type",
-            when (vaultAddEditType) {
-                is VaultAddEditType.AddItem -> "add"
-                is VaultAddEditType.EditItem -> "edit"
-                is VaultAddEditType.CloneItem -> "clone"
-            },
-        )
-        set("vault_edit_id", (vaultAddEditType as? VaultAddEditType.EditItem)?.vaultItemId)
-        set(
-            "vault_item_type",
-            when (vaultItemCipherType) {
-                VaultItemCipherType.LOGIN -> "login"
-                VaultItemCipherType.CARD -> "card"
-                VaultItemCipherType.IDENTITY -> "identity"
-                VaultItemCipherType.SECURE_NOTE -> "secure_note"
-                VaultItemCipherType.SSH_KEY -> "ssh_key"
-            },
+        every { toVaultAddEditArgs() } returns VaultAddEditArgs(
+            vaultAddEditType = vaultAddEditType,
+            vaultItemCipherType = vaultItemCipherType,
         )
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
@@ -47,13 +47,19 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
 
     @BeforeEach
     fun setup() {
-        mockkStatic(CipherView::toViewState)
+        mockkStatic(
+            SavedStateHandle::toAttachmentsArgs,
+            CipherView::toViewState,
+        )
         mockkStatic(Uri::class)
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(CipherView::toViewState)
+        unmockkStatic(
+            SavedStateHandle::toAttachmentsArgs,
+            CipherView::toViewState,
+        )
         unmockkStatic(Uri::class)
     }
 
@@ -624,7 +630,9 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
         vaultRepo = vaultRepository,
         savedStateHandle = SavedStateHandle().apply {
             set("state", initialState)
-            set("cipher_id", initialState?.cipherId ?: "mockId-1")
+            every {
+                toAttachmentsArgs()
+            } returns AttachmentsArgs(cipherId = initialState?.cipherId ?: "mockId-1")
         },
     )
 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
@@ -48,7 +48,10 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
 
     @BeforeEach
     fun setUp() {
-        mockkStatic(Uri::parse)
+        mockkStatic(
+            SavedStateHandle::toImportLoginsArgs,
+            Uri::parse,
+        )
         every { Uri.parse(Environment.Us.environmentUrlData.base) } returns mockk {
             every { host } returns DEFAULT_VAULT_URL
         }
@@ -56,7 +59,10 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(Uri::parse)
+        unmockkStatic(
+            SavedStateHandle::toImportLoginsArgs,
+            Uri::parse,
+        )
     }
 
     private val snackbarRelayManager: SnackbarRelayManagerImpl = mockk {
@@ -521,11 +527,9 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
     private fun createViewModel(
         snackbarRelay: SnackbarRelay = SnackbarRelay.MY_VAULT_RELAY,
     ): ImportLoginsViewModel = ImportLoginsViewModel(
-        savedStateHandle = SavedStateHandle(
-            mapOf(
-                "snackbarRelay" to snackbarRelay.name,
-            ),
-        ),
+        savedStateHandle = SavedStateHandle().apply {
+            every { toImportLoginsArgs() } returns ImportLoginsArgs(snackBarRelay = snackbarRelay)
+        },
         vaultRepository = vaultRepository,
         firstTimeActionManager = firstTimeActionManager,
         environmentRepository = environmentRepository,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -120,12 +120,18 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
     @BeforeEach
     fun setup() {
-        mockkStatic(CipherView::toViewState)
+        mockkStatic(
+            SavedStateHandle::toVaultItemArgs,
+            CipherView::toViewState,
+        )
     }
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(CipherView::toViewState)
+        unmockkStatic(
+            SavedStateHandle::toVaultItemArgs,
+            CipherView::toViewState,
+        )
         unmockkStatic(Uri::class)
     }
 
@@ -3773,18 +3779,10 @@ class VaultItemViewModelTest : BaseViewModelTest() {
     ): VaultItemViewModel = VaultItemViewModel(
         savedStateHandle = SavedStateHandle().apply {
             set("state", state)
-            set("vault_item_id", vaultItemId)
-            set(
-                "vault_item_cipher_type",
-                when (vaultItemCipherType) {
-                    VaultItemCipherType.LOGIN -> "login"
-                    VaultItemCipherType.CARD -> "card"
-                    VaultItemCipherType.IDENTITY -> "identity"
-                    VaultItemCipherType.SECURE_NOTE -> "secure_note"
-                    VaultItemCipherType.SSH_KEY -> "ssh_key"
-                },
-            )
             set("tempAttachmentFile", tempAttachmentFile)
+            every {
+                toVaultItemArgs()
+            } returns VaultItemArgs(vaultItemId = vaultItemId, cipherType = vaultItemCipherType)
         },
         clipboardManager = bitwardenClipboardManager,
         authRepository = authRepository,

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -213,9 +213,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     }
 
     private val initialState = createVaultItemListingState()
-    private val initialSavedStateHandle = createSavedStateHandleWithVaultItemListingType(
-        vaultItemListingType = VaultItemListingType.Login,
-    )
+    private val initialSavedStateHandle
+        get() = createSavedStateHandleWithVaultItemListingType(
+            vaultItemListingType = VaultItemListingType.Login,
+        )
     private val mockProviderGetCredentialRequest =
         mockk<ProviderGetCredentialRequest>(relaxed = true) {
             every {
@@ -236,6 +237,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
     @BeforeEach
     fun setUp() {
+        mockkStatic(SavedStateHandle::toVaultItemListingArgs)
         mockkObject(
             ProviderCreateCredentialRequest.Companion,
             ProviderGetCredentialRequest.Companion,
@@ -252,6 +254,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
     @AfterEach
     fun tearDown() {
+        unmockkStatic(SavedStateHandle::toVaultItemListingArgs)
         unmockkObject(
             ProviderCreateCredentialRequest.Companion,
             ProviderGetCredentialRequest.Companion,
@@ -307,7 +310,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     awaitItem(),
                 )
             }
-    }
+        }
 
     @Test
     fun `on LockAccountClick should call lockVault for the given account`() {
@@ -4713,40 +4716,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
         }
 
-    @Suppress("CyclomaticComplexMethod")
     private fun createSavedStateHandleWithVaultItemListingType(
         vaultItemListingType: VaultItemListingType,
-    ) = SavedStateHandle().apply {
-        set(
-            "vault_item_listing_type",
-            when (vaultItemListingType) {
-                is VaultItemListingType.Card -> "card"
-                is VaultItemListingType.Collection -> "collection"
-                is VaultItemListingType.Folder -> "folder"
-                is VaultItemListingType.Identity -> "identity"
-                is VaultItemListingType.Login -> "login"
-                is VaultItemListingType.SecureNote -> "secure_note"
-                is VaultItemListingType.Trash -> "trash"
-                is VaultItemListingType.SendFile -> "send_file"
-                is VaultItemListingType.SendText -> "send_text"
-                is VaultItemListingType.SshKey -> "ssh_key"
-            },
-        )
-        set(
-            "id",
-            when (vaultItemListingType) {
-                is VaultItemListingType.Card -> null
-                is VaultItemListingType.Collection -> vaultItemListingType.collectionId
-                is VaultItemListingType.Folder -> vaultItemListingType.folderId
-                is VaultItemListingType.Identity -> null
-                is VaultItemListingType.Login -> null
-                is VaultItemListingType.SecureNote -> null
-                is VaultItemListingType.Trash -> null
-                is VaultItemListingType.SendFile -> null
-                is VaultItemListingType.SendText -> null
-                is VaultItemListingType.SshKey -> null
-            },
-        )
+    ): SavedStateHandle = SavedStateHandle().apply {
+        every {
+            toVaultItemListingArgs()
+        } returns VaultItemListingArgs(vaultItemListingType = vaultItemListingType)
     }
 
     private fun setupMockUri() {

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationViewModelTest.kt
@@ -26,17 +26,20 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class VaultMoveToOrganizationViewModelTest : BaseViewModelTest() {
 
     private val initialState = createVaultMoveToOrganizationState()
-    private val initialSavedStateHandle = createSavedStateHandleWithState(
-        state = initialState,
-    )
+    private val initialSavedStateHandle
+        get() = createSavedStateHandleWithState(state = initialState)
 
     private val mutableVaultItemFlow = MutableStateFlow<DataState<CipherView?>>(DataState.Loading)
 
@@ -52,6 +55,16 @@ class VaultMoveToOrganizationViewModelTest : BaseViewModelTest() {
 
     private val authRepository: AuthRepository = mockk {
         every { userStateFlow } returns mutableUserStateFlow
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(SavedStateHandle::toVaultMoveToOrganizationArgs)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SavedStateHandle::toVaultMoveToOrganizationArgs)
     }
 
     @Test
@@ -456,8 +469,10 @@ class VaultMoveToOrganizationViewModelTest : BaseViewModelTest() {
         showOnlyCollections: Boolean = false,
     ) = SavedStateHandle().apply {
         set("state", state)
-        set("vault_move_to_organization_id", vaultItemId)
-        set("vault_move_to_organization_only_collections", "$showOnlyCollections")
+        every { toVaultMoveToOrganizationArgs() } returns VaultMoveToOrganizationArgs(
+            vaultItemId = vaultItemId,
+            showOnlyCollections = showOnlyCollections,
+        )
     }
 
     @Suppress("MaxLineLength")

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -399,6 +399,7 @@ naming:
     rootPackage: ''
   MatchingDeclarationName:
     active: true
+    excludes: [ '**/ui/**/*Navigation.kt' ]
     mustBeFirst: true
   MemberNameEqualsClassName:
     active: true

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -400,27 +400,24 @@ Note in particular how consumers of the above **do not need to know the details 
 <summary>Show example</summary>
 
 ```kotlin
-private const val IS_TOGGLE_ENABLED: String = "is_toggle_enabled"
-private const val EXAMPLE_ROUTE_PREFIX = "example"
-private const val EXAMPLE_ROUTE = "$EXAMPLE_ROUTE_PREFIX/{$IS_TOGGLE_ENABLED}"
+@Serializable
+data class ExampleRoute(
+    val isToggleEnabled: Boolean,
+)
 
 data class ExampleArgs(
     val isToggleEnabledInitialValue: Boolean,
-) {
-    constructor(savedStateHandle: SavedStateHandle) : this(
-        isToggleEnabledInitialValue = checkNotNull(savedStateHandle[IS_TOGGLE_ENABLED]) as Boolean,
-    )
+)
+
+fun SavedStateHandle.toExampleArgs(): ExampleArgs {
+    val route = this.toRoute<ExampleRoute>()
+    return ExampleArgs(isToggleEnabledInitialValue = route.isToggleEnabled)
 }
 
 fun NavGraphBuilder.exampleDestination(
     onNavigateToNextScreen: (CompletionData) -> Unit,
 ) {
-    composableWithSlideTransitions(
-        route = EXAMPLE_ROUTE,
-        arguments = listOf(
-            navArgument(IS_TOGGLE_ENABLED) { type = NavType.BoolType }
-        ),
-    ) {
+    composableWithSlideTransitions<ExampleRoute> {
         ExampleScreen(onNavigateToNextScreen = onNavigateToNextScreen)
     }
 }
@@ -430,8 +427,8 @@ fun NavController.navigateToExample(
     navOptions: NavOptions? = null,
 ) {
     this.navigate(
-        "$EXAMPLE_ROUTE_PREFIX/$isToggleEnabled",
-        navOptions,
+        route = ExampleRoute(isToggleEnabled = isToggleEnabled),
+        navOptions = navOptions,
     )
 }
 ```


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21255](https://bitwarden.atlassian.net/browse/PM-21255)

## 📔 Objective

This PR updates the app to use type-safe navigation throughout the app. This removes the stringly types navigation and allows us to more easily pass through data (like passwords and emails) that might have characters that are unsafe for url routes.

There are still some annoyances in how navigation works with screens that have multiple destinations. I have created a [feature request](https://issuetracker.google.com/issues/415834969) to hopefully address this in the future.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21255]: https://bitwarden.atlassian.net/browse/PM-21255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ