### PR TITLE
[PM-21458] Add UserManagedPrivilegedApps feature flag

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/di/CredentialProviderModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/di/CredentialProviderModule.kt
@@ -89,11 +89,13 @@ object CredentialProviderModule {
         assetManager: AssetManager,
         digitalAssetLinkService: DigitalAssetLinkService,
         privilegedAppRepository: PrivilegedAppRepository,
+        featureFlagManager: FeatureFlagManager,
     ): OriginManager =
         OriginManagerImpl(
             assetManager = assetManager,
             digitalAssetLinkService = digitalAssetLinkService,
             privilegedAppRepository = privilegedAppRepository,
+            featureFlagManager = featureFlagManager,
         )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -36,6 +36,7 @@ sealed class FlagKey<out T : Any> {
                 FlightRecorder,
                 RestrictCipherItemDeletion,
                 PreAuthSettings,
+                UserManagedPrivilegedApps,
             )
         }
     }
@@ -169,6 +170,14 @@ sealed class FlagKey<out T : Any> {
      */
     data object PreAuthSettings : FlagKey<Boolean>() {
         override val keyName: String = "enable-pm-prelogin-settings"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key to enabled user-managed privileged apps.
+     */
+    data object UserManagedPrivilegedApps : FlagKey<Boolean>() {
+        override val keyName: String = "pm-18970-user-managed-privileged-apps"
         override val defaultValue: Boolean = false
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -41,6 +41,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.FlightRecorder,
     FlagKey.RestrictCipherItemDeletion,
     FlagKey.PreAuthSettings,
+    FlagKey.UserManagedPrivilegedApps,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -101,4 +102,7 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.FlightRecorder -> stringResource(R.string.enable_flight_recorder)
     FlagKey.RestrictCipherItemDeletion -> stringResource(R.string.restrict_item_deletion)
     FlagKey.PreAuthSettings -> stringResource(R.string.enable_pre_auth_settings)
+    FlagKey.UserManagedPrivilegedApps -> {
+        stringResource(R.string.user_trusted_privileged_app_management)
+    }
 }

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -30,5 +30,6 @@
     <string name="generate_crash">Generate crash</string>
     <string name="generate_error_report">Generate error report</string>
     <string name="error_reports">Error reports</string>
+    <string name="user_trusted_privileged_app_management">User-trusted privileged app management</string>
     <!-- /Debug Menu -->
 </resources>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -69,6 +69,10 @@ class FlagKeyTest {
             FlagKey.PreAuthSettings.keyName,
             "enable-pm-prelogin-settings",
         )
+        assertEquals(
+            FlagKey.UserManagedPrivilegedApps.keyName,
+            "pm-18970-user-managed-privileged-apps",
+        )
     }
 
     @Test
@@ -90,6 +94,7 @@ class FlagKeyTest {
                 FlagKey.FlightRecorder,
                 FlagKey.RestrictCipherItemDeletion,
                 FlagKey.PreAuthSettings,
+                FlagKey.UserManagedPrivilegedApps,
             ).all {
                 !it.defaultValue
             },

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -159,6 +159,7 @@ private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
     FlagKey.FlightRecorder to true,
     FlagKey.RestrictCipherItemDeletion to true,
     FlagKey.PreAuthSettings to true,
+    FlagKey.UserManagedPrivilegedApps to true,
 )
 
 private val UPDATED_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf(
@@ -177,6 +178,7 @@ private val UPDATED_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
     FlagKey.FlightRecorder to false,
     FlagKey.RestrictCipherItemDeletion to false,
     FlagKey.PreAuthSettings to false,
+    FlagKey.UserManagedPrivilegedApps to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(


### PR DESCRIPTION
## 🎟️ Tracking

PM-22548

## 📔 Objective

This commit introduces a new feature flag `UserManagedPrivilegedApps`.

The following changes are included:
- Added `UserManagedPrivilegedApps` to `FlagKey.kt`
- Added string resource for the feature flag description
- Updated tests in `FlagKeyTest.kt` and `DebugMenuViewModelTest.kt` to include the new flag
- Added the new flag to the debug menu UI in `FeatureFlagListItems.kt`

## 📸 Screenshots

<img width="400" alt="image" src="https://github.com/user-attachments/assets/3083bdf1-c863-4b18-b8d0-8b1d12d49d35" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
