### PR TITLE
[PM-22441] Refactor DigitalAssetLinkService to use source website

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/di/CredentialProviderModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/di/CredentialProviderModule.kt
@@ -14,6 +14,8 @@ import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManager
 import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManagerImpl
 import com.x8bit.bitwarden.data.credentials.manager.OriginManager
 import com.x8bit.bitwarden.data.credentials.manager.OriginManagerImpl
+import com.x8bit.bitwarden.data.credentials.parser.RelyingPartyParser
+import com.x8bit.bitwarden.data.credentials.parser.RelyingPartyParserImpl
 import com.x8bit.bitwarden.data.credentials.processor.CredentialProviderProcessor
 import com.x8bit.bitwarden.data.credentials.processor.CredentialProviderProcessorImpl
 import com.x8bit.bitwarden.data.credentials.repository.PrivilegedAppRepository
@@ -121,4 +123,10 @@ object CredentialProviderModule {
         privilegedAppDiskSource = privilegedAppDiskSource,
         json = json,
     )
+
+    @Provides
+    @Singleton
+    fun provideRelyingPartyParser(
+        json: Json,
+    ): RelyingPartyParser = RelyingPartyParserImpl(json)
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/OriginManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/OriginManager.kt
@@ -11,11 +11,13 @@ interface OriginManager {
     /**
      * Validates the origin of a calling app.
      *
+     * @param relyingPartyId The ID of the relying party that sent the request.
      * @param callingAppInfo The calling app info.
      *
      * @return The result of the validation.
      */
     suspend fun validateOrigin(
+        relyingPartyId: String,
         callingAppInfo: CallingAppInfo,
     ): ValidateOriginResult
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/parser/RelyingPartyParser.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/parser/RelyingPartyParser.kt
@@ -1,0 +1,25 @@
+package com.x8bit.bitwarden.data.credentials.parser
+
+import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
+
+/**
+ * A tool for parsing relying party data from the Credential Manager requests.
+ */
+interface RelyingPartyParser {
+    /**
+     * Parse the relying party ID from the [GetPublicKeyCredentialOption].
+     */
+    fun parse(getPublicKeyCredentialOption: GetPublicKeyCredentialOption): String?
+
+    /**
+     * Parse the relying party ID from the [CreatePublicKeyCredentialRequest].
+     */
+    fun parse(createPublicKeyCredentialRequest: CreatePublicKeyCredentialRequest): String?
+
+    /**
+     * Parse the relying party ID from the [BeginGetPublicKeyCredentialOption].
+     */
+    fun parse(beginGetPublicKeyCredentialOption: BeginGetPublicKeyCredentialOption): String?
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/parser/RelyingPartyParserImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/parser/RelyingPartyParserImpl.kt
@@ -1,0 +1,40 @@
+package com.x8bit.bitwarden.data.credentials.parser
+
+import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
+import com.bitwarden.core.data.util.decodeFromStringOrNull
+import com.x8bit.bitwarden.data.credentials.model.PasskeyAssertionOptions
+import com.x8bit.bitwarden.data.credentials.model.PasskeyAttestationOptions
+import kotlinx.serialization.json.Json
+
+/**
+ * Default implementation of [RelyingPartyParser].
+ */
+class RelyingPartyParserImpl(
+    private val json: Json,
+) : RelyingPartyParser {
+
+    override fun parse(
+        getPublicKeyCredentialOption: GetPublicKeyCredentialOption,
+    ): String? = json
+        .decodeFromStringOrNull<PasskeyAssertionOptions>(getPublicKeyCredentialOption.requestJson)
+        ?.relyingPartyId
+
+    override fun parse(
+        createPublicKeyCredentialRequest: CreatePublicKeyCredentialRequest,
+    ): String? = json
+        .decodeFromStringOrNull<PasskeyAttestationOptions>(
+            createPublicKeyCredentialRequest.requestJson,
+        )
+        ?.relyingParty
+        ?.id
+
+    override fun parse(
+        beginGetPublicKeyCredentialOption: BeginGetPublicKeyCredentialOption,
+    ): String? = json
+        .decodeFromStringOrNull<PasskeyAssertionOptions>(
+            beginGetPublicKeyCredentialOption.requestJson,
+        )
+        ?.relyingPartyId
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/parser/RelyingPartyParserTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/parser/RelyingPartyParserTest.kt
@@ -1,0 +1,180 @@
+package com.x8bit.bitwarden.data.credentials.parser
+
+import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.provider.BeginGetPublicKeyCredentialOption
+import com.bitwarden.core.di.CoreModule
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+
+class RelyingPartyParserTest {
+
+    private val relyingPartyParser = RelyingPartyParserImpl(json = CoreModule.providesJson())
+
+    @Test
+    fun `parse GetPublicKeyCredentialOption should return relyingPartyId`() {
+        val result = relyingPartyParser.parse(
+            mockk<GetPublicKeyCredentialOption> {
+                every { requestJson } returns DEFAULT_ASSERTION_OPTIONS_JSON
+            },
+        )
+
+        assertEquals(
+            DEFAULT_RELYING_PARTY_ID,
+            result,
+        )
+    }
+
+    @Test
+    fun `parse GetPublicKeyCredentialOption should return null if relyingPartyId is missing`() {
+        val result = relyingPartyParser.parse(
+            mockk<GetPublicKeyCredentialOption> {
+                every { requestJson } returns INVALID_ASSERTION_OPTIONS_JSON
+            },
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse CreatePublicKeyCredentialRequest should return relyingPartyId`() {
+        val result = relyingPartyParser.parse(
+            mockk<CreatePublicKeyCredentialRequest> {
+                every { requestJson } returns DEFAULT_ATTESTATION_OPTIONS_JSON
+            },
+        )
+
+        assertEquals(
+            DEFAULT_RELYING_PARTY_ID,
+            result,
+        )
+    }
+
+    @Test
+    fun `parse CreatePublicKeyCredentialRequest should return null if relyingPartyId is missing`() {
+        val result = relyingPartyParser.parse(
+            mockk<CreatePublicKeyCredentialRequest> {
+                every { requestJson } returns INVALID_ATTESTATION_OPTIONS_JSON
+            },
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse BeginGetPublicKeyCredentialOption should return relyingPartyId`() {
+        val result = relyingPartyParser.parse(
+            mockk<BeginGetPublicKeyCredentialOption> {
+                every { requestJson } returns DEFAULT_ASSERTION_OPTIONS_JSON
+            },
+        )
+
+        assertEquals(
+            DEFAULT_RELYING_PARTY_ID,
+            result,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `parse BeginGetPublicKeyCredentialOption should return null if relyingPartyId is missing`() {
+        val result = relyingPartyParser.parse(
+            mockk<BeginGetPublicKeyCredentialOption> {
+                every { requestJson } returns INVALID_ASSERTION_OPTIONS_JSON
+            },
+        )
+
+        assertNull(result)
+    }
+}
+
+private const val DEFAULT_RELYING_PARTY_ID = "www.bitwarden.com"
+private val DEFAULT_ATTESTATION_OPTIONS_JSON = """
+{
+  "attestation": "direct",
+  "authenticatorSelection": {
+    "residentKey": "required",
+    "userVerification": "preferred"
+  },
+  "challenge": "tZ1rLJ_paLC8IMmg",
+  "excludeCredentials": [],
+  "extensions": {
+    "credProps": true
+  },
+  "pubKeyCredParams": [
+    {
+      "alg": -7,
+      "type": "public-key"
+    },
+    {
+      "alg": -257,
+      "type": "public-key"
+    }
+  ],
+  "rp": {
+    "id": "$DEFAULT_RELYING_PARTY_ID",
+    "name": "mockRpName"
+  },
+  "user": {
+    "displayName": "mockDisplayName",
+    "id": "UmhpTE9NOUY",
+    "name": "mockUserName"
+  }
+}
+"""
+    .trimIndent()
+private val INVALID_ATTESTATION_OPTIONS_JSON = """
+{
+  "attestation": "direct",
+  "authenticatorSelection": {
+    "residentKey": "required",
+    "userVerification": "preferred"
+  },
+  "challenge": "tZ1rLJ_paLC8IMmg",
+  "excludeCredentials": [],
+  "extensions": {
+    "credProps": true
+  },
+  "pubKeyCredParams": [
+    {
+      "alg": -7,
+      "type": "public-key"
+    },
+    {
+      "alg": -257,
+      "type": "public-key"
+    }
+  ],
+  "rp": {
+    "name": "mockRpName"
+  },
+  "user": {
+    "displayName": "mockDisplayName",
+    "id": "UmhpTE9NOUY",
+    "name": "mockUserName"
+  }
+}
+"""
+    .trimIndent()
+private val DEFAULT_ASSERTION_OPTIONS_JSON = """
+{
+  "challenge": "FFeZc7g-BPSAPo",
+  "allowCredentials": [],
+  "timeout": 60000,
+  "userVerification": "preferred",
+  "rpId": "$DEFAULT_RELYING_PARTY_ID"
+}
+"""
+    .trimIndent()
+private val INVALID_ASSERTION_OPTIONS_JSON = """
+{
+  "challenge": "FFeZc7g-BPSAPo",
+  "allowCredentials": [],
+  "timeout": 60000,
+  "userVerification": "preferred",
+}
+"""
+    .trimIndent()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -56,6 +56,7 @@ import com.x8bit.bitwarden.data.credentials.model.ValidateOriginResult
 import com.x8bit.bitwarden.data.credentials.model.createMockCreateCredentialRequest
 import com.x8bit.bitwarden.data.credentials.model.createMockFido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.credentials.model.createMockGetCredentialsRequest
+import com.x8bit.bitwarden.data.credentials.parser.RelyingPartyParser
 import com.x8bit.bitwarden.data.credentials.repository.PrivilegedAppRepository
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
@@ -151,7 +152,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         Instant.parse("2023-10-27T12:00:00Z"),
         ZoneOffset.UTC,
     )
-
     private val clipboardManager: BitwardenClipboardManager = mockk {
         every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
     }
@@ -212,7 +212,12 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         coEvery { getCredentialEntries(any()) } returns emptyList<CredentialEntry>().asSuccess()
     }
     private val originManager: OriginManager = mockk {
-        coEvery { validateOrigin(any()) } returns ValidateOriginResult.Success(null)
+        coEvery {
+            validateOrigin(
+                relyingPartyId = any(),
+                callingAppInfo = any(),
+            )
+        } returns ValidateOriginResult.Success(null)
     }
 
     private val organizationEventManager = mockk<OrganizationEventManager> {
@@ -235,17 +240,26 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         every { packageName } returns "mockPackageName"
         every { isOriginPopulated() } returns false
     }
+    private val mockGetPublicKeyCredentialOption = mockk<GetPublicKeyCredentialOption> {
+        every { requestJson } returns "mockRequestJson"
+    }
     private val mockProviderGetCredentialRequest = mockk<ProviderGetCredentialRequest> {
-        every { credentialOptions } returns listOf(mockk<GetPublicKeyCredentialOption>())
+        every { credentialOptions } returns listOf(mockGetPublicKeyCredentialOption)
         every { callingAppInfo } returns mockCallingAppInfo
     }
-    private val mockBeginGetPublicKeyCredentialOption = mockk<BeginGetPublicKeyCredentialOption>()
+    private val mockBeginGetPublicKeyCredentialOption = mockk<BeginGetPublicKeyCredentialOption> {
+        every { requestJson } returns "mockRequestJson"
+    }
     private val mockBeginGetCredentialRequest = mockk<BeginGetCredentialRequest> {
         every { beginGetCredentialOptions } returns listOf(mockBeginGetPublicKeyCredentialOption)
         every { callingAppInfo } returns mockCallingAppInfo
     }
-    val mockProviderCreateCredentialRequest = mockk<ProviderCreateCredentialRequest> {
-        every { callingRequest } returns mockk<CreatePublicKeyCredentialRequest>(relaxed = true)
+    private val mockCreatePublicKeyCredentialRequest = mockk<CreatePublicKeyCredentialRequest> {
+        every { requestJson } returns "mockRequestJson"
+        every { origin } returns "mockOrigin"
+    }
+    private val mockProviderCreateCredentialRequest = mockk<ProviderCreateCredentialRequest> {
+        every { callingRequest } returns mockCreatePublicKeyCredentialRequest
         every { callingAppInfo } returns mockCallingAppInfo
     }
     private val mutableSnackbarDataFlow: MutableSharedFlow<BitwardenSnackbarData> =
@@ -254,6 +268,11 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         every {
             getSnackbarDataFlow(relay = any(), relays = anyVararg())
         } returns mutableSnackbarDataFlow
+    }
+    private val relyingPartyParser = mockk<RelyingPartyParser> {
+        every { parse(any<BeginGetPublicKeyCredentialOption>()) } returns DEFAULT_RELYING_PARTY_ID
+        every { parse(any<GetPublicKeyCredentialOption>()) } returns DEFAULT_RELYING_PARTY_ID
+        every { parse(any<CreatePublicKeyCredentialRequest>()) } returns DEFAULT_RELYING_PARTY_ID
     }
 
     @BeforeEach
@@ -309,7 +328,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     createCredentialRequest = createCredentialRequest,
                 )
             coEvery {
-                originManager.validateOrigin(any())
+                originManager.validateOrigin(any(), any())
             } returns ValidateOriginResult.Success(null)
             val viewModel = createVaultItemListingViewModel()
 
@@ -1914,7 +1933,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 )
             } returns DecryptFido2CredentialAutofillViewResult.Success(emptyList())
             coEvery {
-                originManager.validateOrigin(any())
+                originManager.validateOrigin(any(), any())
             } returns ValidateOriginResult.Success("")
 
             mockFilteredCiphers = listOf(cipherView1)
@@ -1968,7 +1987,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 vaultRepository.getDecryptedFido2CredentialAutofillViews(
                     cipherViewList = listOf(cipherView1, cipherView2),
                 )
-                originManager.validateOrigin(any())
+                originManager.validateOrigin(any(), any())
             }
         }
 
@@ -2624,13 +2643,16 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 createMockCreateCredentialRequest(number = 1),
             )
         coEvery {
-            originManager.validateOrigin(mockCallingAppInfo)
+            originManager.validateOrigin(
+                relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                callingAppInfo = mockCallingAppInfo,
+            )
         } returns ValidateOriginResult.Success("mockOrigin")
 
         createVaultItemListingViewModel()
 
         coVerify(ordering = Ordering.ORDERED) {
-            originManager.validateOrigin(any())
+            originManager.validateOrigin(any(), any())
             vaultRepository.vaultDataStateFlow
         }
     }
@@ -2642,7 +2664,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 createMockCreateCredentialRequest(number = 1),
             )
         coEvery {
-            originManager.validateOrigin(mockCallingAppInfo)
+            originManager.validateOrigin(
+                relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                callingAppInfo = mockCallingAppInfo,
+            )
         } returns ValidateOriginResult.Error.Unknown
 
         val viewModel = createVaultItemListingViewModel()
@@ -2665,7 +2690,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     createCredentialRequest = createMockCreateCredentialRequest(number = 1),
                 )
             coEvery {
-                originManager.validateOrigin(mockCallingAppInfo)
+                originManager.validateOrigin(
+                    relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                    callingAppInfo = mockCallingAppInfo,
+                )
             } returns ValidateOriginResult.Error.PrivilegedAppNotAllowed
 
             val viewModel = createVaultItemListingViewModel()
@@ -2689,7 +2717,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     createCredentialRequest = createMockCreateCredentialRequest(number = 1),
                 )
             coEvery {
-                originManager.validateOrigin(mockCallingAppInfo)
+                originManager.validateOrigin(
+                    relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                    callingAppInfo = mockCallingAppInfo,
+                )
             } returns ValidateOriginResult.Error.PrivilegedAppSignatureNotFound
 
             val viewModel = createVaultItemListingViewModel()
@@ -2712,7 +2743,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     createCredentialRequest = createMockCreateCredentialRequest(number = 1),
                 )
             coEvery {
-                originManager.validateOrigin(mockCallingAppInfo)
+                originManager.validateOrigin(
+                    relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                    callingAppInfo = mockCallingAppInfo,
+                )
             } returns ValidateOriginResult.Error.PasskeyNotSupportedForApp
 
             val viewModel = createVaultItemListingViewModel()
@@ -2735,7 +2769,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     createCredentialRequest = createMockCreateCredentialRequest(number = 1),
                 )
             coEvery {
-                originManager.validateOrigin(mockCallingAppInfo)
+                originManager.validateOrigin(
+                    relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                    callingAppInfo = mockCallingAppInfo,
+                )
             } returns ValidateOriginResult.Error.AssetLinkNotFound
 
             val viewModel = createVaultItemListingViewModel()
@@ -2909,7 +2946,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 bitwardenCredentialManager.getCredentialEntries(any())
             } returns emptyList<PublicKeyCredentialEntry>().asSuccess()
             coEvery {
-                originManager.validateOrigin(callingAppInfo = any())
+                originManager.validateOrigin(relyingPartyId = any(), callingAppInfo = any())
             } returns ValidateOriginResult.Success("mockOrigin")
             every {
                 vaultRepository
@@ -2987,7 +3024,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             assertEquals(
                 VaultItemListingState.DialogState.CredentialManagerOperationFail(
                     title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.generic_error_message.asText(),
+                    message =
+                        R.string.passkey_operation_failed_because_relying_party_cannot_be_identified
+                            .asText(),
                 ),
                 viewModel.stateFlow.value.dialogState,
             )
@@ -3057,7 +3096,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     mockGetCredentialsRequest,
                 )
             coEvery {
-                originManager.validateOrigin(callingAppInfo = any())
+                originManager.validateOrigin(relyingPartyId = any(), callingAppInfo = any())
             } returns ValidateOriginResult.Error.Unknown
 
             val dataState = DataState.Loaded(
@@ -3264,6 +3303,59 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             }
         }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `Fido2Assertion should show error dialog when relying party cannot be identified`() =
+        runTest {
+            setupMockUri()
+            val mockAssertionRequest = createMockFido2CredentialAssertionRequest(number = 1)
+                .copy(cipherId = "mockId-1")
+            val mockFido2CredentialList = createMockSdkFido2CredentialList(number = 1)
+            val mockCipherView = createMockCipherView(
+                number = 1,
+                fido2Credentials = mockFido2CredentialList,
+            )
+            specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Assertion(
+                mockAssertionRequest,
+            )
+            every { bitwardenCredentialManager.isUserVerified } returns true
+            every {
+                vaultRepository
+                    .ciphersStateFlow
+                    .value
+                    .data
+            } returns listOf(mockCipherView)
+            every {
+                relyingPartyParser.parse(mockGetPublicKeyCredentialOption)
+            } returns null
+
+            val dataState = DataState.Loaded(
+                data = VaultData(
+                    cipherViewList = listOf(mockCipherView),
+                    folderViewList = listOf(createMockFolderView(number = 1)),
+                    collectionViewList = listOf(createMockCollectionView(number = 1)),
+                    sendViewList = listOf(createMockSendView(number = 1)),
+                ),
+            )
+            val viewModel = createVaultItemListingViewModel()
+            mutableVaultDataStateFlow.value = dataState
+
+            coVerify(exactly = 0) {
+                originManager.validateOrigin(any(), any())
+            }
+            viewModel.stateFlow.test {
+                assertEquals(
+                    VaultItemListingState.DialogState.CredentialManagerOperationFail(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message =
+                            R.string.passkey_operation_failed_because_relying_party_cannot_be_identified
+                                .asText(),
+                    ),
+                    awaitItem().dialogState,
+                )
+            }
+        }
+
     @Test
     fun `Fido2AssertionRequest should show error dialog when validateOrigin is not Success`() =
         runTest {
@@ -3286,7 +3378,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     .data
             } returns listOf(mockCipherView)
             coEvery {
-                originManager.validateOrigin(any())
+                originManager.validateOrigin(any(), any())
             } returns ValidateOriginResult.Error.Unknown
 
             val dataState = DataState.Loaded(
@@ -3842,7 +3934,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             specialCircumstanceManager.specialCircumstance = SpecialCircumstance.Fido2Assertion(
                 fido2AssertionRequest = mockAssertionRequest,
             )
-
             every {
                 ProviderGetCredentialRequest.fromBundle(any())
             } returns mockk(relaxed = true) {
@@ -4570,7 +4661,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 mockCallingAppInfo.getSignatureFingerprintAsHexString()
             } returns "mockSignature"
             coEvery {
-                originManager.validateOrigin(any())
+                originManager.validateOrigin(any(), any())
             } returns ValidateOriginResult.Error.PrivilegedAppNotAllowed
 
             val viewModel = createVaultItemListingViewModel()
@@ -4641,7 +4732,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 mockCallingAppInfo.getSignatureFingerprintAsHexString()
             } returns "mockSignature"
             coEvery {
-                originManager.validateOrigin(mockCallingAppInfo)
+                originManager.validateOrigin(
+                    relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                    callingAppInfo = mockCallingAppInfo,
+                )
             } returns ValidateOriginResult.Error.PrivilegedAppNotAllowed
             coEvery {
                 bitwardenCredentialManager.getCredentialEntries(any())
@@ -4761,7 +4855,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         cipherId = cipherView.id!!,
                     ),
                 )
-
             every {
                 mockCallingAppInfo.getSignatureFingerprintAsHexString()
             } returns "mockSignature"
@@ -4783,7 +4876,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             )
             every { bitwardenCredentialManager.isUserVerified } returns true
             coEvery {
-                originManager.validateOrigin(mockCallingAppInfo)
+                originManager.validateOrigin(
+                    relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                    callingAppInfo = mockCallingAppInfo,
+                )
             } returns ValidateOriginResult.Success("mockOrigin")
 
             mutableVaultDataStateFlow.value = DataState.Loaded(
@@ -5007,6 +5103,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             networkConnectionManager = networkConnectionManager,
             privilegedAppRepository = privilegedAppRepository,
             snackbarRelayManager = snackbarRelayManager,
+            relyingPartyParser = relyingPartyParser,
         )
 
     @Suppress("MaxLineLength")
@@ -5060,3 +5157,5 @@ private val DEFAULT_USER_STATE = UserState(
     activeUserId = "activeUserId",
     accounts = listOf(DEFAULT_ACCOUNT),
 )
+
+private const val DEFAULT_RELYING_PARTY_ID = "www.bitwarden.com"

--- a/network/src/main/kotlin/com/bitwarden/network/api/DigitalAssetLinkApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/DigitalAssetLinkApi.kt
@@ -13,19 +13,22 @@ import retrofit2.http.Query
 internal interface DigitalAssetLinkApi {
 
     /**
-     * Checks if the given [relation] exists in a digital asset link file.
+     * Checks if the given [relations] are declared in the digital asset link file for the given
+     * [sourceWebSite] for the given [targetPackageName] with a [targetCertificateFingerprint].
+     *
+     * @param sourceWebSite The host of the source digital asset links file.
+     * @param targetPackageName The package name of the target application.
+     * @param targetCertificateFingerprint The certificate fingerprint of the target application.
      */
     @GET("v1/assetlinks:check")
     suspend fun checkDigitalAssetLinksRelations(
-        @Query("source.androidApp.packageName")
-        sourcePackageName: String,
-        @Query("source.androidApp.certificate.sha256Fingerprint")
-        sourceCertificateFingerprint: String,
+        @Query("source.web.site")
+        sourceWebSite: String,
         @Query("target.androidApp.packageName")
         targetPackageName: String,
         @Query("target.androidApp.certificate.sha256Fingerprint")
         targetCertificateFingerprint: String,
         @Query("relation")
-        relation: String,
+        relations: List<String>,
     ): NetworkResult<DigitalAssetLinkCheckResponseJson>
 }

--- a/network/src/main/kotlin/com/bitwarden/network/service/DigitalAssetLinkService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/DigitalAssetLinkService.kt
@@ -7,12 +7,17 @@ import com.bitwarden.network.model.DigitalAssetLinkCheckResponseJson
  */
 interface DigitalAssetLinkService {
     /**
-     * Checks if the given [packageName] with a given [certificateFingerprint] has the given
-     * [relation].
+     * Checks if the given [relations] are declared in the digital asset link file for the given
+     * [sourceWebSite] for the given [targetPackageName] with a [targetCertificateFingerprint].
+     *
+     * @param sourceWebSite The host of the source digital asset links file.
+     * @param targetPackageName The package name of the target application.
+     * @param targetCertificateFingerprint The certificate fingerprint of the target application.
      */
     suspend fun checkDigitalAssetLinksRelations(
-        packageName: String,
-        certificateFingerprint: String,
-        relation: String,
+        sourceWebSite: String,
+        targetPackageName: String,
+        targetCertificateFingerprint: String,
+        relations: List<String>,
     ): Result<DigitalAssetLinkCheckResponseJson>
 }

--- a/network/src/main/kotlin/com/bitwarden/network/service/DigitalAssetLinkServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/DigitalAssetLinkServiceImpl.kt
@@ -12,16 +12,16 @@ internal class DigitalAssetLinkServiceImpl(
 ) : DigitalAssetLinkService {
 
     override suspend fun checkDigitalAssetLinksRelations(
-        packageName: String,
-        certificateFingerprint: String,
-        relation: String,
+        sourceWebSite: String,
+        targetPackageName: String,
+        targetCertificateFingerprint: String,
+        relations: List<String>,
     ): Result<DigitalAssetLinkCheckResponseJson> = digitalAssetLinkApi
         .checkDigitalAssetLinksRelations(
-            sourcePackageName = packageName,
-            sourceCertificateFingerprint = certificateFingerprint,
-            targetPackageName = packageName,
-            targetCertificateFingerprint = certificateFingerprint,
-            relation = relation,
+            sourceWebSite = sourceWebSite,
+            targetPackageName = targetPackageName,
+            targetCertificateFingerprint = targetCertificateFingerprint,
+            relations = relations,
         )
         .toResult()
 }

--- a/network/src/test/kotlin/com/bitwarden/network/service/DigitalAssetLinkServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/DigitalAssetLinkServiceTest.kt
@@ -28,10 +28,11 @@ class DigitalAssetLinkServiceTest : BaseServiceTest() {
             )
                 .asSuccess(),
             digitalAssetLinkService.checkDigitalAssetLinksRelations(
-                packageName = "com.x8bit.bitwarden",
-                certificateFingerprint =
+                sourceWebSite = "https://www.bitwarden.com",
+                targetPackageName = "com.x8bit.bitwarden",
+                targetCertificateFingerprint =
                     "00:01:02:03:04:05:06:07:08:09:0A:0B:0C:0D:0E:0F:10:11:12:13",
-                relation = "delegate_permission/common.handle_all_urls",
+                relations = listOf("delegate_permission/common.handle_all_urls"),
             ),
         )
     }
@@ -42,4 +43,5 @@ private val CHECK_DIGITAL_ASSET_LINKS_RELATIONS_SUCCESS_JSON = """
     "linked": true,
     "maxAge": "47.535162130s"
 }
-""".trimIndent()
+"""
+    .trimIndent()


### PR DESCRIPTION
## 🎟️ Tracking

PM-22441
Closes #5321
Closes #5322

## 📔 Objective

The `DigitalAssetLinkService` and its implementation now take a `sourceWebSite` parameter instead of relying on the target application's package name and certificate fingerprint for the source. This aligns better with how Digital Asset Links work, where the website declares trust in the app.

The `OriginManager` now passes the `relyingPartyId` (which is the source website) to the `DigitalAssetLinkService`.

A `RelyingPartyParser` interface and its implementation `RelyingPartyParserImpl` have been introduced to centralize the logic for parsing relying party IDs from various Credential Manager request objects.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
