### PR TITLE
[PM-22552] Update alg type in PasskeyAttestationOptions

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/model/PasskeyAttestationOptions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/model/PasskeyAttestationOptions.kt
@@ -73,7 +73,7 @@ data class PasskeyAttestationOptions(
         @SerialName("type")
         val type: String,
         @SerialName("alg")
-        val alg: Long,
+        val alg: Double,
     )
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PasskeyAttestationOptionsTestHelpers.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/PasskeyAttestationOptionsTestHelpers.kt
@@ -28,7 +28,7 @@ fun createMockPasskeyAttestationOptions(
     pubKeyCredParams = listOf(
         PasskeyAttestationOptions.PublicKeyCredentialParameters(
             type = "PublicKeyCredentialParametersType-$number",
-            alg = number.toLong(),
+            alg = number.toDouble(),
         ),
     ),
     relyingParty = PasskeyAttestationOptions.PublicKeyCredentialRpEntity(


### PR DESCRIPTION
## 🎟️ Tracking

PM-22552
Closes #5340

## 📔 Objective

The `alg` property in `PasskeyAttestationOptions.PublicKeyCredentialParameters` was changed from `Long` to `Double`. This change is also reflected in the test helpers.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
