### PR TITLE
PM-22551: Update remove password copy

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -561,7 +561,7 @@ class SearchViewModel @Inject constructor(
 
             is RemovePasswordSendResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(SearchEvent.ShowToast(R.string.send_password_removed.asText()))
+                sendEvent(SearchEvent.ShowToast(R.string.password_removed.asText()))
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -216,7 +216,7 @@ class SendViewModel @Inject constructor(
 
             is RemovePasswordSendResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(SendEvent.ShowToast(message = R.string.send_password_removed.asText()))
+                sendEvent(SendEvent.ShowToast(message = R.string.password_removed.asText()))
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -313,9 +313,7 @@ class AddEditSendViewModel @Inject constructor(
                 mutableStateFlow.update { it.copy(dialogState = null) }
                 sendEvent(
                     AddEditSendEvent.ShowSnackbar(
-                        data = BitwardenSnackbarData(
-                            message = R.string.send_password_removed.asText(),
-                        ),
+                        data = BitwardenSnackbarData(message = R.string.password_removed.asText()),
                     ),
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1498,9 +1498,7 @@ class VaultItemListingViewModel @Inject constructor(
             is RemovePasswordSendResult.Success -> {
                 clearDialogState()
                 sendEvent(
-                    VaultItemListingEvent.ShowToast(
-                        text = R.string.send_password_removed.asText(),
-                    ),
+                    VaultItemListingEvent.ShowToast(text = R.string.password_removed.asText()),
                 )
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -454,7 +454,7 @@ Scanning will happen automatically.</string>
     <string name="password_info">Require this password to view the Send.</string>
     <string name="remove_password">Remove password</string>
     <string name="removing_send_password">Removing password</string>
-    <string name="send_password_removed">Password has been removed.</string>
+    <string name="password_removed">Password removed</string>
     <string name="add_a_send">New send</string>
     <string name="copy_link">Copy link</string>
     <string name="share_link">Share link</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -898,7 +898,7 @@ class SearchViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 assertEquals(
-                    SearchEvent.ShowToast(R.string.send_password_removed.asText()),
+                    SearchEvent.ShowToast(R.string.password_removed.asText()),
                     awaitItem(),
                 )
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
@@ -301,7 +301,7 @@ class SendViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(SendAction.RemovePasswordClick(sendItem))
-            assertEquals(SendEvent.ShowToast(R.string.send_password_removed.asText()), awaitItem())
+            assertEquals(SendEvent.ShowToast(R.string.password_removed.asText()), awaitItem())
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -601,9 +601,7 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
                 viewModel.trySendAction(AddEditSendAction.RemovePasswordClick)
                 assertEquals(
                     AddEditSendEvent.ShowSnackbar(
-                        data = BitwardenSnackbarData(
-                            message = R.string.send_password_removed.asText(),
-                        ),
+                        data = BitwardenSnackbarData(message = R.string.password_removed.asText()),
                     ),
                     awaitItem(),
                 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -1518,7 +1518,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 assertEquals(
-                    VaultItemListingEvent.ShowToast(R.string.send_password_removed.asText()),
+                    VaultItemListingEvent.ShowToast(R.string.password_removed.asText()),
                     awaitItem(),
                 )
             }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22551](https://bitwarden.atlassian.net/browse/PM-22551)

## 📔 Objective

This PR updates the copy on the Snackbar when removing a password.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/aa4377f2-db94-4543-a3b1-453bb667abc4" width="300" /> | <img src="https://github.com/user-attachments/assets/c9b9b322-2a9a-4df6-8201-0dca3a2cfb3c" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22551]: https://bitwarden.atlassian.net/browse/PM-22551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ