### PR TITLE
PM-21445: Update the Send delete buttons

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendContent.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendContent.kt
@@ -2,10 +2,10 @@ package com.x8bit.bitwarden.ui.tools.feature.send.addsend
 
 import android.Manifest
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -38,7 +38,9 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.base.util.cardStyle
 import com.x8bit.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
+import com.x8bit.bitwarden.ui.platform.components.button.BitwardenOutlinedErrorButton
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
+import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.divider.BitwardenHorizontalDivider
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
@@ -46,6 +48,7 @@ import com.x8bit.bitwarden.ui.platform.components.header.BitwardenExpandingHeade
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.x8bit.bitwarden.ui.platform.components.stepper.BitwardenStepper
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
+import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
 import com.x8bit.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.ui.tools.feature.send.addsend.handlers.AddSendHandlers
@@ -185,9 +188,47 @@ fun AddSendContent(
             isAddMode = isAddMode,
             addSendHandlers = addSendHandlers,
         )
+
+        if (!isAddMode) {
+            DeleteButton(
+                onDeleteClick = addSendHandlers.onDeleteClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+        }
+
         Spacer(modifier = Modifier.height(height = 12.dp))
         Spacer(modifier = Modifier.navigationBarsPadding())
     }
+}
+
+@Composable
+private fun DeleteButton(
+    onDeleteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var shouldShowDeleteConfirmationDialog by rememberSaveable { mutableStateOf(value = false) }
+    if (shouldShowDeleteConfirmationDialog) {
+        BitwardenTwoButtonDialog(
+            title = stringResource(id = R.string.delete),
+            message = stringResource(id = R.string.are_you_sure_delete_send),
+            confirmButtonText = stringResource(id = R.string.yes),
+            dismissButtonText = stringResource(id = R.string.cancel),
+            onConfirmClick = {
+                onDeleteClick()
+                shouldShowDeleteConfirmationDialog = false
+            },
+            onDismissClick = { shouldShowDeleteConfirmationDialog = false },
+            onDismissRequest = { shouldShowDeleteConfirmationDialog = false },
+        )
+    }
+    BitwardenOutlinedErrorButton(
+        label = stringResource(id = R.string.delete_send),
+        onClick = { shouldShowDeleteConfirmationDialog = true },
+        icon = rememberVectorPainter(id = R.drawable.ic_trash_small),
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -357,11 +398,10 @@ private fun AddSendOptions(
             .standardHorizontalMargin()
             .fillMaxWidth(),
     )
-    // Hide all content if not expanded:
     AnimatedVisibility(
         visible = isExpanded,
-        enter = fadeIn() + slideInVertically(),
-        exit = fadeOut() + slideOutVertically(),
+        enter = fadeIn() + expandVertically(expandFrom = Alignment.Top),
+        exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top),
         modifier = Modifier.clipToBounds(),
     ) {
         Column {
@@ -434,6 +474,7 @@ private fun AddSendOptions(
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
             )
+            Spacer(modifier = Modifier.height(height = 16.dp))
         }
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreen.kt
@@ -9,10 +9,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
@@ -32,7 +29,6 @@ import com.x8bit.bitwarden.ui.platform.components.content.BitwardenErrorContent
 import com.x8bit.bitwarden.ui.platform.components.content.BitwardenLoadingContent
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
-import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.model.TopAppBarDividerStyle
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.segment.BitwardenSegmentedButton
@@ -109,24 +105,6 @@ fun AddSendScreen(
             { viewModel.trySendAction(AddSendAction.DismissDialogClick) }
         },
     )
-    var shouldShowDeleteConfirmationDialog by rememberSaveable { mutableStateOf(false) }
-    if (shouldShowDeleteConfirmationDialog) {
-        BitwardenTwoButtonDialog(
-            title = stringResource(id = R.string.delete),
-            message = stringResource(id = R.string.are_you_sure_delete_send),
-            confirmButtonText = stringResource(id = R.string.yes),
-            dismissButtonText = stringResource(id = R.string.cancel),
-            onConfirmClick = remember(viewModel) {
-                {
-                    viewModel.trySendAction(AddSendAction.DeleteClick)
-                    shouldShowDeleteConfirmationDialog = false
-                }
-            },
-            onDismissClick = { shouldShowDeleteConfirmationDialog = false },
-            onDismissRequest = { shouldShowDeleteConfirmationDialog = false },
-        )
-    }
-
     BitwardenScaffold(
         modifier = Modifier
             .fillMaxSize()
@@ -181,10 +159,6 @@ fun AddSendScreen(
                                     },
                                 )
                                     .takeIf { !state.policyDisablesSend },
-                                OverflowMenuItemData(
-                                    text = stringResource(id = R.string.delete),
-                                    onClick = { shouldShowDeleteConfirmationDialog = true },
-                                ),
                             ),
                         )
                     }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/handlers/AddSendHandlers.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/handlers/AddSendHandlers.kt
@@ -23,6 +23,7 @@ data class AddSendHandlers(
     val onHideEmailToggle: (Boolean) -> Unit,
     val onDeactivateSendToggle: (Boolean) -> Unit,
     val onDeletionDateChange: (ZonedDateTime) -> Unit,
+    val onDeleteClick: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -57,6 +58,7 @@ data class AddSendHandlers(
                 onDeletionDateChange = {
                     viewModel.trySendAction(AddSendAction.DeletionDateChange(it))
                 },
+                onDeleteClick = { viewModel.trySendAction(AddSendAction.DeleteClick) },
             )
     }
 }

--- a/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -58,6 +58,7 @@ import com.x8bit.bitwarden.ui.platform.components.content.BitwardenErrorContent
 import com.x8bit.bitwarden.ui.platform.components.content.BitwardenLoadingContent
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
+import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.fab.BitwardenFloatingActionButton
 import com.x8bit.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenExpandingHeader
@@ -306,10 +307,8 @@ private fun ViewStateContent(
 
         AdditionalOptions(state = state)
 
-        BitwardenOutlinedErrorButton(
-            label = stringResource(id = R.string.delete_send),
-            onClick = onDeleteClick,
-            icon = rememberVectorPainter(id = R.drawable.ic_trash_small),
+        DeleteButton(
+            onDeleteClick = onDeleteClick,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
@@ -317,6 +316,34 @@ private fun ViewStateContent(
         Spacer(modifier = Modifier.height(height = 88.dp))
         Spacer(modifier = Modifier.navigationBarsPadding())
     }
+}
+
+@Composable
+private fun DeleteButton(
+    onDeleteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var shouldShowDeleteConfirmationDialog by rememberSaveable { mutableStateOf(value = false) }
+    if (shouldShowDeleteConfirmationDialog) {
+        BitwardenTwoButtonDialog(
+            title = stringResource(id = R.string.delete),
+            message = stringResource(id = R.string.are_you_sure_delete_send),
+            confirmButtonText = stringResource(id = R.string.yes),
+            dismissButtonText = stringResource(id = R.string.cancel),
+            onConfirmClick = {
+                onDeleteClick()
+                shouldShowDeleteConfirmationDialog = false
+            },
+            onDismissClick = { shouldShowDeleteConfirmationDialog = false },
+            onDismissRequest = { shouldShowDeleteConfirmationDialog = false },
+        )
+    }
+    BitwardenOutlinedErrorButton(
+        label = stringResource(id = R.string.delete_send),
+        onClick = { shouldShowDeleteConfirmationDialog = true },
+        icon = rememberVectorPainter(id = R.drawable.ic_trash_small),
+        modifier = modifier,
+    )
 }
 
 /**

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/addsend/AddSendScreenTest.kt
@@ -162,14 +162,10 @@ class AddSendScreenTest : BaseComposeTest() {
             .onNodeWithText("Share link")
             .assert(hasAnyAncestor(isPopup()))
             .isDisplayed()
-        composeTestRule
-            .onNodeWithText("Delete")
-            .assert(hasAnyAncestor(isPopup()))
-            .isDisplayed()
     }
 
     @Test
-    fun `on overflow button click should only display delete when policy disables send`() {
+    fun `on overflow button should not be present when policy disables send`() {
         mutableStateFlow.value = DEFAULT_STATE.copy(
             addSendType = AddSendType.EditItem(sendItemId = "sendId"),
             policyDisablesSend = true,
@@ -177,21 +173,7 @@ class AddSendScreenTest : BaseComposeTest() {
 
         composeTestRule
             .onNodeWithContentDescription("More")
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText("Remove password")
             .assertDoesNotExist()
-        composeTestRule
-            .onNodeWithText("Copy link")
-            .assertDoesNotExist()
-        composeTestRule
-            .onNodeWithText("Share link")
-            .assertDoesNotExist()
-        composeTestRule
-            .onNodeWithText("Delete")
-            .assert(hasAnyAncestor(isPopup()))
-            .isDisplayed()
     }
 
     @Test
@@ -251,50 +233,6 @@ class AddSendScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `on overflow Delete button click should Display delete confirmation dialog`() {
-        mutableStateFlow.value = DEFAULT_STATE.copy(
-            addSendType = AddSendType.EditItem(sendItemId = "sendId"),
-        )
-
-        composeTestRule
-            .onNodeWithContentDescription("More")
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText("Delete")
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText("Are you sure you want to delete this Send?")
-            .assert(hasAnyAncestor(isDialog()))
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun `on delete confirmation dialog yes click should send DeleteClick`() {
-        mutableStateFlow.value = DEFAULT_STATE.copy(
-            addSendType = AddSendType.EditItem(sendItemId = "sendId"),
-        )
-
-        composeTestRule
-            .onNodeWithContentDescription("More")
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText("Delete")
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText("Yes")
-            .assert(hasAnyAncestor(isDialog()))
-            .performClick()
-
-        verify(exactly = 1) {
-            viewModel.trySendAction(AddSendAction.DeleteClick)
-        }
-    }
-
-    @Test
     fun `on overflow remove Copy link button click should send CopyLinkClick`() {
         mutableStateFlow.value = DEFAULT_STATE.copy(
             addSendType = AddSendType.EditItem(sendItemId = "sendId"),
@@ -310,6 +248,44 @@ class AddSendScreenTest : BaseComposeTest() {
 
         verify(exactly = 1) {
             viewModel.trySendAction(AddSendAction.CopyLinkClick)
+        }
+    }
+
+    @Test
+    fun `on Delete button click should Display delete confirmation dialog`() {
+        mutableStateFlow.value = DEFAULT_STATE.copy(
+            addSendType = AddSendType.EditItem(sendItemId = "sendId"),
+        )
+
+        composeTestRule
+            .onNodeWithText(text = "Delete send")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(text = "Are you sure you want to delete this Send?")
+            .assert(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `on delete confirmation dialog yes click should send DeleteClick`() {
+        mutableStateFlow.value = DEFAULT_STATE.copy(
+            addSendType = AddSendType.EditItem(sendItemId = "sendId"),
+        )
+
+        composeTestRule
+            .onNodeWithText(text = "Delete send")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(text = "Yes")
+            .assert(hasAnyAncestor(isDialog()))
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(AddSendAction.DeleteClick)
         }
     }
 

--- a/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
@@ -125,11 +125,30 @@ class ViewSendScreenTest : BaseComposeTest() {
     }
 
     @Test
-    fun `on delete click should send DeleteClick`() {
+    fun `on Delete button click should Display delete confirmation dialog`() {
         composeTestRule
             .onNodeWithText(text = "Delete send")
             .performScrollTo()
             .performClick()
+
+        composeTestRule
+            .onNodeWithText(text = "Are you sure you want to delete this Send?")
+            .assert(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `oon delete confirmation dialog yes click should send DeleteClick`() {
+        composeTestRule
+            .onNodeWithText(text = "Delete send")
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText(text = "Yes")
+            .assert(hasAnyAncestor(isDialog()))
+            .performClick()
+
         verify(exactly = 1) {
             viewModel.trySendAction(ViewSendAction.DeleteClick)
         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21445](https://bitwarden.atlassian.net/browse/PM-21445)

## 📔 Objective

This PR updates the Send delete buttons in the `ViewSendScreen` and `AddSendScreen`.

* The `ViewSendScreen` is getting a confirmation dialog added.
* The `AddSendScreen` is having the button moved to the bottom of the content instead of the overflow menu.

## 📸 Screenshots

| Edit | View |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/dc701d08-9638-4598-8e50-13a5e9a7c093" width="300" /> | <video src="https://github.com/user-attachments/assets/817c08fd-708a-4d2a-bacd-f2a7380b0ef9" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21445]: https://bitwarden.atlassian.net/browse/PM-21445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ