### PR TITLE
[PM-21585] Display item folder location when only in a single folder

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/component/ItemHeader.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/item/component/ItemHeader.kt
@@ -202,6 +202,28 @@ fun LazyListScope.itemHeader(
         return
     }
 
+    // When the item is assigned to a single folder and not a collection we display the folder name.
+    if (folderLocations.isNotEmpty() && collectionLocations.isEmpty()) {
+        val folderLocation = folderLocations.first()
+        item(key = "folder") {
+            ItemLocationListItem(
+                vectorPainter = rememberVectorPainter(folderLocation.icon),
+                iconTestTag = "ItemLocationIcon",
+                text = folderLocation.name,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .animateItem()
+                    .cardStyle(
+                        cardStyle = CardStyle.Bottom,
+                        paddingVertical = 0.dp,
+                        paddingHorizontal = 16.dp,
+                    ),
+            )
+        }
+        return
+    }
+
     // When the item is assigned to multiple collections we only display the first collection by
     // default and collapse the remaining locations.
     collectionLocations.firstOrNull()
@@ -348,7 +370,7 @@ private fun LazyItemScope.ItemLocationListItem(
 //region Previews
 @Composable
 @Preview
-private fun ItemHeader_LocalIcon_Preview() {
+private fun ItemHeaderWithLocalIcon_Preview() {
     var isExpanded by remember { mutableStateOf(false) }
     BitwardenTheme {
         LazyColumn {
@@ -369,7 +391,7 @@ private fun ItemHeader_LocalIcon_Preview() {
 
 @Composable
 @Preview
-private fun ItemHeader_NetworkIcon_Preview() {
+private fun ItemHeaderWithNetworkIcon_Preview() {
     var isExpanded by remember { mutableStateOf(false) }
     BitwardenTheme {
         LazyColumn {
@@ -391,7 +413,7 @@ private fun ItemHeader_NetworkIcon_Preview() {
 
 @Composable
 @Preview
-private fun ItemHeader_Organization_Preview() {
+private fun ItemHeaderWithOrganization_Preview() {
     var isExpanded by remember { mutableStateOf(false) }
     BitwardenTheme {
         LazyColumn {
@@ -414,7 +436,7 @@ private fun ItemHeader_Organization_Preview() {
 
 @Composable
 @Preview
-private fun ItemNameField_Org_SingleCollection_Preview() {
+private fun ItemHeaderWithOrgAndSingleCollection_Preview() {
     var isExpanded by remember { mutableStateOf(false) }
     BitwardenTheme {
         LazyColumn {
@@ -438,7 +460,7 @@ private fun ItemNameField_Org_SingleCollection_Preview() {
 
 @Composable
 @Preview
-private fun ItemNameField_Org_MultiCollection_Preview() {
+private fun ItemHeaderWithOrgAndMultiCollection_Preview() {
     var isExpanded by remember { mutableStateOf(false) }
     BitwardenTheme {
         LazyColumn {
@@ -463,7 +485,7 @@ private fun ItemNameField_Org_MultiCollection_Preview() {
 
 @Composable
 @Preview
-private fun ItemNameField_Org_SingleCollection_Folder_Preview() {
+private fun ItemHeaderWithOrgSingleCollectionAndFolder_Preview() {
     var isExpanded by remember { mutableStateOf(false) }
     BitwardenTheme {
         LazyColumn {
@@ -476,6 +498,29 @@ private fun ItemNameField_Org_SingleCollection_Folder_Preview() {
                 relatedLocations = persistentListOf(
                     VaultItemLocation.Organization("Stark Industries"),
                     VaultItemLocation.Collection("Marketing"),
+                    VaultItemLocation.Folder("Competition"),
+                ),
+                isExpanded = isExpanded,
+                onExpandClick = { isExpanded = !isExpanded },
+                applyIconBackground = true,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun ItemHeaderFolderOnly_Preview() {
+    var isExpanded by remember { mutableStateOf(false) }
+    BitwardenTheme {
+        LazyColumn {
+            itemHeader(
+                value = "SSH key in a folder",
+                isFavorite = true,
+                iconData = IconData.Local(
+                    iconRes = R.drawable.ic_ssh_key,
+                ),
+                relatedLocations = persistentListOf(
                     VaultItemLocation.Folder("Competition"),
                 ),
                 isExpanded = isExpanded,


### PR DESCRIPTION
## 🎟️ Tracking

PM-21585
Closes #5183 

## 📔 Objective

Display an item's folder location in the item header when the item is only assigned to a single folder and not any collections.

A new preview has also been added to demonstrate this change.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="455" alt="image" src="https://github.com/user-attachments/assets/5241a90b-534f-43b6-a35e-fbe2ec496fb6" /> |<img width="460" alt="image" src="https://github.com/user-attachments/assets/54cd34d1-61f0-493e-8c60-837190b76d04" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
