### PR TITLE
Clean up lint warnings

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.TextToolbar
@@ -123,7 +123,7 @@ fun BitwardenPasswordField(
             value = textFieldValue,
             onValueChange = onValueChange,
             defaultTextToolbar = LocalTextToolbar.current,
-            clipboardManager = LocalClipboardManager.current.nativeClipboard,
+            clipboardManager = LocalClipboard.current.nativeClipboard,
             focusManager = LocalFocusManager.current,
         )
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.TextToolbar
@@ -254,7 +254,7 @@ fun BitwardenTextField(
             value = textFieldValue,
             onValueChange = onValueChange,
             defaultTextToolbar = LocalTextToolbar.current,
-            clipboardManager = LocalClipboardManager.current.nativeClipboard,
+            clipboardManager = LocalClipboard.current.nativeClipboard,
             focusManager = LocalFocusManager.current,
         )
 

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -378,9 +378,9 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     override fun getVaultRegisteredForExport(userId: String): Boolean =
         vaultRegisteredForExport[userId] ?: false
 
-    override fun storeVaultRegisteredForExport(userId: String, registered: Boolean?) {
-        vaultRegisteredForExport[userId] = registered
-        getMutableVaultRegisteredForExportFlow(userId = userId).tryEmit(registered)
+    override fun storeVaultRegisteredForExport(userId: String, isRegistered: Boolean?) {
+        vaultRegisteredForExport[userId] = isRegistered
+        getMutableVaultRegisteredForExportFlow(userId = userId).tryEmit(isRegistered)
     }
 
     override fun getVaultRegisteredForExportFlow(userId: String): Flow<Boolean?> =

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1213,7 +1213,7 @@ class SettingsRepositoryTest {
     @Test
     fun `isVaultRegisteredForExport should return true if it exists`() {
         val userId = "userId"
-        fakeSettingsDiskSource.storeVaultRegisteredForExport(userId = userId, registered = true)
+        fakeSettingsDiskSource.storeVaultRegisteredForExport(userId = userId, isRegistered = true)
         assertTrue(settingsRepository.isVaultRegisteredForExport(userId = userId))
     }
 
@@ -1234,12 +1234,12 @@ class SettingsRepositoryTest {
                     assertFalse(awaitItem())
                     fakeSettingsDiskSource.storeVaultRegisteredForExport(
                         userId = USER_ID,
-                        registered = true,
+                        isRegistered = true,
                     )
                     assertTrue(awaitItem())
                     fakeSettingsDiskSource.storeVaultRegisteredForExport(
                         userId = USER_ID,
-                        registered = false,
+                        isRegistered = false,
                     )
                     assertFalse(awaitItem())
                 }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/autofill/util/InlinePresentationSpecExtensionsTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/autofill/util/InlinePresentationSpecExtensionsTest.kt
@@ -320,6 +320,7 @@ class InlinePresentationSpecExtensionsTest {
         every {
             ContextCompat.getString(testContext, R.string.type_login)
         } returns LOGIN
+        @Suppress("DEPRECATION")
         val slice: Slice = mockk()
         every {
             UiVersions.getVersions(testStyle)
@@ -377,6 +378,7 @@ class InlinePresentationSpecExtensionsTest {
         icon: Icon,
         pendingIntent: PendingIntent,
     ) {
+        @Suppress("DEPRECATION")
         val slice: Slice = mockk()
         every {
             UiVersions.getVersions(testStyle)


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR cleans up a few minor lint warnings and deprecation's where possible.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
