### PR TITLE
PM-22643: Do not clear error dialogs when updating TOTP data

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeViewModel.kt
@@ -282,10 +282,7 @@ class VerificationCodeViewModel @Inject constructor(
     ) {
         val data = verificationCodeData.data
         if (data != null) {
-            updateStateWithVerificationCodeData(
-                verificationCodeData = data,
-                clearDialogState = true,
-            )
+            updateStateWithVerificationCodeData(verificationCodeData = data)
         } else {
             mutableStateFlow.update { currentState ->
                 currentState.copy(
@@ -307,20 +304,14 @@ class VerificationCodeViewModel @Inject constructor(
     private fun vaultPendingReceive(
         verificationCodeData: DataState.Pending<List<VerificationCodeItem>>,
     ) {
-        updateStateWithVerificationCodeData(
-            verificationCodeData = verificationCodeData.data,
-            clearDialogState = false,
-        )
+        updateStateWithVerificationCodeData(verificationCodeData = verificationCodeData.data)
     }
 
     private fun vaultLoadedReceive(
         verificationCodeData:
         DataState.Loaded<List<VerificationCodeItem>>,
     ) {
-        updateStateWithVerificationCodeData(
-            verificationCodeData = verificationCodeData.data,
-            clearDialogState = true,
-        )
+        updateStateWithVerificationCodeData(verificationCodeData = verificationCodeData.data)
         mutableStateFlow.update { it.copy(isRefreshing = false) }
     }
 
@@ -331,10 +322,7 @@ class VerificationCodeViewModel @Inject constructor(
     private fun vaultErrorReceive(vaultData: DataState.Error<List<VerificationCodeItem>>) {
         val data = vaultData.data
         if (data != null) {
-            updateStateWithVerificationCodeData(
-                verificationCodeData = data,
-                clearDialogState = true,
-            )
+            updateStateWithVerificationCodeData(verificationCodeData = data)
         } else {
             mutableStateFlow.update {
                 it.copy(
@@ -350,7 +338,6 @@ class VerificationCodeViewModel @Inject constructor(
 
     private fun updateStateWithVerificationCodeData(
         verificationCodeData: List<VerificationCodeItem>,
-        clearDialogState: Boolean,
     ) {
         if (verificationCodeData.isEmpty()) {
             sendEvent(VerificationCodeEvent.NavigateBack)
@@ -378,7 +365,9 @@ class VerificationCodeViewModel @Inject constructor(
                             )
                         },
                 ),
-                dialogState = state.dialogState.takeUnless { clearDialogState },
+                dialogState = state.dialogState.takeUnless {
+                    it is VerificationCodeState.DialogState.Loading
+                },
             )
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22643](https://bitwarden.atlassian.net/browse/PM-22643)

## 📔 Objective

This PR ensures that the error dialogs are not cleared when new TOTP data arrives.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/23f3b412-4845-4272-9950-248a0f68da9b" width="300" /> | <video src="https://github.com/user-attachments/assets/f52688bc-e8bf-48d4-9081-773b7072be65" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22643]: https://bitwarden.atlassian.net/browse/PM-22643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ