### PR TITLE
PM-22642, PM-22644: Add MP reprompt for TOTP code and secure note

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
@@ -136,9 +136,11 @@ sealed class ListingItemOverflowAction : Parcelable {
          * Click on the copy TOTP code overflow option.
          */
         @Parcelize
-        data class CopyTotpClick(val totpCode: String) : VaultAction() {
+        data class CopyTotpClick(
+            val totpCode: String,
+            override val requiresPasswordReprompt: Boolean,
+        ) : VaultAction() {
             override val title: Text get() = R.string.copy_totp.asText()
-            override val requiresPasswordReprompt: Boolean get() = false
         }
 
         /**
@@ -168,9 +170,11 @@ sealed class ListingItemOverflowAction : Parcelable {
          * Click on the copy secure note overflow option.
          */
         @Parcelize
-        data class CopyNoteClick(val notes: String) : VaultAction() {
+        data class CopyNoteClick constructor(
+            val notes: String,
+            override val requiresPasswordReprompt: Boolean,
+        ) : VaultAction() {
             override val title: Text get() = R.string.copy_notes.asText()
-            override val requiresPasswordReprompt: Boolean get() = false
         }
 
         /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
@@ -11,6 +11,7 @@ import kotlinx.collections.immutable.toImmutableList
 /**
  * Creates the list of overflow actions to be displayed for a [CipherView].
  */
+@Suppress("LongMethod")
 fun CipherView.toOverflowActions(
     hasMasterPassword: Boolean,
     isPremiumUser: Boolean,
@@ -43,7 +44,12 @@ fun CipherView.toOverflowActions(
                     }
                     .takeIf { this.viewPassword },
                 this.login?.totp
-                    ?.let { ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode = it) }
+                    ?.let {
+                        ListingItemOverflowAction.VaultAction.CopyTotpClick(
+                            totpCode = it,
+                            requiresPasswordReprompt = hasMasterPassword,
+                        )
+                    }
                     .takeIf {
                         this.type == CipherType.LOGIN &&
                             (this.organizationUseTotp || isPremiumUser)
@@ -62,7 +68,12 @@ fun CipherView.toOverflowActions(
                     )
                 },
                 this.notes
-                    ?.let { ListingItemOverflowAction.VaultAction.CopyNoteClick(notes = it) }
+                    ?.let {
+                        ListingItemOverflowAction.VaultAction.CopyNoteClick(
+                            notes = it,
+                            requiresPasswordReprompt = hasMasterPassword,
+                        )
+                    }
                     .takeIf { this.type == CipherType.SECURE_NOTE },
                 this.login?.uris?.firstOrNull { it.uri != null }?.uri?.let {
                     ListingItemOverflowAction.VaultAction.LaunchClick(url = it)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -911,7 +911,10 @@ class SearchViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             viewModel.trySendAction(
                 SearchAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyNoteClick(notes = notes),
+                    ListingItemOverflowAction.VaultAction.CopyNoteClick(
+                        notes = notes,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
             verify(exactly = 1) {
@@ -957,7 +960,10 @@ class SearchViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             viewModel.trySendAction(
                 SearchAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode),
+                    ListingItemOverflowAction.VaultAction.CopyTotpClick(
+                        totpCode = totpCode,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
 
@@ -982,7 +988,10 @@ class SearchViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             viewModel.trySendAction(
                 SearchAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode),
+                    ListingItemOverflowAction.VaultAction.CopyTotpClick(
+                        totpCode = totpCode,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
@@ -63,6 +63,7 @@ fun createMockDisplayItemForCipher(
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
                         totpCode = "mockTotp-$number",
+                        requiresPasswordReprompt = true,
                     ),
                     ListingItemOverflowAction.VaultAction.LaunchClick(
                         url = "www.mockuri$number.com",
@@ -109,6 +110,7 @@ fun createMockDisplayItemForCipher(
                     ),
                     ListingItemOverflowAction.VaultAction.CopyNoteClick(
                         notes = "mockNotes-$number",
+                        requiresPasswordReprompt = true,
                     ),
                 ),
                 overflowTestTag = "CipherOptionsButton",

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -1512,7 +1512,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val viewModel = createVaultItemListingViewModel()
             viewModel.trySendAction(
                 VaultItemListingsAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyNoteClick(notes = notes),
+                    ListingItemOverflowAction.VaultAction.CopyNoteClick(
+                        notes = notes,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
             verify(exactly = 1) {
@@ -1612,7 +1615,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val viewModel = createVaultItemListingViewModel()
             viewModel.trySendAction(
                 VaultItemListingsAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode),
+                    ListingItemOverflowAction.VaultAction.CopyTotpClick(
+                        totpCode = totpCode,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
 
@@ -1637,7 +1643,10 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             val viewModel = createVaultItemListingViewModel()
             viewModel.trySendAction(
                 VaultItemListingsAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode),
+                    ListingItemOverflowAction.VaultAction.CopyTotpClick(
+                        totpCode = totpCode,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -66,6 +66,7 @@ fun createMockDisplayItemForCipher(
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
                         totpCode = "mockTotp-$number",
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.LaunchClick(
                         url = "www.mockuri$number.com",
@@ -115,6 +116,7 @@ fun createMockDisplayItemForCipher(
                     ),
                     ListingItemOverflowAction.VaultAction.CopyNoteClick(
                         notes = "mockNotes-$number",
+                        requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                 ),
                 optionsTestTag = "CipherOptionsButton",

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
@@ -46,7 +46,10 @@ class CipherViewExtensionsTest {
                     requiresPasswordReprompt = false,
                     cipherId = id,
                 ),
-                ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode = totpCode),
+                ListingItemOverflowAction.VaultAction.CopyTotpClick(
+                    totpCode = totpCode,
+                    requiresPasswordReprompt = false,
+                ),
                 ListingItemOverflowAction.VaultAction.LaunchClick(url = uri),
             ),
             result,
@@ -298,7 +301,10 @@ class CipherViewExtensionsTest {
                     cipherType = CipherType.SECURE_NOTE,
                     requiresPasswordReprompt = true,
                 ),
-                ListingItemOverflowAction.VaultAction.CopyNoteClick(notes = notes),
+                ListingItemOverflowAction.VaultAction.CopyNoteClick(
+                    notes = notes,
+                    requiresPasswordReprompt = true,
+                ),
             ),
             result,
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1483,7 +1483,10 @@ class VaultViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             viewModel.trySendAction(
                 VaultAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyNoteClick(notes = notes),
+                    ListingItemOverflowAction.VaultAction.CopyNoteClick(
+                        notes = notes,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
             verify(exactly = 1) {
@@ -1556,7 +1559,10 @@ class VaultViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             viewModel.trySendAction(
                 VaultAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode),
+                    ListingItemOverflowAction.VaultAction.CopyTotpClick(
+                        totpCode = totpCode,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
 
@@ -1581,7 +1587,10 @@ class VaultViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             viewModel.trySendAction(
                 VaultAction.OverflowOptionClick(
-                    ListingItemOverflowAction.VaultAction.CopyTotpClick(totpCode),
+                    ListingItemOverflowAction.VaultAction.CopyTotpClick(
+                        totpCode = totpCode,
+                        requiresPasswordReprompt = false,
+                    ),
                 ),
             )
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22642](https://bitwarden.atlassian.net/browse/PM-22642)
[PM-22644](https://bitwarden.atlassian.net/browse/PM-22644)

## 📔 Objective

This PR adds the master password re-prompt to the `Copy totp` and `Copy note` overflow options.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/e03d10dd-1359-4710-aca7-f959c9204d62" width="300" /> | <video src="https://github.com/user-attachments/assets/6d0599c6-ad17-4fe6-b148-25d0e78a01eb" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22642]: https://bitwarden.atlassian.net/browse/PM-22642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-22644]: https://bitwarden.atlassian.net/browse/PM-22644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ