### PR TITLE
PM-21351: Hide new send button from accessibility when on the empty sends screen

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendEmpty.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/SendEmpty.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -84,11 +86,14 @@ fun SendEmpty(
 
         Spacer(modifier = Modifier.height(24.dp))
 
+        // This button is hidden from accessibility to avoid duplicate voice over with the FAB
         BitwardenFilledButton(
             onClick = onAddItemClick,
             label = stringResource(id = R.string.add_a_send),
-            modifier = Modifier.standardHorizontalMargin(),
             icon = rememberVectorPainter(R.drawable.ic_plus_small),
+            modifier = Modifier
+                .semantics { hideFromAccessibility() }
+                .standardHorizontalMargin(),
         )
         Spacer(modifier = Modifier.weight(1F))
         Spacer(modifier = Modifier.navigationBarsPadding())


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21351](https://bitwarden.atlassian.net/browse/PM-21351)

## 📔 Objective

This PR hides the "new send" button from accessibility when on the empty sends screen to avoid duplicated TalkBack announcements for the same functionality.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21351]: https://bitwarden.atlassian.net/browse/PM-21351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ