### PR TITLE
PM-21324: Move common UI transitions to UI module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/NavGraphBuilderExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/base/util/NavGraphBuilderExtensions.kt
@@ -10,7 +10,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import com.bitwarden.core.annotation.OmitFromCoverage
-import com.x8bit.bitwarden.ui.platform.theme.TransitionProviders
+import com.bitwarden.ui.platform.theme.TransitionProviders
 import kotlin.reflect.KType
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -17,6 +17,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
+import com.bitwarden.ui.platform.theme.NonNullEnterTransitionProvider
+import com.bitwarden.ui.platform.theme.NonNullExitTransitionProvider
+import com.bitwarden.ui.platform.theme.RootTransitionProviders
+import com.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupAutofillRoute
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupCompleteRoute
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupUnlockRoute
@@ -56,10 +60,6 @@ import com.x8bit.bitwarden.ui.platform.feature.splash.splashDestination
 import com.x8bit.bitwarden.ui.platform.feature.vaultunlocked.VaultUnlockedGraphRoute
 import com.x8bit.bitwarden.ui.platform.feature.vaultunlocked.navigateToVaultUnlockedGraph
 import com.x8bit.bitwarden.ui.platform.feature.vaultunlocked.vaultUnlockedGraph
-import com.x8bit.bitwarden.ui.platform.theme.NonNullEnterTransitionProvider
-import com.x8bit.bitwarden.ui.platform.theme.NonNullExitTransitionProvider
-import com.x8bit.bitwarden.ui.platform.theme.RootTransitionProviders
-import com.x8bit.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.model.AddSendType
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.navigateToAddSend
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -23,6 +23,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navOptions
 import com.bitwarden.core.annotation.OmitFromCoverage
+import com.bitwarden.ui.platform.theme.RootTransitionProviders
 import com.x8bit.bitwarden.ui.platform.base.util.EventsEffect
 import com.x8bit.bitwarden.ui.platform.components.model.NavigationItem
 import com.x8bit.bitwarden.ui.platform.components.model.ScaffoldNavigationData
@@ -35,7 +36,6 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.navigateToSettingsGraphR
 import com.x8bit.bitwarden.ui.platform.feature.settings.settingsGraph
 import com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.model.VaultUnlockedNavBarTab
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
-import com.x8bit.bitwarden.ui.platform.theme.RootTransitionProviders
 import com.x8bit.bitwarden.ui.tools.feature.generator.generatorGraph
 import com.x8bit.bitwarden.ui.tools.feature.generator.navigateToGeneratorGraph
 import com.x8bit.bitwarden.ui.tools.feature.send.navigateToSendGraph

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
@@ -1,11 +1,11 @@
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.model
 
 import android.os.Parcelable
+import com.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.model.NavigationItem
 import com.x8bit.bitwarden.ui.platform.feature.settings.SettingsGraphRoute
 import com.x8bit.bitwarden.ui.platform.feature.settings.SettingsRoute
-import com.x8bit.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorGraphRoute
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorRoute
 import com.x8bit.bitwarden.ui.tools.feature.send.SendGraphRoute

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/SavedStateHandleExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/util/SavedStateHandleExtensions.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.toRoute
+import com.bitwarden.ui.platform.util.toObjectKClassNavigationRoute
 
 /**
  * Determines if the [SavedStateHandle] contains a route for the specified object class.

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -36,8 +36,11 @@ android {
 
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.animation)
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.kotlinx.serialization)
 }
 
 tasks {

--- a/ui/src/main/java/com/bitwarden/ui/platform/theme/Transition.kt
+++ b/ui/src/main/java/com/bitwarden/ui/platform/theme/Transition.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.theme
+package com.bitwarden.ui.platform.theme
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
@@ -294,8 +294,9 @@ object RootTransitionProviders {
         /**
          * There is no transition for the exiting screen.
          *
-         * Unlike the [stay] transition, this will immediately remove the outgoing screen even if
-         * there is an ongoing enter transition happening for the new screen.
+         * Unlike the [RootTransitionProviders.Exit.stay] transition, this will immediately remove
+         * the outgoing screen even if there is an ongoing enter transition happening for the new
+         * screen.
          */
         val none: NonNullExitTransitionProvider = {
             ExitTransition.None

--- a/ui/src/main/java/com/bitwarden/ui/platform/util/RouteUtil.kt
+++ b/ui/src/main/java/com/bitwarden/ui/platform/util/RouteUtil.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.util
+package com.bitwarden.ui.platform.util
 
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.serializer


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21324](https://bitwarden.atlassian.net/browse/PM-21324)

## 📔 Objective

This PR moves the main UI transitions to the common UI module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21324]: https://bitwarden.atlassian.net/browse/PM-21324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ