### PR TITLE
[Authenticator] Refresh server config and update base URLs

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/MainViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/MainViewModel.kt
@@ -41,7 +41,7 @@ class MainViewModel @Inject constructor(
             }
             .launchIn(viewModelScope)
         viewModelScope.launch {
-            configRepository.getServerConfig(forceRefresh = false)
+            configRepository.getServerConfig(forceRefresh = true)
         }
     }
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/provider/BaseUrlsProviderImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/provider/BaseUrlsProviderImpl.kt
@@ -1,6 +1,7 @@
 package com.bitwarden.authenticator.data.platform.provider
 
 import com.bitwarden.core.annotation.OmitFromCoverage
+import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseApiUrl
 import com.bitwarden.data.repository.util.baseEventsUrl
@@ -13,11 +14,17 @@ import com.bitwarden.network.interceptor.BaseUrlsProvider
 @OmitFromCoverage
 object BaseUrlsProviderImpl : BaseUrlsProvider {
     override fun getBaseApiUrl(): String =
-        Environment.Us.environmentUrlData.baseApiUrl
+        US_QA_ENV.environmentUrlData.baseApiUrl
 
     override fun getBaseIdentityUrl(): String =
-        Environment.Us.environmentUrlData.baseIdentityUrl
+        US_QA_ENV.environmentUrlData.baseIdentityUrl
 
     override fun getBaseEventsUrl(): String =
-        Environment.Us.environmentUrlData.baseEventsUrl
+        US_QA_ENV.environmentUrlData.baseEventsUrl
 }
+
+private val US_QA_ENV: Environment = Environment.SelfHosted(
+    EnvironmentUrlDataJson(
+        base = "https://vault.qa.bitwarden.pw",
+    ),
+)


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

- The `MainViewModel` now refreshes the server config on app start by setting `forceRefresh` to `true` when calling `configRepository.getServerConfig`.
- `BaseUrlsProviderImpl` was updated to use a new `US_QA_ENV` environment as the source for `getBaseApiUrl`, `getBaseIdentityUrl`, and `getBaseEventsUrl` .
- Added new `US_QA_ENV` const which uses `https://vault.qa.bitwarden.pw` as base URL.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
