### PR TITLE
PM-22402: Update File Send error message

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -497,9 +497,8 @@ class AddEditSendViewModel @Inject constructor(
                             it.copy(
                                 dialogState = AddEditSendState.DialogState.Error(
                                     title = R.string.an_error_has_occurred.asText(),
-                                    message = R.string.validation_field_required.asText(
-                                        R.string.file.asText(),
-                                    ),
+                                    message = R.string.you_must_attach_a_file_to_save_this_send
+                                        .asText(),
                                 ),
                             )
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="website_uri">Website (URI)</string>
     <string name="username">Username</string>
     <string name="validation_field_required">The %1$s field is required.</string>
+    <string name="you_must_attach_a_file_to_save_this_send">You must attach a file to save this send.</string>
     <string name="value_has_been_copied">%1$s copied</string>
     <string name="verify_master_password">Verify master password</string>
     <string name="verify_pin">Verify PIN</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -401,7 +401,7 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
             initialState.copy(
                 dialogState = AddEditSendState.DialogState.Error(
                     title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.validation_field_required.asText(R.string.file.asText()),
+                    message = R.string.you_must_attach_a_file_to_save_this_send.asText(),
                 ),
             ),
             viewModel.stateFlow.value,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22402](https://bitwarden.atlassian.net/browse/PM-22402)

## 📔 Objective

This PR updates the error message displayed when a user tries to create a File Send without a file associated with it.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300" /> | <img src="" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
