### PR TITLE
PM-19771: Allow forward slashes in emails

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensions.kt
@@ -45,14 +45,14 @@ fun String?.orZeroWidthSpace(): String = this.orNullIfBlank() ?: ZERO_WIDTH_CHAR
  *
  * This validates that the email is valid by asserting that:
  * * The string starts with a string of characters including periods, underscores, percent symbols,
- * plus's, minus's, and alphanumeric characters.
+ * plus's, minus's, forward slash's, and alphanumeric characters.
  * * Followed by an '@' symbol.
  * * Followed by a string of characters including periods, minus's, and alphanumeric characters.
  * * Followed by a period.
  * * Followed by at least 2 more alphanumeric characters.
  */
 fun String.isValidEmail(): Boolean =
-    this.matches(regex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$".toRegex())
+    this.matches(regex = "^[A-Za-z0-9._%+-/]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$".toRegex())
 
 /**
  * Returns `true` if the given [String] is a non-blank, valid URI and `false` otherwise.

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/base/util/StringExtensionsTest.kt
@@ -26,6 +26,8 @@ class StringExtensionsTest {
             "test@test.test.com" to true,
             "test.test@test.com" to true,
             "test.test@test.test.com" to true,
+            "test/test@test.test.com" to true,
+            "test.test@test/test.com" to false,
         )
         invalidEmails.forEach {
             assertEquals(it.first.isValidEmail(), it.second)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19771](https://bitwarden.atlassian.net/browse/PM-19771)

## 📔 Objective

This PR allows emails to contain a forward slash.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19771]: https://bitwarden.atlassian.net/browse/PM-19771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ