### PR TITLE
PM-19770: Fix the verify email domains

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,9 +76,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-
-                <data android:host="vault.bitwarden.com" />
-                <data android:host="vault.bitwarden.eu" />
+                <data android:host="*.bitwarden.com" />
+                <data android:host="*.bitwarden.eu" />
                 <data android:host="*.bitwarden.pw" />
                 <data android:pathPattern="/redirect-connector.*" />
             </intent-filter>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19770](https://bitwarden.atlassian.net/browse/PM-19770)

## 📔 Objective

This PR changes the domains from used to intercept the verify email link from `vault.bitwarden.com` and `vault.bitwarden.eu` to `*.bitwarden.com` and `*.bitwarden.eu` respectively. This expected value and allows the link to navigate users to the Android app.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/bb734f6b-43b4-4aff-84c6-171a56396c81" width="300" /> | <video src="https://github.com/user-attachments/assets/6e43076a-bcda-499f-ae2d-ebc91099a2f3" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19770]: https://bitwarden.atlassian.net/browse/PM-19770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ