### PR TITLE
PM-21631: Check for Search Screen when navigating after deleting a Send

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -8,6 +8,7 @@ import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupAutoFillS
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupUnlockScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupAutoFillDestination
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupUnlockDestination
+import com.x8bit.bitwarden.ui.platform.feature.search.SearchRoute
 import com.x8bit.bitwarden.ui.platform.feature.search.navigateToSearch
 import com.x8bit.bitwarden.ui.platform.feature.search.searchDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.deleteaccount.deleteAccountDestination
@@ -201,7 +202,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
 
         addEditSendDestination(
             onNavigateBack = { navController.popBackStack() },
-            onNavigateUpToRoot = { navController.navigateToVaultUnlockedRoot() },
+            onNavigateUpToSearchOrRoot = { navController.navigateUpToSearchOrVaultUnlockedRoot() },
         )
         viewSendDestination(
             onNavigateBack = { navController.popBackStack() },
@@ -249,6 +250,12 @@ fun NavGraphBuilder.vaultUnlockedGraph(
     }
 }
 
-private fun NavController.navigateToVaultUnlockedRoot() {
-    this.popBackStack(route = VaultUnlockedNavbarRoute, inclusive = false)
+private fun NavController.navigateUpToSearchOrVaultUnlockedRoot() {
+    if (!this.popBackStack<SearchRoute>(inclusive = false)) {
+        this.navigateUpToVaultUnlockedRoot()
+    }
+}
+
+private fun NavController.navigateUpToVaultUnlockedRoot() {
+    this.popBackStack<VaultUnlockedNavbarRoute>(inclusive = false)
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendNavigation.kt
@@ -56,12 +56,12 @@ fun SavedStateHandle.toAddEditSendArgs(): AddEditSendArgs {
  */
 fun NavGraphBuilder.addEditSendDestination(
     onNavigateBack: () -> Unit,
-    onNavigateUpToRoot: () -> Unit,
+    onNavigateUpToSearchOrRoot: () -> Unit,
 ) {
     composableWithSlideTransitions<AddEditSendRoute> {
         AddEditSendScreen(
             onNavigateBack = onNavigateBack,
-            onNavigateUpToRoot = onNavigateUpToRoot,
+            onNavigateUpToSearchOrRoot = onNavigateUpToSearchOrRoot,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -52,7 +52,7 @@ fun AddEditSendScreen(
     intentManager: IntentManager = LocalIntentManager.current,
     permissionsManager: PermissionsManager = LocalPermissionsManager.current,
     onNavigateBack: () -> Unit,
-    onNavigateUpToRoot: () -> Unit,
+    onNavigateUpToSearchOrRoot: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val addSendHandlers = remember(viewModel) { AddEditSendHandlers.create(viewModel) }
@@ -77,7 +77,7 @@ fun AddEditSendScreen(
 
             is AddEditSendEvent.NavigateBack -> onNavigateBack()
 
-            is AddEditSendEvent.NavigateToRoot -> onNavigateUpToRoot()
+            is AddEditSendEvent.NavigateUpToSearchOrRoot -> onNavigateUpToSearchOrRoot()
 
             is AddEditSendEvent.ShowChooserSheet -> {
                 fileChooserLauncher.launch(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -600,7 +600,7 @@ class AddEditSendViewModel @Inject constructor(
             } else if (isDeleted) {
                 // We need to make sure we don't land on the View Send screen
                 // since it has now been deleted.
-                AddEditSendEvent.NavigateToRoot
+                AddEditSendEvent.NavigateUpToSearchOrRoot
             } else {
                 AddEditSendEvent.NavigateBack
             },
@@ -833,9 +833,9 @@ sealed class AddEditSendEvent {
     data object NavigateBack : AddEditSendEvent()
 
     /**
-     * Navigate up to the root.
+     * Navigate up to the search screen or the root screen depending where you came from.
      */
-    data object NavigateToRoot : AddEditSendEvent()
+    data object NavigateUpToSearchOrRoot : AddEditSendEvent()
 
     /**
      * Show file chooser sheet.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -49,7 +49,7 @@ import java.time.ZonedDateTime
 class AddEditSendScreenTest : BitwardenComposeTest() {
 
     private var onNavigateBackCalled = false
-    private var onNavigateUpToRootCalled = false
+    private var onNavigateUpToSearchOrRootCalled = false
 
     private val exitManager: ExitManager = mockk(relaxed = true) {
         every { exitApplication() } just runs
@@ -75,7 +75,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
             AddEditSendScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
-                onNavigateUpToRoot = { onNavigateUpToRootCalled = true },
+                onNavigateUpToSearchOrRoot = { onNavigateUpToSearchOrRootCalled = true },
             )
         }
     }
@@ -87,9 +87,9 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `on NavigateToRoot should call onNavigateUpToRoot`() {
-        mutableEventFlow.tryEmit(AddEditSendEvent.NavigateToRoot)
-        assertTrue(onNavigateUpToRootCalled)
+    fun `on NavigateUpToSearchOrRoot should call onNavigateUpToSearchOrRootCalled`() {
+        mutableEventFlow.tryEmit(AddEditSendEvent.NavigateUpToSearchOrRoot)
+        assertTrue(onNavigateUpToSearchOrRootCalled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -661,7 +661,7 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
 
         viewModel.eventFlow.test {
             viewModel.trySendAction(AddEditSendAction.DeleteClick)
-            assertEquals(AddEditSendEvent.NavigateToRoot, awaitItem())
+            assertEquals(AddEditSendEvent.NavigateUpToSearchOrRoot, awaitItem())
             assertEquals(AddEditSendEvent.ShowToast(R.string.send_deleted.asText()), awaitItem())
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21631](https://bitwarden.atlassian.net/browse/PM-21631)

## 📔 Objective

When deleting a Send from the `AddEditSendScreen`, we need to check if the user came from the `SearchScreen` in order to navigate to the correct location. If they came from Search then we should go there, otherwise the Root is the correct destination.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/60e1791f-b79e-4150-a348-a1eb3e34d5f8" width="300" /> | <video src="https://github.com/user-attachments/assets/383967d8-1302-420c-bafe-6117a88ea7e5" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21631]: https://bitwarden.atlassian.net/browse/PM-21631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ