### PR TITLE
[PM-21405] Delete account error message

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/DeleteAccountResult.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/data/auth/repository/model/DeleteAccountResult.kt
@@ -10,6 +10,11 @@ sealed class DeleteAccountResult {
     data object Success : DeleteAccountResult()
 
     /**
+     * There was an error deleting the account owned by organization.
+     */
+    data object CannotDeleteAccountOwnedByOrg : DeleteAccountResult()
+
+    /**
      * There was an error deleting the account.
      */
     data class Error(

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
@@ -117,7 +117,6 @@ class DeleteAccountViewModel @Inject constructor(
         dismissDialog()
     }
 
-    @Suppress("MaxLineLength")
     private fun handleDeleteAccountComplete(
         action: DeleteAccountAction.Internal.DeleteAccountComplete,
     ) {
@@ -138,6 +137,7 @@ class DeleteAccountViewModel @Inject constructor(
 
             is DeleteAccountResult.CannotDeleteAccountOwnedByOrg -> {
                 updateDialogState(
+                    @Suppress("MaxLineLength")
                     DeleteAccountState.DeleteAccountDialog.Error(
                         message = R.string.cannot_delete_accounts_owned_by_an_organization_contact_your_organization_administrator_for_additional_details.asText(),
                     ),

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
@@ -117,6 +117,7 @@ class DeleteAccountViewModel @Inject constructor(
         dismissDialog()
     }
 
+    @Suppress("MaxLineLength")
     private fun handleDeleteAccountComplete(
         action: DeleteAccountAction.Internal.DeleteAccountComplete,
     ) {
@@ -133,6 +134,14 @@ class DeleteAccountViewModel @Inject constructor(
                         ),
                     )
                 }
+            }
+
+            is DeleteAccountResult.CannotDeleteAccountOwnedByOrg -> {
+                updateDialogState(
+                    DeleteAccountState.DeleteAccountDialog.Error(
+                        message = R.string.cannot_delete_accounts_owned_by_an_organization_contact_your_organization_administrator_for_additional_details.asText(),
+                    ),
+                )
             }
 
             is DeleteAccountResult.Error -> {

--- a/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
@@ -161,6 +161,12 @@ class DeleteAccountConfirmationViewModel @Inject constructor(
                         )
                     }
 
+                    is DeleteAccountResult.CannotDeleteAccountOwnedByOrg -> {
+                        DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.Error(
+                            message = R.string.cannot_delete_accounts_owned_by_an_organization_contact_your_organization_administrator_for_additional_details.asText(),
+                        )
+                    }
+
                     DeleteAccountResult.Success -> {
                         DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.DeleteSuccess()
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1276,4 +1276,5 @@ Do you want to switch to this account?</string>
     <string name="dynamic_colors">Dynamic colors</string>
     <string name="dynamic_colors_description">Apply dynamic colors based on your wallpaper</string>
     <string name="dynamic_colors_may_not_adhere_to_accessibility_guidelines">Dynamic colors uses the system colors and may not meet all accessibility guidelines.</string>
+    <string name="cannot_delete_accounts_owned_by_an_organization_contact_your_organization_administrator_for_additional_details">Cannot delete accounts owned by an organization. Contact your organization administrator for additional details.</string>
 </resources>

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
@@ -157,6 +157,34 @@ class DeleteAccountViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    @Suppress("MaxLineLength")
+    fun `on DeleteAccountClick should update dialog state when deleteAccount fails with CannotDeleteAccountOwnedByOrg`() = runTest {
+        val viewModel = createViewModel()
+        val masterPassword = "ckasb kcs ja"
+        coEvery {
+            authRepo.validatePassword(any())
+        } returns ValidatePasswordResult.Success(isValid = true)
+        coEvery {
+            authRepo.deleteAccountWithMasterPassword(masterPassword)
+        } returns DeleteAccountResult.CannotDeleteAccountOwnedByOrg
+
+        viewModel.trySendAction(DeleteAccountAction.DeleteAccountConfirmDialogClick(masterPassword))
+
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialog = DeleteAccountState.DeleteAccountDialog.Error(
+                    message = R.string.cannot_delete_accounts_owned_by_an_organization_contact_your_organization_administrator_for_additional_details.asText(),
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+
+        coVerify {
+            authRepo.deleteAccountWithMasterPassword(masterPassword)
+        }
+    }
+
+    @Test
     fun `on DeleteAccountClick should update dialog state when invalid master pass is invalid`() =
         runTest {
             val viewModel = createViewModel()

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
@@ -158,31 +158,36 @@ class DeleteAccountViewModelTest : BaseViewModelTest() {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `on DeleteAccountClick should update dialog state when deleteAccount fails with CannotDeleteAccountOwnedByOrg`() = runTest {
-        val viewModel = createViewModel()
-        val masterPassword = "ckasb kcs ja"
-        coEvery {
-            authRepo.validatePassword(any())
-        } returns ValidatePasswordResult.Success(isValid = true)
-        coEvery {
-            authRepo.deleteAccountWithMasterPassword(masterPassword)
-        } returns DeleteAccountResult.CannotDeleteAccountOwnedByOrg
+    fun `on DeleteAccountClick should update dialog state when deleteAccount fails with CannotDeleteAccountOwnedByOrg`() =
+        runTest {
+            val viewModel = createViewModel()
+            val masterPassword = "ckasb kcs ja"
+            coEvery {
+                authRepo.validatePassword(any())
+            } returns ValidatePasswordResult.Success(isValid = true)
+            coEvery {
+                authRepo.deleteAccountWithMasterPassword(masterPassword)
+            } returns DeleteAccountResult.CannotDeleteAccountOwnedByOrg
 
-        viewModel.trySendAction(DeleteAccountAction.DeleteAccountConfirmDialogClick(masterPassword))
-
-        assertEquals(
-            DEFAULT_STATE.copy(
-                dialog = DeleteAccountState.DeleteAccountDialog.Error(
-                    message = R.string.cannot_delete_accounts_owned_by_an_organization_contact_your_organization_administrator_for_additional_details.asText(),
+            viewModel.trySendAction(
+                DeleteAccountAction.DeleteAccountConfirmDialogClick(
+                    masterPassword,
                 ),
-            ),
-            viewModel.stateFlow.value,
-        )
+            )
 
-        coVerify {
-            authRepo.deleteAccountWithMasterPassword(masterPassword)
+            assertEquals(
+                DEFAULT_STATE.copy(
+                    dialog = DeleteAccountState.DeleteAccountDialog.Error(
+                        message = R.string.cannot_delete_accounts_owned_by_an_organization_contact_your_organization_administrator_for_additional_details.asText(),
+                    ),
+                ),
+                viewModel.stateFlow.value,
+            )
+
+            coVerify {
+                authRepo.deleteAccountWithMasterPassword(masterPassword)
+            }
         }
-    }
 
     @Test
     fun `on DeleteAccountClick should update dialog state when invalid master pass is invalid`() =

--- a/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModelTest.kt
@@ -157,6 +157,42 @@ class DeleteAccountConfirmationViewModelTest : BaseViewModelTest() {
 
     @Test
     @Suppress("MaxLineLength")
+    fun `on DeleteAccountClick with DeleteAccountResult CannotDeleteAccountOwnedByOrg should set dialog to Error with message`() =
+        runTest {
+            coEvery {
+                authRepo.deleteAccountWithOneTimePassword("123456")
+            } returns DeleteAccountResult.CannotDeleteAccountOwnedByOrg
+            val initialState = DEFAULT_STATE.copy(
+                verificationCode = "123456",
+            )
+            val viewModel = createViewModel(
+                state = initialState,
+            )
+            viewModel.stateFlow.test {
+                assertEquals(initialState, awaitItem())
+                viewModel.trySendAction(
+                    DeleteAccountConfirmationAction.DeleteAccountClick,
+                )
+                assertEquals(
+                    initialState.copy(
+                        dialog = DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.Loading(),
+                    ),
+                    awaitItem(),
+                )
+                assertEquals(
+                    initialState.copy(
+                        dialog = DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.Error(
+                            message = R.string.cannot_delete_accounts_owned_by_an_organization_contact_your_organization_administrator_for_additional_details.asText(),
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+            coVerify { authRepo.deleteAccountWithOneTimePassword("123456") }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
     fun `on ResendCodeClick with requestOneTimePasscode Success should set dialog to null`() =
         runTest {
             coEvery {

--- a/network/src/main/kotlin/com/bitwarden/network/model/DeleteAccountResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/DeleteAccountResponseJson.kt
@@ -15,23 +15,40 @@ sealed class DeleteAccountResponseJson {
 
     /**
      * Models the json body of a deletion error.
-     *
+     * @param message a human readable error message.
      * @param validationErrors a map where each value is a list of error messages for each key.
      * The values in the array should be used for display to the user, since the keys tend to come
      * back as nonsense. (eg: empty string key)
      */
     @Serializable
+    @Suppress("MaxLineLength")
     data class Invalid(
+        @SerialName("message")
+        override val message: String,
+
         @SerialName("validationErrors")
-        private val validationErrors: Map<String, List<String?>>?,
-    ) : DeleteAccountResponseJson() {
+        override val validationErrors: Map<String, List<String>>?,
+    ) : DeleteAccountResponseJson(), InvalidJsonResponse {
         /**
-         * A human readable error message.
+         * The type of invalid responses that can be received.
          */
-        val message: String?
-            get() = validationErrors
-                ?.values
-                ?.firstOrNull()
-                ?.firstOrNull()
+        sealed class InvalidType {
+            /**
+             * Represents cannot delete accounts owned by an organization invalid response
+             */
+            data object CannotDeleteAccountOwnedByOrg : InvalidType()
+
+            /**
+             * Represents generic invalid response
+             */
+            data object GenericInvalid : InvalidType()
+        }
+
+        val invalidType: InvalidType
+            get() = if (message == "Cannot delete accounts owned by an organization. Contact your organization administrator for additional details.") {
+                InvalidType.CannotDeleteAccountOwnedByOrg
+            } else {
+                InvalidType.GenericInvalid
+            }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21405

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When a user completes JIT provisioning into an organization with a claimed domain, their account may enter a “Needs confirmation” state. If the user then attempts to delete their account, the server returns an error.

This PR adds handling for that specific server error and displays a localised error dialog to inform the user appropriately.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<p align="center">
    <img src="https://github.com/user-attachments/assets/d62a999f-bc7e-4dfc-98a2-5dc0f40cff79" alt="Description" width="300">
</p>
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
