### PR TITLE
PM-21080: Remove the isRemotelyConfigured flag

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerImpl.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerImpl.kt
@@ -61,7 +61,6 @@ class FeatureFlagManagerImpl(
  */
 fun <T : Any> ServerConfig?.getFlagValueOrDefault(key: FlagKey<T>): T {
     val defaultValue = key.defaultValue
-    if (!key.isRemotelyConfigured) return key.defaultValue
     return this
         ?.serverData
         ?.featureStates
@@ -76,9 +75,9 @@ fun <T : Any> ServerConfig?.getFlagValueOrDefault(key: FlagKey<T>): T {
                     Int::class -> it.content.toInt() as T
                     else -> defaultValue
                 }
-            } catch (ex: ClassCastException) {
+            } catch (_: ClassCastException) {
                 defaultValue
-            } catch (ex: NumberFormatException) {
+            } catch (_: NumberFormatException) {
                 defaultValue
             }
         }

--- a/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -14,11 +14,6 @@ sealed class FlagKey<out T : Any> {
      */
     abstract val defaultValue: T
 
-    /**
-     * Indicates if the flag should respect the network value or not.
-     */
-    abstract val isRemotelyConfigured: Boolean
-
     @Suppress("UndocumentedPublicClass")
     companion object {
         /**
@@ -53,7 +48,6 @@ sealed class FlagKey<out T : Any> {
     data object AuthenticatorSync : FlagKey<Boolean>() {
         override val keyName: String = "enable-pm-bwa-sync"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -62,7 +56,6 @@ sealed class FlagKey<out T : Any> {
     data object EmailVerification : FlagKey<Boolean>() {
         override val keyName: String = "email-verification"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -71,7 +64,6 @@ sealed class FlagKey<out T : Any> {
     data object MobileErrorReporting : FlagKey<Boolean>() {
         override val keyName: String = "mobile-error-reporting"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -80,7 +72,6 @@ sealed class FlagKey<out T : Any> {
     data object FlightRecorder : FlagKey<Boolean>() {
         override val keyName: String = "enable-pm-flight-recorder"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
     }
 
     /**
@@ -89,7 +80,6 @@ sealed class FlagKey<out T : Any> {
     data object OnboardingFlow : FlagKey<Boolean>() {
         override val keyName: String = "native-create-account-flow"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -98,7 +88,6 @@ sealed class FlagKey<out T : Any> {
     data object ImportLoginsFlow : FlagKey<Boolean>() {
         override val keyName: String = "import-logins-flow"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -107,7 +96,6 @@ sealed class FlagKey<out T : Any> {
     data object VerifiedSsoDomainEndpoint : FlagKey<Boolean>() {
         override val keyName: String = "pm-12337-refactor-sso-details-endpoint"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -117,7 +105,6 @@ sealed class FlagKey<out T : Any> {
     data object CredentialExchangeProtocolImport : FlagKey<Boolean>() {
         override val keyName: String = "cxp-import-mobile"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -127,7 +114,6 @@ sealed class FlagKey<out T : Any> {
     data object CredentialExchangeProtocolExport : FlagKey<Boolean>() {
         override val keyName: String = "cxp-export-mobile"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -136,7 +122,6 @@ sealed class FlagKey<out T : Any> {
     data object CipherKeyEncryption : FlagKey<Boolean>() {
         override val keyName: String = "cipher-key-encryption"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -145,7 +130,6 @@ sealed class FlagKey<out T : Any> {
     data object MutualTls : FlagKey<Boolean>() {
         override val keyName: String = "mutual-tls"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -154,7 +138,6 @@ sealed class FlagKey<out T : Any> {
     data object SingleTapPasskeyCreation : FlagKey<Boolean>() {
         override val keyName: String = "single-tap-passkey-creation"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -163,7 +146,6 @@ sealed class FlagKey<out T : Any> {
     data object SingleTapPasskeyAuthentication : FlagKey<Boolean>() {
         override val keyName: String = "single-tap-passkey-authentication"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -173,7 +155,6 @@ sealed class FlagKey<out T : Any> {
     data object AnonAddySelfHostAlias : FlagKey<Boolean>() {
         override val keyName: String = "anon-addy-self-host-alias"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -182,7 +163,6 @@ sealed class FlagKey<out T : Any> {
     data object SimpleLoginSelfHostAlias : FlagKey<Boolean>() {
         override val keyName: String = "simple-login-self-host-alias"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -192,7 +172,6 @@ sealed class FlagKey<out T : Any> {
     data object ChromeAutofill : FlagKey<Boolean>() {
         override val keyName: String = "android-chrome-autofill"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -201,7 +180,6 @@ sealed class FlagKey<out T : Any> {
     data object RestrictCipherItemDeletion : FlagKey<Boolean>() {
         override val keyName: String = "pm-15493-restrict-item-deletion-to-can-manage-permission"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -210,7 +188,6 @@ sealed class FlagKey<out T : Any> {
     data object PreAuthSettings : FlagKey<Boolean>() {
         override val keyName: String = "enable-pm-prelogin-settings"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
     }
 
     //region Dummy keys for testing
@@ -220,15 +197,12 @@ sealed class FlagKey<out T : Any> {
     data object DummyBoolean : FlagKey<Boolean>() {
         override val keyName: String = "dummy-boolean"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
      * Data object holding the key for an [Int] flag to be used in tests.
      */
-    data class DummyInt(
-        override val isRemotelyConfigured: Boolean = true,
-    ) : FlagKey<Int>() {
+    data object DummyInt : FlagKey<Int>() {
         override val keyName: String = "dummy-int"
         override val defaultValue: Int = Int.MIN_VALUE
     }
@@ -239,7 +213,6 @@ sealed class FlagKey<out T : Any> {
     data object DummyString : FlagKey<String>() {
         override val keyName: String = "dummy-string"
         override val defaultValue: String = "defaultValue"
-        override val isRemotelyConfigured: Boolean = true
     }
     //endregion Dummy keys for testing
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/FeatureFlagOverrideDiskSourceTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/datasource/disk/FeatureFlagOverrideDiskSourceTest.kt
@@ -81,7 +81,7 @@ class FeatureFlagOverrideDiskSourceTest {
 
     @Test
     fun `call to save feature flag should update SharedPreferences for ints`() {
-        val key = FlagKey.DummyInt()
+        val key = FlagKey.DummyInt
         assertEquals(
             fakeSharedPreferences.getInt(
                 "$BASE_STORAGE_PREFIX${key.keyName}",
@@ -102,7 +102,7 @@ class FeatureFlagOverrideDiskSourceTest {
 
     @Test
     fun `call to get feature flag should return correct value for ints`() {
-        val key = FlagKey.DummyInt()
+        val key = FlagKey.DummyInt
         assertNull(featureFlagOverrideDiskSource.getFeatureFlag(key))
         val expectedValue = 1
         fakeSharedPreferences.edit {

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
@@ -147,7 +147,7 @@ class FeatureFlagManagerTest {
         )
 
         val flagValue = manager.getFeatureFlag(
-            key = FlagKey.DummyInt(),
+            key = FlagKey.DummyInt,
             forceRefresh = false,
         )
 
@@ -168,7 +168,7 @@ class FeatureFlagManagerTest {
         )
 
         val flagValue = manager.getFeatureFlag(
-            key = FlagKey.DummyInt(),
+            key = FlagKey.DummyInt,
             forceRefresh = false,
         )
 
@@ -240,22 +240,7 @@ class FeatureFlagManagerTest {
         fakeServerConfigRepository.serverConfigValue = null
 
         val flagValue = manager.getFeatureFlag(
-            key = FlagKey.DummyInt(),
-            forceRefresh = false,
-        )
-
-        assertEquals(
-            Int.MIN_VALUE,
-            flagValue,
-        )
-    }
-
-    @Test
-    fun `getFeatureFlag Int should return default value when not remotely controlled`() = runTest {
-        fakeServerConfigRepository.serverConfigValue = null
-
-        val flagValue = manager.getFeatureFlag(
-            key = FlagKey.DummyInt(isRemotelyConfigured = false),
+            key = FlagKey.DummyInt,
             forceRefresh = false,
         )
 
@@ -288,7 +273,7 @@ class FeatureFlagManagerTest {
             ),
         )
 
-        val flagValue = manager.getFeatureFlag(key = FlagKey.DummyInt())
+        val flagValue = manager.getFeatureFlag(key = FlagKey.DummyInt)
 
         assertEquals(Int.MIN_VALUE, flagValue)
     }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -105,39 +105,4 @@ class FlagKeyTest {
             },
         )
     }
-
-    @Test
-    fun `All feature flags are correctly set to be remotely configured`() {
-        assertTrue(
-            listOf(
-                FlagKey.AuthenticatorSync,
-                FlagKey.EmailVerification,
-                FlagKey.OnboardingFlow,
-                FlagKey.ImportLoginsFlow,
-                FlagKey.VerifiedSsoDomainEndpoint,
-                FlagKey.CredentialExchangeProtocolImport,
-                FlagKey.CredentialExchangeProtocolExport,
-                FlagKey.CipherKeyEncryption,
-                FlagKey.SingleTapPasskeyCreation,
-                FlagKey.SingleTapPasskeyAuthentication,
-                FlagKey.MutualTls,
-                FlagKey.AnonAddySelfHostAlias,
-                FlagKey.SimpleLoginSelfHostAlias,
-                FlagKey.ChromeAutofill,
-                FlagKey.MobileErrorReporting,
-                FlagKey.RestrictCipherItemDeletion,
-            ).all {
-                it.isRemotelyConfigured
-            },
-        )
-
-        assertTrue(
-            listOf(
-                FlagKey.FlightRecorder,
-                FlagKey.PreAuthSettings,
-            ).all {
-                !it.isRemotelyConfigured
-            },
-        )
-    }
 }

--- a/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.data.platform.repository
 import app.cash.turbine.test
 import com.bitwarden.data.datasource.disk.model.ServerConfig
 import com.bitwarden.data.repository.ServerConfigRepository
-import com.bitwarden.network.model.ConfigResponseJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
@@ -17,7 +16,6 @@ import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -27,7 +25,7 @@ class DebugMenuRepositoryTest {
     private val mockFeatureFlagOverrideDiskSource = mockk<FeatureFlagOverrideDiskSource> {
         every { getFeatureFlag(FlagKey.DummyBoolean) } returns true
         every { getFeatureFlag(FlagKey.DummyString) } returns TEST_STRING_VALUE
-        every { getFeatureFlag(FlagKey.DummyInt()) } returns TEST_INT_VALUE
+        every { getFeatureFlag(FlagKey.DummyInt) } returns TEST_INT_VALUE
         every { saveFeatureFlag(any(), any()) } just runs
     }
     private val mutableServerConfigStateFlow = MutableStateFlow<ServerConfig?>(null)
@@ -80,12 +78,12 @@ class DebugMenuRepositoryTest {
 
     @Test
     fun `getFeatureFlag should return the feature flag string value from disk`() {
-        assertEquals(TEST_STRING_VALUE, debugMenuRepository.getFeatureFlag(FlagKey.DummyString)!!)
+        assertEquals(TEST_STRING_VALUE, debugMenuRepository.getFeatureFlag(FlagKey.DummyString))
     }
 
     @Test
     fun `getFeatureFlag should return the feature flag int value from disk`() {
-        assertEquals(TEST_INT_VALUE, debugMenuRepository.getFeatureFlag(FlagKey.DummyInt())!!)
+        assertEquals(TEST_INT_VALUE, debugMenuRepository.getFeatureFlag(FlagKey.DummyInt))
     }
 
     @Test
@@ -113,39 +111,6 @@ class DebugMenuRepositoryTest {
                 awaitItem() // initial value on subscription
                 awaitItem()
                 expectNoEvents()
-            }
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `resetFeatureFlagOverrides should save all feature flags to values from the server config if remote configured is on`() =
-        runTest {
-            val mockServerData = mockk<ConfigResponseJson>(relaxed = true) {
-                every { featureStates } returns mapOf(
-                    FlagKey.EmailVerification.keyName to JsonPrimitive(true),
-                    FlagKey.OnboardingFlow.keyName to JsonPrimitive(true),
-                )
-            }
-            val mockServerConfig = mockk<ServerConfig>(relaxed = true) {
-                every { serverData } returns mockServerData
-            }
-            mutableServerConfigStateFlow.value = mockServerConfig
-
-            debugMenuRepository.resetFeatureFlagOverrides()
-
-            assertTrue(FlagKey.EmailVerification.isRemotelyConfigured)
-            verify(exactly = 1) {
-                mockFeatureFlagOverrideDiskSource.saveFeatureFlag(FlagKey.EmailVerification, true)
-                mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
-                    FlagKey.OnboardingFlow,
-                    true,
-                )
-            }
-
-            debugMenuRepository.featureFlagOverridesUpdatedFlow.test {
-                awaitItem() // initial value on subscription
-                awaitItem()
-                cancel()
             }
         }
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerImpl.kt
@@ -41,7 +41,6 @@ class FeatureFlagManagerImpl(
  */
 fun <T : Any> ServerConfig?.getFlagValueOrDefault(key: FlagKey<T>): T {
     val defaultValue = key.defaultValue
-    if (!key.isRemotelyConfigured) return key.defaultValue
     return this
         ?.serverData
         ?.featureStates
@@ -56,9 +55,9 @@ fun <T : Any> ServerConfig?.getFlagValueOrDefault(key: FlagKey<T>): T {
                     Int::class -> it.content.toInt() as T
                     else -> defaultValue
                 }
-            } catch (ex: ClassCastException) {
+            } catch (_: ClassCastException) {
                 defaultValue
-            } catch (ex: NumberFormatException) {
+            } catch (_: NumberFormatException) {
                 defaultValue
             }
         }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/model/FlagKey.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/model/FlagKey.kt
@@ -14,11 +14,6 @@ sealed class FlagKey<out T : Any> {
      */
     abstract val defaultValue: T
 
-    /**
-     * Indicates if the flag should respect the network value or not.
-     */
-    abstract val isRemotelyConfigured: Boolean
-
     @Suppress("UndocumentedPublicClass")
     companion object {
         /**
@@ -38,7 +33,6 @@ sealed class FlagKey<out T : Any> {
     data object BitwardenAuthenticationEnabled : FlagKey<Boolean>() {
         override val keyName: String = "bitwarden-authentication-enabled"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = false
     }
 
     /**
@@ -47,7 +41,6 @@ sealed class FlagKey<out T : Any> {
     data object PasswordManagerSync : FlagKey<Boolean>() {
         override val keyName: String = "enable-pm-bwa-sync"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
@@ -56,15 +49,12 @@ sealed class FlagKey<out T : Any> {
     data object DummyBoolean : FlagKey<Boolean>() {
         override val keyName: String = "dummy-boolean"
         override val defaultValue: Boolean = false
-        override val isRemotelyConfigured: Boolean = true
     }
 
     /**
      * Data object holding the key for an [Int] flag to be used in tests.
      */
-    data class DummyInt(
-        override val isRemotelyConfigured: Boolean = true,
-    ) : FlagKey<Int>() {
+    data object DummyInt : FlagKey<Int>() {
         override val keyName: String = "dummy-int"
         override val defaultValue: Int = Int.MIN_VALUE
     }
@@ -75,6 +65,5 @@ sealed class FlagKey<out T : Any> {
     data object DummyString : FlagKey<String>() {
         override val keyName: String = "dummy-string"
         override val defaultValue: String = "defaultValue"
-        override val isRemotelyConfigured: Boolean = true
     }
 }

--- a/authenticator/src/test/java/com/bitwarden/authenticator/data/platform/datasource/disk/FeatureFlagOverrideDiskSourceTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/data/platform/datasource/disk/FeatureFlagOverrideDiskSourceTest.kt
@@ -81,7 +81,7 @@ class FeatureFlagOverrideDiskSourceTest {
 
     @Test
     fun `call to save feature flag should update SharedPreferences for ints`() {
-        val key = FlagKey.DummyInt()
+        val key = FlagKey.DummyInt
         assertEquals(
             fakeSharedPreferences.getInt(
                 "$BASE_STORAGE_PREFIX${key.keyName}",
@@ -102,7 +102,7 @@ class FeatureFlagOverrideDiskSourceTest {
 
     @Test
     fun `call to get feature flag should return correct value for ints`() {
-        val key = FlagKey.DummyInt()
+        val key = FlagKey.DummyInt
         assertNull(featureFlagOverrideDiskSource.getFeatureFlag(key))
         val expectedValue = 1
         fakeSharedPreferences.edit {

--- a/authenticator/src/test/java/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
@@ -90,7 +90,7 @@ class FeatureFlagManagerTest {
         )
 
         val flagValue = manager.getFeatureFlag(
-            key = FlagKey.DummyInt(),
+            key = FlagKey.DummyInt,
             forceRefresh = false,
         )
 
@@ -111,7 +111,7 @@ class FeatureFlagManagerTest {
         )
 
         val flagValue = manager.getFeatureFlag(
-            key = FlagKey.DummyInt(),
+            key = FlagKey.DummyInt,
             forceRefresh = false,
         )
 
@@ -183,22 +183,7 @@ class FeatureFlagManagerTest {
         fakeServerConfigRepository.serverConfigValue = null
 
         val flagValue = manager.getFeatureFlag(
-            key = FlagKey.DummyInt(),
-            forceRefresh = false,
-        )
-
-        assertEquals(
-            Int.MIN_VALUE,
-            flagValue,
-        )
-    }
-
-    @Test
-    fun `getFeatureFlag Int should return default value when not remotely controlled`() = runTest {
-        fakeServerConfigRepository.serverConfigValue = null
-
-        val flagValue = manager.getFeatureFlag(
-            key = FlagKey.DummyInt(isRemotelyConfigured = false),
+            key = FlagKey.DummyInt,
             forceRefresh = false,
         )
 
@@ -231,7 +216,7 @@ class FeatureFlagManagerTest {
             ),
         )
 
-        val flagValue = manager.getFeatureFlag(key = FlagKey.DummyInt())
+        val flagValue = manager.getFeatureFlag(key = FlagKey.DummyInt)
 
         assertEquals(Int.MIN_VALUE, flagValue)
     }

--- a/authenticator/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
@@ -2,7 +2,6 @@ package com.bitwarden.authenticator.data.platform.manager
 
 import com.bitwarden.authenticator.data.platform.manager.model.FlagKey
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -29,11 +28,5 @@ class FlagKeyTest {
                 !it.defaultValue
             },
         )
-    }
-
-    @Test
-    fun `All feature flags are correctly set to be remotely configured`() {
-        assertTrue(FlagKey.PasswordManagerSync.isRemotelyConfigured)
-        assertFalse(FlagKey.BitwardenAuthenticationEnabled.isRemotelyConfigured)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21080](https://bitwarden.atlassian.net/browse/PM-21080)

## 📔 Objective

This PR removes the `isRemotelyConfigured` flag from the app, since we are moving to a version based system for this functionality.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21080]: https://bitwarden.atlassian.net/browse/PM-21080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ