### PR TITLE
PM-13040: Add known username field for the Disney Plus App

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/util/KnownUsernameFieldUtil.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/util/KnownUsernameFieldUtil.kt
@@ -188,6 +188,14 @@ private val LEGACY_KNOWN_USERNAME_FIELDS: List<KnownUsernameField> = listOf(
         accessOption = AccessOptions(matchValue = "/sso/url_slug", usernameViewId = "url_slug"),
     ),
     KnownUsernameField(
+        uriAuthority = "com.disney.disneyplus",
+        accessOption = AccessOptions(
+            matchValue = "",
+            matchingStrategy = AccessOptions.MatchingStrategy.CONTAINS_CASE_SENSITIVE,
+            usernameViewId = "editFieldEditText",
+        ),
+    ),
+    KnownUsernameField(
         uriAuthority = "signin.befr.ebay.be",
         accessOptions = listOf(
             AccessOptions(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13040](https://bitwarden.atlassian.net/browse/PM-13040)

## 📔 Objective

This PR adds a known username field for the Disney Plus app in order to accommodate the Accessibility service. This will work for the username field but not for the password field as the password field is not present in the node graph at all.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
