### PR TITLE
[PM-21676] Relocate Authenticator local manager providers

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/MainActivity.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.bitwarden.authenticator.data.platform.util.isSuspicious
+import com.bitwarden.authenticator.ui.platform.composition.LocalManagerProvider
 import com.bitwarden.authenticator.ui.platform.feature.debugmenu.manager.DebugMenuLaunchManager
 import com.bitwarden.authenticator.ui.platform.feature.debugmenu.navigateToDebugMenuScreen
 import com.bitwarden.authenticator.ui.platform.feature.rootnav.RootNavScreen
@@ -53,14 +54,16 @@ class MainActivity : AppCompatActivity() {
             val state by mainViewModel.stateFlow.collectAsStateWithLifecycle()
             val navController = rememberNavController()
             observeViewModelEvents(navController)
-            AuthenticatorTheme(
-                theme = state.theme,
-            ) {
-                RootNavScreen(
-                    navController = navController,
-                    onSplashScreenRemoved = { shouldShowSplashScreen = false },
-                    onExitApplication = { finishAffinity() },
-                )
+            LocalManagerProvider {
+                AuthenticatorTheme(
+                    theme = state.theme,
+                ) {
+                    RootNavScreen(
+                        navController = navController,
+                        onSplashScreenRemoved = { shouldShowSplashScreen = false },
+                        onExitApplication = { finishAffinity() },
+                    )
+                }
             }
         }
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
@@ -34,8 +34,8 @@ import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenBasicD
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.bitwarden.authenticator.ui.platform.components.dialog.LoadingDialogState
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.authenticator.ui.platform.composition.LocalBiometricsManager
 import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
-import com.bitwarden.authenticator.ui.platform.theme.LocalBiometricsManager
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.util.asText
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -70,10 +70,10 @@ import com.bitwarden.authenticator.ui.platform.components.header.BitwardenListHe
 import com.bitwarden.authenticator.ui.platform.components.model.IconResource
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.authenticator.ui.platform.components.util.rememberVectorPainter
+import com.bitwarden.authenticator.ui.platform.composition.LocalIntentManager
+import com.bitwarden.authenticator.ui.platform.composition.LocalPermissionsManager
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManager
-import com.bitwarden.authenticator.ui.platform.theme.LocalIntentManager
-import com.bitwarden.authenticator.ui.platform.theme.LocalPermissionsManager
 import com.bitwarden.authenticator.ui.platform.theme.Typography
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -44,10 +44,10 @@ import com.bitwarden.authenticator.ui.platform.components.dialog.LoadingDialogSt
 import com.bitwarden.authenticator.ui.platform.components.field.BitwardenPasswordField
 import com.bitwarden.authenticator.ui.platform.components.field.BitwardenTextField
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.authenticator.ui.platform.composition.LocalIntentManager
+import com.bitwarden.authenticator.ui.platform.composition.LocalPermissionsManager
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManager
-import com.bitwarden.authenticator.ui.platform.theme.LocalIntentManager
-import com.bitwarden.authenticator.ui.platform.theme.LocalPermissionsManager
 import com.bitwarden.ui.platform.base.util.EventsEffect
 
 /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/composition/LocalManagerProvider.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/composition/LocalManagerProvider.kt
@@ -1,0 +1,65 @@
+@file:OmitFromCoverage
+
+package com.bitwarden.authenticator.ui.platform.composition
+
+import android.app.Activity
+import androidx.activity.compose.LocalActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocal
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
+import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManagerImpl
+import com.bitwarden.authenticator.ui.platform.manager.exit.ExitManager
+import com.bitwarden.authenticator.ui.platform.manager.exit.ExitManagerImpl
+import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
+import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManagerImpl
+import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManager
+import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManagerImpl
+import com.bitwarden.core.annotation.OmitFromCoverage
+
+/**
+ * Helper [Composable] that wraps a [content] and provides manager classes via [CompositionLocal].
+ */
+@Composable
+fun LocalManagerProvider(
+    activity: Activity = requireNotNull(LocalActivity.current),
+    content: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(
+        LocalPermissionsManager provides PermissionsManagerImpl(activity),
+        LocalIntentManager provides IntentManagerImpl(activity),
+        LocalExitManager provides ExitManagerImpl(activity),
+        LocalBiometricsManager provides BiometricsManagerImpl(activity),
+        content = content,
+    )
+}
+
+/**
+ * Provides access to the intent manager throughout the app.
+ */
+val LocalIntentManager: ProvidableCompositionLocal<IntentManager> = compositionLocalOf {
+    error("CompositionLocal LocalIntentManager not present")
+}
+
+/**
+ * Provides access to the biometrics manager throughout the app.
+ */
+val LocalBiometricsManager: ProvidableCompositionLocal<BiometricsManager> = compositionLocalOf {
+    error("CompositionLocal BiometricsManager not present")
+}
+
+/**
+ * Provides access to the exit manager throughout the app.
+ */
+val LocalExitManager: ProvidableCompositionLocal<ExitManager> = compositionLocalOf {
+    error("CompositionLocal ExitManager not present")
+}
+
+/**
+ * Provides access to the permission manager throughout the app.
+ */
+val LocalPermissionsManager: ProvidableCompositionLocal<PermissionsManager> = compositionLocalOf {
+    error("CompositionLocal LocalPermissionsManager not present")
+}

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -58,12 +58,12 @@ import com.bitwarden.authenticator.ui.platform.components.row.BitwardenTextRow
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.authenticator.ui.platform.components.toggle.BitwardenWideSwitch
 import com.bitwarden.authenticator.ui.platform.components.util.rememberVectorPainter
+import com.bitwarden.authenticator.ui.platform.composition.LocalBiometricsManager
+import com.bitwarden.authenticator.ui.platform.composition.LocalIntentManager
 import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
-import com.bitwarden.authenticator.ui.platform.theme.LocalBiometricsManager
-import com.bitwarden.authenticator.ui.platform.theme.LocalIntentManager
 import com.bitwarden.authenticator.ui.platform.util.displayLabel
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
@@ -38,9 +38,9 @@ import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenTwoBut
 import com.bitwarden.authenticator.ui.platform.components.dialog.LoadingDialogState
 import com.bitwarden.authenticator.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.authenticator.ui.platform.composition.LocalIntentManager
 import com.bitwarden.authenticator.ui.platform.feature.settings.export.model.ExportVaultFormat
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
-import com.bitwarden.authenticator.ui.platform.theme.LocalIntentManager
 import com.bitwarden.authenticator.ui.platform.util.displayLabel
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import kotlinx.collections.immutable.toImmutableList

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
@@ -35,8 +35,8 @@ import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenTwoBut
 import com.bitwarden.authenticator.ui.platform.components.dialog.LoadingDialogState
 import com.bitwarden.authenticator.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.authenticator.ui.platform.composition.LocalIntentManager
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
-import com.bitwarden.authenticator.ui.platform.theme.LocalIntentManager
 import com.bitwarden.authenticator.ui.platform.util.displayLabel
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import kotlinx.collections.immutable.toImmutableList

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/theme/AuthenticatorTheme.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/theme/AuthenticatorTheme.kt
@@ -20,14 +20,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import com.bitwarden.authenticator.R
-import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
-import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManagerImpl
-import com.bitwarden.authenticator.ui.platform.manager.exit.ExitManager
-import com.bitwarden.authenticator.ui.platform.manager.exit.ExitManagerImpl
-import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
-import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManagerImpl
-import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManager
-import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManagerImpl
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 
 /**
@@ -47,7 +39,6 @@ fun AuthenticatorTheme(
 
     // Get the current scheme
     val context = LocalContext.current
-    val activity = context as Activity
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
@@ -79,10 +70,6 @@ fun AuthenticatorTheme(
     CompositionLocalProvider(
         LocalNonMaterialColors provides nonMaterialColors,
         LocalNonMaterialTypography provides nonMaterialTypography,
-        LocalPermissionsManager provides PermissionsManagerImpl(activity),
-        LocalIntentManager provides IntentManagerImpl(context),
-        LocalExitManager provides ExitManagerImpl(activity),
-        LocalBiometricsManager provides BiometricsManagerImpl(activity),
     ) {
         // Set overall theme based on color scheme and typography settings
         MaterialTheme(
@@ -170,34 +157,6 @@ private fun lightColorScheme(context: Context): ColorScheme =
 @ColorRes
 private fun Int.toColor(context: Context): Color =
     Color(context.getColor(this))
-
-/**
- * Provides access to the biometrics manager throughout the app.
- */
-val LocalBiometricsManager: ProvidableCompositionLocal<BiometricsManager> = compositionLocalOf {
-    error("CompositionLocal BiometricsManager not present")
-}
-
-/**
- * Provides access to the exit manager throughout the app.
- */
-val LocalExitManager: ProvidableCompositionLocal<ExitManager> = compositionLocalOf {
-    error("CompositionLocal ExitManager not present")
-}
-
-/**
- * Provides access to the intent manager throughout the app.
- */
-val LocalIntentManager: ProvidableCompositionLocal<IntentManager> = compositionLocalOf {
-    error("CompositionLocal LocalIntentManager not present")
-}
-
-/**
- * Provides access to the permission manager throughout the app.
- */
-val LocalPermissionsManager: ProvidableCompositionLocal<PermissionsManager> = compositionLocalOf {
-    error("CompositionLocal LocalPermissionsManager not present")
-}
 
 /**
  * Provides access to non material theme typography throughout the app.


### PR DESCRIPTION
## 🎟️ Tracking

PM-21676

## 📔 Objective

Move the `CompositionLocal` providers for various managers (PermissionsManager, IntentManager, ExitManager, BiometricsManager) from `AuthenticatorTheme.kt` to a new dedicated composable `LocalManagerProvider.kt`.

This change improves code organization by centralizing the provision of these managers. Screen composables have been updated to import these local providers from the new `composition` package.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
