### PR TITLE
Update BitwardenContentBlock divider padding logic

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/content/BitwardenContentBlock.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/content/BitwardenContentBlock.kt
@@ -12,15 +12,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -71,28 +65,18 @@ private fun BitwardenContentBlock(
     @DrawableRes iconVectorResource: Int? = null,
     backgroundColor: Color = BitwardenTheme.colorScheme.background.secondary,
 ) {
-    var dividerStartPadding by remember { mutableStateOf(0.dp) }
-    val localDensity = LocalDensity.current
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(backgroundColor)
             .bottomDivider(
                 enabled = showDivider,
-                paddingStart = dividerStartPadding,
+                paddingStart = iconVectorResource?.let { 48.dp } ?: 0.dp,
             )
             .then(modifier),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            modifier = Modifier
-                .onGloballyPositioned {
-                    dividerStartPadding = with(localDensity) {
-                        it.size.width.toDp()
-                    }
-                },
-        ) {
+        Row {
             iconVectorResource
                 ?.let {
                     Spacer(Modifier.width(12.dp))


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

Update the `BitwardenContentBlock` divider to span the entire width unless an icon is present.

## 📸 Screenshots

<img width="365" alt="image" src="https://github.com/user-attachments/assets/daab5703-b64a-4802-b96a-fdd9cf5b9eaf" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
