### PR TITLE
PM-21952: Move navigation package to UI module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
@@ -19,11 +19,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.x8bit.bitwarden.ui.platform.components.card.color.bitwardenCardColors
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/model/ScaffoldNavigationData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/model/ScaffoldNavigationData.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.components.model
 
+import com.bitwarden.ui.platform.components.navigation.model.NavigationItem
 import kotlinx.collections.immutable.ImmutableList
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/row/BitwardenPushRow.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/row/BitwardenPushRow.kt
@@ -17,11 +17,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.base.util.mirrorIfRtl
+import com.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.x8bit.bitwarden.ui.platform.components.icon.BitwardenIcon
 import com.x8bit.bitwarden.ui.platform.components.model.IconData
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/scaffold/BitwardenScaffold.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/scaffold/BitwardenScaffold.kt
@@ -40,14 +40,14 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.bitwarden.ui.platform.base.util.toDp
+import com.bitwarden.ui.platform.components.navigation.BitwardenBottomAppBar
+import com.bitwarden.ui.platform.components.navigation.BitwardenNavigationRail
 import com.bitwarden.ui.platform.model.WindowSize
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.platform.util.rememberWindowSize
 import com.x8bit.bitwarden.ui.platform.components.model.BitwardenPullToRefreshState
 import com.x8bit.bitwarden.ui.platform.components.model.ScaffoldNavigationData
 import com.x8bit.bitwarden.ui.platform.components.model.rememberBitwardenPullToRefreshState
-import com.x8bit.bitwarden.ui.platform.components.navigation.BitwardenBottomAppBar
-import com.x8bit.bitwarden.ui.platform.components.navigation.BitwardenNavigationRail
 import com.x8bit.bitwarden.ui.platform.components.scrim.BitwardenAnimatedScrim
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -35,6 +35,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.theme.BitwardenTheme
@@ -44,7 +45,6 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
-import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.x8bit.bitwarden.ui.platform.components.button.BitwardenTextButton
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -31,12 +31,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
-import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.x8bit.bitwarden.ui.platform.components.card.actionCardExitAnimation
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
@@ -28,11 +28,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
-import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.x8bit.bitwarden.ui.platform.components.card.actionCardExitAnimation
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -20,8 +20,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navOptions
 import com.bitwarden.ui.platform.base.util.EventsEffect
+import com.bitwarden.ui.platform.components.navigation.model.NavigationItem
 import com.bitwarden.ui.platform.theme.RootTransitionProviders
-import com.x8bit.bitwarden.ui.platform.components.model.NavigationItem
 import com.x8bit.bitwarden.ui.platform.components.model.ScaffoldNavigationData
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.util.rememberBitwardenNavController

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar.model
 
 import android.os.Parcelable
+import com.bitwarden.ui.platform.components.navigation.model.NavigationItem
 import com.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.R
-import com.x8bit.bitwarden.ui.platform.components.model.NavigationItem
 import com.x8bit.bitwarden.ui.platform.feature.settings.SettingsGraphRoute
 import com.x8bit.bitwarden.ui.platform.feature.settings.SettingsRoute
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorGraphRoute

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kotlinx.serialization)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.collections.immutable)
 
     // For now we are restricted to running Compose tests for debug builds only
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/badge/NotificationBadge.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/badge/NotificationBadge.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.badge
+package com.bitwarden.ui.platform.components.badge
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/BitwardenBottomAppBar.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/BitwardenBottomAppBar.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.navigation
+package com.bitwarden.ui.platform.components.navigation
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.BottomAppBar
@@ -8,8 +8,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.bitwarden.ui.platform.base.util.topDivider
+import com.bitwarden.ui.platform.components.navigation.model.NavigationItem
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.x8bit.bitwarden.ui.platform.components.model.NavigationItem
 import kotlinx.collections.immutable.ImmutableList
 
 /**

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/BitwardenNavigationBarItem.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/BitwardenNavigationBarItem.kt
@@ -1,20 +1,20 @@
-package com.x8bit.bitwarden.ui.platform.components.navigation
+package com.bitwarden.ui.platform.components.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import com.bitwarden.ui.platform.components.badge.NotificationBadge
+import com.bitwarden.ui.platform.components.navigation.color.bitwardenNavigationBarItemColors
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
-import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
-import com.x8bit.bitwarden.ui.platform.components.navigation.color.bitwardenNavigationRailItemColors
 
 /**
  * A custom Bitwarden-themed bottom app bar.
@@ -29,7 +29,7 @@ import com.x8bit.bitwarden.ui.platform.components.navigation.color.bitwardenNavi
  * @param notificationCount The notification count for the navigation item.
  */
 @Composable
-fun ColumnScope.BitwardenNavigationRailItem(
+fun RowScope.BitwardenNavigationBarItem(
     @StringRes labelRes: Int,
     @StringRes contentDescriptionRes: Int,
     @DrawableRes selectedIconRes: Int,
@@ -39,7 +39,7 @@ fun ColumnScope.BitwardenNavigationRailItem(
     modifier: Modifier = Modifier,
     notificationCount: Int = 0,
 ) {
-    NavigationRailItem(
+    NavigationBarItem(
         icon = {
             BadgedBox(
                 badge = {
@@ -67,7 +67,7 @@ fun ColumnScope.BitwardenNavigationRailItem(
         },
         selected = isSelected,
         onClick = onClick,
-        colors = bitwardenNavigationRailItemColors(),
+        colors = bitwardenNavigationBarItemColors(),
         modifier = modifier,
     )
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/BitwardenNavigationRail.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/BitwardenNavigationRail.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.navigation
+package com.bitwarden.ui.platform.components.navigation
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -26,8 +26,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.endDivider
 import com.bitwarden.ui.platform.base.util.toDp
+import com.bitwarden.ui.platform.components.navigation.model.NavigationItem
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.x8bit.bitwarden.ui.platform.components.model.NavigationItem
 import kotlinx.collections.immutable.ImmutableList
 
 /**

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/BitwardenNavigationRailItem.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/BitwardenNavigationRailItem.kt
@@ -1,20 +1,20 @@
-package com.x8bit.bitwarden.ui.platform.components.navigation
+package com.bitwarden.ui.platform.components.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import com.bitwarden.ui.platform.components.badge.NotificationBadge
+import com.bitwarden.ui.platform.components.navigation.color.bitwardenNavigationRailItemColors
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
-import com.x8bit.bitwarden.ui.platform.components.badge.NotificationBadge
-import com.x8bit.bitwarden.ui.platform.components.navigation.color.bitwardenNavigationBarItemColors
 
 /**
  * A custom Bitwarden-themed bottom app bar.
@@ -29,7 +29,7 @@ import com.x8bit.bitwarden.ui.platform.components.navigation.color.bitwardenNavi
  * @param notificationCount The notification count for the navigation item.
  */
 @Composable
-fun RowScope.BitwardenNavigationBarItem(
+fun ColumnScope.BitwardenNavigationRailItem(
     @StringRes labelRes: Int,
     @StringRes contentDescriptionRes: Int,
     @DrawableRes selectedIconRes: Int,
@@ -39,7 +39,7 @@ fun RowScope.BitwardenNavigationBarItem(
     modifier: Modifier = Modifier,
     notificationCount: Int = 0,
 ) {
-    NavigationBarItem(
+    NavigationRailItem(
         icon = {
             BadgedBox(
                 badge = {
@@ -67,7 +67,7 @@ fun RowScope.BitwardenNavigationBarItem(
         },
         selected = isSelected,
         onClick = onClick,
-        colors = bitwardenNavigationBarItemColors(),
+        colors = bitwardenNavigationRailItemColors(),
         modifier = modifier,
     )
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/color/BitwardenNavigationBarItemColors.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/color/BitwardenNavigationBarItemColors.kt
@@ -1,15 +1,15 @@
-package com.x8bit.bitwarden.ui.platform.components.navigation.color
+package com.bitwarden.ui.platform.components.navigation.color
 
-import androidx.compose.material3.NavigationRailItemColors
+import androidx.compose.material3.NavigationBarItemColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
- * Provides a default set of Bitwarden-styled colors for navigation rail items.
+ * Provides a default set of Bitwarden-styled colors for navigation bar items.
  */
 @Composable
-fun bitwardenNavigationRailItemColors(): NavigationRailItemColors = NavigationRailItemColors(
+fun bitwardenNavigationBarItemColors(): NavigationBarItemColors = NavigationBarItemColors(
     selectedIconColor = BitwardenTheme.colorScheme.icon.secondary,
     unselectedIconColor = BitwardenTheme.colorScheme.icon.primary,
     disabledIconColor = BitwardenTheme.colorScheme.outlineButton.foregroundDisabled,

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/color/BitwardenNavigationRailItemColors.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/color/BitwardenNavigationRailItemColors.kt
@@ -1,15 +1,15 @@
-package com.x8bit.bitwarden.ui.platform.components.navigation.color
+package com.bitwarden.ui.platform.components.navigation.color
 
-import androidx.compose.material3.NavigationBarItemColors
+import androidx.compose.material3.NavigationRailItemColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
- * Provides a default set of Bitwarden-styled colors for navigation bar items.
+ * Provides a default set of Bitwarden-styled colors for navigation rail items.
  */
 @Composable
-fun bitwardenNavigationBarItemColors(): NavigationBarItemColors = NavigationBarItemColors(
+fun bitwardenNavigationRailItemColors(): NavigationRailItemColors = NavigationRailItemColors(
     selectedIconColor = BitwardenTheme.colorScheme.icon.secondary,
     unselectedIconColor = BitwardenTheme.colorScheme.icon.primary,
     disabledIconColor = BitwardenTheme.colorScheme.outlineButton.foregroundDisabled,

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/model/NavigationItem.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/model/NavigationItem.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.model
+package com.bitwarden.ui.platform.components.navigation.model
 
 /**
  * Represents a user-interactable item to navigate a user via the bottom app bar or navigation rail.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21952](https://bitwarden.atlassian.net/browse/PM-21952)

## 📔 Objective

This PR moves the navigation and badge packages to the shared ui module.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
