### PR TITLE
PM-22362: AddSendScreen should include 'Required.' when describing the max file size

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
@@ -289,7 +289,7 @@ private fun ColumnScope.FileTypeContent(
         )
         Spacer(modifier = Modifier.height(height = 8.dp))
         Text(
-            text = stringResource(id = R.string.max_file_size),
+            text = stringResource(id = R.string.required_max_file_size),
             color = BitwardenTheme.colorScheme.text.secondary,
             style = BitwardenTheme.typography.bodySmall,
             modifier = Modifier
@@ -336,7 +336,7 @@ private fun ColumnScope.FileTypeContent(
         )
         Spacer(modifier = Modifier.height(height = 8.dp))
         Text(
-            text = stringResource(id = R.string.max_file_size),
+            text = stringResource(id = R.string.required_max_file_size),
             color = BitwardenTheme.colorScheme.text.secondary,
             style = BitwardenTheme.typography.bodySmall,
             modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,6 +200,7 @@ Scanning will happen automatically.</string>
     <string name="no_attachments">There are no attachments.</string>
     <string name="file_source">File Source</string>
     <string name="max_file_size">Maximum file size is 100 MB.</string>
+    <string name="required_max_file_size">Required. Maximum file size is 100 MB.</string>
     <string name="learn_more">Learn more</string>
     <string name="api_url">API server URL</string>
     <string name="client_certificate_mtls">Client certificate (mTLS)</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22362](https://bitwarden.atlassian.net/browse/PM-22362)

## 📔 Objective

This PR adds the `Required. ` prefix to the max file size description text on the Add Send Screen.


| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/f715d0a1-4ad3-4f86-a32d-c7a300b63169" width="300" /> | <img src="https://github.com/user-attachments/assets/3e6dc873-3b4a-48ed-892a-8f3713985c12" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22362]: https://bitwarden.atlassian.net/browse/PM-22362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ