### PR TITLE
Add Brave integration toggle

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -335,6 +335,9 @@
 
         <!-- To Query Chrome Stable: -->
         <package android:name="com.android.chrome" />
+
+        <!-- To Query Brave Stable: -->
+        <package android:name="com.brave.browser" />
     </queries>
 
 </manifest>

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerImpl.kt
@@ -27,6 +27,7 @@ class AutofillActivityManagerImpl(
 
     private val browserAutofillStatus: BrowserThirdPartyAutofillStatus
         get() = BrowserThirdPartyAutofillStatus(
+            braveStableStatusData = browserThirdPartyAutofillManager.stableBraveAutofillStatus,
             chromeStableStatusData = browserThirdPartyAutofillManager.stableChromeAutofillStatus,
             chromeBetaChannelStatusData = browserThirdPartyAutofillManager.betaChromeAutofillStatus,
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillEnabledManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillEnabledManagerImpl.kt
@@ -41,6 +41,10 @@ class BrowserThirdPartyAutofillEnabledManagerImpl(
 }
 
 private val DEFAULT_STATUS = BrowserThirdPartyAutofillStatus(
+    braveStableStatusData = BrowserThirdPartyAutoFillData(
+        isAvailable = false,
+        isThirdPartyEnabled = false,
+    ),
     chromeStableStatusData = BrowserThirdPartyAutoFillData(
         isAvailable = false,
         isThirdPartyEnabled = false,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManager.kt
@@ -9,6 +9,11 @@ import com.x8bit.bitwarden.data.autofill.model.browser.BrowserThirdPartyAutoFill
 interface BrowserThirdPartyAutofillManager {
 
     /**
+     * The data representing the status of the stable Brave version
+     */
+    val stableBraveAutofillStatus: BrowserThirdPartyAutoFillData
+
+    /**
      * The data representing the status of the stable Chrome version
      */
     val stableChromeAutofillStatus: BrowserThirdPartyAutoFillData

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManagerImpl.kt
@@ -21,6 +21,8 @@ private const val THIRD_PARTY_MODE_ACTIONS_URI_PATH = "autofill_third_party_mode
 class BrowserThirdPartyAutofillManagerImpl(
     private val context: Context,
 ) : BrowserThirdPartyAutofillManager {
+    override val stableBraveAutofillStatus: BrowserThirdPartyAutoFillData
+        get() = getThirdPartyAutoFillStatusForChannel(BrowserPackage.BRAVE_RELEASE)
     override val stableChromeAutofillStatus: BrowserThirdPartyAutoFillData
         get() = getThirdPartyAutoFillStatusForChannel(BrowserPackage.CHROME_STABLE)
     override val betaChromeAutofillStatus: BrowserThirdPartyAutoFillData

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserPackage.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserPackage.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.autofill.model.browser
 
+private const val BRAVE_CHANNEL_PACKAGE = "com.brave.browser"
 private const val CHROME_BETA_CHANNEL_PACKAGE = "com.chrome.beta"
 private const val CHROME_RELEASE_CHANNEL_PACKAGE = "com.android.chrome"
 
@@ -9,6 +10,7 @@ private const val CHROME_RELEASE_CHANNEL_PACKAGE = "com.android.chrome"
  * @property packageName the package name of the release channel for the browser version.
  */
 enum class BrowserPackage(val packageName: String) {
+    BRAVE_RELEASE(BRAVE_CHANNEL_PACKAGE),
     CHROME_STABLE(CHROME_RELEASE_CHANNEL_PACKAGE),
     CHROME_BETA(CHROME_BETA_CHANNEL_PACKAGE),
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserThirdPartyAutoFillData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserThirdPartyAutoFillData.kt
@@ -12,6 +12,7 @@ data class BrowserThirdPartyAutoFillData(
  * The overall status for all relevant browsers.
  */
 data class BrowserThirdPartyAutofillStatus(
+    val braveStableStatusData: BrowserThirdPartyAutoFillData,
     val chromeStableStatusData: BrowserThirdPartyAutoFillData,
     val chromeBetaChannelStatusData: BrowserThirdPartyAutoFillData,
 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -297,6 +297,10 @@ data class AutoFillState(
 @Suppress("MaxLineLength")
 private fun BrowserThirdPartyAutofillStatus.toBrowserAutoFillSettingsOptions(): ImmutableList<BrowserAutofillSettingsOption> =
     persistentListOfNotNull(
+        BrowserAutofillSettingsOption.BraveStable(
+            enabled = this.braveStableStatusData.isThirdPartyEnabled,
+        )
+            .takeIf { this.braveStableStatusData.isAvailable },
         BrowserAutofillSettingsOption.ChromeStable(
             enabled = this.chromeStableStatusData.isThirdPartyEnabled,
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/BrowserAutofillSettingsCard.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/BrowserAutofillSettingsCard.kt
@@ -62,7 +62,7 @@ fun BrowserAutofillSettingsCard(
         }
         Text(
             text = stringResource(
-                R.string.improves_login_filling_for_supported_websites_on_chrome,
+                id = R.string.improves_login_filling_for_supported_websites_on_selected_browsers,
             ),
             style = BitwardenTheme.typography.bodyMedium,
             color = BitwardenTheme.colorScheme.text.secondary,
@@ -84,6 +84,7 @@ private fun ChromeAutofillSettingsCard_preview() {
     BitwardenTheme {
         BrowserAutofillSettingsCard(
             options = persistentListOf(
+                BrowserAutofillSettingsOption.BraveStable(enabled = true),
                 BrowserAutofillSettingsOption.ChromeStable(enabled = false),
                 BrowserAutofillSettingsOption.ChromeBeta(enabled = true),
             ),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/model/BrowserAutofillSettingsOption.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/model/BrowserAutofillSettingsOption.kt
@@ -18,6 +18,19 @@ sealed class BrowserAutofillSettingsOption(val isEnabled: Boolean) : Parcelable 
     abstract val optionText: Text
 
     /**
+     * Represents the Brave release channel.
+     */
+    @Parcelize
+    data class BraveStable(
+        val enabled: Boolean,
+    ) : BrowserAutofillSettingsOption(isEnabled = enabled) {
+        override val browserPackage: BrowserPackage
+            get() = BrowserPackage.BRAVE_RELEASE
+        override val optionText: Text
+            get() = R.string.use_brave_autofill_integration.asText()
+    }
+
+    /**
      * Represents the stable Chrome release channel.
      */
     @Parcelize

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -908,9 +908,10 @@ Do you want to switch to this account?</string>
     <string name="passkey_operation_failed_because_no_item_was_selected">Passkey operation failed because no item was selected.</string>
     <string name="passkey_operation_failed_because_the_request_is_unsupported">Passkey operation failed because the request is unsupported.</string>
     <string name="self_host_server_url">Self-host server URL</string>
+    <string name="use_brave_autofill_integration">Use Brave autofill integration</string>
     <string name="use_chrome_autofill_integration">Use Chrome autofill integration</string>
     <string name="use_chrome_beta_autofill_integration">Use Chrome autofill integration (Beta)</string>
-    <string name="improves_login_filling_for_supported_websites_on_chrome">Improves login filling for supported websites on Chrome. Once enabled, you’ll be directed to Chrome settings to enable third-party autofill.</string>
+    <string name="improves_login_filling_for_supported_websites_on_selected_browsers">Improves login filling for supported websites on selected browsers. Once enabled, you’ll be directed to browser settings to enable third-party autofill.</string>
     <string name="show_more">Show more</string>
     <string name="no_folder">No folder</string>
     <string name="show_less">Show less</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerTest.kt
@@ -43,6 +43,7 @@ class AutofillActivityManagerTest {
         every { coroutineContext } returns UnconfinedTestDispatcher()
     }
     private val browserThirdPartyAutofillManager = mockk<BrowserThirdPartyAutofillManager> {
+        every { stableBraveAutofillStatus } returns DEFAULT_BROWSER_AUTOFILL_DATA
         every { stableChromeAutofillStatus } returns DEFAULT_BROWSER_AUTOFILL_DATA
         every { betaChromeAutofillStatus } returns DEFAULT_BROWSER_AUTOFILL_DATA
     }
@@ -120,6 +121,7 @@ private val DEFAULT_BROWSER_AUTOFILL_DATA = BrowserThirdPartyAutoFillData(
 )
 
 private val DEFAULT_EXPECTED_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
+    braveStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeBetaChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillEnabledManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillEnabledManagerTest.kt
@@ -109,6 +109,7 @@ private val DEFAULT_BROWSER_AUTOFILL_DATA = BrowserThirdPartyAutoFillData(
 )
 
 private val DEFAULT_EXPECTED_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
+    braveStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeBetaChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -518,8 +518,8 @@ class AutoFillScreenTest : BitwardenComposeTest() {
     @Test
     fun `BrowserAutofillSettingsCard is only displayed when there are options in the list`() {
         val browserAutofillSupportingText =
-            "Improves login filling for supported websites on Chrome. " +
-                "Once enabled, you’ll be directed to Chrome settings to enable " +
+            "Improves login filling for supported websites on selected browsers. " +
+                "Once enabled, you’ll be directed to browser settings to enable " +
                 "third-party autofill."
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -474,6 +474,7 @@ private val DEFAULT_BROWSER_AUTOFILL_DATA = BrowserThirdPartyAutoFillData(
 )
 
 private val DEFAULT_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
+    braveStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeBetaChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
 )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds support for Brave as a browser that requires opt-in for 3rd part Autofill support.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e2e09df2-b17e-45d0-bed2-093a35c709b7" width="300" /> | <img src="https://github.com/user-attachments/assets/a1b7be97-6ee1-4fb6-ac0e-e716bbca6c3f" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
