### PR TITLE
PM-22213: Update the order of items in the Send and Cipher overflows

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendListItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendListItem.kt
@@ -67,20 +67,20 @@ fun SendListItem(
         onClick = onClick,
         selectionDataList = persistentListOfNotNull(
             SelectionItemData(
-                text = stringResource(id = R.string.view),
-                onClick = onViewClick,
-            ),
-            SelectionItemData(
-                text = stringResource(id = R.string.edit),
-                onClick = onEditClick,
-            ),
-            SelectionItemData(
                 text = stringResource(id = R.string.copy_link),
                 onClick = onCopyClick,
             ),
             SelectionItemData(
                 text = stringResource(id = R.string.share_link),
                 onClick = onShareClick,
+            ),
+            SelectionItemData(
+                text = stringResource(id = R.string.view),
+                onClick = onViewClick,
+            ),
+            SelectionItemData(
+                text = stringResource(id = R.string.edit),
+                onClick = onEditClick,
             ),
             onRemovePasswordClick?.let {
                 SelectionItemData(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SendViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SendViewExtensions.kt
@@ -40,14 +40,14 @@ fun SendView.toOverflowActions(
         .id
         ?.let { sendId ->
             listOfNotNull(
-                ListingItemOverflowAction.SendAction.ViewClick(sendId = sendId, sendType = type),
-                ListingItemOverflowAction.SendAction.EditClick(sendId = sendId, sendType = type),
                 ListingItemOverflowAction.SendAction.CopyUrlClick(
                     sendUrl = toSendUrl(baseWebSendUrl = baseWebSendUrl),
                 ),
                 ListingItemOverflowAction.SendAction.ShareUrlClick(
                     sendUrl = toSendUrl(baseWebSendUrl = baseWebSendUrl),
                 ),
+                ListingItemOverflowAction.SendAction.ViewClick(sendId = sendId, sendType = type),
+                ListingItemOverflowAction.SendAction.EditClick(sendId = sendId, sendType = type),
                 ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = sendId).takeIf {
                     hasPassword
                 },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensions.kt
@@ -20,17 +20,6 @@ fun CipherView.toOverflowActions(
         .id
         ?.let { cipherId ->
             listOfNotNull(
-                ListingItemOverflowAction.VaultAction.ViewClick(
-                    cipherId = cipherId,
-                    cipherType = this.type,
-                    requiresPasswordReprompt = hasMasterPassword,
-                ),
-                ListingItemOverflowAction.VaultAction.EditClick(
-                    cipherId = cipherId,
-                    cipherType = this.type,
-                    requiresPasswordReprompt = hasMasterPassword,
-                )
-                    .takeUnless { this.deletedDate != null || !this.edit },
                 this.login?.username?.let {
                     ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = it)
                 },
@@ -75,6 +64,17 @@ fun CipherView.toOverflowActions(
                         )
                     }
                     .takeIf { this.type == CipherType.SECURE_NOTE },
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = cipherId,
+                    cipherType = this.type,
+                    requiresPasswordReprompt = hasMasterPassword,
+                ),
+                ListingItemOverflowAction.VaultAction.EditClick(
+                    cipherId = cipherId,
+                    cipherType = this.type,
+                    requiresPasswordReprompt = hasMasterPassword,
+                )
+                    .takeUnless { this.deletedDate != null || !this.edit },
                 this.login?.uris?.firstOrNull { it.uri != null }?.uri?.let {
                     ListingItemOverflowAction.VaultAction.LaunchClick(url = it)
                 },

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
@@ -43,16 +43,6 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(
-                        cipherId = "mockId-$number",
-                        cipherType = CipherType.LOGIN,
-                        requiresPasswordReprompt = true,
-                    ),
-                    ListingItemOverflowAction.VaultAction.EditClick(
-                        cipherId = "mockId-$number",
-                        cipherType = CipherType.LOGIN,
-                        requiresPasswordReprompt = true,
-                    ),
                     ListingItemOverflowAction.VaultAction.CopyUsernameClick(
                         username = "mockUsername-$number",
                     ),
@@ -63,6 +53,16 @@ fun createMockDisplayItemForCipher(
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
                         totpCode = "mockTotp-$number",
+                        requiresPasswordReprompt = true,
+                    ),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = CipherType.LOGIN,
+                        requiresPasswordReprompt = true,
+                    ),
+                    ListingItemOverflowAction.VaultAction.EditClick(
+                        cipherId = "mockId-$number",
+                        cipherType = CipherType.LOGIN,
                         requiresPasswordReprompt = true,
                     ),
                     ListingItemOverflowAction.VaultAction.LaunchClick(
@@ -98,6 +98,10 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
+                    ListingItemOverflowAction.VaultAction.CopyNoteClick(
+                        notes = "mockNotes-$number",
+                        requiresPasswordReprompt = true,
+                    ),
                     ListingItemOverflowAction.VaultAction.ViewClick(
                         cipherId = "mockId-$number",
                         cipherType = CipherType.SECURE_NOTE,
@@ -106,10 +110,6 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
                         cipherType = CipherType.SECURE_NOTE,
-                        requiresPasswordReprompt = true,
-                    ),
-                    ListingItemOverflowAction.VaultAction.CopyNoteClick(
-                        notes = "mockNotes-$number",
                         requiresPasswordReprompt = true,
                     ),
                 ),
@@ -142,6 +142,15 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
+                    ListingItemOverflowAction.VaultAction.CopyNumberClick(
+                        number = "mockNumber-$number",
+                        requiresPasswordReprompt = true,
+                    ),
+                    ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
+                        securityCode = "mockCode-$number",
+                        cipherId = "mockId-$number",
+                        requiresPasswordReprompt = true,
+                    ),
                     ListingItemOverflowAction.VaultAction.ViewClick(
                         cipherId = "mockId-$number",
                         cipherType = CipherType.CARD,
@@ -150,15 +159,6 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
                         cipherType = CipherType.CARD,
-                        requiresPasswordReprompt = true,
-                    ),
-                    ListingItemOverflowAction.VaultAction.CopyNumberClick(
-                        number = "mockNumber-$number",
-                        requiresPasswordReprompt = true,
-                    ),
-                    ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
-                        securityCode = "mockCode-$number",
-                        cipherId = "mockId-$number",
                         requiresPasswordReprompt = true,
                     ),
                 ),
@@ -276,6 +276,12 @@ fun createMockDisplayItemForSend(
                     ),
                 ),
                 overflowOptions = listOf(
+                    ListingItemOverflowAction.SendAction.CopyUrlClick(
+                        sendUrl = "https://vault.bitwarden.com/#/send/mockAccessId-$number/mockKey-$number",
+                    ),
+                    ListingItemOverflowAction.SendAction.ShareUrlClick(
+                        sendUrl = "https://vault.bitwarden.com/#/send/mockAccessId-$number/mockKey-$number",
+                    ),
                     ListingItemOverflowAction.SendAction.ViewClick(
                         sendId = "mockId-$number",
                         sendType = sendType,
@@ -283,12 +289,6 @@ fun createMockDisplayItemForSend(
                     ListingItemOverflowAction.SendAction.EditClick(
                         sendId = "mockId-$number",
                         sendType = sendType,
-                    ),
-                    ListingItemOverflowAction.SendAction.CopyUrlClick(
-                        sendUrl = "https://vault.bitwarden.com/#/send/mockAccessId-$number/mockKey-$number",
-                    ),
-                    ListingItemOverflowAction.SendAction.ShareUrlClick(
-                        sendUrl = "https://vault.bitwarden.com/#/send/mockAccessId-$number/mockKey-$number",
                     ),
                     ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = "mockId-$number"),
                     ListingItemOverflowAction.SendAction.DeleteClick(sendId = "mockId-$number"),
@@ -322,6 +322,12 @@ fun createMockDisplayItemForSend(
                     ),
                 ),
                 overflowOptions = listOf(
+                    ListingItemOverflowAction.SendAction.CopyUrlClick(
+                        sendUrl = "https://vault.bitwarden.com/#/send/mockAccessId-$number/mockKey-$number",
+                    ),
+                    ListingItemOverflowAction.SendAction.ShareUrlClick(
+                        sendUrl = "https://vault.bitwarden.com/#/send/mockAccessId-$number/mockKey-$number",
+                    ),
                     ListingItemOverflowAction.SendAction.ViewClick(
                         sendId = "mockId-$number",
                         sendType = sendType,
@@ -329,12 +335,6 @@ fun createMockDisplayItemForSend(
                     ListingItemOverflowAction.SendAction.EditClick(
                         sendId = "mockId-$number",
                         sendType = sendType,
-                    ),
-                    ListingItemOverflowAction.SendAction.CopyUrlClick(
-                        sendUrl = "https://vault.bitwarden.com/#/send/mockAccessId-$number/mockKey-$number",
-                    ),
-                    ListingItemOverflowAction.SendAction.ShareUrlClick(
-                        sendUrl = "https://vault.bitwarden.com/#/send/mockAccessId-$number/mockKey-$number",
                     ),
                     ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = "mockId-$number"),
                     ListingItemOverflowAction.SendAction.DeleteClick(sendId = "mockId-$number"),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SendViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SendViewExtensionsTest.kt
@@ -151,6 +151,12 @@ private val ALL_SEND_STATUS_ICONS: ImmutableList<IconData> = persistentListOf(
 
 private val ALL_SEND_OVERFLOW_OPTIONS: List<ListingItemOverflowAction> =
     listOf(
+        ListingItemOverflowAction.SendAction.CopyUrlClick(
+            sendUrl = "www.test.commockAccessId-1/mockKey-1",
+        ),
+        ListingItemOverflowAction.SendAction.ShareUrlClick(
+            sendUrl = "www.test.commockAccessId-1/mockKey-1",
+        ),
         ListingItemOverflowAction.SendAction.ViewClick(
             sendId = "mockId-1",
             sendType = SendType.FILE,
@@ -158,12 +164,6 @@ private val ALL_SEND_OVERFLOW_OPTIONS: List<ListingItemOverflowAction> =
         ListingItemOverflowAction.SendAction.EditClick(
             sendId = "mockId-1",
             sendType = SendType.FILE,
-        ),
-        ListingItemOverflowAction.SendAction.CopyUrlClick(
-            sendUrl = "www.test.commockAccessId-1/mockKey-1",
-        ),
-        ListingItemOverflowAction.SendAction.ShareUrlClick(
-            sendUrl = "www.test.commockAccessId-1/mockKey-1",
         ),
         ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = "mockId-1"),
         ListingItemOverflowAction.SendAction.DeleteClick(sendId = "mockId-1"),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -2422,6 +2422,8 @@ private fun createDisplayItem(number: Int): VaultItemListingState.DisplayItem =
             ),
         ),
         overflowOptions = listOf(
+            ListingItemOverflowAction.SendAction.CopyUrlClick(sendUrl = "www.test.com"),
+            ListingItemOverflowAction.SendAction.ShareUrlClick(sendUrl = "www.test.com"),
             ListingItemOverflowAction.SendAction.ViewClick(
                 sendId = "mockId-$number",
                 sendType = SendType.FILE,
@@ -2430,8 +2432,6 @@ private fun createDisplayItem(number: Int): VaultItemListingState.DisplayItem =
                 sendId = "mockId-$number",
                 sendType = SendType.TEXT,
             ),
-            ListingItemOverflowAction.SendAction.CopyUrlClick(sendUrl = "www.test.com"),
-            ListingItemOverflowAction.SendAction.ShareUrlClick(sendUrl = "www.test.com"),
             ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = "mockId-$number"),
             ListingItemOverflowAction.SendAction.DeleteClick(sendId = "mockId-$number"),
         ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -46,16 +46,6 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
-                    ListingItemOverflowAction.VaultAction.ViewClick(
-                        cipherId = "mockId-$number",
-                        cipherType = cipherType,
-                        requiresPasswordReprompt = requiresPasswordReprompt,
-                    ),
-                    ListingItemOverflowAction.VaultAction.EditClick(
-                        cipherId = "mockId-$number",
-                        cipherType = cipherType,
-                        requiresPasswordReprompt = requiresPasswordReprompt,
-                    ),
                     ListingItemOverflowAction.VaultAction.CopyUsernameClick(
                         username = "mockUsername-$number",
                     ),
@@ -66,6 +56,16 @@ fun createMockDisplayItemForCipher(
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
                         totpCode = "mockTotp-$number",
+                        requiresPasswordReprompt = requiresPasswordReprompt,
+                    ),
+                    ListingItemOverflowAction.VaultAction.ViewClick(
+                        cipherId = "mockId-$number",
+                        cipherType = cipherType,
+                        requiresPasswordReprompt = requiresPasswordReprompt,
+                    ),
+                    ListingItemOverflowAction.VaultAction.EditClick(
+                        cipherId = "mockId-$number",
+                        cipherType = cipherType,
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.LaunchClick(
@@ -104,6 +104,10 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
+                    ListingItemOverflowAction.VaultAction.CopyNoteClick(
+                        notes = "mockNotes-$number",
+                        requiresPasswordReprompt = requiresPasswordReprompt,
+                    ),
                     ListingItemOverflowAction.VaultAction.ViewClick(
                         cipherId = "mockId-$number",
                         cipherType = cipherType,
@@ -112,10 +116,6 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
                         cipherType = cipherType,
-                        requiresPasswordReprompt = requiresPasswordReprompt,
-                    ),
-                    ListingItemOverflowAction.VaultAction.CopyNoteClick(
-                        notes = "mockNotes-$number",
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                 ),
@@ -151,6 +151,15 @@ fun createMockDisplayItemForCipher(
                     ),
                 ),
                 overflowOptions = listOf(
+                    ListingItemOverflowAction.VaultAction.CopyNumberClick(
+                        number = "mockNumber-$number",
+                        requiresPasswordReprompt = requiresPasswordReprompt,
+                    ),
+                    ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
+                        securityCode = "mockCode-$number",
+                        cipherId = "mockId-$number",
+                        requiresPasswordReprompt = requiresPasswordReprompt,
+                    ),
                     ListingItemOverflowAction.VaultAction.ViewClick(
                         cipherId = "mockId-$number",
                         cipherType = cipherType,
@@ -159,15 +168,6 @@ fun createMockDisplayItemForCipher(
                     ListingItemOverflowAction.VaultAction.EditClick(
                         cipherId = "mockId-$number",
                         cipherType = cipherType,
-                        requiresPasswordReprompt = requiresPasswordReprompt,
-                    ),
-                    ListingItemOverflowAction.VaultAction.CopyNumberClick(
-                        number = "mockNumber-$number",
-                        requiresPasswordReprompt = requiresPasswordReprompt,
-                    ),
-                    ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
-                        securityCode = "mockCode-$number",
-                        cipherId = "mockId-$number",
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                 ),
@@ -299,6 +299,12 @@ fun createMockDisplayItemForSend(
                     ),
                 ),
                 overflowOptions = listOf(
+                    ListingItemOverflowAction.SendAction.CopyUrlClick(
+                        sendUrl = "https://send.bitwarden.com/#mockAccessId-$number/mockKey-$number",
+                    ),
+                    ListingItemOverflowAction.SendAction.ShareUrlClick(
+                        sendUrl = "https://send.bitwarden.com/#mockAccessId-$number/mockKey-$number",
+                    ),
                     ListingItemOverflowAction.SendAction.ViewClick(
                         sendId = "mockId-$number",
                         sendType = sendType,
@@ -306,12 +312,6 @@ fun createMockDisplayItemForSend(
                     ListingItemOverflowAction.SendAction.EditClick(
                         sendId = "mockId-$number",
                         sendType = sendType,
-                    ),
-                    ListingItemOverflowAction.SendAction.CopyUrlClick(
-                        sendUrl = "https://send.bitwarden.com/#mockAccessId-$number/mockKey-$number",
-                    ),
-                    ListingItemOverflowAction.SendAction.ShareUrlClick(
-                        sendUrl = "https://send.bitwarden.com/#mockAccessId-$number/mockKey-$number",
                     ),
                     ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = "mockId-$number"),
                     ListingItemOverflowAction.SendAction.DeleteClick(sendId = "mockId-$number"),
@@ -348,6 +348,12 @@ fun createMockDisplayItemForSend(
                     ),
                 ),
                 overflowOptions = listOf(
+                    ListingItemOverflowAction.SendAction.CopyUrlClick(
+                        sendUrl = "https://send.bitwarden.com/#mockAccessId-$number/mockKey-$number",
+                    ),
+                    ListingItemOverflowAction.SendAction.ShareUrlClick(
+                        sendUrl = "https://send.bitwarden.com/#mockAccessId-$number/mockKey-$number",
+                    ),
                     ListingItemOverflowAction.SendAction.ViewClick(
                         sendId = "mockId-$number",
                         sendType = sendType,
@@ -355,12 +361,6 @@ fun createMockDisplayItemForSend(
                     ListingItemOverflowAction.SendAction.EditClick(
                         sendId = "mockId-$number",
                         sendType = sendType,
-                    ),
-                    ListingItemOverflowAction.SendAction.CopyUrlClick(
-                        sendUrl = "https://send.bitwarden.com/#mockAccessId-$number/mockKey-$number",
-                    ),
-                    ListingItemOverflowAction.SendAction.ShareUrlClick(
-                        sendUrl = "https://send.bitwarden.com/#mockAccessId-$number/mockKey-$number",
                     ),
                     ListingItemOverflowAction.SendAction.RemovePasswordClick(sendId = "mockId-$number"),
                     ListingItemOverflowAction.SendAction.DeleteClick(sendId = "mockId-$number"),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherViewExtensionsTest.kt
@@ -30,16 +30,6 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
-                ListingItemOverflowAction.VaultAction.ViewClick(
-                    cipherId = id,
-                    cipherType = CipherType.LOGIN,
-                    requiresPasswordReprompt = false,
-                ),
-                ListingItemOverflowAction.VaultAction.EditClick(
-                    cipherId = id,
-                    cipherType = CipherType.LOGIN,
-                    requiresPasswordReprompt = false,
-                ),
                 ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = username),
                 ListingItemOverflowAction.VaultAction.CopyPasswordClick(
                     password = password,
@@ -48,6 +38,16 @@ class CipherViewExtensionsTest {
                 ),
                 ListingItemOverflowAction.VaultAction.CopyTotpClick(
                     totpCode = totpCode,
+                    requiresPasswordReprompt = false,
+                ),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.LOGIN,
+                    requiresPasswordReprompt = false,
+                ),
+                ListingItemOverflowAction.VaultAction.EditClick(
+                    cipherId = id,
+                    cipherType = CipherType.LOGIN,
                     requiresPasswordReprompt = false,
                 ),
                 ListingItemOverflowAction.VaultAction.LaunchClick(url = uri),
@@ -71,6 +71,12 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
+                ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = username),
+                ListingItemOverflowAction.VaultAction.CopyPasswordClick(
+                    password = password,
+                    requiresPasswordReprompt = false,
+                    cipherId = id,
+                ),
                 ListingItemOverflowAction.VaultAction.ViewClick(
                     cipherId = id,
                     cipherType = CipherType.LOGIN,
@@ -80,12 +86,6 @@ class CipherViewExtensionsTest {
                     cipherId = id,
                     cipherType = CipherType.LOGIN,
                     requiresPasswordReprompt = false,
-                ),
-                ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = username),
-                ListingItemOverflowAction.VaultAction.CopyPasswordClick(
-                    password = password,
-                    requiresPasswordReprompt = false,
-                    cipherId = id,
                 ),
                 ListingItemOverflowAction.VaultAction.LaunchClick(url = uri),
             ),
@@ -109,6 +109,7 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
+                ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = username),
                 ListingItemOverflowAction.VaultAction.ViewClick(
                     cipherId = id,
                     cipherType = CipherType.LOGIN,
@@ -119,7 +120,6 @@ class CipherViewExtensionsTest {
                     cipherType = CipherType.LOGIN,
                     requiresPasswordReprompt = true,
                 ),
-                ListingItemOverflowAction.VaultAction.CopyUsernameClick(username = username),
                 ListingItemOverflowAction.VaultAction.LaunchClick(url = uri),
             ),
             result,
@@ -173,6 +173,15 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
+                ListingItemOverflowAction.VaultAction.CopyNumberClick(
+                    number = number,
+                    requiresPasswordReprompt = true,
+                ),
+                ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
+                    securityCode = securityCode,
+                    cipherId = id,
+                    requiresPasswordReprompt = true,
+                ),
                 ListingItemOverflowAction.VaultAction.ViewClick(
                     cipherId = id,
                     cipherType = CipherType.CARD,
@@ -181,15 +190,6 @@ class CipherViewExtensionsTest {
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
                     cipherType = CipherType.CARD,
-                    requiresPasswordReprompt = true,
-                ),
-                ListingItemOverflowAction.VaultAction.CopyNumberClick(
-                    number = number,
-                    requiresPasswordReprompt = true,
-                ),
-                ListingItemOverflowAction.VaultAction.CopySecurityCodeClick(
-                    securityCode = securityCode,
-                    cipherId = id,
                     requiresPasswordReprompt = true,
                 ),
             ),
@@ -291,6 +291,10 @@ class CipherViewExtensionsTest {
 
         assertEquals(
             listOf(
+                ListingItemOverflowAction.VaultAction.CopyNoteClick(
+                    notes = notes,
+                    requiresPasswordReprompt = true,
+                ),
                 ListingItemOverflowAction.VaultAction.ViewClick(
                     cipherId = id,
                     cipherType = CipherType.SECURE_NOTE,
@@ -299,10 +303,6 @@ class CipherViewExtensionsTest {
                 ListingItemOverflowAction.VaultAction.EditClick(
                     cipherId = id,
                     cipherType = CipherType.SECURE_NOTE,
-                    requiresPasswordReprompt = true,
-                ),
-                ListingItemOverflowAction.VaultAction.CopyNoteClick(
-                    notes = notes,
                     requiresPasswordReprompt = true,
                 ),
             ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22213](https://bitwarden.atlassian.net/browse/PM-22213)

## 📔 Objective

This PR rearranges the options in the Cipher and Send overflow menus.

The general order is:
1. Copy/Share
2. View
3. Edit
4. Destructive

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/4f7ebf4f-0a59-40a1-8214-04da7adfb9b5" width="300" /> | <img src="https://github.com/user-attachments/assets/14ef112e-1aa6-4816-9d53-f064a50f9440" width="300" /> |
| <img src="https://github.com/user-attachments/assets/c7c8d3f8-cf31-4b2b-be75-787a3239f312" width="300" /> | <img src="https://github.com/user-attachments/assets/6dedda9b-ffce-4320-815f-f14846e6dd38" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22213]: https://bitwarden.atlassian.net/browse/PM-22213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ