### PR TITLE
[PM-21367] Support passkey requests with multiple options

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManager.kt
@@ -2,14 +2,13 @@ package com.x8bit.bitwarden.data.credentials.manager
 
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
-import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
+import androidx.credentials.provider.BeginGetCredentialOption
 import androidx.credentials.provider.CallingAppInfo
 import androidx.credentials.provider.CredentialEntry
 import androidx.credentials.provider.ProviderGetCredentialRequest
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.credentials.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
-import com.x8bit.bitwarden.data.credentials.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.credentials.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.credentials.model.UserVerificationRequirement
 
@@ -35,13 +34,6 @@ interface BitwardenCredentialManager {
     fun getPasskeyAttestationOptionsOrNull(
         requestJson: String,
     ): PasskeyAttestationOptions?
-
-    /**
-     * Attempt to extract FIDO 2 passkey assertion options from the system [requestJson], or null.
-     */
-    fun getPasskeyAssertionOptionsOrNull(
-        requestJson: String,
-    ): PasskeyAssertionOptions?
 
     /**
      * Register a new FIDO 2 credential to a users vault.
@@ -99,10 +91,10 @@ interface BitwardenCredentialManager {
 
     /**
      * Retrieve a list of [CredentialEntry] objects representing vault items matching the given
-     * request [option].
+     * request [options].
      */
-    suspend fun getPublicKeyCredentialEntries(
+    suspend fun getCredentialEntries(
         userId: String,
-        option: BeginGetPublicKeyCredentialOption,
+        options: List<BeginGetCredentialOption>,
     ): Result<List<CredentialEntry>>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/model/GetCredentialsRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/model/GetCredentialsRequest.kt
@@ -29,16 +29,15 @@ data class GetCredentialsRequest(
     }
 
     /**
-     * The first [BeginGetPublicKeyCredentialOption] of the [providerRequest], or null if the
-     * [providerRequest] is not a [BeginGetCredentialRequest] or does not contain a
-     * [BeginGetPublicKeyCredentialOption].
+     * The [BeginGetPublicKeyCredentialOption]s of the [providerRequest], or an empty list if no
+     * public key credentials are present.
      */
     @IgnoredOnParcel
-    val beginGetPublicKeyCredentialOption: BeginGetPublicKeyCredentialOption? by lazy {
+    val beginGetPublicKeyCredentialOptions: List<BeginGetPublicKeyCredentialOption> by lazy {
         providerRequest
             ?.beginGetCredentialOptions
             ?.filterIsInstance<BeginGetPublicKeyCredentialOption>()
-            ?.firstOrNull()
+            .orEmpty()
     }
 
     /**
@@ -47,16 +46,4 @@ data class GetCredentialsRequest(
      */
     @IgnoredOnParcel
     val callingAppInfo: CallingAppInfo? by lazy { providerRequest?.callingAppInfo }
-
-    /**
-     * The first [BeginGetPublicKeyCredentialOption] of the [providerRequest], or null if the
-     * [providerRequest] does not contain a [BeginGetPublicKeyCredentialOption].
-     */
-    @IgnoredOnParcel
-    val option: BeginGetPublicKeyCredentialOption? by lazy {
-        providerRequest?.beginGetCredentialOptions
-            ?.firstNotNullOfOrNull {
-                it as? BeginGetPublicKeyCredentialOption
-            }
-    }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/processor/CredentialProviderProcessorImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/processor/CredentialProviderProcessorImpl.kt
@@ -16,7 +16,6 @@ import androidx.credentials.exceptions.CreateCredentialUnknownException
 import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialException
 import androidx.credentials.exceptions.GetCredentialUnknownException
-import androidx.credentials.exceptions.GetCredentialUnsupportedException
 import androidx.credentials.provider.AuthenticationAction
 import androidx.credentials.provider.BeginCreateCredentialRequest
 import androidx.credentials.provider.BeginCreateCredentialResponse
@@ -28,7 +27,6 @@ import androidx.credentials.provider.BiometricPromptData
 import androidx.credentials.provider.CreateEntry
 import androidx.credentials.provider.CredentialEntry
 import androidx.credentials.provider.ProviderClearCredentialStateRequest
-import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.data.manager.DispatcherManager
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -219,17 +217,13 @@ class CredentialProviderProcessorImpl(
         userId: String,
         request: BeginGetCredentialRequest,
     ): Result<List<CredentialEntry>> =
-        request
-            .beginGetCredentialOptions
-            .firstNotNullOfOrNull { it as? BeginGetPublicKeyCredentialOption }
-            ?.let {
-                bitwardenCredentialManager
-                    .getPublicKeyCredentialEntries(
-                        userId = userId,
-                        option = it,
-                    )
-            }
-            ?: GetCredentialUnsupportedException("Unsupported option.").asFailure()
+        bitwardenCredentialManager
+            .getCredentialEntries(
+                userId = userId,
+                options = request
+                    .beginGetCredentialOptions
+                    .filterIsInstance<BeginGetPublicKeyCredentialOption>(),
+            )
 
     private fun CreateEntry.Builder.setBiometricPromptDataIfSupported(
         cipher: Cipher,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/credentials/manager/model/GetCredentialsResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/credentials/manager/model/GetCredentialsResult.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.credentials.manager.model
 
-import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
 import androidx.credentials.provider.CredentialEntry
 import com.bitwarden.ui.util.Text
 
@@ -15,7 +14,6 @@ sealed class GetCredentialsResult {
      */
     data class Success(
         val credentialEntries: List<CredentialEntry>,
-        val option: BeginGetPublicKeyCredentialOption,
         val userId: String,
     ) : GetCredentialsResult()
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1690,8 +1690,8 @@ class VaultItemListingViewModel @Inject constructor(
         request: GetCredentialsRequest,
     ) {
         val beginGetCredentialOption = request
-            .beginGetPublicKeyCredentialOption
-            ?: run {
+            .beginGetPublicKeyCredentialOptions
+            .ifEmpty {
                 showCredentialManagerErrorDialog(
                     R.string.passkey_operation_failed_because_the_request_is_invalid.asText(),
                 )
@@ -1714,15 +1714,14 @@ class VaultItemListingViewModel @Inject constructor(
                     sendEvent(
                         VaultItemListingEvent.CompleteProviderGetCredentialsRequest(
                             GetCredentialsResult.Success(
-                                userId = request.userId,
-                                option = beginGetCredentialOption,
                                 credentialEntries = bitwardenCredentialManager
-                                    .getPublicKeyCredentialEntries(
+                                    .getCredentialEntries(
                                         userId = request.userId,
-                                        option = beginGetCredentialOption,
+                                        options = beginGetCredentialOption,
                                     )
                                     .getOrNull()
                                     .orEmpty(),
+                                userId = request.userId,
                             ),
                         ),
                     )

--- a/app/src/test/java/com/x8bit/bitwarden/data/credentials/processor/CredentialProviderProcessorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/credentials/processor/CredentialProviderProcessorTest.kt
@@ -36,7 +36,6 @@ import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAssertionOptions
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
@@ -68,12 +67,10 @@ class CredentialProviderProcessorTest {
         every { activeUserId } returns "mockActiveUserId"
         every { userStateFlow } returns mutableUserStateFlow
     }
-    private val passkeyAssertionOptions = createMockPasskeyAssertionOptions(number = 1)
     private val credentialEntries = listOf(mockk<CredentialEntry>(relaxed = true))
     private val bitwardenCredentialManager: BitwardenCredentialManager = mockk {
-        every { getPasskeyAssertionOptionsOrNull(any()) } returns passkeyAssertionOptions
         coEvery {
-            getPublicKeyCredentialEntries(any(), any())
+            getCredentialEntries(any(), any())
         } returns credentialEntries.asSuccess()
     }
     private val intentManager: IntentManager = mockk()
@@ -462,9 +459,9 @@ class CredentialProviderProcessorTest {
             every { cancellationSignal.setOnCancelListener(any()) } just runs
             every { callback.onError(capture(captureSlot)) } just runs
             coEvery {
-                bitwardenCredentialManager.getPublicKeyCredentialEntries(
+                bitwardenCredentialManager.getCredentialEntries(
                     userId = DEFAULT_USER_STATE.activeUserId,
-                    option = mockOption,
+                    options = listOf(mockOption),
                 )
             } returns Result.failure(Exception("Error decrypting credentials."))
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/credentials/manager/CredentialProviderCompletionManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/credentials/manager/CredentialProviderCompletionManagerTest.kt
@@ -200,9 +200,8 @@ class CredentialProviderCompletionManagerTest {
             credentialProviderCompletionManager
                 .completeProviderGetCredentialsRequest(
                     GetCredentialsResult.Success(
-                        userId = "mockUserId",
                         credentialEntries = emptyList(),
-                        option = mockk(),
+                        userId = "mockUserId",
                     ),
                 )
 
@@ -235,9 +234,8 @@ class CredentialProviderCompletionManagerTest {
             credentialProviderCompletionManager
                 .completeProviderGetCredentialsRequest(
                     GetCredentialsResult.Success(
-                        userId = "mockUserId",
                         credentialEntries = listOf(mockCredentialEntry),
-                        option = mockk(),
+                        userId = "mockUserId",
                     ),
                 )
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -1933,9 +1933,8 @@ class VaultItemListingScreenTest : BaseComposeTest() {
     @Test
     fun `CompleteProviderGetCredentialsRequest event should call CredentialProviderCompletionManager with result`() {
         val result = GetCredentialsResult.Success(
-            userId = "mockUserId",
             credentialEntries = listOf(mockk()),
-            option = mockk(),
+            userId = "mockUserId",
         )
         mutableEventFlow.tryEmit(
             VaultItemListingEvent.CompleteProviderGetCredentialsRequest(result),

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -44,7 +44,6 @@ import com.x8bit.bitwarden.data.credentials.manager.OriginManager
 import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
 import com.x8bit.bitwarden.data.credentials.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
-import com.x8bit.bitwarden.data.credentials.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.credentials.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.credentials.model.ValidateOriginResult
 import com.x8bit.bitwarden.data.credentials.model.createMockCreateCredentialRequest
@@ -81,7 +80,6 @@ import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.vault.components.model.CreateVaultItemType
-import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAssertionOptions
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAttestationOptions
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.util.createMockDisplayItemForCipher
@@ -2964,18 +2962,14 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 number = 1,
                 fido2Credentials = mockFido2CredentialsList,
             )
-            val mockPasskeyAssertionOptions = mockk<PasskeyAssertionOptions>(relaxed = true)
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.ProviderGetCredentials(
                     mockGetCredentialsRequest,
                 )
-            every {
-                bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns mockPasskeyAssertionOptions
             coEvery {
-                bitwardenCredentialManager.getPublicKeyCredentialEntries(
+                bitwardenCredentialManager.getCredentialEntries(
                     userId = "mockUserId-1",
-                    option = mockBeginGetPublicKeyCredentialOption,
+                    options = listOf(mockBeginGetPublicKeyCredentialOption),
                 )
             } returns emptyList<PublicKeyCredentialEntry>().asSuccess()
             coEvery {
@@ -3004,9 +2998,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     VaultItemListingEvent.CompleteProviderGetCredentialsRequest(
                         result = GetCredentialsResult.Success(
-                            userId = "mockUserId-1",
-                            option = mockBeginGetPublicKeyCredentialOption,
                             credentialEntries = emptyList(),
+                            userId = "mockUserId-1",
                         ),
                     ),
                     awaitItem(),
@@ -3035,9 +3028,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     .value
                     .data
             } returns listOf(mockCipherView)
-            every {
-                bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns mockk(relaxed = true)
             every {
                 mockBeginGetCredentialRequest.beginGetCredentialOptions
             } returns emptyList()
@@ -3087,9 +3077,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     .data
             } returns listOf(mockCipherView)
             every {
-                bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns mockk(relaxed = true)
-            every {
                 mockBeginGetCredentialRequest.callingAppInfo
             } returns null
 
@@ -3130,9 +3117,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 SpecialCircumstance.ProviderGetCredentials(
                     mockGetCredentialsRequest,
                 )
-            every {
-                bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns mockk(relaxed = true)
             coEvery {
                 originManager.validateOrigin(callingAppInfo = any())
             } returns ValidateOriginResult.Error.Unknown
@@ -3298,12 +3282,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 )
             } returns UserVerificationRequirement.DISCOURAGED
             every {
-                bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
-            )
-            every {
                 vaultRepository
                     .ciphersStateFlow
                     .value
@@ -3353,10 +3331,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             setupMockUri()
             val mockAssertionRequest = createMockFido2CredentialAssertionRequest(number = 1)
                 .copy(cipherId = "mockId-1")
-            val mockAssertionOptions = createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.DISCOURAGED,
-            )
             val mockFido2CredentialList = createMockSdkFido2CredentialList(number = 1)
             val mockCipherView = createMockCipherView(
                 number = 1,
@@ -3372,9 +3346,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     .value
                     .data
             } returns listOf(mockCipherView)
-            every {
-                bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns mockAssertionOptions
             coEvery {
                 originManager.validateOrigin(any())
             } returns ValidateOriginResult.Error.Unknown
@@ -3499,12 +3470,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 any<ProviderGetCredentialRequest>(),
             )
         } returns UserVerificationRequirement.PREFERRED
-        every {
-            bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-        } returns createMockPasskeyAssertionOptions(
-            number = 1,
-            userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-        )
         coEvery {
             bitwardenCredentialManager.authenticateFido2Credential(
                 userId = "activeUserId",
@@ -3561,20 +3526,11 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         )
         every { bitwardenCredentialManager.isUserVerified } returns true
         every {
-            bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull("mockRequestJson")
-        } returns createMockPasskeyAssertionOptions(
-            number = 1,
-            userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-        )
-        every {
             vaultRepository
                 .ciphersStateFlow
                 .value
                 .data
         } returns listOf(mockCipherView)
-        every {
-            bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull("mockRequestJson")
-        } returns createMockPasskeyAssertionOptions(number = 1)
         every { authRepository.activeUserId } returns null
 
         val dataState = DataState.Loaded(
@@ -3625,20 +3581,11 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         )
         every { bitwardenCredentialManager.isUserVerified } returns true
         every {
-            bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull("mockRequestJson")
-        } returns createMockPasskeyAssertionOptions(
-            number = 1,
-            userVerificationRequirement = UserVerificationRequirement.PREFERRED,
-        )
-        every {
             vaultRepository
                 .ciphersStateFlow
                 .value
                 .data
         } returns listOf(mockCipherView)
-        every {
-            bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull("mockRequestJson")
-        } returns createMockPasskeyAssertionOptions(number = 1)
         every { authRepository.activeUserId } returns null
 
         val dataState = DataState.Loaded(
@@ -3698,9 +3645,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     .value
                     .data
             } returns listOf(mockCipherView)
-            every {
-                bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns createMockPasskeyAssertionOptions(number = 1)
             coEvery {
                 bitwardenCredentialManager.authenticateFido2Credential(
                     DEFAULT_USER_STATE.activeUserId,
@@ -3986,12 +3930,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     number = 1,
                     fido2Credentials = mockFido2CredentialList,
                 ),
-            )
-            every {
-                bitwardenCredentialManager.getPasskeyAssertionOptionsOrNull(any())
-            } returns createMockPasskeyAssertionOptions(
-                number = 1,
-                userVerificationRequirement = UserVerificationRequirement.PREFERRED,
             )
             coEvery {
                 bitwardenCredentialManager.authenticateFido2Credential(


### PR DESCRIPTION
## 🎟️ Tracking

PM-21367

## 📔 Objective

Refactor the logic for retrieving credential entries and improve the handling of multiple credential options.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
