### PR TITLE
[PM-22998] Fix isBuildVersionAtLeast check

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -130,6 +130,7 @@ class AutoFillViewModelTest : BaseViewModelTest() {
         assertEquals(
             DEFAULT_STATE.copy(
                 showInlineAutofillOption = true,
+                showPasskeyManagementRow = false,
             ),
             viewModel.stateFlow.value,
         )

--- a/core/src/main/kotlin/com/bitwarden/core/util/AndroidBuildUtils.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/util/AndroidBuildUtils.kt
@@ -14,4 +14,4 @@ import com.bitwarden.annotation.OmitFromCoverage
 @ChecksSdkIntAtLeast(parameter = 0)
 fun isBuildVersionAtLeast(
     version: Int,
-): Boolean = version >= Build.VERSION.SDK_INT
+): Boolean = Build.VERSION.SDK_INT >= version


### PR DESCRIPTION
## 🎟️ Tracking

PM-22998

## 📔 Objective

The `isBuildVersionAtLeast` function in `AndroidBuildUtils.kt` was previously checking if a given version was greater than or equal to the current SDK version. This commit corrects the logic to check if the current SDK version is greater than or equal to the given version.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
