### PR TITLE
[PM-21577] Handle organization limitItemDeletion from sync response.

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/Organization.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/Organization.kt
@@ -12,6 +12,8 @@ import com.bitwarden.network.model.OrganizationType
  * @property shouldUseKeyConnector Indicates that the organization uses a key connector.
  * @property role The user's role in the organization.
  * @property keyConnectorUrl The key connector domain (if applicable).
+ * @property userIsClaimedByOrganization Indicates that the user is claimed by the organization.
+ * @property limitItemDeletion Indicates that the organization limits item deletion.
  */
 data class Organization(
     val id: String,
@@ -21,4 +23,5 @@ data class Organization(
     val role: OrganizationType,
     val keyConnectorUrl: String?,
     val userIsClaimedByOrganization: Boolean,
+    val limitItemDeletion: Boolean = false,
 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensions.kt
@@ -24,6 +24,7 @@ fun SyncResponseJson.Profile.Organization.toOrganization(): Organization =
         shouldManageResetPassword = this.permissions.shouldManageResetPassword,
         keyConnectorUrl = this.keyConnectorUrl,
         userIsClaimedByOrganization = this.userIsClaimedByOrganization,
+        limitItemDeletion = this.limitItemDeletion,
     )
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1754,9 +1754,21 @@ class VaultAddEditViewModel @Inject constructor(
                     ) {
                         cipherView.permissions?.delete == true
                     } else {
+                        val needsManagePermission = cipherView
+                            ?.organizationId
+                            ?.let { orgId ->
+                                currentAccount
+                                    .organizations
+                                    .firstOrNull { it.id == orgId }
+                                    ?.limitItemDeletion
+                            }
+
                         internalVaultData
                             .collectionViewList
-                            .hasDeletePermissionInAtLeastOneCollection(cipherView?.collectionIds)
+                            .hasDeletePermissionInAtLeastOneCollection(
+                                collectionIds = cipherView?.collectionIds,
+                                needsManagePermission = needsManagePermission == true,
+                            )
                     }
 
                     val canAssignToCollections = internalVaultData

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -138,8 +138,18 @@ class VaultItemViewModel @Inject constructor(
                         ) {
                             cipherView.permissions?.delete == true
                         } else {
+                            val needsManagePermission = cipherView
+                                ?.organizationId
+                                ?.let { orgId ->
+                                    userState
+                                        ?.activeAccount
+                                        ?.organizations
+                                        ?.firstOrNull { it.id == orgId }
+                                        ?.limitItemDeletion
+                                }
                             collectionsState.data.hasDeletePermissionInAtLeastOneCollection(
                                 collectionIds = cipherView?.collectionIds,
+                                needsManagePermission = needsManagePermission == true,
                             )
                         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensions.kt
@@ -93,17 +93,32 @@ fun String.toCollectionDisplayName(list: List<CollectionView>): String {
 /**
  * Checks if the user has delete permission in at least one collection.
  *
- * Deletion is allowed when the item is in any collection that the user has "manage" permission for.
+ * Deletion is allowed when the item is in any collection that the user has "manage" permission for
+ * if [needsManagePermission] is true. Otherwise, deletion is allowed when the item is in any with
+ * manage or edit permission.
  */
 fun List<CollectionView>?.hasDeletePermissionInAtLeastOneCollection(
     collectionIds: List<String>?,
+    needsManagePermission: Boolean = false,
 ): Boolean {
     if (this.isNullOrEmpty() || collectionIds.isNullOrEmpty()) return true
     return this
         .any { collectionView ->
             collectionIds
                 .contains(collectionView.id)
-                .let { isInCollection -> isInCollection && collectionView.manage }
+                .let { isInCollection ->
+                    if (!isInCollection) {
+                        return false
+                    }
+
+                    if (needsManagePermission) {
+                        return collectionView.manage
+                    }
+
+                    return collectionView.manage ||
+                        collectionView.permission == CollectionPermission.EDIT ||
+                        collectionView.permission == CollectionPermission.EDIT_EXCEPT_PASSWORD
+                }
         }
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -4752,6 +4752,7 @@ class AuthRepositoryTest {
                 every { type } returns OrganizationType.USER
                 every { keyConnectorUrl } returns null
                 every { userIsClaimedByOrganization } returns false
+                every { limitItemDeletion } returns false
             },
         )
         fakeAuthDiskSource.storeOrganizations(userId = USER_ID_1, organizations = organizations)
@@ -4782,6 +4783,7 @@ class AuthRepositoryTest {
                     every { type } returns OrganizationType.USER
                     every { keyConnectorUrl } returns url
                     every { userIsClaimedByOrganization } returns false
+                    every { limitItemDeletion } returns false
                 },
             )
             fakeAuthDiskSource.storeOrganizations(userId = USER_ID_1, organizations = organizations)
@@ -4820,6 +4822,7 @@ class AuthRepositoryTest {
                     every { type } returns OrganizationType.USER
                     every { keyConnectorUrl } returns url
                     every { userIsClaimedByOrganization } returns false
+                    every { limitItemDeletion } returns false
                 },
             )
             fakeAuthDiskSource.storeOrganizations(userId = USER_ID_1, organizations = organizations)
@@ -4861,6 +4864,7 @@ class AuthRepositoryTest {
                     every { type } returns OrganizationType.USER
                     every { keyConnectorUrl } returns url
                     every { userIsClaimedByOrganization } returns false
+                    every { limitItemDeletion } returns false
                 },
             )
             fakeAuthDiskSource.storeOrganizations(userId = USER_ID_1, organizations = organizations)
@@ -4901,6 +4905,7 @@ class AuthRepositoryTest {
                     every { type } returns OrganizationType.USER
                     every { keyConnectorUrl } returns url
                     every { userIsClaimedByOrganization } returns false
+                    every { limitItemDeletion } returns false
                 },
             )
             fakeAuthDiskSource.storeOrganizations(userId = USER_ID_1, organizations = organizations)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -416,7 +416,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         specialCircumstanceManager.specialCircumstance =
             SpecialCircumstance.ProviderCreateCredential(
                 createCredentialRequest = createCredentialRequest,
-        )
+            )
         val fido2ContentState = createCredentialRequest.toDefaultAddTypeContent(
             attestationOptions = createMockPasskeyAttestationOptions(number = 1),
             isIndividualVaultDisabled = false,
@@ -1467,8 +1467,28 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `in edit mode, canDelete should be false when cipher is in a collection the user cannot manage`() =
+    fun `in edit mode, canDelete should be false when cipher is in a collection the user cannot manage and org has limitItemDeletion`() =
         runTest {
+            val userState = createUserState().copy(
+                accounts = listOf(
+                    createUserState().accounts.first().copy(
+                        organizations = listOf(
+                            Organization(
+                                id = "mockOrganizationId-1",
+                                name = "Mock Organization Name 1",
+                                shouldManageResetPassword = false,
+                                shouldUseKeyConnector = false,
+                                role = OrganizationType.ADMIN,
+                                keyConnectorUrl = null,
+                                userIsClaimedByOrganization = false,
+                                limitItemDeletion = true,
+                            ),
+                        ),
+                    ),
+                ),
+            )
+            mutableUserStateFlow.value = userState
+
             val cipherView = createMockCipherView(1)
             val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
             val stateWithName = createVaultAddItemState(
@@ -2115,7 +2135,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.ProviderCreateCredential(
                     createCredentialRequest = mockFido2CredentialRequest,
-            )
+                )
 
             setupFido2CreateRequest()
 
@@ -2174,7 +2194,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         specialCircumstanceManager.specialCircumstance =
             SpecialCircumstance.ProviderCreateCredential(
                 createCredentialRequest = mockFidoRequest,
-        )
+            )
         setupFido2CreateRequest(
             mockCallingAppInfo = mockCallingAppInfo,
             mockCreatePublicKeyCredentialRequest = mockCreatePublicKeyCredentialRequest,
@@ -2254,7 +2274,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             specialCircumstanceManager.specialCircumstance =
                 SpecialCircumstance.ProviderCreateCredential(
                     createCredentialRequest = mockFidoRequest,
-            )
+                )
 
             setupFido2CreateRequest()
 
@@ -4501,7 +4521,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.ProviderCreateCredential(
                         createCredentialRequest = mockRequest,
-                )
+                    )
                 setupFido2CreateRequest()
                 every { authRepository.activeUserId } returns "activeUserId"
                 coEvery {
@@ -4529,7 +4549,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.ProviderCreateCredential(
                         createCredentialRequest = mockRequest,
-                )
+                    )
                 every { authRepository.activeUserId } returns "activeUserId"
                 coEvery {
                     bitwardenCredentialManager.registerFido2Credential(
@@ -4577,7 +4597,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.ProviderCreateCredential(
                         createCredentialRequest = mockRequest,
-                )
+                    )
                 setupFido2CreateRequest()
                 every { authRepository.activeUserId } returns "activeUserId"
                 coEvery {
@@ -4780,6 +4800,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                             role = OrganizationType.ADMIN,
                             keyConnectorUrl = null,
                             userIsClaimedByOrganization = false,
+                            limitItemDeletion = false,
                         ),
                     ),
                     isBiometricsEnabled = true,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
@@ -93,7 +93,7 @@ class CollectionViewExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `hasDeletePermissionInAtLeastOneCollection should return false if the user does not have manage permission in at least one collection`() {
+    fun `hasDeletePermissionInAtLeastOneCollection should return false if the user does not have manage permission in at least one collection and org has limitItemDeletion active`() {
         val collectionList: List<CollectionView> = listOf(
             createEditCollectionView(number = 1),
             createEditExceptPasswordsCollectionView(number = 2),
@@ -101,7 +101,30 @@ class CollectionViewExtensionsTest {
             createViewExceptPasswordsCollectionView(number = 4),
         )
         val collectionIds = collectionList.mapNotNull { it.id }
-        assertFalse(collectionList.hasDeletePermissionInAtLeastOneCollection(collectionIds))
+        assertFalse(
+            collectionList.hasDeletePermissionInAtLeastOneCollection(
+                collectionIds = collectionIds,
+                needsManagePermission = true,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `hasDeletePermissionInAtLeastOneCollection should return true if the user does not have manage permission in at least one collection and org has limitItemDeletion off and has edit permissions`() {
+        val collectionList: List<CollectionView> = listOf(
+            createEditCollectionView(number = 1),
+            createEditExceptPasswordsCollectionView(number = 2),
+            createViewCollectionView(number = 3),
+            createViewExceptPasswordsCollectionView(number = 4),
+        )
+        val collectionIds = collectionList.mapNotNull { it.id }
+        assertTrue(
+            collectionList.hasDeletePermissionInAtLeastOneCollection(
+                collectionIds = collectionIds,
+                needsManagePermission = false,
+            ),
+        )
     }
 
     @Suppress("MaxLineLength")

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CollectionViewExtensionsTest.kt
@@ -129,6 +129,24 @@ class CollectionViewExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `hasDeletePermissionInAtLeastOneCollection should return false if ids don't match any collection`() {
+        val collectionList: List<CollectionView> = listOf(
+            createEditCollectionView(number = 1),
+            createEditExceptPasswordsCollectionView(number = 2),
+            createViewCollectionView(number = 3),
+            createViewExceptPasswordsCollectionView(number = 4),
+        )
+        val collectionIds = listOf("notInCollectionId")
+        assertFalse(
+            collectionList.hasDeletePermissionInAtLeastOneCollection(
+                collectionIds = collectionIds,
+                needsManagePermission = false,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `hasDeletePermissionInAtLeastOneCollection should return true if the collectionView list is null`() {
         val collectionIds = listOf("mockId-1", "mockId-2")
         assertTrue(null.hasDeletePermissionInAtLeastOneCollection(collectionIds))

--- a/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
@@ -347,6 +347,9 @@ data class SyncResponseJson(
 
             @SerialName("userIsClaimedByOrganization")
             val userIsClaimedByOrganization: Boolean = false,
+
+            @SerialName("limitItemDeletion")
+            val limitItemDeletion: Boolean = false,
         )
 
         /**

--- a/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
@@ -250,6 +250,7 @@ data class SyncResponseJson(
          * @property familySponsorshipValidUntil The family sponsorship valid until
          * of the organization (nullable).
          * @property status The status of the organization.
+         * @property limitItemDeletion If the organization limits item deletion.
          */
         @Serializable
         data class Organization(

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseProfileUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseProfileUtil.kt
@@ -93,6 +93,7 @@ fun createMockOrganization(
     familySponsorshipValidUntil: ZonedDateTime? = ZonedDateTime.parse("2023-10-27T12:00:00Z"),
     status: OrganizationStatusType = OrganizationStatusType.ACCEPTED,
     userIsClaimedByOrganization: Boolean = false,
+    limitItemDeletion: Boolean = false,
 ): SyncResponseJson.Profile.Organization =
     SyncResponseJson.Profile.Organization(
         shouldUsePolicies = shouldUsePolicies,
@@ -126,6 +127,7 @@ fun createMockOrganization(
         familySponsorshipValidUntil = familySponsorshipValidUntil,
         status = status,
         userIsClaimedByOrganization = userIsClaimedByOrganization,
+        limitItemDeletion = limitItemDeletion,
     )
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-21577

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When organization `Limit item deletion to Members with Manage permission` is off, users with `Can Edit` permission or `Can edit, hide password` permission should be able to see the delete button in the menu.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Soon™
 
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
