### PR TITLE
PM-22357: Delete Send button should use a capital S

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -956,7 +956,7 @@ Do you want to switch to this account?</string>
     <string name="this_account_will_soon_be_deleted_log_in_at_x_to_continue_using_bitwarden">This account will soon be deleted. Log in at %1$s to continue using Bitwarden.</string>
     <string name="view_file_send">View file Send</string>
     <string name="view_text_send">View text Send</string>
-    <string name="delete_send">Delete send</string>
+    <string name="delete_send">Delete Send</string>
     <string name="missing_send_resync_your_vault">Missing Send re-sync your vault</string>
     <string name="dynamic_colors">Dynamic colors</string>
     <string name="dynamic_colors_description">Apply dynamic colors based on your wallpaper</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -284,7 +284,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithText(text = "Delete send")
+            .onNodeWithText(text = "Delete Send")
             .performScrollTo()
             .performClick()
 
@@ -301,7 +301,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithText(text = "Delete send")
+            .onNodeWithText(text = "Delete Send")
             .performScrollTo()
             .performClick()
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreenTest.kt
@@ -132,7 +132,7 @@ class ViewSendScreenTest : BitwardenComposeTest() {
     @Test
     fun `on Delete button click should Display delete confirmation dialog`() {
         composeTestRule
-            .onNodeWithText(text = "Delete send")
+            .onNodeWithText(text = "Delete Send")
             .performScrollTo()
             .performClick()
 
@@ -145,7 +145,7 @@ class ViewSendScreenTest : BitwardenComposeTest() {
     @Test
     fun `on delete confirmation dialog yes click should send DeleteClick`() {
         composeTestRule
-            .onNodeWithText(text = "Delete send")
+            .onNodeWithText(text = "Delete Send")
             .performScrollTo()
             .performClick()
 
@@ -311,7 +311,7 @@ class ViewSendScreenTest : BitwardenComposeTest() {
             .performClick()
 
         // Overscroll to the delete button in order to avoid clicking the FAB
-        composeTestRule.onNodeWithText(text = "Delete send").performScrollTo()
+        composeTestRule.onNodeWithText(text = "Delete Send").performScrollTo()
         composeTestRule.onNodeWithContentDescription(label = "Copy note").performClick()
 
         verify(exactly = 1) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22357](https://bitwarden.atlassian.net/browse/PM-22357)

## 📔 Objective

This PR updates the Delete Send button to use a capital S.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
