### PR TITLE
[PM-15910] Add Quetta Browser to autofill compatibility packages

### DIFF
--- a/app/src/main/res/xml/autofill_service_configuration.xml
+++ b/app/src/main/res/xml/autofill_service_configuration.xml
@@ -212,6 +212,9 @@
         android:name="net.dezor.browser"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package
+        android:name="net.quetta.browser"
+        android:maxLongVersionCode="10000000000" />
+    <compatibility-package
         android:name="net.slions.fulguris.full.download"
         android:maxLongVersionCode="10000000000" />
     <compatibility-package


### PR DESCRIPTION
## 🎟️ Tracking

PM-15910
Relates to https://github.com/bitwarden/android/pull/4449

## 📔 Objective

This change adds `net.quetta.browser` to the list of compatibility packages in the autofill service configuration.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
