### PR TITLE
Update authenticator compose tests to allow for easier use of local compositions

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/composition/LocalManagerProvider.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/composition/LocalManagerProvider.kt
@@ -25,13 +25,17 @@ import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsMa
 @Composable
 fun LocalManagerProvider(
     activity: Activity = requireNotNull(LocalActivity.current),
+    permissionsManager: PermissionsManager = PermissionsManagerImpl(activity),
+    intentManager: IntentManager = IntentManagerImpl(activity),
+    exitManager: ExitManager = ExitManagerImpl(activity),
+    biometricsManager: BiometricsManager = BiometricsManagerImpl(activity),
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
-        LocalPermissionsManager provides PermissionsManagerImpl(activity),
-        LocalIntentManager provides IntentManagerImpl(activity),
-        LocalExitManager provides ExitManagerImpl(activity),
-        LocalBiometricsManager provides BiometricsManagerImpl(activity),
+        LocalPermissionsManager provides permissionsManager,
+        LocalIntentManager provides intentManager,
+        LocalExitManager provides exitManager,
+        LocalBiometricsManager provides biometricsManager,
         content = content,
     )
 }

--- a/authenticator/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
@@ -49,11 +49,12 @@ class ItemListingScreenTest : AuthenticatorComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+            permissionsManager = permissionsManager,
+        ) {
             ItemListingScreen(
                 viewModel = viewModel,
-                intentManager = intentManager,
-                permissionsManager = permissionsManager,
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToSearch = { onNavigateToSearchCalled = true },
                 onNavigateToQrCodeScanner = { onNavigateToQrCodeScannerCalled = true },

--- a/authenticator/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreenTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreenTest.kt
@@ -33,13 +33,14 @@ class ManualCodeEntryScreenTest : AuthenticatorComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            intentManager = intentManager,
+            permissionsManager = permissionsManager,
+        ) {
             ManualCodeEntryScreen(
                 onNavigateBack = {},
                 onNavigateToQrCodeScreen = {},
                 viewModel = viewModel,
-                intentManager = intentManager,
-                permissionsManager = permissionsManager,
             )
         }
     }

--- a/authenticator/src/test/java/com/bitwarden/authenticator/ui/platform/base/AuthenticatorComposeTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/ui/platform/base/AuthenticatorComposeTest.kt
@@ -2,9 +2,14 @@ package com.bitwarden.authenticator.ui.platform.base
 
 import androidx.compose.runtime.Composable
 import com.bitwarden.authenticator.ui.platform.composition.LocalManagerProvider
+import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
+import com.bitwarden.authenticator.ui.platform.manager.exit.ExitManager
+import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
+import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManager
 import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
 import com.bitwarden.ui.platform.base.BaseComposeTest
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import io.mockk.mockk
 
 /**
  * A base class that can be used for performing Compose-layer testing using Robolectric, Compose
@@ -16,13 +21,24 @@ abstract class AuthenticatorComposeTest : BaseComposeTest() {
      * Helper for testing a basic Composable function that only requires a Composable environment
      * with the [AuthenticatorTheme].
      */
+    @Suppress("LongParameterList")
     protected fun setContent(
         theme: AppTheme = AppTheme.DEFAULT,
+        permissionsManager: PermissionsManager = mockk(),
+        intentManager: IntentManager = mockk(),
+        exitManager: ExitManager = mockk(),
+        biometricsManager: BiometricsManager = mockk(),
         test: @Composable () -> Unit,
     ) {
         setTestContent {
             AuthenticatorTheme(theme = theme) {
-                LocalManagerProvider { test() }
+                LocalManagerProvider(
+                    permissionsManager = permissionsManager,
+                    intentManager = intentManager,
+                    exitManager = exitManager,
+                    biometricsManager = biometricsManager,
+                    content = test,
+                )
             }
         }
     }

--- a/authenticator/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/authenticator/src/test/java/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -56,11 +56,12 @@ class SettingsScreenTest : AuthenticatorComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            biometricsManager = biometricsManager,
+            intentManager = intentManager,
+        ) {
             SettingsScreen(
                 viewModel = viewModel,
-                biometricsManager = biometricsManager,
-                intentManager = intentManager,
                 onNavigateToTutorial = { onNavigateToTutorialCalled = true },
                 onNavigateToExport = { onNaviateToExportCalled = true },
                 onNavigateToImport = { onNavigateToImportCalled = true },


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the `AuthenticatorComposeTest` to mirror the `BitwardenComposeTest` by allowing the tests to more easily override custom local compositions.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
