### PR TITLE
PM-22346: Remove the period from the generic error title

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenBasicDialog.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenBasicDialog.kt
@@ -107,7 +107,7 @@ fun BitwardenBasicDialog(
 private fun BitwardenBasicDialog_preview() {
     BitwardenTheme {
         BitwardenBasicDialog(
-            title = "An error has occurred.",
+            title = "An error has occurred",
             message = "Username or password is incorrect. Try again.",
             onDismissRequest = {},
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="about">About</string>
     <string name="add_folder">Add folder</string>
     <string name="add_item">Add Item</string>
-    <string name="an_error_has_occurred">An error has occurred.</string>
+    <string name="an_error_has_occurred">An error has occurred</string>
     <string name="back">Back</string>
     <string name="bitwarden">Bitwarden</string>
     <string name="cancel">Cancel</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
@@ -97,7 +97,7 @@ class EnvironmentScreenTest : BitwardenComposeTest() {
         composeTestRule.onNode(isDialog()).assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText("An error has occurred.")
+            .onNodeWithText(text = "An error has occurred")
             .assert(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
@@ -393,7 +393,7 @@ class LandingScreenTest : BitwardenComposeTest() {
         composeTestRule.onNode(isDialog()).assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText("An error has occurred.")
+            .onNodeWithText(text = "An error has occurred")
             .assert(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreenTest.kt
@@ -97,7 +97,7 @@ class LoginApprovalScreenTest : BitwardenComposeTest() {
 
     @Test
     fun `on error dialog dismiss click should send ErrorDialogDismiss`() = runTest {
-        val title = "An error has occurred."
+        val title = "An error has occurred"
         val message = "We were unable to process your request."
         mutableStateFlow.tryEmit(
             DEFAULT_STATE.copy(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreenTest.kt
@@ -191,7 +191,7 @@ class FolderAddEditScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithText("An error has occurred.")
+            .onNodeWithText(text = "An error has occurred")
             .assert(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModelTest.kt
@@ -70,7 +70,7 @@ class PasswordHistoryViewModelTest : BaseViewModelTest() {
     @Test
     fun `when repository emits Error state the state updates correctly`() = runTest {
         fakeGeneratorRepository.emitPasswordHistoryState(
-            state = LocalDataState.Error(Exception("An error has occurred.")),
+            state = LocalDataState.Error(Exception("An error has occurred")),
         )
         val viewModel = createViewModel()
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreenTests.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreenTests.kt
@@ -147,7 +147,7 @@ class ManualCodeEntryScreenTests : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onAllNodesWithText(text = "An error has occurred.")
+            .onAllNodesWithText(text = "An error has occurred")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenBasicDialog.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenBasicDialog.kt
@@ -61,7 +61,7 @@ private fun BitwardenBasicDialog_preview() {
     AuthenticatorTheme {
         BitwardenBasicDialog(
             visibilityState = BasicDialogState.Shown(
-                title = "An error has occurred.".asText(),
+                title = "An error has occurred".asText(),
                 message = "Username or password is incorrect. Try again.".asText(),
             ),
             onDismissRequest = {},


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22346](https://bitwarden.atlassian.net/browse/PM-22346)

## 📔 Objective

This PR removes the period from the generic error title.

`An error has occurred.` --> `An error has occurred`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22346]: https://bitwarden.atlassian.net/browse/PM-22346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ