### PR TITLE
PM-21610: Update SearchScreen and VaultItemListingScreen for better Sends support

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.base.util.toListItemCardStyle
@@ -126,7 +125,7 @@ fun SearchContent(
                     } else if (it.autofillSelectionOptions.isNotEmpty()) {
                         autofillSelectionOptionsItem = it
                     } else {
-                        searchHandlers.onItemClick(it.id, it.cipherType)
+                        searchHandlers.onItemClick(it.id, it.itemType)
                     }
                 },
                 trailingLabelIcons = it.extraIconList,
@@ -184,7 +183,7 @@ private fun AutofillSelectionDialog(
     displayItem: SearchState.DisplayItem,
     onAutofillItemClick: (cipherId: String) -> Unit,
     onAutofillAndSaveItemClick: (cipherId: String) -> Unit,
-    onViewItemClick: (cipherId: String, cipherType: CipherType?) -> Unit,
+    onViewItemClick: (id: String, type: SearchState.DisplayItem.ItemType) -> Unit,
     onMasterPasswordRepromptRequest: (MasterPasswordRepromptData) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -238,7 +237,7 @@ private fun AutofillSelectionDialog(
                     text = stringResource(id = R.string.view),
                     onClick = {
                         onDismissRequest()
-                        onViewItemClick(displayItem.id, displayItem.cipherType)
+                        onViewItemClick(displayItem.id, displayItem.itemType)
                     },
                 )
             }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/handlers/SearchHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/handlers/SearchHandlers.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.ui.platform.feature.search.handlers
 
-import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.ui.platform.feature.search.MasterPasswordRepromptData
 import com.x8bit.bitwarden.ui.platform.feature.search.SearchAction
+import com.x8bit.bitwarden.ui.platform.feature.search.SearchState
 import com.x8bit.bitwarden.ui.platform.feature.search.SearchViewModel
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
@@ -13,7 +13,7 @@ import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 data class SearchHandlers(
     val onBackClick: () -> Unit,
     val onDismissRequest: () -> Unit,
-    val onItemClick: (cipherId: String, cipherType: CipherType?) -> Unit,
+    val onItemClick: (id: String, type: SearchState.DisplayItem.ItemType) -> Unit,
     val onAutofillItemClick: (String) -> Unit,
     val onAutofillAndSaveItemClick: (String) -> Unit,
     val onMasterPasswordRepromptSubmit: (password: String, MasterPasswordRepromptData) -> Unit,
@@ -31,13 +31,8 @@ data class SearchHandlers(
             SearchHandlers(
                 onBackClick = { viewModel.trySendAction(SearchAction.BackClick) },
                 onDismissRequest = { viewModel.trySendAction(SearchAction.DismissDialogClick) },
-                onItemClick = { cipherId, cipherType ->
-                    viewModel.trySendAction(
-                        SearchAction.ItemClick(
-                            itemId = cipherId,
-                            cipherType = cipherType,
-                        ),
-                    )
+                onItemClick = { id, type ->
+                    viewModel.trySendAction(SearchAction.ItemClick(itemId = id, itemType = type))
                 },
                 onAutofillItemClick = {
                     viewModel.trySendAction(SearchAction.AutofillItemClick(it))

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
@@ -6,6 +6,7 @@ import androidx.annotation.DrawableRes
 import com.bitwarden.core.data.repository.util.SpecialCharWithPrecedenceComparator
 import com.bitwarden.send.SendType
 import com.bitwarden.send.SendView
+import com.bitwarden.ui.util.asText
 import com.bitwarden.vault.CipherRepromptType
 import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
@@ -14,7 +15,6 @@ import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
 import com.x8bit.bitwarden.data.platform.util.subtitle
-import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.platform.base.util.removeDiacritics
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 import com.x8bit.bitwarden.ui.platform.feature.search.SearchState
@@ -233,7 +233,7 @@ private fun CipherView.toDisplayItem(
             },
         isTotp = isTotp,
         shouldDisplayMasterPasswordReprompt = reprompt == CipherRepromptType.PASSWORD,
-        cipherType = this.type,
+        itemType = SearchState.DisplayItem.ItemType.Vault(type = this.type),
     )
 
 private fun CipherView.toIconData(
@@ -375,7 +375,7 @@ private fun SendView.toDisplayItem(
         autofillSelectionOptions = emptyList(),
         isTotp = false,
         shouldDisplayMasterPasswordReprompt = false,
-        cipherType = null,
+        itemType = SearchState.DisplayItem.ItemType.Sends(type = this.type),
     )
 
 /**

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.base.util.toListItemCardStyle
@@ -42,7 +41,7 @@ fun VaultItemListingContent(
     showAddTotpBanner: Boolean,
     collectionClick: (id: String) -> Unit,
     folderClick: (id: String) -> Unit,
-    vaultItemClick: (id: String, cipherType: CipherType?) -> Unit,
+    vaultItemClick: (id: String, type: VaultItemListingState.DisplayItem.ItemType) -> Unit,
     masterPasswordRepromptSubmit: (password: String, data: MasterPasswordRepromptData) -> Unit,
     onOverflowItemClick: (action: ListingItemOverflowAction) -> Unit,
     modifier: Modifier = Modifier,
@@ -222,7 +221,7 @@ fun VaultItemListingContent(
                                 cipherId = it.id,
                             )
                         } else {
-                            vaultItemClick(it.id, it.type)
+                            vaultItemClick(it.id, it.itemType)
                         }
                     },
                     trailingLabelIcons = it.extraIconList,

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/handlers/VaultItemListingHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/handlers/VaultItemListingHandlers.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.ui.vault.feature.itemlisting.handlers
 
-import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.MasterPasswordRepromptData
+import com.x8bit.bitwarden.ui.vault.feature.itemlisting.VaultItemListingState
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.VaultItemListingViewModel
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.VaultItemListingsAction
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
@@ -18,7 +18,7 @@ data class VaultItemListingHandlers(
     val backClick: () -> Unit,
     val searchIconClick: () -> Unit,
     val addVaultItemClick: () -> Unit,
-    val itemClick: (id: String, cipherType: CipherType?) -> Unit,
+    val itemClick: (id: String, type: VaultItemListingState.DisplayItem.ItemType) -> Unit,
     val folderClick: (id: String) -> Unit,
     val collectionClick: (id: String) -> Unit,
     val masterPasswordRepromptSubmit: (password: String, MasterPasswordRepromptData) -> Unit,
@@ -56,9 +56,9 @@ data class VaultItemListingHandlers(
                 collectionClick = {
                     viewModel.trySendAction(VaultItemListingsAction.CollectionClick(it))
                 },
-                itemClick = { cipherId, cipherType ->
+                itemClick = { id, type ->
                     viewModel.trySendAction(
-                        VaultItemListingsAction.ItemClick(id = cipherId, cipherType = cipherType),
+                        VaultItemListingsAction.ItemClick(id = id, type = type),
                     )
                 },
                 folderClick = { viewModel.trySendAction(VaultItemListingsAction.FolderClick(it)) },

--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -410,7 +410,7 @@ private fun CipherView.toDisplayItem(
         isTotp = isTotp,
         shouldShowMasterPasswordReprompt = (reprompt == CipherRepromptType.PASSWORD) &&
             hasMasterPassword,
-        type = this.type,
+        itemType = VaultItemListingState.DisplayItem.ItemType.Vault(type = this.type),
     )
 
 private fun CipherView.toSecondSubtitle(fido2CredentialRpId: String?): String? =
@@ -482,7 +482,7 @@ private fun SendView.toDisplayItem(
         shouldShowMasterPasswordReprompt = false,
         isCredentialCreation = false,
         isTotp = false,
-        type = null,
+        itemType = VaultItemListingState.DisplayItem.ItemType.Sends(type = this.type),
     )
 
 @get:DrawableRes

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
@@ -237,7 +237,12 @@ class SearchScreenTest : BaseComposeTest() {
             .assertIsDisplayed()
             .performClick()
         verify {
-            viewModel.trySendAction(SearchAction.ItemClick("mockId-1", CipherType.LOGIN))
+            viewModel.trySendAction(
+                SearchAction.ItemClick(
+                    itemId = "mockId-1",
+                    itemType = SearchState.DisplayItem.ItemType.Vault(type = CipherType.LOGIN),
+                ),
+            )
         }
     }
 
@@ -381,7 +386,7 @@ class SearchScreenTest : BaseComposeTest() {
             viewModel.trySendAction(
                 SearchAction.ItemClick(
                     itemId = "mockId-1",
-                    cipherType = CipherType.LOGIN,
+                    itemType = SearchState.DisplayItem.ItemType.Vault(type = CipherType.LOGIN),
                 ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -9,6 +9,7 @@ import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.send.SendType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -204,7 +205,7 @@ class SearchViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 SearchAction.ItemClick(
                     itemId = "mock",
-                    cipherType = CipherType.LOGIN,
+                    itemType = SearchState.DisplayItem.ItemType.Vault(type = CipherType.LOGIN),
                 ),
             )
             assertEquals(
@@ -224,7 +225,10 @@ class SearchViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(
-                SearchAction.ItemClick(itemId = "mock", cipherType = CipherType.LOGIN),
+                SearchAction.ItemClick(
+                    itemId = "mock",
+                    itemType = SearchState.DisplayItem.ItemType.Vault(type = CipherType.LOGIN),
+                ),
             )
             assertEquals(
                 SearchEvent.NavigateToEditCipher(
@@ -240,7 +244,12 @@ class SearchViewModelTest : BaseViewModelTest() {
     fun `ItemClick for send item should emit NavigateToEditSend`() = runTest {
         val viewModel = createViewModel(DEFAULT_STATE.copy(searchType = SearchTypeData.Sends.All))
         viewModel.eventFlow.test {
-            viewModel.trySendAction(SearchAction.ItemClick(itemId = "mock", cipherType = null))
+            viewModel.trySendAction(
+                SearchAction.ItemClick(
+                    itemId = "mock",
+                    itemType = SearchState.DisplayItem.ItemType.Sends(type = SendType.TEXT),
+                ),
+            )
             assertEquals(SearchEvent.NavigateToEditSend(sendId = "mock"), awaitItem())
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
@@ -73,7 +73,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = isTotp,
-                cipherType = CipherType.LOGIN,
+                itemType = SearchState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
 
@@ -116,7 +116,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
-                cipherType = CipherType.SECURE_NOTE,
+                itemType = SearchState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
 
@@ -165,7 +165,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
-                cipherType = CipherType.CARD,
+                itemType = SearchState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
 
@@ -205,7 +205,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
-                cipherType = CipherType.IDENTITY,
+                itemType = SearchState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
 
@@ -240,7 +240,7 @@ fun createMockDisplayItemForCipher(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
-                cipherType = CipherType.SSH_KEY,
+                itemType = SearchState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
     }
@@ -290,7 +290,7 @@ fun createMockDisplayItemForSend(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
-                cipherType = null,
+                itemType = SearchState.DisplayItem.ItemType.Sends(type = sendType),
             )
         }
 
@@ -330,7 +330,7 @@ fun createMockDisplayItemForSend(
                 autofillSelectionOptions = emptyList(),
                 shouldDisplayMasterPasswordReprompt = false,
                 isTotp = false,
-                cipherType = null,
+                itemType = SearchState.DisplayItem.ItemType.Sends(type = sendType),
             )
         }
     }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -19,6 +19,7 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.data.repository.util.baseWebSendUrl
+import com.bitwarden.send.SendType
 import com.bitwarden.ui.util.asText
 import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.R
@@ -1043,7 +1044,7 @@ class VaultItemListingScreenTest : BaseComposeTest() {
             viewModel.trySendAction(
                 VaultItemListingsAction.ItemClick(
                     id = "mockId-1",
-                    cipherType = null,
+                    type = VaultItemListingState.DisplayItem.ItemType.Sends(type = SendType.TEXT),
                 ),
             )
         }
@@ -2337,7 +2338,7 @@ private fun createDisplayItem(number: Int): VaultItemListingState.DisplayItem =
         shouldShowMasterPasswordReprompt = false,
         iconTestTag = null,
         isTotp = false,
-        type = null,
+        itemType = VaultItemListingState.DisplayItem.ItemType.Sends(type = SendType.TEXT),
     )
 
 private fun createCipherDisplayItem(number: Int): VaultItemListingState.DisplayItem =
@@ -2364,5 +2365,5 @@ private fun createCipherDisplayItem(number: Int): VaultItemListingState.DisplayI
         shouldShowMasterPasswordReprompt = false,
         iconTestTag = null,
         isTotp = true,
-        type = CipherType.LOGIN,
+        itemType = VaultItemListingState.DisplayItem.ItemType.Vault(type = CipherType.LOGIN),
     )

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -20,6 +20,7 @@ import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.data.repository.util.baseWebSendUrl
 import com.bitwarden.network.model.PolicyTypeJson
+import com.bitwarden.send.SendType
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -527,7 +528,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 viewModel.trySendAction(
                     VaultItemListingsAction.ItemClick(
                         id = "mockId-1",
-                        cipherType = CipherType.LOGIN,
+                        type = VaultItemListingState.DisplayItem.ItemType.Vault(
+                            type = CipherType.LOGIN,
+                        ),
                     ),
                 )
                 assertEquals(cipherView, awaitItem())
@@ -575,7 +578,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 viewModel.trySendAction(
                     VaultItemListingsAction.ItemClick(
                         id = "mockId-1",
-                        cipherType = CipherType.LOGIN,
+                        type = VaultItemListingState.DisplayItem.ItemType.Vault(
+                            type = CipherType.LOGIN,
+                        ),
                     ),
                 )
                 assertEquals(
@@ -610,7 +615,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(
             VaultItemListingsAction.ItemClick(
                 id = cipherView.id.orEmpty(),
-                cipherType = CipherType.LOGIN,
+                type = VaultItemListingState.DisplayItem.ItemType.Vault(
+                    type = CipherType.LOGIN,
+                ),
             ),
         )
 
@@ -660,10 +667,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
             coEvery {
                 bitwardenCredentialManager.registerFido2Credential(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
+                    userId = any(),
+                    callingAppInfo = any(),
+                    createPublicKeyCredentialRequest = any(),
+                    selectedCipherView = any(),
                 )
             } returns Fido2RegisterCredentialResult.Success("mockResponse")
 
@@ -671,7 +678,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 VaultItemListingsAction.ItemClick(
                     id = cipherView.id.orEmpty(),
-                    cipherType = CipherType.LOGIN,
+                    type = VaultItemListingState.DisplayItem.ItemType.Vault(
+                        type = CipherType.LOGIN,
+                    ),
                 ),
             )
 
@@ -722,10 +731,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
             coEvery {
                 bitwardenCredentialManager.registerFido2Credential(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
+                    userId = any(),
+                    callingAppInfo = any(),
+                    createPublicKeyCredentialRequest = any(),
+                    selectedCipherView = any(),
                 )
             } returns Fido2RegisterCredentialResult.Success("mockResponse")
 
@@ -733,7 +742,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 VaultItemListingsAction.ItemClick(
                     id = cipherView.id.orEmpty(),
-                    cipherType = CipherType.LOGIN,
+                    type = VaultItemListingState.DisplayItem.ItemType.Vault(
+                        type = CipherType.LOGIN,
+                    ),
                 ),
             )
 
@@ -802,7 +813,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 VaultItemListingsAction.ItemClick(
                     id = cipherView.id.orEmpty(),
-                    cipherType = CipherType.LOGIN,
+                    type = VaultItemListingState.DisplayItem.ItemType.Vault(
+                        type = CipherType.LOGIN,
+                    ),
                 ),
             )
 
@@ -861,7 +874,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(
             VaultItemListingsAction.ItemClick(
                 id = cipherView.id.orEmpty(),
-                cipherType = CipherType.LOGIN,
+                type = VaultItemListingState.DisplayItem.ItemType.Vault(
+                    type = CipherType.LOGIN,
+                ),
             ),
         )
 
@@ -881,7 +896,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         val viewModel = createVaultItemListingViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(
-                VaultItemListingsAction.ItemClick(id = "mock", cipherType = CipherType.LOGIN),
+                VaultItemListingsAction.ItemClick(
+                    id = "mock",
+                    type = VaultItemListingState.DisplayItem.ItemType.Vault(
+                        type = CipherType.LOGIN,
+                    ),
+                ),
             )
             assertEquals(
                 VaultItemListingEvent.NavigateToVaultItem(
@@ -900,7 +920,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         )
         viewModel.eventFlow.test {
             viewModel.trySendAction(
-                VaultItemListingsAction.ItemClick(id = "mock", cipherType = null),
+                VaultItemListingsAction.ItemClick(
+                    id = "mock",
+                    type = VaultItemListingState.DisplayItem.ItemType.Sends(type = SendType.FILE),
+                ),
             )
             assertEquals(VaultItemListingEvent.NavigateToEditSendItem(id = "mock"), awaitItem())
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -78,7 +78,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "LoginCipherIcon",
                 isTotp = isTotp,
-                type = cipherType,
+                itemType = VaultItemListingState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
 
@@ -124,7 +124,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "SecureNoteCipherIcon",
                 isTotp = false,
-                type = cipherType,
+                itemType = VaultItemListingState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
 
@@ -176,7 +176,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "CardCipherIcon",
                 isTotp = false,
-                type = cipherType,
+                itemType = VaultItemListingState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
 
@@ -219,7 +219,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "IdentityCipherIcon",
                 isTotp = false,
-                type = cipherType,
+                itemType = VaultItemListingState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
 
@@ -262,7 +262,7 @@ fun createMockDisplayItemForCipher(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = "SshKeyCipherIcon",
                 isTotp = false,
-                type = cipherType,
+                itemType = VaultItemListingState.DisplayItem.ItemType.Vault(type = cipherType),
             )
         }
     }
@@ -315,7 +315,7 @@ fun createMockDisplayItemForSend(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = null,
                 isTotp = false,
-                type = null,
+                itemType = VaultItemListingState.DisplayItem.ItemType.Sends(type = sendType),
             )
         }
 
@@ -358,7 +358,7 @@ fun createMockDisplayItemForSend(
                 shouldShowMasterPasswordReprompt = false,
                 iconTestTag = null,
                 isTotp = false,
-                type = null,
+                itemType = VaultItemListingState.DisplayItem.ItemType.Sends(type = sendType),
             )
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21610](https://bitwarden.atlassian.net/browse/PM-21610)

## 📔 Objective

This PR updates the `SearchScreen` and `VaultItemListingScreen` to better support the sends types.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21610]: https://bitwarden.atlassian.net/browse/PM-21610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ