### PR TITLE
[PM-21365] Migrate BitwardenColorScheme to ui module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/autofill/BitwardenRemoteViews.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/autofill/BitwardenRemoteViews.kt
@@ -5,12 +5,12 @@ import android.widget.RemoteViews
 import androidx.annotation.DrawableRes
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import com.bitwarden.ui.platform.theme.color.BitwardenColorScheme
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.model.AutofillAppInfo
 import com.x8bit.bitwarden.data.autofill.model.AutofillCipher
 import com.x8bit.bitwarden.ui.autofill.util.getAutofillSuggestionContentDescription
 import com.x8bit.bitwarden.ui.autofill.util.isSystemDarkMode
-import com.x8bit.bitwarden.ui.platform.theme.color.BitwardenColorScheme
 import com.x8bit.bitwarden.ui.platform.theme.color.darkBitwardenColorScheme
 import com.x8bit.bitwarden.ui.platform.theme.color.lightBitwardenColorScheme
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/BitwardenTheme.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/BitwardenTheme.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowCompat
+import com.bitwarden.ui.platform.theme.color.BitwardenColorScheme
 import com.x8bit.bitwarden.ui.platform.components.field.interceptor.IncognitoInput
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
-import com.x8bit.bitwarden.ui.platform.theme.color.BitwardenColorScheme
 import com.x8bit.bitwarden.ui.platform.theme.color.darkBitwardenColorScheme
 import com.x8bit.bitwarden.ui.platform.theme.color.dynamicBitwardenColorScheme
 import com.x8bit.bitwarden.ui.platform.theme.color.lightBitwardenColorScheme

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/color/ColorScheme.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/color/ColorScheme.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.theme.color
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
+import com.bitwarden.ui.platform.theme.color.BitwardenColorScheme
 
 /**
  * The default [BitwardenColorScheme] for dark mode.

--- a/ui/src/main/java/com/bitwarden/ui/platform/theme/color/BitwardenColorScheme.kt
+++ b/ui/src/main/java/com/bitwarden/ui/platform/theme/color/BitwardenColorScheme.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.theme.color
+package com.bitwarden.ui.platform.theme.color
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color


### PR DESCRIPTION
## 🎟️ Tracking

PM-21365

## 📔 Objective

Move the `BitwardenColorScheme` data class from the `app` module to the `ui` module. This change is part of a larger refactor to improve code organization and reusability.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
