### PR TITLE
PM-21135: Fix view send field order

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -272,6 +272,17 @@ private fun ViewStateContent(
                 .padding(horizontal = 16.dp),
         )
         Spacer(modifier = Modifier.height(height = 8.dp))
+        BitwardenTextField(
+            label = stringResource(id = R.string.send_name_required),
+            value = state.sendName,
+            onValueChange = {},
+            readOnly = true,
+            cardStyle = CardStyle.Full,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(height = 8.dp))
         when (val sendType = state.sendType) {
             is ViewSendState.ViewState.Content.SendType.FileType -> {
                 FileSendContent(
@@ -291,18 +302,6 @@ private fun ViewStateContent(
                 )
             }
         }
-        Spacer(modifier = Modifier.height(height = 8.dp))
-
-        BitwardenTextField(
-            label = stringResource(id = R.string.send_name_required),
-            value = state.sendName,
-            onValueChange = {},
-            readOnly = true,
-            cardStyle = CardStyle.Full,
-            modifier = Modifier
-                .fillMaxWidth()
-                .standardHorizontalMargin(),
-        )
         Spacer(modifier = Modifier.height(height = 8.dp))
 
         BitwardenTextField(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21135](https://bitwarden.atlassian.net/browse/PM-21135)

## 📔 Objective

This PR updates the field order for the View Send Screen to match the latest designs.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/0f18b5c2-ee0c-431a-bd85-9473ebd73f19" width="300" /> | <img src="https://github.com/user-attachments/assets/68004212-16f2-41bb-9805-de271f50f327" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21135]: https://bitwarden.atlassian.net/browse/PM-21135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ