### PR TITLE
PM-21696: Make sure environment is up-to-date

### DIFF
--- a/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -5920,6 +5920,7 @@ class AuthRepositoryTest {
             firstTimeState = FIRST_TIME_STATE,
         )
         fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        fakeEnvironmentRepository.environment = Environment.Eu
         assertEquals(
             originalUserState,
             repository.userStateFlow.value,
@@ -5936,6 +5937,7 @@ class AuthRepositoryTest {
             repository.userStateFlow.value,
         )
         assertFalse(repository.hasPendingAccountAddition)
+        assertEquals(Environment.Us, fakeEnvironmentRepository.environment)
     }
 
     @Suppress("MaxLineLength")
@@ -5955,6 +5957,7 @@ class AuthRepositoryTest {
             firstTimeState = FIRST_TIME_STATE,
         )
         fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+        fakeEnvironmentRepository.environment = Environment.Eu
         assertEquals(
             originalUserState,
             repository.userStateFlow.value,
@@ -5969,6 +5972,7 @@ class AuthRepositoryTest {
             originalUserState,
             repository.userStateFlow.value,
         )
+        assertEquals(Environment.Us, fakeEnvironmentRepository.environment)
     }
 
     @Suppress("MaxLineLength")
@@ -5988,6 +5992,7 @@ class AuthRepositoryTest {
             firstTimeState = FIRST_TIME_STATE,
         )
         fakeAuthDiskSource.userState = MULTI_USER_STATE
+        fakeEnvironmentRepository.environment = Environment.Eu
         assertEquals(
             originalUserState,
             repository.userStateFlow.value,
@@ -6004,6 +6009,7 @@ class AuthRepositoryTest {
             repository.userStateFlow.value,
         )
         assertFalse(repository.hasPendingAccountAddition)
+        assertEquals(Environment.Eu, fakeEnvironmentRepository.environment)
     }
 
     @Test
@@ -7078,7 +7084,7 @@ class AuthRepositoryTest {
         private val ACCOUNT_1 = AccountJson(
             profile = PROFILE_1,
             settings = AccountJson.Settings(
-                environmentUrlData = null,
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
             ),
         )
         private val ACCOUNT_2 = AccountJson(
@@ -7101,7 +7107,7 @@ class AuthRepositoryTest {
                 creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
             ),
             settings = AccountJson.Settings(
-                environmentUrlData = null,
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_EU,
             ),
         )
         private val SINGLE_USER_STATE_1 = UserStateJson(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21696](https://bitwarden.atlassian.net/browse/PM-21696)

## 📔 Objective

This PR fixes a bug where a user could change their environment in the app by starting to add a new account but if they switch back to the original account before finalizing the new account, the environment was not reverting back to the active users account.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21696]: https://bitwarden.atlassian.net/browse/PM-21696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ