### PR TITLE
[PM-22665] Add BitwardenPackageManager abstraction

### DIFF
--- a/data/src/main/kotlin/com/bitwarden/data/manager/BitwardenPackageManager.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/BitwardenPackageManager.kt
@@ -1,0 +1,16 @@
+package com.bitwarden.data.manager
+
+/**
+ * Abstraction for interacting with Android package manager.
+ */
+interface BitwardenPackageManager {
+    /**
+     * Checks if the package is installed.
+     */
+    fun isPackageInstalled(packageName: String): Boolean
+
+    /**
+     * Gets the app name from the package name or null if the package name is not found.
+     */
+    fun getAppLabelForPackageOrNull(packageName: String): String?
+}

--- a/data/src/main/kotlin/com/bitwarden/data/manager/BitwardenPackageManagerImpl.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/BitwardenPackageManagerImpl.kt
@@ -1,0 +1,33 @@
+package com.bitwarden.data.manager
+import android.content.Context
+import android.content.pm.PackageManager
+
+/**
+ * Primary implementation of [BitwardenPackageManager].
+ */
+class BitwardenPackageManagerImpl(
+    context: Context,
+) : BitwardenPackageManager {
+
+    private val nativePackageManager = context.packageManager
+
+    override fun isPackageInstalled(packageName: String): Boolean {
+        return try {
+            nativePackageManager.getApplicationInfo(packageName, 0)
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            false
+        }
+    }
+
+    override fun getAppLabelForPackageOrNull(packageName: String): String? {
+        return try {
+            val appInfo = nativePackageManager.getApplicationInfo(packageName, 0)
+            nativePackageManager
+                .getApplicationLabel(appInfo)
+                .toString()
+        } catch (_: PackageManager.NameNotFoundException) {
+            null
+        }
+    }
+}

--- a/data/src/main/kotlin/com/bitwarden/data/manager/di/DataManagerModule.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/di/DataManagerModule.kt
@@ -1,0 +1,25 @@
+package com.bitwarden.data.manager.di
+
+import android.content.Context
+import com.bitwarden.data.manager.BitwardenPackageManager
+import com.bitwarden.data.manager.BitwardenPackageManagerImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Provides managers in the data module.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object DataManagerModule {
+
+    @Provides
+    @Singleton
+    fun provideBitwardenPackageManager(
+        @ApplicationContext context: Context,
+    ): BitwardenPackageManager = BitwardenPackageManagerImpl(context = context)
+}

--- a/data/src/test/kotlin/com/bitwarden/data/manager/BitwardenPackageManagerTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/manager/BitwardenPackageManagerTest.kt
@@ -1,0 +1,110 @@
+package com.bitwarden.data.manager
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BitwardenPackageManagerTest {
+
+    private val mockPackageManager: PackageManager = mockk()
+    private val context: Context = mockk {
+        every { packageManager } returns mockPackageManager
+    }
+    private val bitwardenPackageManager = BitwardenPackageManagerImpl(context)
+
+    @Test
+    fun `isPackageInstalled returns true for installed package`() {
+        val packageName = "com.example.installed"
+        every { mockPackageManager.getApplicationInfo(packageName, 0) } returns ApplicationInfo()
+        val result = bitwardenPackageManager.isPackageInstalled(packageName)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isPackageInstalled returns false for non existent package`() {
+        val packageName = "com.example.nonexistent"
+        every {
+            mockPackageManager.getApplicationInfo(packageName, 0)
+        } throws PackageManager.NameNotFoundException()
+        val result = bitwardenPackageManager.isPackageInstalled(packageName)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isPackageInstalled handles empty package name`() {
+        val packageName = ""
+        every {
+            mockPackageManager.getApplicationInfo(packageName, 0)
+        } throws PackageManager.NameNotFoundException()
+        val result = bitwardenPackageManager.isPackageInstalled(packageName)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isPackageInstalled handles package name with special characters`() {
+        val packageName = "com.example.invalid name!"
+        every {
+            mockPackageManager.getApplicationInfo(packageName, 0)
+        } throws PackageManager.NameNotFoundException()
+        val result = bitwardenPackageManager.isPackageInstalled(packageName)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `getAppLabelForPackageOrNull returns correct label for installed package`() {
+        val packageName = "com.example.installed"
+        val appLabel = "Example App"
+        val applicationInfo = ApplicationInfo()
+        every { mockPackageManager.getApplicationInfo(packageName, 0) } returns applicationInfo
+        every { mockPackageManager.getApplicationLabel(applicationInfo) } returns appLabel
+        val result = bitwardenPackageManager.getAppLabelForPackageOrNull(packageName)
+        assertEquals(appLabel, result)
+    }
+
+    @Test
+    fun `getAppLabelForPackageOrNull returns null for non existent package`() {
+        val packageName = "com.example.nonexistent"
+        every {
+            mockPackageManager.getApplicationInfo(packageName, 0)
+        } throws PackageManager.NameNotFoundException()
+        val result = bitwardenPackageManager.getAppLabelForPackageOrNull(packageName)
+        assertNull(result)
+    }
+
+    @Test
+    fun `getAppLabelForPackageOrNull handles package with no label`() {
+        val packageName = "com.example.nolabel"
+        val applicationInfo = ApplicationInfo()
+        every { mockPackageManager.getApplicationInfo(packageName, 0) } returns applicationInfo
+        every { mockPackageManager.getApplicationLabel(applicationInfo) } returns ""
+        val result = bitwardenPackageManager.getAppLabelForPackageOrNull(packageName)
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `getAppLabelForPackageOrNull handles empty package name`() {
+        val packageName = ""
+        every {
+            mockPackageManager.getApplicationInfo(packageName, 0)
+        } throws PackageManager.NameNotFoundException()
+        val result = bitwardenPackageManager.getAppLabelForPackageOrNull(packageName)
+        assertNull(result)
+    }
+
+    @Test
+    fun `getAppLabelForPackageOrNull handles package name with special characters`() {
+        val packageName = "com.example.invalid name!"
+        every {
+            mockPackageManager.getApplicationInfo(packageName, 0)
+        } throws PackageManager.NameNotFoundException()
+        val result = bitwardenPackageManager.getAppLabelForPackageOrNull(packageName)
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-22665

## 📔 Objective

Introduce a manager for interacting with Android's package manager.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
