### PR TITLE
[PM-21782] Improve create cipher error handling

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/CreateCipherResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/CreateCipherResult.kt
@@ -11,7 +11,8 @@ sealed class CreateCipherResult {
     data object Success : CreateCipherResult()
 
     /**
-     * Generic error while creating cipher.
+     * Generic error while creating cipher. The optional [errorMessage] may be displayed directly in
+     * the UI when present.
      */
-    data class Error(val error: Throwable) : CreateCipherResult()
+    data class Error(val errorMessage: String?, val error: Throwable?) : CreateCipherResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1598,7 +1598,11 @@ class VaultAddEditViewModel @Inject constructor(
             is CreateCipherResult.Error -> {
                 showDialog(
                     dialogState = VaultAddEditState.DialogState.Generic(
-                        message = R.string.generic_error_message.asText(),
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = result
+                            .errorMessage
+                            ?.asText()
+                            ?: R.string.generic_error_message.asText(),
                         error = result.error,
                     ),
                 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -1876,7 +1876,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
             coEvery {
                 vaultRepository.createCipherInOrganization(any(), any())
-            } returns CreateCipherResult.Error(error = Throwable("Oh dang"))
+            } returns CreateCipherResult.Error(errorMessage = null, error = Throwable("Oh dang"))
             viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
 
             assertEquals(
@@ -1884,6 +1884,61 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     dialog = VaultAddEditState.DialogState.Generic(
                         title = R.string.internet_connection_required_title.asText(),
                         message = R.string.internet_connection_required_message.asText(),
+                    ),
+                ),
+                viewModel.stateFlow.value,
+            )
+        }
+
+    @Test
+    fun `in edit mode, SaveClick should show network error message in dialog when not null`() =
+        runTest {
+            val stateWithName = createVaultAddItemState(
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                ),
+            )
+            mutableVaultDataFlow.value = DataState.Loaded(createVaultData())
+
+            val viewModel = createAddVaultItemViewModel(
+                createSavedStateHandleWithState(
+                    state = stateWithName,
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
+                ),
+            )
+
+            coEvery {
+                vaultRepository.createCipherInOrganization(any(), any())
+            } returns CreateCipherResult.Error(
+                errorMessage = "Network error message",
+                error = null,
+            )
+            viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
+
+            assertEquals(
+                stateWithName.copy(
+                    dialog = VaultAddEditState.DialogState.Generic(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = "Network error message".asText(),
+                    ),
+                ),
+                viewModel.stateFlow.value,
+            )
+
+            // Verify default error message is shown when errorMessage is null
+            coEvery {
+                vaultRepository.createCipherInOrganization(any(), any())
+            } returns CreateCipherResult.Error(
+                errorMessage = null,
+                error = null,
+            )
+            viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
+            assertEquals(
+                stateWithName.copy(
+                    dialog = VaultAddEditState.DialogState.Generic(
+                        title = R.string.an_error_has_occurred.asText(),
+                        message = R.string.generic_error_message.asText(),
                     ),
                 ),
                 viewModel.stateFlow.value,

--- a/network/src/main/kotlin/com/bitwarden/network/model/CreateCipherResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/CreateCipherResponseJson.kt
@@ -1,0 +1,32 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models the response from the create cipher request.
+ */
+sealed class CreateCipherResponseJson {
+
+    /**
+     * The request completed successfully and returned the created [cipher].
+     */
+    data class Success(val cipher: SyncResponseJson.Cipher) : CreateCipherResponseJson()
+
+    /**
+     * Represents the json body of an invalid create request.
+     *
+     * @param message A general, user-displayable error message.
+     * @param validationErrors a map where each value is a list of error messages for each key.
+     * The values in the array should be used for display to the user, since the keys tend to come
+     * back as nonsense. (eg: empty string key)
+     */
+    @Serializable
+    data class Invalid(
+        @SerialName("message")
+        val message: String?,
+
+        @SerialName("validationErrors")
+        val validationErrors: Map<String, List<String>>?,
+    ) : CreateCipherResponseJson()
+}

--- a/network/src/main/kotlin/com/bitwarden/network/service/CiphersService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/CiphersService.kt
@@ -5,6 +5,7 @@ import com.bitwarden.network.model.AttachmentJsonRequest
 import com.bitwarden.network.model.AttachmentJsonResponse
 import com.bitwarden.network.model.CipherJsonRequest
 import com.bitwarden.network.model.CreateCipherInOrganizationJsonRequest
+import com.bitwarden.network.model.CreateCipherResponseJson
 import com.bitwarden.network.model.ImportCiphersJsonRequest
 import com.bitwarden.network.model.ImportCiphersResponseJson
 import com.bitwarden.network.model.ShareCipherJsonRequest
@@ -21,14 +22,14 @@ interface CiphersService {
     /**
      * Attempt to create a cipher.
      */
-    suspend fun createCipher(body: CipherJsonRequest): Result<SyncResponseJson.Cipher>
+    suspend fun createCipher(body: CipherJsonRequest): Result<CreateCipherResponseJson>
 
     /**
      * Attempt to create a cipher that belongs to an organization.
      */
     suspend fun createCipherInOrganization(
         body: CreateCipherInOrganizationJsonRequest,
-    ): Result<SyncResponseJson.Cipher>
+    ): Result<CreateCipherResponseJson>
 
     /**
      * Attempt to upload an attachment file.

--- a/network/src/test/kotlin/com/bitwarden/network/service/CiphersServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/CiphersServiceTest.kt
@@ -6,6 +6,7 @@ import com.bitwarden.network.api.CiphersApi
 import com.bitwarden.network.base.BaseServiceTest
 import com.bitwarden.network.model.AttachmentJsonResponse
 import com.bitwarden.network.model.CreateCipherInOrganizationJsonRequest
+import com.bitwarden.network.model.CreateCipherResponseJson
 import com.bitwarden.network.model.FileUploadType
 import com.bitwarden.network.model.ImportCiphersJsonRequest
 import com.bitwarden.network.model.ImportCiphersResponseJson
@@ -67,7 +68,22 @@ class CiphersServiceTest : BaseServiceTest() {
             body = createMockCipherJsonRequest(number = 1),
         )
         assertEquals(
-            createMockCipher(number = 1),
+            CreateCipherResponseJson.Success(createMockCipher(number = 1)),
+            result.getOrThrow(),
+        )
+    }
+
+    @Test
+    fun `createCipher should return Invalid with correct data`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(400).setBody(CREATE_CIPHER_INVALID_JSON))
+        val result = ciphersService.createCipher(
+            body = createMockCipherJsonRequest(number = 1),
+        )
+        assertEquals(
+            CreateCipherResponseJson.Invalid(
+                message = "Cipher was not encrypted for the current user. Please try again.",
+                validationErrors = null,
+            ),
             result.getOrThrow(),
         )
     }
@@ -82,10 +98,29 @@ class CiphersServiceTest : BaseServiceTest() {
             ),
         )
         assertEquals(
-            createMockCipher(number = 1),
+            CreateCipherResponseJson.Success(createMockCipher(number = 1)),
             result.getOrThrow(),
         )
     }
+
+    @Test
+    fun `createCipherInOrganization should return Invalid with correct data`() =
+        runTest {
+            server.enqueue(MockResponse().setResponseCode(400).setBody(CREATE_CIPHER_INVALID_JSON))
+            val result = ciphersService.createCipherInOrganization(
+                body = CreateCipherInOrganizationJsonRequest(
+                    cipher = createMockCipherJsonRequest(number = 1),
+                    collectionIds = listOf("12345"),
+                ),
+            )
+            assertEquals(
+                CreateCipherResponseJson.Invalid(
+                    message = "Cipher was not encrypted for the current user. Please try again.",
+                    validationErrors = null,
+                ),
+                result.getOrThrow(),
+            )
+        }
 
     @Test
     fun `createAttachment should return the correct response`() = runTest {
@@ -603,6 +638,12 @@ private const val CREATE_RESTORE_UPDATE_CIPHER_SUCCESS_JSON = """
 private const val UPDATE_CIPHER_INVALID_JSON = """
 {
   "message": "You do not have permission to edit this.",
+  "validationErrors": null
+}
+"""
+private const val CREATE_CIPHER_INVALID_JSON = """
+{
+  "message": "Cipher was not encrypted for the current user. Please try again.",
   "validationErrors": null
 }
 """


### PR DESCRIPTION
## 🎟️ Tracking

PM-21782

## 📔 Objective

This commit introduces a new `CreateCipherResponseJson` sealed class to better handle responses from the create cipher API endpoint. This allows for more specific error messages to be displayed to the user when a cipher creation fails due to invalid data.

The `CreateCipherResult.Error` class has been updated to include an optional `errorMessage` string, which can be directly displayed in the UI.

The `CipherManagerImpl` and `VaultAddEditViewModel` have been updated to utilize this new error handling, providing more informative feedback to the user.

## 📸 Screenshots

<img width="285" alt="image" src="https://github.com/user-attachments/assets/a91522ab-5c62-477b-b664-c37f31221276" />




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
