### PR TITLE
PM-21707: Allow nullable captcha token

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/RegisterResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/RegisterResult.kt
@@ -9,7 +9,7 @@ sealed class RegisterResult {
      *
      * @param captchaToken the captcha bypass token to bypass future captcha verifications.
      */
-    data class Success(val captchaToken: String) : RegisterResult()
+    data class Success(val captchaToken: String?) : RegisterResult()
 
     /**
      * Captcha verification is required.

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountNavigation.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountNavigation.kt
@@ -24,7 +24,7 @@ fun NavController.navigateToCreateAccount(navOptions: NavOptions? = null) {
  */
 fun NavGraphBuilder.createAccountDestination(
     onNavigateBack: () -> Unit,
-    onNavigateToLogin: (emailAddress: String, captchaToken: String) -> Unit,
+    onNavigateToLogin: (emailAddress: String, captchaToken: String?) -> Unit,
 ) {
     composableWithSlideTransitions<CreateAccountRoute> {
         CreateAccountScreen(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
@@ -75,7 +75,7 @@ import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 @Composable
 fun CreateAccountScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToLogin: (emailAddress: String, captchaToken: String) -> Unit,
+    onNavigateToLogin: (emailAddress: String, captchaToken: String?) -> Unit,
     intentManager: IntentManager = LocalIntentManager.current,
     viewModel: CreateAccountViewModel = hiltViewModel(),
 ) {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModel.kt
@@ -494,7 +494,7 @@ sealed class CreateAccountEvent {
      */
     data class NavigateToLogin(
         val email: String,
-        val captchaToken: String,
+        val captchaToken: String?,
     ) : CreateAccountEvent()
 
     /**

--- a/network/src/main/kotlin/com/bitwarden/network/model/RegisterResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/RegisterResponseJson.kt
@@ -19,7 +19,7 @@ sealed class RegisterResponseJson {
     @Serializable
     data class Success(
         @SerialName("captchaBypassToken")
-        val captchaBypassToken: String,
+        val captchaBypassToken: String?,
     ) : RegisterResponseJson()
 
     /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21707](https://bitwarden.atlassian.net/browse/PM-21707)

## 📔 Objective

This PR updates the `RegisterResponseJson` response to allow for a nullable `captchaBypassToken`. This should have always been the case but it is now necessary since the cloud will be removing the field entirely in the future.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21707]: https://bitwarden.atlassian.net/browse/PM-21707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ