### PR TITLE
PM-22875: Done button on keyboard should submit pin or password from dialog

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenMasterPasswordDialog.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/dialog/BitwardenMasterPasswordDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -75,6 +76,9 @@ fun BitwardenMasterPasswordDialog(
                     label = stringResource(id = R.string.master_password),
                     value = masterPassword,
                     onValueChange = { masterPassword = it },
+                    keyboardActions = KeyboardActions(
+                        onDone = { onConfirmClick(masterPassword) },
+                    ),
                     autoFocus = true,
                     passwordFieldTestTag = "AlertInputField",
                     cardStyle = CardStyle.Full,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -94,6 +95,7 @@ import kotlinx.collections.immutable.toImmutableList
  * an entire line before breaking. `false` by default.
  * @param visualTransformation Transforms the visual representation of the input [value].
  * @param keyboardType the preferred type of keyboard input.
+ * @param keyboardActions the callbacks of keyboard actions.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
  * @param textFieldTestTag The optional test tag associated with the inner text field.
  * @param cardStyle Indicates the type of card style to be applied.
@@ -120,6 +122,7 @@ fun BitwardenTextField(
     textStyle: TextStyle = BitwardenTheme.typography.bodyLarge,
     shouldAddCustomLineBreaks: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     isError: Boolean = false,
     autoFocus: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
@@ -154,6 +157,7 @@ fun BitwardenTextField(
         textStyle = textStyle,
         shouldAddCustomLineBreaks = shouldAddCustomLineBreaks,
         keyboardType = keyboardType,
+        keyboardActions = keyboardActions,
         isError = isError,
         autoFocus = autoFocus,
         visualTransformation = visualTransformation,
@@ -191,6 +195,7 @@ fun BitwardenTextField(
  * an entire line before breaking. `false` by default.
  * @param visualTransformation Transforms the visual representation of the input [value].
  * @param keyboardType the preferred type of keyboard input.
+ * @param keyboardActions the callbacks of keyboard actions.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
  * @param textFieldTestTag The optional test tag associated with the inner text field.
  * @param cardStyle Indicates the type of card style to be applied.
@@ -219,6 +224,7 @@ fun BitwardenTextField(
     textStyle: TextStyle = BitwardenTheme.typography.bodyLarge,
     shouldAddCustomLineBreaks: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     isError: Boolean = false,
     autoFocus: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
@@ -343,6 +349,7 @@ fun BitwardenTextField(
                     readOnly = readOnly,
                     textStyle = textStyle,
                     keyboardOptions = KeyboardOptions.Default.copy(keyboardType = keyboardType),
+                    keyboardActions = keyboardActions,
                     trailingIcon = actions?.let {
                         {
                             BitwardenRowOfActions(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/PinInputDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -58,6 +60,7 @@ fun PinInputDialog(
     isPinCreation: Boolean = false,
 ) {
     var pin by remember { mutableStateOf(value = "") }
+    val isDoneEnabled: () -> Boolean = { !isPinCreation || pin.length >= MINIMUM_PIN_LENGTH }
     Dialog(
         onDismissRequest = onDismissRequest,
     ) {
@@ -115,6 +118,14 @@ fun PinInputDialog(
                     onValueChange = { newValue ->
                         pin = newValue.filter { it.isDigit() || !isPinCreation }
                     },
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            pin
+                                .takeIf { isDoneEnabled() }
+                                ?.let(onSubmitClick)
+                                ?: defaultKeyboardAction(ImeAction.Done)
+                        },
+                    ),
                     keyboardType = KeyboardType.Number,
                     textFieldTestTag = "AlertInputField",
                     cardStyle = CardStyle.Full,
@@ -138,7 +149,7 @@ fun PinInputDialog(
 
                 BitwardenFilledButton(
                     label = stringResource(id = R.string.submit),
-                    isEnabled = !isPinCreation || pin.length >= MINIMUM_PIN_LENGTH,
+                    isEnabled = isDoneEnabled(),
                     onClick = { onSubmitClick(pin) },
                     modifier = Modifier.testTag(tag = "AcceptAlertButton"),
                 )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22875](https://bitwarden.atlassian.net/browse/PM-22875)

## 📔 Objective

This PR updates the `BitwardenMasterPasswordDialog` and `PinInputDialog` to submit their values when the `Done` button on the keyboard is clicked.

Note: this still honors the minimum 4 character rule for pins.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22875]: https://bitwarden.atlassian.net/browse/PM-22875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ