### PR TITLE
[PM-21572] Migrate NoPersonalizedLearningInterceptor to ui module

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/BitwardenTheme.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/theme/BitwardenTheme.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowCompat
+import com.bitwarden.ui.platform.components.field.interceptor.IncognitoInput
 import com.bitwarden.ui.platform.theme.color.BitwardenColorScheme
-import com.x8bit.bitwarden.ui.platform.components.field.interceptor.IncognitoInput
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.ui.platform.theme.color.darkBitwardenColorScheme
 import com.x8bit.bitwarden.ui.platform.theme.color.dynamicBitwardenColorScheme

--- a/ui/src/main/java/com/bitwarden/ui/platform/components/field/interceptor/NoPersonalizedLearningInterceptor.kt
+++ b/ui/src/main/java/com/bitwarden/ui/platform/components/field/interceptor/NoPersonalizedLearningInterceptor.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.field.interceptor
+package com.bitwarden.ui.platform.components.field.interceptor
 
 import android.view.inputmethod.EditorInfo
 import androidx.compose.runtime.Composable
@@ -7,12 +7,10 @@ import androidx.compose.ui.platform.InterceptPlatformTextInput
 import androidx.compose.ui.platform.PlatformTextInputInterceptor
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSession
-import com.bitwarden.core.annotation.OmitFromCoverage
 
 /**
  * Interceptor that disables the [EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING] flag on text inputs.
  */
-@OmitFromCoverage
 @OptIn(ExperimentalComposeUiApi::class)
 object NoPersonalizedLearningInterceptor : PlatformTextInputInterceptor {
     override suspend fun interceptStartInputMethod(


### PR DESCRIPTION
## 🎟️ Tracking

PM-21572

## 📔 Objective

Move the `NoPersonalizedLearningInterceptor` class from the `app` module to the `ui` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
