### PR TITLE
PM-22265: Add Copy Notes button to ViewSendScreen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -48,6 +48,7 @@ import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.appbar.NavigationIcon
+import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.bitwarden.ui.platform.components.fab.BitwardenFloatingActionButton
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
@@ -159,6 +160,9 @@ fun ViewSendScreen(
             onCopyClick = remember(viewModel) {
                 { viewModel.trySendAction(ViewSendAction.CopyClick) }
             },
+            onCopyNotesClick = remember(viewModel) {
+                { viewModel.trySendAction(ViewSendAction.CopyNotesClick) }
+            },
             onDeleteClick = remember(viewModel) {
                 { viewModel.trySendAction(ViewSendAction.DeleteClick) }
             },
@@ -196,6 +200,7 @@ private fun ViewSendDialogs(
 private fun ViewSendScreenContent(
     state: ViewSendState,
     onCopyClick: () -> Unit,
+    onCopyNotesClick: () -> Unit,
     onDeleteClick: () -> Unit,
     onShareClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -205,6 +210,7 @@ private fun ViewSendScreenContent(
             ViewStateContent(
                 state = viewState,
                 onCopyClick = onCopyClick,
+                onCopyNotesClick = onCopyNotesClick,
                 onDeleteClick = onDeleteClick,
                 onShareClick = onShareClick,
                 modifier = modifier,
@@ -229,6 +235,7 @@ private fun ViewSendScreenContent(
 private fun ViewStateContent(
     state: ViewSendState.ViewState.Content,
     onCopyClick: () -> Unit,
+    onCopyNotesClick: () -> Unit,
     onDeleteClick: () -> Unit,
     onShareClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -320,7 +327,10 @@ private fun ViewStateContent(
                 .standardHorizontalMargin(),
         )
 
-        AdditionalOptions(state = state)
+        AdditionalOptions(
+            state = state,
+            onCopyNotesClick = onCopyNotesClick,
+        )
 
         DeleteButton(
             onDeleteClick = onDeleteClick,
@@ -454,6 +464,7 @@ private fun TextSendContent(
 @Composable
 private fun ColumnScope.AdditionalOptions(
     state: ViewSendState.ViewState.Content,
+    onCopyNotesClick: () -> Unit,
 ) {
     if (state.maxAccessCount == null && state.notes == null) {
         Spacer(modifier = Modifier.height(height = 16.dp))
@@ -503,6 +514,14 @@ private fun ColumnScope.AdditionalOptions(
                     label = stringResource(id = R.string.private_notes),
                     readOnly = true,
                     value = it,
+                    actions = {
+                        BitwardenStandardIconButton(
+                            vectorIconRes = R.drawable.ic_copy,
+                            contentDescription = stringResource(id = R.string.copy_notes),
+                            onClick = onCopyNotesClick,
+                            modifier = Modifier.testTag(tag = "ViewSendNotesCopyButton"),
+                        )
+                    },
                     singleLine = false,
                     onValueChange = {},
                     cardStyle = CardStyle.Full,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
@@ -66,6 +66,7 @@ class ViewSendViewModel @Inject constructor(
         when (action) {
             ViewSendAction.CloseClick -> handleCloseClick()
             ViewSendAction.CopyClick -> handleCopyClick()
+            ViewSendAction.CopyNotesClick -> handleCopyNotesClick()
             ViewSendAction.DeleteClick -> handleDeleteClick()
             ViewSendAction.DialogDismiss -> handleDialogDismiss()
             ViewSendAction.EditClick -> handleEditClick()
@@ -87,6 +88,10 @@ class ViewSendViewModel @Inject constructor(
 
     private fun handleCopyClick() {
         onContent { clipboardManager.setText(text = it.shareLink) }
+    }
+
+    private fun handleCopyNotesClick() {
+        onContent { clipboardManager.setText(text = it.notes.orEmpty()) }
     }
 
     private fun handleDeleteClick() {
@@ -355,6 +360,11 @@ sealed class ViewSendAction {
      * The user has clicked the copy button.
      */
     data object CopyClick : ViewSendAction()
+
+    /**
+     * The user has clicked the copy notes button.
+     */
+    data object CopyNotesClick : ViewSendAction()
 
     /**
      * The user has clicked the delete button.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
@@ -143,7 +143,7 @@ class ViewSendScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `oon delete confirmation dialog yes click should send DeleteClick`() {
+    fun `on delete confirmation dialog yes click should send DeleteClick`() {
         composeTestRule
             .onNodeWithText(text = "Delete send")
             .performScrollTo()
@@ -301,6 +301,22 @@ class ViewSendScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "Private notes")
             .performScrollTo()
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun `on copy notes click should send CopyNotesClick`() {
+        composeTestRule
+            .onNodeWithText(text = "Additional options")
+            .performScrollTo()
+            .performClick()
+
+        // Overscroll to the delete button in order to avoid clicking the FAB
+        composeTestRule.onNodeWithText(text = "Delete send").performScrollTo()
+        composeTestRule.onNodeWithContentDescription(label = "Copy note").performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(ViewSendAction.CopyNotesClick)
+        }
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModelTest.kt
@@ -96,6 +96,20 @@ class ViewSendViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `on CopyNotesClick should call setText on ClipboardManger`() {
+        val viewModel = createViewModel()
+        val sendView = createMockSendView(number = 1)
+        every {
+            sendView.toViewSendViewStateContent(baseWebSendUrl = any(), clock = FIXED_CLOCK)
+        } returns DEFAULT_CONTENT_VIEW_STATE
+        mutableSendStateFlow.value = DataState.Loaded(data = sendView)
+        viewModel.trySendAction(ViewSendAction.CopyNotesClick)
+        verify(exactly = 1) {
+            clipboardManager.setText(text = "notes")
+        }
+    }
+
+    @Test
     fun `on DeleteClick with failure should display error dialog`() = runTest {
         val initialState = DEFAULT_STATE.copy(viewState = DEFAULT_CONTENT_VIEW_STATE)
         val sendView = createMockSendView(number = 1)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22265](https://bitwarden.atlassian.net/browse/PM-22265)

## 📔 Objective

This PR adds a Copy button for the private notes field on the `ViewSendScreen`.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ce854698-ea8d-4fc2-99a6-903b91c5d2ce" width="300" /> | <img src="https://github.com/user-attachments/assets/85a4800a-8e29-42c6-89b1-e254b86b03db" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22265]: https://bitwarden.atlassian.net/browse/PM-22265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ