### PR TITLE
PM-22835: Update the passkey creation date format style

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
@@ -2,8 +2,7 @@
 
 package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
-import com.bitwarden.core.data.util.toFormattedDateStyle
-import com.bitwarden.core.data.util.toFormattedTimeStyle
+import com.bitwarden.core.data.util.toFormattedDateTimeStyle
 import com.bitwarden.ui.util.asText
 import com.bitwarden.vault.CipherRepromptType
 import com.bitwarden.vault.CipherType
@@ -328,9 +327,12 @@ private fun List<Fido2Credential>?.getPrimaryFido2CredentialOrNull(
 
 /**
  * Return the creation date and time of the primary FIDO2 credential, formatted as
- * "M/d/yy, hh:mm a".
+ * "MMM d, yyyy, hh:mm a".
  */
-private fun Fido2Credential.getCreationDateTime(clock: Clock) = R.string.created_xy.asText(
-    creationDate.toFormattedDateStyle(dateStyle = FormatStyle.SHORT, clock = clock),
-    creationDate.toFormattedTimeStyle(timeStyle = FormatStyle.SHORT, clock = clock),
+private fun Fido2Credential.getCreationDateTime(clock: Clock) = R.string.created_x.asText(
+    creationDate.toFormattedDateTimeStyle(
+        dateStyle = FormatStyle.MEDIUM,
+        timeStyle = FormatStyle.SHORT,
+        clock = clock,
+    ),
 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensions.kt
@@ -1,9 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.item.util
 
 import androidx.annotation.DrawableRes
-import com.bitwarden.core.data.util.toFormattedDateStyle
 import com.bitwarden.core.data.util.toFormattedDateTimeStyle
-import com.bitwarden.core.data.util.toFormattedTimeStyle
 import com.bitwarden.ui.platform.base.util.nullIfAllEqual
 import com.bitwarden.ui.platform.base.util.orNullIfBlank
 import com.bitwarden.ui.platform.base.util.orZeroWidthSpace
@@ -256,19 +254,14 @@ private fun LoginUriView.toUriData() =
         isLaunchable = !uri.isNullOrBlank(),
     )
 
-private fun Fido2Credential?.getCreationDateText(clock: Clock): Text? =
-    this?.let {
-        R.string.created_xy.asText(
-            creationDate.toFormattedDateStyle(
-                dateStyle = FormatStyle.SHORT,
-                clock = clock,
-            ),
-            creationDate.toFormattedTimeStyle(
-                timeStyle = FormatStyle.SHORT,
-                clock = clock,
-            ),
-        )
-    }
+private fun Fido2Credential.getCreationDateText(clock: Clock): Text? =
+    R.string.created_x.asText(
+        this.creationDate.toFormattedDateTimeStyle(
+            dateStyle = FormatStyle.MEDIUM,
+            timeStyle = FormatStyle.SHORT,
+            clock = clock,
+        ),
+    )
 
 private fun CipherView.toIconData(
     baseIconUrl: String,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -675,7 +675,7 @@ Do you want to switch to this account?</string>
     <string name="privacy_policy_description_long">Check out our privacy policy on bitwarden.com.</string>
     <string name="explore_more_features_of_your_bitwarden_account_on_the_web_app">Explore more features of your Bitwarden account on the web app.</string>
     <string name="learn_about_organizations_description_long">Bitwarden allows you to share your vault items with others by using an organization. Learn more on the bitwarden.com website.</string>
-    <string name="created_xy">Created %1$s, %2$s</string>
+    <string name="created_x">Created %1$s</string>
     <string name="your_organization_requires_you_to_set_a_master_password">Your organization requires you to set a master password.</string>
     <string name="set_up_an_unlock_option_to_change_your_vault_timeout_action">Set up an unlock option to change your vault timeout action.</string>
     <string name="save_passkey_as_new_login">Save passkey as new login</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -2179,9 +2179,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     originalCipher = cipherView,
                 ),
                 typeContentViewState = createLoginTypeContentViewState(
-                    fido2CredentialCreationDateTime = R.string.created_xy.asText(
-                        "05/08/24",
-                        "14:30 PM",
+                    fido2CredentialCreationDateTime = R.string.created_x.asText(
+                        "May 08, 2024, 4:30 PM",
                     ),
                 ),
                 createCredentialRequest = mockFido2CredentialRequest,
@@ -2859,9 +2858,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 savedStateHandle = createSavedStateHandleWithState(
                     state = createVaultAddItemState(
                         typeContentViewState = createLoginTypeContentViewState(
-                            fido2CredentialCreationDateTime = R.string.created_xy.asText(
-                                "05/08/24",
-                                "14:30 PM",
+                            fido2CredentialCreationDateTime = R.string.created_x.asText(
+                                "May 08, 2024, 4:30 PM",
                             ),
                         ),
                     ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -215,9 +215,8 @@ class CipherViewExtensionsTest {
                     ),
                     totp = "otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example",
                     canViewPassword = false,
-                    fido2CredentialCreationDateTime = R.string.created_xy.asText(
-                        "10/27/23",
-                        "12:00 PM",
+                    fido2CredentialCreationDateTime = R.string.created_x.asText(
+                        "Oct 27, 2023, 12:00 PM",
                     ),
                 ),
             ),
@@ -277,9 +276,8 @@ class CipherViewExtensionsTest {
                     ),
                     totp = totp,
                     canViewPassword = false,
-                    fido2CredentialCreationDateTime = R.string.created_xy.asText(
-                        "10/27/23",
-                        "12:00 PM",
+                    fido2CredentialCreationDateTime = R.string.created_x.asText(
+                        "Oct 27, 2023, 12:00 PM",
                     ),
                 ),
             ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -2061,7 +2061,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithText(text = "Created 3/13/24, 3:56 PM")
+            .onNodeWithText(text = "Created Mar 13, 2024, 3:56 PM")
             .assertIsDisplayed()
     }
 
@@ -3192,10 +3192,7 @@ private val DEFAULT_COMMON: VaultItemState.ViewState.Content.Common =
         relatedLocations = persistentListOf(),
     )
 
-private val DEFAULT_PASSKEY = R.string.created_xy.asText(
-    "3/13/24",
-    "3:56 PM",
-)
+private val DEFAULT_PASSKEY = R.string.created_x.asText("Mar 13, 2024, 3:56 PM")
 
 private val DEFAULT_LOGIN: VaultItemState.ViewState.Content.ItemType.Login =
     VaultItemState.ViewState.Content.ItemType.Login(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/util/VaultItemTestUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/util/VaultItemTestUtil.kt
@@ -280,8 +280,8 @@ fun createLoginContent(isEmpty: Boolean): VaultItemState.ViewState.Content.ItemT
             totpCode = "testCode",
         )
             .takeUnless { isEmpty },
-        fido2CredentialCreationDateText = R.string.created_xy
-            .asText("10/27/23", "12:00 PM")
+        fido2CredentialCreationDateText = R.string.created_x
+            .asText("Oct 27, 2023, 12:00 PM")
             .takeUnless { isEmpty },
         canViewTotpCode = true,
     )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22835](https://bitwarden.atlassian.net/browse/PM-22835)

## 📔 Objective

This PR updates the passkey creation date format style.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ada52515-8954-4e46-aa2a-b8e0c928a11a" width="300" /> | <img src="https://github.com/user-attachments/assets/c04b1066-89ec-41e7-9075-7a3881daa57e" width="300" /> |
| <img src="https://github.com/user-attachments/assets/5acde551-f468-4796-83ab-94f2c534190a" width="300" /> | <img src="https://github.com/user-attachments/assets/540afdb5-d184-4953-9657-5124a7009ada" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22835]: https://bitwarden.atlassian.net/browse/PM-22835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ