### PR TITLE
PM-21555: Fix crash on older server versions

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
@@ -346,7 +346,7 @@ data class SyncResponseJson(
             val status: OrganizationStatusType,
 
             @SerialName("userIsClaimedByOrganization")
-            val userIsClaimedByOrganization: Boolean,
+            val userIsClaimedByOrganization: Boolean = false,
         )
 
         /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21555](https://bitwarden.atlassian.net/browse/PM-21555)

## 📔 Objective

This PR fixes a crash caused when an older server version that does not support the `userIsClaimedByOrganization` property is used in conjunction with the latest android app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
