### PR TITLE
[PM-21354] Migrate ColorExtensions and its tests to ui module 

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/account/BitwardenAccountActionItem.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/account/BitwardenAccountActionItem.kt
@@ -14,10 +14,10 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.bitwarden.ui.platform.base.util.toSafeOverlayColor
 import com.bitwarden.ui.platform.base.util.toUnscaledTextUnit
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.base.util.toSafeOverlayColor
 import com.x8bit.bitwarden.ui.platform.components.button.color.bitwardenStandardIconButtonColors
 import com.x8bit.bitwarden.ui.platform.components.util.rememberVectorPainter
 

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/account/BitwardenAccountSwitcher.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/components/account/BitwardenAccountSwitcher.kt
@@ -51,10 +51,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.lowercaseWithCurrentLocal
 import com.bitwarden.ui.platform.base.util.scrolledContainerBackground
+import com.bitwarden.ui.platform.base.util.toSafeOverlayColor
 import com.bitwarden.ui.platform.base.util.toUnscaledTextUnit
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.base.util.toSafeOverlayColor
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLogoutConfirmationDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenRemovalConfirmationDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -30,6 +30,11 @@ android {
         sourceCompatibility(libs.versions.jvmTarget.get())
         targetCompatibility(libs.versions.jvmTarget.get())
     }
+    testOptions {
+        // Required for Robolectric
+        unitTests.isIncludeAndroidResources = true
+        unitTests.isReturnDefaultValues = true
+    }
     kotlinOptions {
         jvmTarget = libs.versions.jvmTarget.get()
     }
@@ -57,11 +62,16 @@ dependencies {
     implementation(libs.kotlinx.serialization)
     implementation(libs.kotlinx.coroutines.core)
 
+    // For now we are restricted to running Compose tests for debug builds only
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.junit5)
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.junit.vintage)
     testImplementation(libs.mockk.mockk)
+    testImplementation(libs.robolectric.robolectric)
 
     testFixturesImplementation(libs.androidx.activity.compose)
     testFixturesImplementation(libs.androidx.compose.ui.test)

--- a/ui/src/main/java/com/bitwarden/ui/platform/base/util/ColorExtensions.kt
+++ b/ui/src/main/java/com/bitwarden/ui/platform/base/util/ColorExtensions.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.base.util
+package com.bitwarden.ui.platform.base.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/base/util/ColorExtensionsTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/base/util/ColorExtensionsTest.kt
@@ -1,62 +1,73 @@
-package com.x8bit.bitwarden.data.platform.base.util
+package com.bitwarden.ui.platform.base.util
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import com.bitwarden.ui.platform.base.BaseComposeTest
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
-import com.x8bit.bitwarden.ui.platform.base.util.isLightOverlayRequired
-import com.x8bit.bitwarden.ui.platform.base.util.toSafeOverlayColor
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert
 import org.junit.Test
 
-class ColorExtensionsTest : BitwardenComposeTest() {
+class ColorExtensionsTest : BaseComposeTest() {
+
     @Suppress("MaxLineLength")
     @Test
     fun `isLightOverlayRequired for a color with luminance below the light threshold should return true`() {
-        assertTrue(Color.Blue.isLightOverlayRequired)
+        Assert.assertTrue(Color.Companion.Blue.isLightOverlayRequired)
     }
 
     @Suppress("MaxLineLength")
     @Test
     fun `isLightOverlayRequired for a color with luminance above the light threshold should return false`() {
-        assertFalse(Color.Yellow.isLightOverlayRequired)
+        Assert.assertFalse(Color.Companion.Yellow.isLightOverlayRequired)
     }
 
     @Test
     fun `toSafeOverlayColor for a dark color in light mode should use the surface color`() =
         setContent(theme = AppTheme.LIGHT) {
-            assertEquals(
+            Assert.assertEquals(
                 BitwardenTheme.colorScheme.background.primary,
-                Color.Blue.toSafeOverlayColor(),
+                Color.Companion.Blue.toSafeOverlayColor(),
             )
         }
 
     @Test
     fun `toSafeOverlayColor for a dark color in dark mode should use the onSurface color`() =
         setContent(theme = AppTheme.DARK) {
-            assertEquals(
+            Assert.assertEquals(
                 BitwardenTheme.colorScheme.text.primary,
-                Color.Blue.toSafeOverlayColor(),
+                Color.Companion.Blue.toSafeOverlayColor(),
             )
         }
 
     @Test
     fun `toSafeOverlayColor for a light color in light mode should use the onSurface color`() =
         setContent(theme = AppTheme.LIGHT) {
-            assertEquals(
+            Assert.assertEquals(
                 BitwardenTheme.colorScheme.text.primary,
-                Color.Yellow.toSafeOverlayColor(),
+                Color.Companion.Yellow.toSafeOverlayColor(),
             )
         }
 
     @Test
     fun `toSafeOverlayColor for a light color in dark mode should use the surface color`() =
         setContent(theme = AppTheme.DARK) {
-            assertEquals(
+            Assert.assertEquals(
                 BitwardenTheme.colorScheme.background.primary,
-                Color.Yellow.toSafeOverlayColor(),
+                Color.Companion.Yellow.toSafeOverlayColor(),
             )
         }
+
+    @Suppress("LongParameterList")
+    fun setContent(
+        theme: AppTheme = AppTheme.DEFAULT,
+        test: @Composable () -> Unit,
+    ) {
+        setTestContent {
+            BitwardenTheme(
+                theme = theme,
+                content = test,
+            )
+        }
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-21354

## 📔 Objective

This commit moves the `ColorExtensions.kt` file and its corresponding test file `ColorExtensionsTest.kt` from the `app` module to the `ui` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
