### PR TITLE
PM-10286: VerificationCodeScreen should not show MP reprompt if there is no master password

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
@@ -57,6 +57,11 @@ class VerificationCodeViewModel @Inject constructor(
             viewState = VerificationCodeState.ViewState.Loading,
             dialogState = null,
             isRefreshing = false,
+            hasMasterPassword = authRepository
+                .userStateFlow
+                .value
+                ?.activeAccount
+                ?.hasMasterPassword == true,
         )
     },
 ) {
@@ -83,11 +88,8 @@ class VerificationCodeViewModel @Inject constructor(
                     listDataState
                 }
             }
-            .onEach {
-                sendAction(
-                    VerificationCodeAction.Internal.AuthCodesReceive(it),
-                )
-            }
+            .map { VerificationCodeAction.Internal.AuthCodesReceive(it) }
+            .onEach(::sendAction)
             .launchIn(viewModelScope)
     }
 
@@ -363,7 +365,7 @@ class VerificationCodeViewModel @Inject constructor(
                             VerificationCodeDisplayItem(
                                 id = item.id,
                                 authCode = item.code,
-                                hideAuthCode = item.hasPasswordReprompt,
+                                hideAuthCode = item.hasPasswordReprompt && state.hasMasterPassword,
                                 label = item.name,
                                 supportingLabel = item.username,
                                 periodSeconds = item.periodSeconds,
@@ -412,6 +414,7 @@ data class VerificationCodeState(
     val dialogState: DialogState?,
     val isPullToRefreshSettingEnabled: Boolean,
     val isRefreshing: Boolean,
+    val hasMasterPassword: Boolean,
 ) : Parcelable {
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
@@ -518,4 +518,5 @@ private val DEFAULT_STATE = VerificationCodeState(
     isPullToRefreshSettingEnabled = false,
     dialogState = null,
     isRefreshing = false,
+    hasMasterPassword = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModelTest.kt
@@ -64,6 +64,7 @@ class VerificationCodeViewModelTest : BaseViewModelTest() {
 
     private val mockUserAccount: UserState.Account = mockk {
         every { isPremium } returns true
+        every { hasMasterPassword } returns true
     }
 
     private val mockUserState: UserState = mockk {
@@ -602,7 +603,6 @@ class VerificationCodeViewModelTest : BaseViewModelTest() {
             authRepository = authRepository,
         )
 
-    @Suppress("MaxLineLength")
     private fun createVerificationCodeState(
         viewState: VerificationCodeState.ViewState = VerificationCodeState.ViewState.Loading,
     ) = VerificationCodeState(
@@ -613,6 +613,7 @@ class VerificationCodeViewModelTest : BaseViewModelTest() {
         dialogState = null,
         isPullToRefreshSettingEnabled = settingsRepository.getPullToRefreshEnabledFlow().value,
         isRefreshing = false,
+        hasMasterPassword = true,
     )
 
     private fun createDisplayItemList() = listOf(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10286](https://bitwarden.atlassian.net/browse/PM-10286)

## 📔 Objective

This PR updates the `VerificationCodeViewModel` to verify that the user has a master password before prompting the user for one. If no password exists, we ignore the reprompt behavior.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10286]: https://bitwarden.atlassian.net/browse/PM-10286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ