### PR TITLE
Fix duplicated launched effect key

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenSelectionDialog.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenSelectionDialog.kt
@@ -54,7 +54,7 @@ fun BitwardenSelectionDialog(
         val scrollState = rememberScrollState()
         var canScrollForward by remember { mutableStateOf(value = false) }
         var canScrollBackward by remember { mutableStateOf(value = false) }
-        LaunchedEffect(scrollState.canScrollForward, scrollState.canScrollForward) {
+        LaunchedEffect(scrollState.canScrollBackward, scrollState.canScrollForward) {
             canScrollForward = scrollState.canScrollForward
             canScrollBackward = scrollState.canScrollBackward
         }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes a duplicated launched effect key, it makes no functional change but it is now technically correct.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
