### PR TITLE
🍒 [PM-21537] Fix remove individual vault collection selection cherrypick

### DIFF
--- a/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -960,11 +960,12 @@ class VaultAddEditViewModel @Inject constructor(
     ) {
         updateCommonContent { currentCommonContentState ->
             currentCommonContentState.copy(
+                selectedOwnerId = currentCommonContentState.selectedOwner?.id,
                 availableOwners = currentCommonContentState
                     .availableOwners
                     .toUpdatedOwners(
                         selectedCollectionId = action.collection.id,
-                        selectedOwnerId = currentCommonContentState.selectedOwnerId,
+                        selectedOwnerId = currentCommonContentState.selectedOwner?.id,
                     ),
             )
         }

--- a/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/java/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -4058,6 +4058,58 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
         @Suppress("MaxLineLength")
         @Test
+        fun `CollectionSelect should update selectedOwnerId when isIndividualVaultDisabled is true`() =
+            runTest {
+                every {
+                    policyManager.getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
+                } returns listOf(
+                    SyncResponseJson.Policy(
+                        organizationId = "Test Org",
+                        id = "testId",
+                        type = PolicyTypeJson.PERSONAL_OWNERSHIP,
+                        isEnabled = true,
+                        data = null,
+                    ),
+                )
+
+                val vaultAddEditType = VaultAddEditType.AddItem
+                val vaultItemCipherType = VaultItemCipherType.LOGIN
+                mutableVaultDataFlow.value = DataState.Loaded(
+                    data = createVaultData(),
+                )
+
+                val viewModel = createAddVaultItemViewModel(
+                    savedStateHandle = createSavedStateHandleWithState(
+                        state = null,
+                        vaultAddEditType = vaultAddEditType,
+                        vaultItemCipherType = vaultItemCipherType,
+                    ),
+                )
+
+                val action = collectionSelectAction()
+                viewModel.trySendAction(action)
+
+                val expectedState = vaultAddItemInitialState.copy(
+                    viewState = VaultAddEditState.ViewState.Content(
+                        common = createCommonContentViewState(
+                            availableOwners = listOf(
+                                VaultAddEditState.Owner(
+                                    id = "organizationId",
+                                    name = "organizationName",
+                                    collections = emptyList(),
+                                ),
+                            ),
+                            selectedOwnerId = "organizationId",
+                        ),
+                        isIndividualVaultDisabled = true,
+                        type = createLoginTypeContentViewState(),
+                    ),
+                )
+                assertEquals(expectedState, viewModel.stateFlow.value)
+            }
+
+        @Suppress("MaxLineLength")
+        @Test
         fun `UserVerificationLockout should set isUserVerified to false and display Fido2ErrorDialog`() {
             viewModel.trySendAction(VaultAddEditAction.Common.UserVerificationLockOut)
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21537

## 📔 Objective
When RemoveIndividualVault is active, `selectedOwner` is returning data but `selectedOwnerId` is not set. This updated the`selectedOwnerId` to match `selectedOwner`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
