### PR TITLE
PM-22345: Flight recorder banner should not dismiss when navigating to settings

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -228,7 +228,6 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleFlightRecorderGoToSettingsClick() {
-        settingsRepository.dismissFlightRecorderBanner()
         sendEvent(VaultEvent.NavigateToAbout)
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -432,10 +432,6 @@ class VaultViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(VaultAction.FlightRecorderGoToSettingsClick)
             assertEquals(VaultEvent.NavigateToAbout, awaitItem())
         }
-
-        verify(exactly = 1) {
-            settingsRepository.dismissFlightRecorderBanner()
-        }
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22345](https://bitwarden.atlassian.net/browse/PM-22345)

## 📔 Objective

This PR updates the Flight Recorder banner to not dismiss after clicking on the `Go to settings` button.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22345]: https://bitwarden.atlassian.net/browse/PM-22345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ