### PR TITLE
PM-21631: Update Edit Send Screen to navigate to Vault Unlocked root

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -201,7 +201,10 @@ fun NavGraphBuilder.vaultUnlockedGraph(
             onNavigateBack = { navController.popBackStack() },
         )
 
-        addSendDestination(onNavigateBack = { navController.popBackStack() })
+        addSendDestination(
+            onNavigateBack = { navController.popBackStack() },
+            onNavigateUpToRoot = { navController.navigateToVaultUnlockedRoot() },
+        )
         viewSendDestination(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToEditSend = {
@@ -248,4 +251,8 @@ fun NavGraphBuilder.vaultUnlockedGraph(
             onNavigateBack = { navController.popBackStack() },
         )
     }
+}
+
+private fun NavController.navigateToVaultUnlockedRoot() {
+    this.popBackStack(route = VaultUnlockedNavbarRoute, inclusive = false)
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendNavigation.kt
@@ -60,9 +60,13 @@ private fun SavedStateHandle.toAddSendType(): AddSendType {
  */
 fun NavGraphBuilder.addSendDestination(
     onNavigateBack: () -> Unit,
+    onNavigateUpToRoot: () -> Unit,
 ) {
     composableWithSlideTransitions<AddSendRoute> {
-        AddSendScreen(onNavigateBack = onNavigateBack)
+        AddSendScreen(
+            onNavigateBack = onNavigateBack,
+            onNavigateUpToRoot = onNavigateUpToRoot,
+        )
     }
 }
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreen.kt
@@ -60,6 +60,7 @@ fun AddSendScreen(
     intentManager: IntentManager = LocalIntentManager.current,
     permissionsManager: PermissionsManager = LocalPermissionsManager.current,
     onNavigateBack: () -> Unit,
+    onNavigateUpToRoot: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val addSendHandlers = remember(viewModel) { AddSendHandlers.create(viewModel) }
@@ -83,6 +84,8 @@ fun AddSendScreen(
             AddSendEvent.ExitApp -> exitManager.exitApplication()
 
             is AddSendEvent.NavigateBack -> onNavigateBack()
+
+            is AddSendEvent.NavigateToRoot -> onNavigateUpToRoot()
 
             is AddSendEvent.ShowChooserSheet -> {
                 fileChooserLauncher.launch(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModel.kt
@@ -259,7 +259,7 @@ class AddSendViewModel @Inject constructor(
 
             is DeleteSendResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                navigateBack()
+                navigateBack(isDeleted = true)
                 sendEvent(AddSendEvent.ShowToast(message = R.string.send_deleted.asText()))
             }
         }
@@ -628,11 +628,15 @@ class AddSendViewModel @Inject constructor(
         }
     }
 
-    private fun navigateBack() {
+    private fun navigateBack(isDeleted: Boolean = false) {
         specialCircumstanceManager.specialCircumstance = null
         sendEvent(
             event = if (state.shouldFinishOnComplete) {
                 AddSendEvent.ExitApp
+            } else if (isDeleted) {
+                // We need to make sure we don't land on the View Send screen
+                // since it has now been deleted.
+                AddSendEvent.NavigateToRoot
             } else {
                 AddSendEvent.NavigateBack
             },
@@ -866,6 +870,11 @@ sealed class AddSendEvent {
      * Navigate back.
      */
     data object NavigateBack : AddSendEvent()
+
+    /**
+     * Navigate up to the root.
+     */
+    data object NavigateToRoot : AddSendEvent()
 
     /**
      * Show file chooser sheet.

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextInput
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
-import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.bitwarden.ui.util.asText
+import com.x8bit.bitwarden.ui.platform.base.BaseComposeTest
 import com.x8bit.bitwarden.ui.platform.manager.exit.ExitManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.FakePermissionManager
@@ -41,6 +41,7 @@ import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.time.ZonedDateTime
@@ -49,6 +50,7 @@ import java.time.ZonedDateTime
 class AddSendScreenTest : BaseComposeTest() {
 
     private var onNavigateBackCalled = false
+    private var onNavigateUpToRootCalled = false
 
     private val exitManager: ExitManager = mockk(relaxed = true) {
         every { exitApplication() } just runs
@@ -74,6 +76,7 @@ class AddSendScreenTest : BaseComposeTest() {
             AddSendScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
+                onNavigateUpToRoot = { onNavigateUpToRootCalled = true },
             )
         }
     }
@@ -81,7 +84,13 @@ class AddSendScreenTest : BaseComposeTest() {
     @Test
     fun `on NavigateBack should call onNavigateBack`() {
         mutableEventFlow.tryEmit(AddSendEvent.NavigateBack)
-        assert(onNavigateBackCalled)
+        assertTrue(onNavigateBackCalled)
+    }
+
+    @Test
+    fun `on NavigateToRoot should call onNavigateUpToRoot`() {
+        mutableEventFlow.tryEmit(AddSendEvent.NavigateToRoot)
+        assertTrue(onNavigateUpToRootCalled)
     }
 
     @Test

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendViewModelTest.kt
@@ -667,7 +667,7 @@ class AddSendViewModelTest : BaseViewModelTest() {
 
         viewModel.eventFlow.test {
             viewModel.trySendAction(AddSendAction.DeleteClick)
-            assertEquals(AddSendEvent.NavigateBack, awaitItem())
+            assertEquals(AddSendEvent.NavigateToRoot, awaitItem())
             assertEquals(AddSendEvent.ShowToast(R.string.send_deleted.asText()), awaitItem())
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21631](https://bitwarden.atlassian.net/browse/PM-21631)

## 📔 Objective

This PR updates the `AddSendScreen` to navigate to the Vault Unlocked root after deleting the send. This is to ensure we do not land the user on the `ViewSendScreen` for the send they just deleted.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/c92297b4-8753-4db9-9969-45cb8d84d649" width="300" /> | <video src="https://github.com/user-attachments/assets/41249216-04d1-4b86-8ef2-29ef5a416ca5" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21631]: https://bitwarden.atlassian.net/browse/PM-21631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ