### PR TITLE
[PM-21567] Implement `CredentialEntryBuilder` interface

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/builder/CredentialEntryBuilder.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/builder/CredentialEntryBuilder.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.data.credentials.builder
+
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
+import androidx.credentials.provider.PublicKeyCredentialEntry
+import com.bitwarden.fido.Fido2CredentialAutofillView
+
+/**
+ * Builder for credential entries.
+ */
+interface CredentialEntryBuilder {
+
+    /**
+     * Build public key credential entries from the given cipher views and options.
+     */
+    fun buildPublicKeyCredentialEntries(
+        userId: String,
+        fido2CredentialAutofillViews: List<Fido2CredentialAutofillView>,
+        beginGetPublicKeyCredentialOptions: List<BeginGetPublicKeyCredentialOption>,
+        isUserVerified: Boolean,
+    ): List<PublicKeyCredentialEntry>
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/builder/CredentialEntryBuilderImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/builder/CredentialEntryBuilderImpl.kt
@@ -1,0 +1,96 @@
+package com.x8bit.bitwarden.data.credentials.builder
+
+import android.content.Context
+import android.graphics.drawable.Icon
+import androidx.core.graphics.drawable.IconCompat
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
+import androidx.credentials.provider.PublicKeyCredentialEntry
+import com.bitwarden.fido.Fido2CredentialAutofillView
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.credentials.processor.GET_PASSKEY_INTENT
+import com.x8bit.bitwarden.data.credentials.util.setBiometricPromptDataIfSupported
+import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
+import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import kotlin.random.Random
+
+/**
+ * Primary implementation of [CredentialEntryBuilder].
+ */
+class CredentialEntryBuilderImpl(
+    private val context: Context,
+    private val intentManager: IntentManager,
+    private val featureFlagManager: FeatureFlagManager,
+    private val biometricsEncryptionManager: BiometricsEncryptionManager,
+) : CredentialEntryBuilder {
+
+    override fun buildPublicKeyCredentialEntries(
+        userId: String,
+        fido2CredentialAutofillViews: List<Fido2CredentialAutofillView>,
+        beginGetPublicKeyCredentialOptions: List<BeginGetPublicKeyCredentialOption>,
+        isUserVerified: Boolean,
+    ): List<PublicKeyCredentialEntry> = beginGetPublicKeyCredentialOptions
+        .flatMap { option ->
+            fido2CredentialAutofillViews
+                .toPublicKeyCredentialEntryList(
+                    userId = userId,
+                    option = option,
+                    isUserVerified = isUserVerified,
+                )
+        }
+
+    private fun List<Fido2CredentialAutofillView>.toPublicKeyCredentialEntryList(
+        userId: String,
+        option: BeginGetPublicKeyCredentialOption,
+        isUserVerified: Boolean,
+    ): List<PublicKeyCredentialEntry> = this
+        .map { fido2AutofillView ->
+            PublicKeyCredentialEntry
+                .Builder(
+                    context = context,
+                    username = fido2AutofillView.userNameForUi
+                        ?: context.getString(R.string.no_username),
+                    pendingIntent = intentManager
+                        .createFido2GetCredentialPendingIntent(
+                            action = GET_PASSKEY_INTENT,
+                            userId = userId,
+                            credentialId = fido2AutofillView.credentialId.toString(),
+                            cipherId = fido2AutofillView.cipherId,
+                            isUserVerified = isUserVerified,
+                            requestCode = Random.nextInt(),
+                        ),
+                    beginGetPublicKeyCredentialOption = option,
+                )
+                .setIcon(
+                    getCredentialEntryIcon(
+                        isPasskey = true,
+                    ),
+                )
+                .also { builder ->
+                    if (!isUserVerified) {
+                        builder.setBiometricPromptDataIfSupported(
+                            cipher = biometricsEncryptionManager
+                                .getOrCreateCipher(userId),
+                            isSingleTapAuthEnabled = featureFlagManager
+                                .getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication),
+                        )
+                    }
+                }
+                .build()
+        }
+
+    // TODO: [PM-20176] Enable web icons in credential entries
+    // Leave web icons disabled until CredentialManager TransactionTooLargeExceptions
+    // are addressed. See https://issuetracker.google.com/issues/355141766 for details.
+    private fun getCredentialEntryIcon(isPasskey: Boolean): Icon = IconCompat
+        .createWithResource(
+            context,
+            if (isPasskey) {
+                R.drawable.ic_bw_passkey
+            } else {
+                R.drawable.ic_globe
+            },
+        )
+        .toIcon(context)
+}

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/di/CredentialProviderModule.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/di/CredentialProviderModule.kt
@@ -7,6 +7,8 @@ import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.network.service.DigitalAssetLinkService
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.credentials.builder.CredentialEntryBuilder
+import com.x8bit.bitwarden.data.credentials.builder.CredentialEntryBuilderImpl
 import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManager
 import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManagerImpl
 import com.x8bit.bitwarden.data.credentials.manager.OriginManager
@@ -16,7 +18,6 @@ import com.x8bit.bitwarden.data.credentials.processor.CredentialProviderProcesso
 import com.x8bit.bitwarden.data.platform.manager.AssetManager
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
-import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
@@ -63,28 +64,20 @@ object CredentialProviderModule {
     @Provides
     @Singleton
     fun provideBitwardenCredentialManager(
-        @ApplicationContext context: Context,
-        intentManager: IntentManager,
-        featureFlagManager: FeatureFlagManager,
-        biometricsEncryptionManager: BiometricsEncryptionManager,
         vaultSdkSource: VaultSdkSource,
         fido2CredentialStore: Fido2CredentialStore,
         json: Json,
-        environmentRepository: EnvironmentRepository,
         vaultRepository: VaultRepository,
         dispatcherManager: DispatcherManager,
+        credentialEntryBuilder: CredentialEntryBuilder,
     ): BitwardenCredentialManager =
         BitwardenCredentialManagerImpl(
-            context = context,
             vaultSdkSource = vaultSdkSource,
             fido2CredentialStore = fido2CredentialStore,
-            intentManager = intentManager,
-            featureFlagManager = featureFlagManager,
-            biometricsEncryptionManager = biometricsEncryptionManager,
             json = json,
-            environmentRepository = environmentRepository,
             vaultRepository = vaultRepository,
             dispatcherManager = dispatcherManager,
+            credentialEntryBuilder = credentialEntryBuilder,
         )
 
     @Provides
@@ -97,4 +90,18 @@ object CredentialProviderModule {
             assetManager = assetManager,
             digitalAssetLinkService = digitalAssetLinkService,
         )
+
+    @Provides
+    @Singleton
+    fun provideCredentialEntryBuilder(
+        @ApplicationContext context: Context,
+        intentManager: IntentManager,
+        featureFlagManager: FeatureFlagManager,
+        biometricsEncryptionManager: BiometricsEncryptionManager,
+    ): CredentialEntryBuilder = CredentialEntryBuilderImpl(
+        context = context,
+        intentManager = intentManager,
+        featureFlagManager = featureFlagManager,
+        biometricsEncryptionManager = biometricsEncryptionManager,
+    )
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManager.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManager.kt
@@ -2,13 +2,13 @@ package com.x8bit.bitwarden.data.credentials.manager
 
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
-import androidx.credentials.provider.BeginGetCredentialOption
 import androidx.credentials.provider.CallingAppInfo
 import androidx.credentials.provider.CredentialEntry
 import androidx.credentials.provider.ProviderGetCredentialRequest
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.credentials.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
+import com.x8bit.bitwarden.data.credentials.model.GetCredentialsRequest
 import com.x8bit.bitwarden.data.credentials.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.credentials.model.UserVerificationRequirement
 
@@ -91,10 +91,9 @@ interface BitwardenCredentialManager {
 
     /**
      * Retrieve a list of [CredentialEntry] objects representing vault items matching the given
-     * request [options].
+     * [getCredentialsRequest].
      */
     suspend fun getCredentialEntries(
-        userId: String,
-        options: List<BeginGetCredentialOption>,
+        getCredentialsRequest: GetCredentialsRequest,
     ): Result<List<CredentialEntry>>
 }

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManagerImpl.kt
@@ -1,52 +1,34 @@
 package com.x8bit.bitwarden.data.credentials.manager
 
-import android.content.Context
-import android.os.Build
-import androidx.annotation.RequiresApi
-import androidx.annotation.WorkerThread
-import androidx.biometric.BiometricManager
-import androidx.biometric.BiometricPrompt
-import androidx.core.graphics.drawable.IconCompat
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
 import androidx.credentials.exceptions.GetCredentialUnknownException
-import androidx.credentials.provider.BeginGetCredentialOption
 import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
-import androidx.credentials.provider.BiometricPromptData
 import androidx.credentials.provider.CallingAppInfo
 import androidx.credentials.provider.CredentialEntry
 import androidx.credentials.provider.ProviderGetCredentialRequest
-import androidx.credentials.provider.PublicKeyCredentialEntry
-import com.bitwarden.core.annotation.OmitFromCoverage
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.takeUntilLoaded
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.core.data.util.decodeFromStringOrNull
 import com.bitwarden.data.manager.DispatcherManager
-import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.fido.ClientData
-import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.fido.Origin
 import com.bitwarden.fido.UnverifiedAssetLink
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.vault.CipherView
-import com.bumptech.glide.Glide
-import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
+import com.x8bit.bitwarden.data.credentials.builder.CredentialEntryBuilder
 import com.x8bit.bitwarden.data.credentials.model.Fido2CredentialAssertionResult
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
+import com.x8bit.bitwarden.data.credentials.model.GetCredentialsRequest
 import com.x8bit.bitwarden.data.credentials.model.PasskeyAssertionOptions
 import com.x8bit.bitwarden.data.credentials.model.PasskeyAttestationOptions
 import com.x8bit.bitwarden.data.credentials.model.UserVerificationRequirement
-import com.x8bit.bitwarden.data.credentials.processor.GET_PASSKEY_INTENT
-import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
-import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.util.getAppOrigin
 import com.x8bit.bitwarden.data.platform.util.getAppSigningSignatureFingerprint
 import com.x8bit.bitwarden.data.platform.util.getSignatureFingerprintAsHexString
-import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.AuthenticateFido2CredentialRequest
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.RegisterFido2CredentialRequest
@@ -55,32 +37,22 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.util.toAndroidFido2PublicKe
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.DecryptFido2CredentialAutofillViewResult
 import com.x8bit.bitwarden.ui.platform.base.util.prefixHttpsIfNecessaryOrNull
-import com.x8bit.bitwarden.ui.platform.components.model.IconData
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
-import com.x8bit.bitwarden.ui.vault.feature.vault.util.toLoginIconData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import timber.log.Timber
-import java.util.concurrent.ExecutionException
-import javax.crypto.Cipher
-import kotlin.random.Random
 
 /**
  * Primary implementation of [BitwardenCredentialManager].
  */
 @Suppress("TooManyFunctions", "LongParameterList")
 class BitwardenCredentialManagerImpl(
-    private val context: Context,
     private val vaultSdkSource: VaultSdkSource,
     private val fido2CredentialStore: Fido2CredentialStore,
-    private val intentManager: IntentManager,
-    private val featureFlagManager: FeatureFlagManager,
-    private val biometricsEncryptionManager: BiometricsEncryptionManager,
+    private val credentialEntryBuilder: CredentialEntryBuilder,
     private val json: Json,
     private val vaultRepository: VaultRepository,
-    private val environmentRepository: EnvironmentRepository,
     dispatcherManager: DispatcherManager,
 ) : BitwardenCredentialManager,
     Fido2CredentialStore by fido2CredentialStore {
@@ -194,8 +166,7 @@ class BitwardenCredentialManagerImpl(
         ?: fallbackRequirement
 
     override suspend fun getCredentialEntries(
-        userId: String,
-        options: List<BeginGetCredentialOption>,
+        getCredentialsRequest: GetCredentialsRequest,
     ): Result<List<CredentialEntry>> = withContext(ioScope.coroutineContext) {
         val cipherViews = vaultRepository
             .ciphersStateFlow
@@ -209,33 +180,18 @@ class BitwardenCredentialManagerImpl(
                     else -> emptyList()
                 }
             }
+            .filter { it.isActiveWithFido2Credentials }
             .ifEmpty {
                 return@withContext emptyList<CredentialEntry>().asSuccess()
             }
 
-        val publicKeyCredentialOptions = options
-            .filterIsInstance<BeginGetPublicKeyCredentialOption>()
-            .ifEmpty { return@withContext emptyList<CredentialEntry>().asSuccess() }
-
-        when (
-            val decryptResult =
-                vaultRepository.getDecryptedFido2CredentialAutofillViews(cipherViews)
-        ) {
-            is DecryptFido2CredentialAutofillViewResult.Error -> {
-                GetCredentialUnknownException(
-                    "Error decrypting user's FIDO 2 credentials.",
-                )
-                    .asFailure()
-            }
-
-            is DecryptFido2CredentialAutofillViewResult.Success -> {
-                publicKeyCredentialOptions.toPublicKeyCredentialEntries(
-                    userId = userId,
-                    cipherViews = cipherViews,
-                    fido2CredentialAutofillViews = decryptResult.fido2CredentialAutofillViews,
-                )
-            }
-        }
+        getCredentialsRequest
+            .beginGetPublicKeyCredentialOptions
+            .toPublicKeyCredentialEntries(
+                userId = getCredentialsRequest.userId,
+                cipherViewsWithPublicKeyCredentials = cipherViews,
+            )
+            .onFailure { Timber.e(it, "Failed to get FIDO 2 credential entries.") }
     }
 
     private fun getPasskeyAssertionOptionsOrNull(
@@ -244,156 +200,37 @@ class BitwardenCredentialManagerImpl(
 
     private suspend fun List<BeginGetPublicKeyCredentialOption>.toPublicKeyCredentialEntries(
         userId: String,
-        cipherViews: List<CipherView>,
-        fido2CredentialAutofillViews: List<Fido2CredentialAutofillView>,
-    ): Result<List<PublicKeyCredentialEntry>> {
-        val baseIconUrl = environmentRepository
-            .environment
-            .environmentUrlData
-            .baseIconUrl
+        cipherViewsWithPublicKeyCredentials: List<CipherView>,
+    ): Result<List<CredentialEntry>> {
+        val relyingPartyIds = this
+            .mapNotNull { getPasskeyAssertionOptionsOrNull(it.requestJson)?.relyingPartyId }
+            .distinct()
+            .ifEmpty {
+                return GetCredentialUnknownException("Relying party id required.").asFailure()
+            }
 
-        var options: PasskeyAssertionOptions
-        var relyingPartyId: String
-        return this
-            .flatMap { option ->
-                options = getPasskeyAssertionOptionsOrNull(option.requestJson)
-                    ?: return GetCredentialUnknownException(
-                        "Invalid passkey request. Could not deserialize request options.",
-                    )
-                        .asFailure()
+        val decryptResult = vaultRepository
+            .getDecryptedFido2CredentialAutofillViews(cipherViewsWithPublicKeyCredentials)
 
-                relyingPartyId = options.relyingPartyId
-                    ?: return GetCredentialUnknownException(
-                        "Invalid passkey request. Relying party ID is required.",
-                    )
-                        .asFailure()
+        return when (decryptResult) {
+            is DecryptFido2CredentialAutofillViewResult.Error -> {
+                GetCredentialUnknownException("Error decrypting credentials.").asFailure()
+            }
 
-                val autofillViews = fido2CredentialAutofillViews
-                    .filter { it.rpId == relyingPartyId }
-                    .ifEmpty {
-                        return emptyList<PublicKeyCredentialEntry>().asSuccess()
-                    }
-
-                val cipherIdsToMatch = autofillViews
-                    .map { it.cipherId }
-                    .toSet()
-
-                cipherViews
-                    .filter { cipherView -> cipherView.id in cipherIdsToMatch }
-                    .associateWith { cipherView ->
-                        // We can safely call first() here because we know the cipherId exists in
-                        // the collection of autofill views.
-                        autofillViews.first { it.cipherId == cipherView.id }
-                    }
-                    .toPublicKeyCredentialEntryList(
-                        baseIconUrl = baseIconUrl,
+            is DecryptFido2CredentialAutofillViewResult.Success -> {
+                credentialEntryBuilder
+                    .buildPublicKeyCredentialEntries(
                         userId = userId,
-                        option = option,
-                    )
-            }
-            .asSuccess()
-    }
-
-    private suspend fun Map<CipherView, Fido2CredentialAutofillView>.toPublicKeyCredentialEntryList(
-        baseIconUrl: String,
-        userId: String,
-        option: BeginGetPublicKeyCredentialOption,
-    ): List<PublicKeyCredentialEntry> = this.map { (cipherView, autofillView) ->
-        val loginIconData = cipherView.login
-            ?.uris
-            .toLoginIconData(
-                // TODO: [PM-20176] Enable web icons in passkey credential entries
-                // Leave web icons disabled until CredentialManager TransactionTooLargeExceptions
-                // are addressed. See https://issuetracker.google.com/issues/355141766 for details.
-                isIconLoadingDisabled = true,
-                baseIconUrl = baseIconUrl,
-                usePasskeyDefaultIcon = true,
-            )
-        val iconCompat = when (loginIconData) {
-            is IconData.Local -> {
-                IconCompat.createWithResource(context, loginIconData.iconRes)
-            }
-
-            is IconData.Network -> {
-                loginIconData.toIconCompat()
-            }
-        }
-
-        val pkEntryBuilder = PublicKeyCredentialEntry
-            .Builder(
-                context = context,
-                username = autofillView.userNameForUi
-                    ?: context.getString(R.string.no_username),
-                pendingIntent = intentManager
-                    .createFido2GetCredentialPendingIntent(
-                        action = GET_PASSKEY_INTENT,
-                        userId = userId,
-                        credentialId = autofillView.credentialId.toString(),
-                        cipherId = autofillView.cipherId,
+                        fido2CredentialAutofillViews = decryptResult
+                            .fido2CredentialAutofillViews
+                            .filter { it.rpId in relyingPartyIds },
+                        beginGetPublicKeyCredentialOptions = this,
                         isUserVerified = isUserVerified,
-                        requestCode = Random.nextInt(),
-                    ),
-                beginGetPublicKeyCredentialOption = option,
-            )
-            .setIcon(iconCompat.toIcon(context))
-
-        if (featureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication) &&
-            !isUserVerified
-        ) {
-            biometricsEncryptionManager
-                .getOrCreateCipher(userId)
-                ?.let { cipher ->
-                    pkEntryBuilder
-                        .setBiometricPromptDataIfSupported(cipher = cipher)
-                }
+                    )
+                    .asSuccess()
+            }
         }
-
-        pkEntryBuilder.build()
     }
-
-    private fun PublicKeyCredentialEntry.Builder.setBiometricPromptDataIfSupported(
-        cipher: Cipher,
-    ): PublicKeyCredentialEntry.Builder =
-        if (isBuildVersionBelow(Build.VERSION_CODES.VANILLA_ICE_CREAM)) {
-            this
-        } else {
-            setBiometricPromptData(
-                biometricPromptData = buildPromptDataWithCipher(cipher),
-            )
-        }
-
-    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
-    private fun buildPromptDataWithCipher(
-        cipher: Cipher,
-    ): BiometricPromptData = BiometricPromptData.Builder()
-        .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
-        .setCryptoObject(BiometricPrompt.CryptoObject(cipher))
-        .build()
-
-    /**
-     * Converts a network icon to an [IconCompat]. Performs a blocking network request to fetch the
-     * icon, so only call this method from a background thread or coroutine.
-     */
-    @OmitFromCoverage
-    @WorkerThread
-    private suspend fun IconData.Network.toIconCompat(): IconCompat = try {
-        val futureTargetBitmap = Glide
-            .with(context)
-            .asBitmap()
-            .load(this.uri)
-            .placeholder(R.drawable.ic_bw_passkey)
-            .submit()
-
-        IconCompat.createWithBitmap(futureTargetBitmap.get())
-    } catch (_: ExecutionException) {
-        null
-    } catch (_: InterruptedException) {
-        null
-    }
-        ?: IconCompat.createWithResource(
-            context,
-            this.fallbackIconRes,
-        )
 
     private suspend fun registerFido2CredentialForUnprivilegedApp(
         userId: String,

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/model/GetCredentialsRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/model/GetCredentialsRequest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.credentials.model
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.credentials.provider.BeginGetCredentialRequest
+import androidx.credentials.provider.BeginGetPasswordOption
 import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
 import androidx.credentials.provider.CallingAppInfo
 import kotlinx.parcelize.IgnoredOnParcel
@@ -30,13 +31,25 @@ data class GetCredentialsRequest(
 
     /**
      * The [BeginGetPublicKeyCredentialOption]s of the [providerRequest], or an empty list if no
-     * public key credentials are present.
+     * public key options are present.
      */
     @IgnoredOnParcel
     val beginGetPublicKeyCredentialOptions: List<BeginGetPublicKeyCredentialOption> by lazy {
         providerRequest
             ?.beginGetCredentialOptions
             ?.filterIsInstance<BeginGetPublicKeyCredentialOption>()
+            .orEmpty()
+    }
+
+    /**
+     * The [BeginGetPasswordOption]s of the [providerRequest], or an empty list if no password
+     * options are present.
+     */
+    @IgnoredOnParcel
+    val beginGetPasswordOptions: List<BeginGetPasswordOption> by lazy {
+        providerRequest
+            ?.beginGetCredentialOptions
+            ?.filterIsInstance<BeginGetPasswordOption>()
             .orEmpty()
     }
 

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/model/ProviderGetPasswordCredentialRequest.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/model/ProviderGetPasswordCredentialRequest.kt
@@ -1,0 +1,23 @@
+package com.x8bit.bitwarden.data.credentials.model
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.credentials.provider.ProviderGetCredentialRequest
+import kotlinx.parcelize.Parcelize
+
+/**
+ * A wrapper around [ProviderGetCredentialRequest] that includes additional information needed to
+ * fulfill the request.
+ *
+ * @param userId The ID of the user that owns the credential being requested.
+ * @param cipherId The ID of the cipher containing the password to be retrieved.
+ * @param isUserVerified Whether the user has been verified prior to this request.
+ * @param requestData The original request data from the system.
+ */
+@Parcelize
+data class ProviderGetPasswordCredentialRequest(
+    val userId: String,
+    val cipherId: String,
+    val isUserVerified: Boolean,
+    val requestData: Bundle,
+) : Parcelable

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/util/BiometricPromptDataUtils.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/util/BiometricPromptDataUtils.kt
@@ -1,0 +1,22 @@
+@file:OmitFromCoverage
+
+package com.x8bit.bitwarden.data.credentials.util
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.credentials.provider.BiometricPromptData
+import com.bitwarden.core.annotation.OmitFromCoverage
+import javax.crypto.Cipher
+
+/**
+ * Builds a [BiometricPromptData] instance with the provided [Cipher].
+ */
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+fun buildPromptDataWithCipher(
+    cipher: Cipher,
+): BiometricPromptData = BiometricPromptData.Builder()
+    .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+    .setCryptoObject(BiometricPrompt.CryptoObject(cipher))
+    .build()

--- a/app/src/main/java/com/x8bit/bitwarden/data/credentials/util/PublicKeyCredentialEntryBuilderExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/credentials/util/PublicKeyCredentialEntryBuilderExtensions.kt
@@ -1,0 +1,27 @@
+@file:OmitFromCoverage
+
+package com.x8bit.bitwarden.data.credentials.util
+
+import android.os.Build
+import androidx.credentials.provider.PublicKeyCredentialEntry
+import com.bitwarden.core.annotation.OmitFromCoverage
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
+import javax.crypto.Cipher
+
+/**
+ * Sets the biometric prompt data on the [PublicKeyCredentialEntry.Builder] if supported.
+ */
+fun PublicKeyCredentialEntry.Builder.setBiometricPromptDataIfSupported(
+    cipher: Cipher?,
+    isSingleTapAuthEnabled: Boolean,
+): PublicKeyCredentialEntry.Builder =
+    if (!isBuildVersionBelow(Build.VERSION_CODES.VANILLA_ICE_CREAM) &&
+        cipher != null &&
+        isSingleTapAuthEnabled
+    ) {
+        setBiometricPromptData(
+            biometricPromptData = buildPromptDataWithCipher(cipher),
+        )
+    } else {
+        this
+    }

--- a/app/src/test/java/com/x8bit/bitwarden/data/credentials/builder/CredentialEntryBuilderTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/credentials/builder/CredentialEntryBuilderTest.kt
@@ -1,0 +1,243 @@
+package com.x8bit.bitwarden.data.credentials.builder
+
+import android.app.PendingIntent
+import android.content.Context
+import android.graphics.drawable.Icon
+import androidx.core.graphics.drawable.IconCompat
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
+import androidx.credentials.provider.PublicKeyCredentialEntry
+import com.bitwarden.fido.Fido2CredentialAutofillView
+import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
+import com.x8bit.bitwarden.data.platform.util.isBuildVersionBelow
+import com.x8bit.bitwarden.data.util.mockBuilder
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFido2CredentialAutofillView
+import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CredentialEntryBuilderTest {
+
+    private val mockContext = mockk<Context>()
+    private val mockGetPublicKeyCredentialIntent = mockk<PendingIntent>(relaxed = true)
+    private val mockIntentManager = mockk<IntentManager> {
+        every {
+            createFido2GetCredentialPendingIntent(
+                action = any(),
+                userId = any(),
+                cipherId = any(),
+                credentialId = any(),
+                requestCode = any(),
+                isUserVerified = any(),
+            )
+        } returns mockGetPublicKeyCredentialIntent
+    }
+    private val mockFeatureFlagManager = mockk<FeatureFlagManager>()
+    private val mockBiometricsEncryptionManager = mockk<BiometricsEncryptionManager>()
+    private val mockBeginGetPublicKeyOption = mockk<BeginGetPublicKeyCredentialOption>()
+    private val credentialEntryBuilder = CredentialEntryBuilderImpl(
+        context = mockContext,
+        intentManager = mockIntentManager,
+        featureFlagManager = mockFeatureFlagManager,
+        biometricsEncryptionManager = mockBiometricsEncryptionManager,
+    )
+    private val mockPublicKeyCredentialEntry = mockk<PublicKeyCredentialEntry>(relaxed = true)
+    private val mockIcon = mockk<Icon>()
+
+    @BeforeEach
+    @Test
+    fun setUp() {
+        mockkConstructor(PublicKeyCredentialEntry.Builder::class)
+        mockkStatic(IconCompat::class)
+        mockBuilder<PublicKeyCredentialEntry.Builder> { it.setIcon(any()) }
+        every { IconCompat.createWithResource(any(), any()) } returns mockk {
+            every { toIcon(mockContext) } returns mockIcon
+        }
+        every {
+            anyConstructed<PublicKeyCredentialEntry.Builder>().build()
+        } returns mockPublicKeyCredentialEntry
+    }
+
+    @AfterEach
+    @Test
+    fun tearDown() {
+        unmockkStatic(IconCompat::class)
+        unmockkStatic(::isBuildVersionBelow)
+        unmockkConstructor(PublicKeyCredentialEntry.Builder::class)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `buildPublicKeyCredentialEntries should return Success with empty list when options list is empty`() =
+        runTest {
+            val options = emptyList<BeginGetPublicKeyCredentialOption>()
+            val fido2AutofillViews: List<Fido2CredentialAutofillView> = listOf(
+                createMockFido2CredentialAutofillView(number = 1),
+            )
+
+            val result = credentialEntryBuilder
+                .buildPublicKeyCredentialEntries(
+                    userId = "userId",
+                    isUserVerified = false,
+                    fido2CredentialAutofillViews = fido2AutofillViews,
+                    beginGetPublicKeyCredentialOptions = options,
+                )
+            assertTrue(result.isEmpty())
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `buildPublicKeyCredentialEntries should return Success with empty list when fido2AutofillViews is empty`() =
+        runTest {
+            val options = listOf(mockBeginGetPublicKeyOption)
+            val fido2AutofillViews = emptyList<Fido2CredentialAutofillView>()
+            val result = credentialEntryBuilder
+                .buildPublicKeyCredentialEntries(
+                    userId = "userId",
+                    isUserVerified = false,
+                    fido2CredentialAutofillViews = fido2AutofillViews,
+                    beginGetPublicKeyCredentialOptions = options,
+                )
+            assertTrue(result.isEmpty())
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `buildPublicKeyCredentialEntries should return Success with list of PublicKeyCredentialEntry`() =
+        runTest {
+            val options = listOf(mockBeginGetPublicKeyOption)
+            val fido2AutofillViews: List<Fido2CredentialAutofillView> = listOf(
+                createMockFido2CredentialAutofillView(number = 1),
+            )
+
+            every {
+                mockFeatureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)
+            } returns false
+            every {
+                mockBiometricsEncryptionManager.getOrCreateCipher("userId")
+            } returns null
+
+            val result = credentialEntryBuilder
+                .buildPublicKeyCredentialEntries(
+                    userId = "userId",
+                    isUserVerified = false,
+                    fido2CredentialAutofillViews = fido2AutofillViews,
+                    beginGetPublicKeyCredentialOptions = options,
+                )
+
+            assertTrue(result.isNotEmpty())
+
+            verify {
+                mockIntentManager.createFido2GetCredentialPendingIntent(
+                    action = "com.x8bit.bitwarden.credentials.ACTION_GET_PASSKEY",
+                    userId = "userId",
+                    cipherId = "mockCipherId-1",
+                    credentialId = fido2AutofillViews.first().credentialId.toString(),
+                    requestCode = any(),
+                    isUserVerified = false,
+                )
+
+                anyConstructed<PublicKeyCredentialEntry.Builder>().setIcon(mockIcon)
+            }
+        }
+
+    @Test
+    fun `buildPublicKeyCredentialEntries should set biometric prompt data correctly`() = runTest {
+        mockkStatic(::isBuildVersionBelow)
+        val options = listOf(mockBeginGetPublicKeyOption)
+        val fido2AutofillViews: List<Fido2CredentialAutofillView> = listOf(
+            createMockFido2CredentialAutofillView(number = 1),
+        )
+
+        // Verify biometric prompt data is not set when flag is false, buildVersion is < 35, and
+        // cipher is null.
+        every {
+            mockFeatureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)
+        } returns false
+        every {
+            mockBiometricsEncryptionManager.getOrCreateCipher("userId")
+        } returns null
+        every { isBuildVersionBelow(any()) } returns false
+
+        credentialEntryBuilder
+            .buildPublicKeyCredentialEntries(
+                userId = "userId",
+                isUserVerified = false,
+                fido2CredentialAutofillViews = fido2AutofillViews,
+                beginGetPublicKeyCredentialOptions = options,
+            )
+        verify(exactly = 0) {
+            anyConstructed<PublicKeyCredentialEntry.Builder>().setBiometricPromptData(any())
+        }
+
+        // Verify biometric prompt data is not set when flag is true, buildVersion is < 35, and
+        // cipher is null.
+        every {
+            mockFeatureFlagManager.getFeatureFlag(FlagKey.SingleTapPasskeyAuthentication)
+        } returns true
+        credentialEntryBuilder
+            .buildPublicKeyCredentialEntries(
+                userId = "userId",
+                isUserVerified = false,
+                fido2CredentialAutofillViews = fido2AutofillViews,
+                beginGetPublicKeyCredentialOptions = options,
+            )
+
+        verify(exactly = 0) {
+            anyConstructed<PublicKeyCredentialEntry.Builder>().setBiometricPromptData(any())
+        }
+
+        // Verify biometric prompt data is not set when flag is true, buildVersion is >= 35, and
+        // cipher is null
+        every { isBuildVersionBelow(any()) } returns false
+        credentialEntryBuilder
+            .buildPublicKeyCredentialEntries(
+                userId = "userId",
+                isUserVerified = false,
+                fido2CredentialAutofillViews = fido2AutofillViews,
+                beginGetPublicKeyCredentialOptions = options,
+            )
+        verify(exactly = 0) {
+            anyConstructed<PublicKeyCredentialEntry.Builder>().setBiometricPromptData(any())
+        }
+
+        // Verify biometric prompt data is not set when user is verified
+        every {
+            mockBiometricsEncryptionManager.getOrCreateCipher(any())
+        } returns mockk(relaxed = true)
+        credentialEntryBuilder
+            .buildPublicKeyCredentialEntries(
+                userId = "userId",
+                isUserVerified = true,
+                fido2CredentialAutofillViews = fido2AutofillViews,
+                beginGetPublicKeyCredentialOptions = options,
+            )
+        verify(exactly = 0) {
+            anyConstructed<PublicKeyCredentialEntry.Builder>().setBiometricPromptData(any())
+        }
+
+        // Verify biometric prompt data is set when flag is true, buildVersion is >= 35, cipher is
+        // not null, and user is not verified
+        credentialEntryBuilder
+            .buildPublicKeyCredentialEntries(
+                userId = "userId",
+                isUserVerified = false,
+                fido2CredentialAutofillViews = fido2AutofillViews,
+                beginGetPublicKeyCredentialOptions = options,
+            )
+        verify(exactly = 1) {
+            anyConstructed<PublicKeyCredentialEntry.Builder>().setBiometricPromptData(any())
+        }
+    }
+}

--- a/app/src/test/java/com/x8bit/bitwarden/data/credentials/processor/CredentialProviderProcessorTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/credentials/processor/CredentialProviderProcessorTest.kt
@@ -69,9 +69,7 @@ class CredentialProviderProcessorTest {
     }
     private val credentialEntries = listOf(mockk<CredentialEntry>(relaxed = true))
     private val bitwardenCredentialManager: BitwardenCredentialManager = mockk {
-        coEvery {
-            getCredentialEntries(any(), any())
-        } returns credentialEntries.asSuccess()
+        coEvery { getCredentialEntries(any()) } returns credentialEntries.asSuccess()
     }
     private val intentManager: IntentManager = mockk()
     private val dispatcherManager: DispatcherManager = FakeDispatcherManager()
@@ -459,10 +457,7 @@ class CredentialProviderProcessorTest {
             every { cancellationSignal.setOnCancelListener(any()) } just runs
             every { callback.onError(capture(captureSlot)) } just runs
             coEvery {
-                bitwardenCredentialManager.getCredentialEntries(
-                    userId = DEFAULT_USER_STATE.activeUserId,
-                    options = listOf(mockOption),
-                )
+                bitwardenCredentialManager.getCredentialEntries(any())
             } returns Result.failure(Exception("Error decrypting credentials."))
 
             credentialProviderProcessor.processGetCredentialRequest(

--- a/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherViewUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherViewUtil.kt
@@ -95,11 +95,13 @@ fun createMockCipherView(
 /**
  * Create a mock [LoginView] with a given [number].
  */
+@Suppress("LongParameterList")
 fun createMockLoginView(
     number: Int,
     totp: String? = "mockTotp-$number",
     clock: Clock = FIXED_CLOCK,
     hasUris: Boolean = true,
+    uris: List<LoginUriView>? = listOf(createMockUriView(number = number)),
     fido2Credentials: List<Fido2Credential>? = createMockSdkFido2CredentialList(number, clock),
 ): LoginView =
     LoginView(
@@ -107,7 +109,7 @@ fun createMockLoginView(
         password = "mockPassword-$number",
         passwordRevisionDate = clock.instant(),
         autofillOnPageLoad = false,
-        uris = listOf(createMockUriView(number = number)).takeIf { hasUris },
+        uris = uris.takeIf { hasUris },
         totp = totp,
         fido2Credentials = fido2Credentials,
     )
@@ -162,9 +164,9 @@ fun createMockFido2CredentialAutofillView(
 /**
  * Create a mock [LoginUriView] with a given [number].
  */
-fun createMockUriView(number: Int): LoginUriView =
+fun createMockUriView(number: Int, uri: String = "www.mockuri$number.com"): LoginUriView =
     LoginUriView(
-        uri = "www.mockuri$number.com",
+        uri = uri,
         match = UriMatchType.HOST,
         uriChecksum = "mockUriChecksum-$number",
     )


### PR DESCRIPTION
## 🎟️ Tracking

PM-21567

## 📔 Objective

Extract logic responsible for building CredentialEntry objects to a dedicated CredentialEntryBuilder class. This reduces the responsibilities of `BitwardenCredentialManager` and improves testability of the process and its components.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
