### PR TITLE
[PM-22461] Add About privileged apps screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsNavigation.kt
@@ -95,6 +95,7 @@ fun NavGraphBuilder.settingsGraph(
     onNavigateToFlightRecorder: () -> Unit,
     onNavigateToRecordedLogs: () -> Unit,
     onNavigateToImportLogins: () -> Unit,
+    onNavigateToAboutPrivilegedApps: () -> Unit,
 ) {
     navigation<SettingsGraphRoute>(
         startDestination = SettingsRoute.Standard,
@@ -130,6 +131,7 @@ fun NavGraphBuilder.settingsGraph(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToBlockAutoFillScreen = { navController.navigateToBlockAutoFillScreen() },
             onNavigateToSetupAutofill = onNavigateToSetupAutoFillScreen,
+            onNavigateToAboutPrivilegedAppsScreen = onNavigateToAboutPrivilegedApps,
         )
         otherDestination(
             isPreAuth = false,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillNavigation.kt
@@ -1,8 +1,10 @@
+@file:OmitFromCoverage
 package com.x8bit.bitwarden.ui.platform.feature.settings.autofill
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.ui.platform.base.util.composableWithPushTransitions
 import kotlinx.serialization.Serializable
 
@@ -19,12 +21,14 @@ fun NavGraphBuilder.autoFillDestination(
     onNavigateBack: () -> Unit,
     onNavigateToBlockAutoFillScreen: () -> Unit,
     onNavigateToSetupAutofill: () -> Unit,
+    onNavigateToAboutPrivilegedAppsScreen: () -> Unit,
 ) {
     composableWithPushTransitions<AutofillRoute> {
         AutoFillScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToBlockAutoFillScreen = onNavigateToBlockAutoFillScreen,
             onNavigateToSetupAutofill = onNavigateToSetupAutofill,
+            onNavigateToAboutPrivilegedAppsScreen = onNavigateToAboutPrivilegedAppsScreen,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -43,12 +43,14 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
+import com.x8bit.bitwarden.ui.platform.components.model.TooltipData
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenTextRow
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.chrome.ChromeAutofillSettingsCard
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.handlers.AutoFillHandlers
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.util.displayLabel
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import kotlinx.collections.immutable.toImmutableList
@@ -65,6 +67,7 @@ fun AutoFillScreen(
     intentManager: IntentManager = LocalIntentManager.current,
     onNavigateToBlockAutoFillScreen: () -> Unit,
     onNavigateToSetupAutofill: () -> Unit,
+    onNavigateToAboutPrivilegedAppsScreen: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -102,6 +105,10 @@ fun AutoFillScreen(
                     releaseChannel = event.releaseChannel,
                 )
             }
+
+            AutoFillEvent.NavigateToAboutPrivilegedAppsScreen -> {
+                onNavigateToAboutPrivilegedAppsScreen()
+            }
         }
     }
 
@@ -114,6 +121,7 @@ fun AutoFillScreen(
     }
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    val autoFillHandlers = remember(viewModel) { AutoFillHandlers.create(viewModel = viewModel) }
     BitwardenScaffold(
         modifier = Modifier
             .fillMaxSize()
@@ -130,187 +138,188 @@ fun AutoFillScreen(
             )
         },
     ) {
-        Column(
+        AutoFillScreenContent(
+            state = state,
+            autoFillHandlers = autoFillHandlers,
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState()),
+        )
+    }
+}
+
+@Suppress("LongMethod")
+@Composable
+private fun AutoFillScreenContent(
+    state: AutoFillState,
+    autoFillHandlers: AutoFillHandlers,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Spacer(modifier = Modifier.height(height = 12.dp))
+        AnimatedVisibility(
+            visible = state.showAutofillActionCard,
+            label = "AutofillActionCard",
+            exit = actionCardExitAnimation(),
         ) {
-            Spacer(modifier = Modifier.height(height = 12.dp))
-            AnimatedVisibility(
-                visible = state.showAutofillActionCard,
-                label = "AutofillActionCard",
-                exit = actionCardExitAnimation(),
-            ) {
-                BitwardenActionCard(
-                    cardTitle = stringResource(R.string.turn_on_autofill),
-                    actionText = stringResource(R.string.get_started),
-                    onActionClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(AutoFillAction.AutofillActionCardCtaClick)
-                        }
-                    },
-                    onDismissClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(AutoFillAction.DismissShowAutofillActionCard)
-                        }
-                    },
-                    leadingContent = {
-                        NotificationBadge(notificationCount = 1)
-                    },
+            BitwardenActionCard(
+                cardTitle = stringResource(R.string.turn_on_autofill),
+                actionText = stringResource(R.string.get_started),
+                onActionClick = autoFillHandlers.onAutofillActionCardClick,
+                onDismissClick = autoFillHandlers.onAutofillActionCardDismissClick,
+                leadingContent = { NotificationBadge(notificationCount = 1) },
+                modifier = Modifier
+                    .standardHorizontalMargin()
+                    .padding(bottom = 16.dp),
+            )
+        }
+        BitwardenListHeaderText(
+            label = stringResource(id = R.string.autofill),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin()
+                .padding(horizontal = 16.dp),
+        )
+        Spacer(modifier = Modifier.height(height = 8.dp))
+        BitwardenSwitch(
+            label = stringResource(id = R.string.autofill_services),
+            supportingText = stringResource(id = R.string.autofill_services_explanation_long),
+            isChecked = state.isAutoFillServicesEnabled,
+            onCheckedChange = autoFillHandlers.onAutofillServicesClick,
+            cardStyle = CardStyle.Full,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("AutofillServicesSwitch")
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(height = 8.dp))
+        if (state.showInlineAutofillOption) {
+            BitwardenSwitch(
+                label = stringResource(id = R.string.inline_autofill),
+                supportingText = stringResource(
+                    id = R.string.use_inline_autofill_explanation_long,
+                ),
+                isChecked = state.isUseInlineAutoFillEnabled,
+                onCheckedChange = autoFillHandlers.onUseInlineAutofillClick,
+                enabled = state.canInteractWithInlineAutofillToggle,
+                cardStyle = CardStyle.Full,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("InlineAutofillSwitch")
+                    .standardHorizontalMargin(),
+            )
+            Spacer(modifier = Modifier.height(height = 8.dp))
+        }
+
+        if (state.chromeAutofillSettingsOptions.isNotEmpty()) {
+            ChromeAutofillSettingsCard(
+                options = state.chromeAutofillSettingsOptions,
+                onOptionClicked = autoFillHandlers.onChromeAutofillSelected,
+                enabled = state.isAutoFillServicesEnabled,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        if (state.showPasskeyManagementRow) {
+            BitwardenExternalLinkRow(
+                text = stringResource(id = R.string.passkey_management),
+                description = stringResource(
+                    id = R.string.passkey_management_explanation_long,
+                ),
+                onConfirmClick = autoFillHandlers.onPasskeyManagementClick,
+                dialogTitle = stringResource(id = R.string.continue_to_device_settings),
+                dialogMessage = stringResource(
+                    id = R.string.set_bitwarden_as_passkey_manager_description,
+                ),
+                withDivider = false,
+                cardStyle = if (state.isUserManagedPrivilegedAppsEnabled) {
+                    CardStyle.Top()
+                } else {
+                    CardStyle.Full
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+            if (state.isUserManagedPrivilegedAppsEnabled) {
+                BitwardenTextRow(
+                    text = stringResource(R.string.privileged_apps),
+                    onClick = autoFillHandlers.onPrivilegedAppsClick,
+                    tooltip = TooltipData(
+                        contentDescription =
+                            stringResource(R.string.learn_more_about_privileged_apps),
+                        onClick = autoFillHandlers.onPrivilegedAppsHelpLinkClick,
+                    ),
+                    cardStyle = CardStyle.Bottom,
                     modifier = Modifier
                         .standardHorizontalMargin()
-                        .padding(bottom = 16.dp),
+                        .fillMaxWidth(),
                 )
             }
-            BitwardenListHeaderText(
-                label = stringResource(id = R.string.autofill),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin()
-                    .padding(horizontal = 16.dp),
-            )
             Spacer(modifier = Modifier.height(height = 8.dp))
-            BitwardenSwitch(
-                label = stringResource(id = R.string.autofill_services),
-                supportingText = stringResource(id = R.string.autofill_services_explanation_long),
-                isChecked = state.isAutoFillServicesEnabled,
-                onCheckedChange = remember(viewModel) {
-                    { viewModel.trySendAction(AutoFillAction.AutoFillServicesClick(it)) }
-                },
-                cardStyle = CardStyle.Full,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("AutofillServicesSwitch")
-                    .standardHorizontalMargin(),
-            )
-            Spacer(modifier = Modifier.height(height = 8.dp))
-            if (state.showInlineAutofillOption) {
-                BitwardenSwitch(
-                    label = stringResource(id = R.string.inline_autofill),
-                    supportingText = stringResource(
-                        id = R.string.use_inline_autofill_explanation_long,
-                    ),
-                    isChecked = state.isUseInlineAutoFillEnabled,
-                    onCheckedChange = remember(viewModel) {
-                        { viewModel.trySendAction(AutoFillAction.UseInlineAutofillClick(it)) }
-                    },
-                    enabled = state.canInteractWithInlineAutofillToggle,
-                    cardStyle = CardStyle.Full,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag("InlineAutofillSwitch")
-                        .standardHorizontalMargin(),
-                )
-                Spacer(modifier = Modifier.height(height = 8.dp))
-            }
-
-            if (state.chromeAutofillSettingsOptions.isNotEmpty()) {
-                ChromeAutofillSettingsCard(
-                    options = state.chromeAutofillSettingsOptions,
-                    onOptionClicked = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(AutoFillAction.ChromeAutofillSelected(it))
-                        }
-                    },
-                    enabled = state.isAutoFillServicesEnabled,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-
-            if (state.showPasskeyManagementRow) {
-                BitwardenExternalLinkRow(
-                    text = stringResource(id = R.string.passkey_management),
-                    description = stringResource(
-                        id = R.string.passkey_management_explanation_long,
-                    ),
-                    onConfirmClick = remember(viewModel) {
-                        { viewModel.trySendAction(AutoFillAction.PasskeyManagementClick) }
-                    },
-                    dialogTitle = stringResource(id = R.string.continue_to_device_settings),
-                    dialogMessage = stringResource(
-                        id = R.string.set_bitwarden_as_passkey_manager_description,
-                    ),
-                    withDivider = false,
-                    cardStyle = CardStyle.Full,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .standardHorizontalMargin(),
-                )
-                Spacer(modifier = Modifier.height(height = 8.dp))
-            }
-            AccessibilityAutofillSwitch(
-                isAccessibilityAutoFillEnabled = state.isAccessibilityAutofillEnabled,
-                onCheckedChange = remember(viewModel) {
-                    { viewModel.trySendAction(AutoFillAction.UseAccessibilityAutofillClick) }
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin(),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            BitwardenListHeaderText(
-                label = stringResource(id = R.string.additional_options),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin()
-                    .padding(horizontal = 16.dp),
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            BitwardenSwitch(
-                label = stringResource(id = R.string.copy_totp_automatically),
-                supportingText = stringResource(id = R.string.copy_totp_automatically_description),
-                isChecked = state.isCopyTotpAutomaticallyEnabled,
-                onCheckedChange = remember(viewModel) {
-                    { viewModel.trySendAction(AutoFillAction.CopyTotpAutomaticallyClick(it)) }
-                },
-                cardStyle = CardStyle.Full,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("CopyTotpAutomaticallySwitch")
-                    .standardHorizontalMargin(),
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            BitwardenSwitch(
-                label = stringResource(id = R.string.ask_to_add_login),
-                supportingText = stringResource(id = R.string.ask_to_add_login_description),
-                isChecked = state.isAskToAddLoginEnabled,
-                onCheckedChange = remember(viewModel) {
-                    { viewModel.trySendAction(AutoFillAction.AskToAddLoginClick(it)) }
-                },
-                cardStyle = CardStyle.Full,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("AskToAddLoginSwitch")
-                    .standardHorizontalMargin(),
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            DefaultUriMatchTypeRow(
-                selectedUriMatchType = state.defaultUriMatchType,
-                onUriMatchTypeSelect = remember(viewModel) {
-                    { viewModel.trySendAction(AutoFillAction.DefaultUriMatchTypeSelect(it)) }
-                },
-                modifier = Modifier
-                    .testTag("DefaultUriMatchDetectionChooser")
-                    .standardHorizontalMargin()
-                    .fillMaxWidth(),
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            BitwardenTextRow(
-                text = stringResource(id = R.string.block_auto_fill),
-                description = stringResource(
-                    id = R.string.auto_fill_will_not_be_offered_for_these_ur_is,
-                ),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(AutoFillAction.BlockAutoFillClick) }
-                },
-                cardStyle = CardStyle.Full,
-                modifier = Modifier
-                    .standardHorizontalMargin()
-                    .fillMaxWidth(),
-            )
-            Spacer(modifier = Modifier.height(height = 16.dp))
-            Spacer(modifier = Modifier.navigationBarsPadding())
         }
+        AccessibilityAutofillSwitch(
+            isAccessibilityAutoFillEnabled = state.isAccessibilityAutofillEnabled,
+            onCheckedChange = autoFillHandlers.onUseAccessibilityServiceClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        BitwardenListHeaderText(
+            label = stringResource(id = R.string.additional_options),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin()
+                .padding(horizontal = 16.dp),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        BitwardenSwitch(
+            label = stringResource(id = R.string.copy_totp_automatically),
+            supportingText = stringResource(id = R.string.copy_totp_automatically_description),
+            isChecked = state.isCopyTotpAutomaticallyEnabled,
+            onCheckedChange = autoFillHandlers.onCopyTotpAutomaticallyClick,
+            cardStyle = CardStyle.Full,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("CopyTotpAutomaticallySwitch")
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        BitwardenSwitch(
+            label = stringResource(id = R.string.ask_to_add_login),
+            supportingText = stringResource(id = R.string.ask_to_add_login_description),
+            isChecked = state.isAskToAddLoginEnabled,
+            onCheckedChange = autoFillHandlers.onAskToAddLoginClick,
+            cardStyle = CardStyle.Full,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("AskToAddLoginSwitch")
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        DefaultUriMatchTypeRow(
+            selectedUriMatchType = state.defaultUriMatchType,
+            onUriMatchTypeSelect = autoFillHandlers.onDefaultUriMatchTypeSelect,
+            modifier = Modifier
+                .testTag("DefaultUriMatchDetectionChooser")
+                .standardHorizontalMargin()
+                .fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        BitwardenTextRow(
+            text = stringResource(id = R.string.block_auto_fill),
+            description = stringResource(
+                id = R.string.auto_fill_will_not_be_offered_for_these_ur_is,
+            ),
+            onClick = autoFillHandlers.onBlockAutoFillClick,
+            cardStyle = CardStyle.Full,
+            modifier = Modifier
+                .standardHorizontalMargin()
+                .fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(height = 16.dp))
+        Spacer(modifier = Modifier.navigationBarsPadding())
     }
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/handlers/AutoFillHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/handlers/AutoFillHandlers.kt
@@ -1,0 +1,98 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.handlers
+
+import com.x8bit.bitwarden.data.autofill.model.chrome.ChromeReleaseChannel
+import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.AutoFillAction
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.AutoFillViewModel
+
+/**
+ * Handlers for the AutoFill screen.
+ */
+@Suppress("LongParameterList")
+class AutoFillHandlers(
+    val onBackClick: () -> Unit,
+    val onAutofillActionCardClick: () -> Unit,
+    val onAutofillActionCardDismissClick: () -> Unit,
+    val onAutofillServicesClick: (isEnabled: Boolean) -> Unit,
+    val onUseInlineAutofillClick: (isEnabled: Boolean) -> Unit,
+    val onChromeAutofillSelected: (releaseChannel: ChromeReleaseChannel) -> Unit,
+    val onPasskeyManagementClick: () -> Unit,
+    val onPrivilegedAppsClick: () -> Unit,
+    val onPrivilegedAppsHelpLinkClick: () -> Unit,
+    val onUseAccessibilityServiceClick: () -> Unit,
+    val onCopyTotpAutomaticallyClick: (isEnabled: Boolean) -> Unit,
+    val onAskToAddLoginClick: (isEnabled: Boolean) -> Unit,
+    val onDefaultUriMatchTypeSelect: (defaultUriMatchType: UriMatchType) -> Unit,
+    val onBlockAutoFillClick: () -> Unit,
+) {
+    @Suppress("UndocumentedPublicClass")
+    companion object {
+
+        /**
+         * Creates a new instance of [AutoFillHandlers] from the given [AutoFillViewModel].
+         */
+        @Suppress("LongMethod")
+        fun create(viewModel: AutoFillViewModel): AutoFillHandlers = AutoFillHandlers(
+            onBackClick = { viewModel.trySendAction(AutoFillAction.BackClick) },
+            onAutofillActionCardClick = {
+                viewModel.trySendAction(AutoFillAction.AutofillActionCardCtaClick)
+            },
+            onAutofillActionCardDismissClick = {
+                viewModel.trySendAction(AutoFillAction.DismissShowAutofillActionCard)
+            },
+            onAutofillServicesClick = {
+                viewModel.trySendAction(
+                    AutoFillAction.AutoFillServicesClick(
+                        it,
+                    ),
+                )
+            },
+            onUseInlineAutofillClick = {
+                viewModel.trySendAction(
+                    AutoFillAction.UseInlineAutofillClick(
+                        it,
+                    ),
+                )
+            },
+            onChromeAutofillSelected = {
+                viewModel.trySendAction(
+                    AutoFillAction.ChromeAutofillSelected(
+                        it,
+                    ),
+                )
+            },
+            onPasskeyManagementClick = {
+                viewModel.trySendAction(AutoFillAction.PasskeyManagementClick)
+            },
+            onPrivilegedAppsClick = {
+                // TODO (PM-19108): Open privileged apps screen when available
+            },
+            onPrivilegedAppsHelpLinkClick = {
+                viewModel.trySendAction(AutoFillAction.AboutPrivilegedAppsClick)
+            },
+            onUseAccessibilityServiceClick = {
+                viewModel.trySendAction(
+                    AutoFillAction.UseAccessibilityAutofillClick,
+                )
+            },
+            onCopyTotpAutomaticallyClick = {
+                viewModel.trySendAction(
+                    AutoFillAction.CopyTotpAutomaticallyClick(
+                        it,
+                    ),
+                )
+            },
+            onAskToAddLoginClick = {
+                viewModel.trySendAction(AutoFillAction.AskToAddLoginClick(it))
+            },
+            onDefaultUriMatchTypeSelect = {
+                viewModel.trySendAction(
+                    AutoFillAction.DefaultUriMatchTypeSelect(
+                        it,
+                    ),
+                )
+            },
+            onBlockAutoFillClick = { viewModel.trySendAction(AutoFillAction.BlockAutoFillClick) },
+        )
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/about/AboutPrivilegedAppsNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/about/AboutPrivilegedAppsNavigation.kt
@@ -1,0 +1,38 @@
+@file:OmitFromCoverage
+
+package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.privilegedapps.about
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import kotlinx.serialization.Serializable
+
+/**
+ * The type-safe route to the about privileged apps screen.
+ */
+@Serializable
+data object AboutPrivilegedAppsRoute
+
+/**
+ * Add about privileged apps destination to the nav graph.
+ */
+fun NavGraphBuilder.aboutPrivilegedAppsDestination(
+    onNavigateBack: () -> Unit,
+) {
+    composableWithSlideTransitions<AboutPrivilegedAppsRoute> {
+        AboutPrivilegedAppsScreen(
+            onNavigateBack = onNavigateBack,
+        )
+    }
+}
+
+/**
+ * Navigate to the about privileged apps screen.
+ */
+fun NavController.navigateToAboutPrivilegedAppsScreen(
+    navOptions: NavOptions? = null,
+) {
+    navigate(route = AboutPrivilegedAppsRoute, navOptions = navOptions)
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/about/AboutPrivilegedAppsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/about/AboutPrivilegedAppsScreen.kt
@@ -1,0 +1,102 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.privilegedapps.about
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
+import com.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.components.card.BitwardenContentCard
+import com.x8bit.bitwarden.ui.platform.components.model.ContentBlockData
+import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import kotlinx.collections.immutable.persistentListOf
+
+/**
+ * Top level composable for the About Privileged Apps screen.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutPrivilegedAppsScreen(
+    onNavigateBack: () -> Unit,
+) {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    BitwardenScaffold(
+        topBar = {
+            BitwardenTopAppBar(
+                title = stringResource(R.string.about_privileged_applications),
+                scrollBehavior = scrollBehavior,
+                navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
+                navigationIconContentDescription = stringResource(id = R.string.back),
+                onNavigationIconClick = remember { onNavigateBack },
+            )
+        },
+    ) {
+        AboutPrivilegedAppsContent(
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+}
+
+@Composable
+private fun AboutPrivilegedAppsContent(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = stringResource(R.string.privileged_apps_description),
+            textAlign = TextAlign.Center,
+            style = BitwardenTheme.typography.bodyMedium,
+            color = BitwardenTheme.colorScheme.text.primary,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        BitwardenContentCard(
+            contentItems = persistentListOf(
+                ContentBlockData(
+                    headerText = stringResource(R.string.trusted_by_you),
+                    subtitleText = stringResource(R.string.trusted_by_you_learn_more),
+                ),
+                ContentBlockData(
+                    headerText = stringResource(R.string.trusted_by_the_community),
+                    subtitleText = stringResource(R.string.trusted_by_community_learn_more),
+                ),
+                ContentBlockData(
+                    headerText = stringResource(R.string.trusted_by_google),
+                    subtitleText = stringResource(R.string.trusted_by_google_learn_more),
+                ),
+            ),
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.navigationBarsPadding())
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AboutPrivilegedAppsContent_Preview() {
+    BitwardenTheme {
+        AboutPrivilegedAppsContent()
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -1,9 +1,12 @@
+@file:OmitFromCoverage
+
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlocked
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.navigation
+import com.bitwarden.annotation.OmitFromCoverage
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupAutoFillScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.navigateToSetupUnlockScreen
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.setupAutoFillDestination
@@ -19,6 +22,8 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.loginapp
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.loginapproval.navigateToLoginApproval
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.pendingrequests.navigateToPendingRequests
 import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.pendingrequests.pendingRequestsDestination
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.privilegedapps.about.aboutPrivilegedAppsDestination
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.privilegedapps.about.navigateToAboutPrivilegedAppsScreen
 import com.x8bit.bitwarden.ui.platform.feature.settings.exportvault.exportVaultDestination
 import com.x8bit.bitwarden.ui.platform.feature.settings.exportvault.navigateToExportVault
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.flightRecorderDestination
@@ -124,6 +129,9 @@ fun NavGraphBuilder.vaultUnlockedGraph(
                 navController.navigateToFlightRecorder(isPreAuth = false)
             },
             onNavigateToRecordedLogs = { navController.navigateToRecordedLogs(isPreAuth = false) },
+            onNavigateToAboutPrivilegedApps = {
+                navController.navigateToAboutPrivilegedAppsScreen()
+            },
         )
         flightRecorderDestination(
             isPreAuth = false,
@@ -131,6 +139,9 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         )
         recordedLogsDestination(
             isPreAuth = false,
+            onNavigateBack = { navController.popBackStack() },
+        )
+        aboutPrivilegedAppsDestination(
             onNavigateBack = { navController.popBackStack() },
         )
         deleteAccountDestination(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarNavigation.kt
@@ -1,8 +1,10 @@
+@file:OmitFromCoverage
 package com.x8bit.bitwarden.ui.platform.feature.vaultunlockednavbar
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.ui.platform.base.util.composableWithStayTransitions
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendRoute
@@ -47,6 +49,7 @@ fun NavGraphBuilder.vaultUnlockedNavBarDestination(
     onNavigateToRecordedLogs: () -> Unit,
     onNavigateToImportLogins: () -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderName: String?) -> Unit,
+    onNavigateToAboutPrivilegedApps: () -> Unit,
 ) {
     composableWithStayTransitions<VaultUnlockedNavbarRoute> {
         VaultUnlockedNavBarScreen(
@@ -68,6 +71,7 @@ fun NavGraphBuilder.vaultUnlockedNavBarDestination(
             onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
             onNavigateToFlightRecorder = onNavigateToFlightRecorder,
             onNavigateToRecordedLogs = onNavigateToRecordedLogs,
+            onNavigateToAboutPrivilegedApps = onNavigateToAboutPrivilegedApps,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -72,6 +72,7 @@ fun VaultUnlockedNavBarScreen(
     onNavigateToRecordedLogs: () -> Unit,
     onNavigateToImportLogins: () -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
+    onNavigateToAboutPrivilegedApps: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
@@ -146,6 +147,7 @@ fun VaultUnlockedNavBarScreen(
         onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
         onNavigateToFlightRecorder = onNavigateToFlightRecorder,
         onNavigateToRecordedLogs = onNavigateToRecordedLogs,
+        onNavigateToAboutPrivilegedApps = onNavigateToAboutPrivilegedApps,
     )
 }
 
@@ -179,6 +181,7 @@ private fun VaultUnlockedNavBarScaffold(
     onNavigateToRecordedLogs: () -> Unit,
     onNavigateToImportLogins: () -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
+    onNavigateToAboutPrivilegedApps: () -> Unit,
 ) {
     var shouldDimNavBar by rememberSaveable { mutableStateOf(value = false) }
 
@@ -258,6 +261,7 @@ private fun VaultUnlockedNavBarScaffold(
                 onNavigateToImportLogins = onNavigateToImportLogins,
                 onNavigateToFlightRecorder = onNavigateToFlightRecorder,
                 onNavigateToRecordedLogs = onNavigateToRecordedLogs,
+                onNavigateToAboutPrivilegedApps = onNavigateToAboutPrivilegedApps,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -969,4 +969,14 @@ Do you want to switch to this account?</string>
     <string name="passkey_operation_failed_because_browser_x_is_not_trusted">Passkey operation failed because browser (%1$s) is not trusted. Select \"Trust\" to add %1$s to the list of trusted applications or \"Cancel"\ to abort the operation.</string>
     <string name="passkey_operation_failed_because_the_browser_is_not_trusted">Passkey operation failed because the browser is not trusted.</string>
     <string name="trust">Trust</string>
+    <string name="trusted_by_you_learn_more">These are applications or browsers that Bitwarden does not trust by default, but YOU trust to perform passkey operations.</string>
+    <string name="trusted_by_community_learn_more">These are applications not included in the Google Play Store, but Bitwarden trusts to perform passkey operations after community members use and report them as safe.</string>
+    <string name="trusted_by_google_learn_more">These are applications Google considers safe and are available in Google\'s Play Store.</string>
+    <string name="trusted_by_you">Trusted by You</string>
+    <string name="trusted_by_the_community">Trusted by the Community</string>
+    <string name="trusted_by_google">Trusted by Google</string>
+    <string name="privileged_apps_description">To protect users from phishing attempts, by default, Bitwarden only completes passkey operations through web browsers trusted by Google or the Bitwarden community.</string>
+    <string name="about_privileged_applications">About privileged applications</string>
+    <string name="learn_more_about_privileged_apps">Learn more about privileged apps</string>
+    <string name="privileged_apps">Privileged apps</string>
 </resources>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -39,6 +39,7 @@ class AutoFillScreenTest : BitwardenComposeTest() {
     private var onNavigateBackCalled = false
     private var onNavigateToBlockAutoFillScreenCalled = false
     private var onNavigateToSetupAutoFillScreenCalled = false
+    private var onNavigateToAboutPrivilegedAppsScreenCalled = false
 
     private val mutableEventFlow = bufferedMutableSharedFlow<AutoFillEvent>()
     private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
@@ -62,6 +63,9 @@ class AutoFillScreenTest : BitwardenComposeTest() {
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToBlockAutoFillScreen = { onNavigateToBlockAutoFillScreenCalled = true },
                 onNavigateToSetupAutofill = { onNavigateToSetupAutoFillScreenCalled = true },
+                onNavigateToAboutPrivilegedAppsScreen = {
+                    onNavigateToAboutPrivilegedAppsScreenCalled = true
+                },
                 viewModel = viewModel,
             )
         }
@@ -587,6 +591,42 @@ class AutoFillScreenTest : BitwardenComposeTest() {
             intentManager.startChromeAutofillSettingsActivity(ChromeReleaseChannel.STABLE)
         }
     }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `NavigateToAboutPrivilegedAppsScreen event should call onNavigateToAboutPrivilegedAppsScreen`() {
+        mutableEventFlow.tryEmit(AutoFillEvent.NavigateToAboutPrivilegedAppsScreen)
+        assertTrue(onNavigateToAboutPrivilegedAppsScreenCalled)
+    }
+
+    @Test
+    fun `PrivilegedAppsRow should display based on state`() {
+        composeTestRule
+            .onNodeWithText("Privileged apps")
+            .assertDoesNotExist()
+
+        mutableStateFlow.update {
+            it.copy(isUserManagedPrivilegedAppsEnabled = true)
+        }
+        composeTestRule
+            .onNodeWithText("Privileged apps")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `privileged app help link click should send AboutPrivilegedAppsClick`() {
+        mutableStateFlow.update { it.copy(isUserManagedPrivilegedAppsEnabled = true) }
+        composeTestRule
+            .onNodeWithContentDescription("Learn more about privileged apps")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(AutoFillAction.AboutPrivilegedAppsClick)
+        }
+    }
 }
 
 private val DEFAULT_STATE: AutoFillState = AutoFillState(
@@ -601,4 +641,5 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     showAutofillActionCard = false,
     activeUserId = "activeUserId",
     chromeAutofillSettingsOptions = persistentListOf(),
+    isUserManagedPrivilegedAppsEnabled = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/AboutPrivilegedAppsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/AboutPrivilegedAppsScreenTest.kt
@@ -1,0 +1,79 @@
+package com.x8bit.bitwarden.ui.platform.feature.settings.autofill.privilegedapps
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.privilegedapps.about.AboutPrivilegedAppsScreen
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AboutPrivilegedAppsScreenTest : BitwardenComposeTest() {
+
+    private var onNavigateBackCalled = false
+
+    @Before
+    fun setUp() {
+        setContent {
+            AboutPrivilegedAppsScreen(
+                onNavigateBack = { onNavigateBackCalled = true },
+            )
+        }
+    }
+
+    @Test
+    fun `on NavigateBack should call onNavigateBack`() {
+        composeTestRule
+            .onNodeWithContentDescription("Back")
+            .performClick()
+
+        assertTrue(onNavigateBackCalled)
+    }
+
+    @Test
+    fun `content is displayed correctly`() {
+        composeTestRule
+            .onNodeWithText(
+                "To protect users from phishing attempts, by default, Bitwarden only completes " +
+                    "passkey operations through web browsers trusted by Google or the Bitwarden " +
+                    "community.",
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("Trusted by You")
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(
+                "These are applications or browsers that Bitwarden does not trust by default, " +
+                    "but YOU trust to perform passkey operations.",
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("Trusted by the Community")
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(
+                "These are applications not included in the Google Play Store, but Bitwarden " +
+                    "trusts to perform passkey operations after community members use and report " +
+                    "them as safe.",
+            )
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("Trusted by Google")
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(
+                "These are applications Google considers safe and are available in Google's " +
+                    "Play Store.",
+            )
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreenTest.kt
@@ -62,6 +62,7 @@ class VaultUnlockedNavBarScreenTest : BitwardenComposeTest() {
                 onNavigateToAddFolderScreen = {},
                 onNavigateToFlightRecorder = {},
                 onNavigateToRecordedLogs = {},
+                onNavigateToAboutPrivilegedApps = {},
             )
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

PM-22461

## 📔 Objective

This commit introduces the AboutPrivilegedAppsScreen, which provides information about privileged applications in the context of autofill and passkey operations.

The new screen explains the different trust levels for applications:
- Trusted by You
- Trusted by the Community
- Trusted by Google

This screen is accessible from the AutoFill settings screen via a new "Privileged apps" row and a help icon if the `UserManagedPrivilegedApps` feature flag is enabled.

The following changes are included:
- Added `AboutPrivilegedAppsScreen.kt` with the UI for the new screen.
- Added `AboutPrivilegedAppsNavigation.kt` for navigation to and from the screen.
- Updated `SettingsNavigation.kt` to include the new destination.
- Updated `AutoFillScreen.kt` to display the "Privileged apps" row and help icon when the feature flag is enabled.
- Updated `AutoFillViewModel.kt` to handle navigation to the new screen and to observe the `UserManagedPrivilegedApps` feature flag.
- Added new string resources for the screen content and labels.
- Added UI tests for `AboutPrivilegedAppsScreen` and updated tests for `AutoFillScreen` and `AutoFillViewModel`.
- Introduced `AutoFillHandlers.kt` to centralize action handling for the AutoFill screen.

## 📸 Screenshots

<img width="365" alt="image" src="https://github.com/user-attachments/assets/70f7b73a-bda7-4a92-afe7-ae06d401fe75" />


<img width="365" alt="image" src="https://github.com/user-attachments/assets/2dc17090-7095-453c-9e42-7a735127ed86" />



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
