### PR TITLE
PM-22634: Fix parsing of system language

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/util/LocaleExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/util/LocaleExtensions.kt
@@ -10,4 +10,4 @@ import java.util.Locale
 val Locale.appLanguage: AppLanguage?
     get() = AppLanguage
         .entries
-        .find { it.localeName?.lowercase(this) == this.language.lowercase(this) }
+        .find { it.localeName?.lowercase(this) == this.toLanguageTag().lowercase(this) }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/util/LocaleExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/util/LocaleExtensionsTest.kt
@@ -9,8 +9,8 @@ import java.util.Locale
 class LocaleExtensionsTest {
 
     @Test
-    fun `locale with Espanol language returns AppLanguage SPANISH`() {
-        val locale = Locale("es")
+    fun `locale with spanish language returns AppLanguage SPANISH`() {
+        val locale = Locale.forLanguageTag("es")
         assertEquals(
             AppLanguage.SPANISH,
             locale.appLanguage,
@@ -19,7 +19,7 @@ class LocaleExtensionsTest {
 
     @Test
     fun `locale with GB english returns AppLanguage ENGLISH_BRITISH`() {
-        val locale = Locale("en-GB")
+        val locale = Locale.forLanguageTag("en-GB")
         assertEquals(
             AppLanguage.ENGLISH_BRITISH,
             locale.appLanguage,
@@ -28,7 +28,7 @@ class LocaleExtensionsTest {
 
     @Test
     fun `locale with non existent app language returns null`() {
-        val locale = Locale("😅😅😅")
+        val locale = Locale.forLanguageTag("😅😅😅")
         assertNull(locale.appLanguage)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22634](https://bitwarden.atlassian.net/browse/PM-22634)

## 📔 Objective

This PR updates the way we parse the system locale to fix a bug when switching locales in the app.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="" width="300" /> | <video src="" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
