### PR TITLE
PM-22522: Update time picker language

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenTimePickerDialog.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenTimePickerDialog.kt
@@ -81,10 +81,7 @@ fun BitwardenTimePickerDialog(
         inputToggleButton = {
             BitwardenStandardIconButton(
                 vectorIconRes = R.drawable.ic_keyboard,
-                contentDescription = stringResource(
-                    // TODO: Get our own string for this (BIT-1405)
-                    id = androidx.compose.material3.R.string.m3c_date_picker_switch_to_input_mode,
-                ),
+                contentDescription = stringResource(id = R.string.switch_input_mode),
                 onClick = { showTimeInput = !showTimeInput },
             )
         },
@@ -161,8 +158,7 @@ private fun TimePickerDialog(
                         .testTag("AlertTitleText")
                         .fillMaxWidth()
                         .padding(bottom = 20.dp),
-                    // TODO: This should be "Select time" but we don't have that string (BIT-1405)
-                    text = stringResource(id = R.string.time),
+                    text = stringResource(id = R.string.select_time),
                     color = BitwardenTheme.colorScheme.text.secondary,
                     style = BitwardenTheme.typography.labelMedium,
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -547,6 +547,8 @@ select Add TOTP to store the key safely</string>
     <string name="device_type">Device type</string>
     <string name="ip_address">IP address</string>
     <string name="time">Time</string>
+    <string name="select_time">Select time</string>
+    <string name="switch_input_mode">Switch input mode</string>
     <string name="confirm_log_in">Confirm login</string>
     <string name="deny_log_in">Deny login</string>
     <string name="log_in_denied">Login denied</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -927,7 +927,7 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText("Time")
+            .onAllNodesWithText(text = "Select time")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22522](https://bitwarden.atlassian.net/browse/PM-22522)

## 📔 Objective

This PR updates the language used on the time picker to match the designs.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e019d11f-028f-444f-8f0f-820ffce16c32" width="300" /> | <img src="https://github.com/user-attachments/assets/57e28e7f-45bd-4482-8887-bbcbbf90d046" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22522]: https://bitwarden.atlassian.net/browse/PM-22522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ