### PR TITLE
[PM-21386] Fix typo in sync with Bitwarden message

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -745,7 +745,7 @@ private fun SyncWithBitwardenActionCard(
     actionIcon = rememberVectorPainter(R.drawable.ic_refresh),
     actionText = stringResource(R.string.sync_with_bitwarden_action_card_message),
     callToActionText = stringResource(R.string.go_to_settings),
-    titleText = stringResource(R.string.sync_with_bitwarden_app),
+    titleText = stringResource(R.string.sync_with_the_bitwarden_app),
     onCardClicked = onSyncWithBitwardenClick,
     trailingContent = {
         IconButton(

--- a/authenticator/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
@@ -181,7 +181,7 @@ class ItemListingScreenTest : AuthenticatorComposeTest() {
             ),
         )
         composeTestRule
-            .onNodeWithText("Sync with Bitwarden app")
+            .onNodeWithText("Sync with the Bitwarden app")
             .performClick()
         verify { viewModel.trySendAction(ItemListingAction.SyncWithBitwardenClick) }
     }
@@ -198,7 +198,7 @@ class ItemListingScreenTest : AuthenticatorComposeTest() {
             ),
         )
         composeTestRule
-            .onNodeWithText("Sync with Bitwarden app")
+            .onNodeWithText("Sync with the Bitwarden app")
             .performClick()
         verify { viewModel.trySendAction(ItemListingAction.SyncWithBitwardenClick) }
     }


### PR DESCRIPTION
## 🎟️ Tracking

PM-21386

## 📔 Objective

The title text for the sync with Bitwarden action card was updated to "Sync with the Bitwarden app" from "Sync with Bitwarden app".

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="450" alt="image" src="https://github.com/user-attachments/assets/22033b0e-084e-4c73-9c03-1aa2d9c5df4d" /> | <img width="476" alt="image" src="https://github.com/user-attachments/assets/474f34db-5dfb-48ab-97e5-bd048d7b1c84" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
