### PR TITLE
[PM-22640] Updating screen capture flag when the setting is changed

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
@@ -186,6 +186,10 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 is MainEvent.UpdateAppTheme -> AppCompatDelegate.setDefaultNightMode(event.osTheme)
+
+                is MainEvent.ScreenCaptureSettingChange -> {
+                    updateScreenCapture(event.isAllowed)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
@@ -84,7 +84,6 @@ class MainActivity : AppCompatActivity() {
             val navController = rememberBitwardenNavController(name = "MainActivity")
             SetupEventsEffect(navController = navController)
             val state by mainViewModel.stateFlow.collectAsStateWithLifecycle()
-            updateScreenCapture(isScreenCaptureAllowed = state.isScreenCaptureAllowed)
             LocalManagerProvider(featureFlagsState = state.featureFlagsState) {
                 ObserveScreenDataEffect(
                     onDataUpdate = remember(mainViewModel) {
@@ -188,7 +187,7 @@ class MainActivity : AppCompatActivity() {
                 is MainEvent.UpdateAppTheme -> AppCompatDelegate.setDefaultNightMode(event.osTheme)
 
                 is MainEvent.ScreenCaptureSettingChange -> {
-                    updateScreenCapture(event.isAllowed)
+                    handleScreenCaptureSettingChange(isScreenCaptureAllowed = event.isAllowed)
                 }
             }
         }
@@ -218,7 +217,7 @@ class MainActivity : AppCompatActivity() {
         recreate()
     }
 
-    private fun updateScreenCapture(isScreenCaptureAllowed: Boolean) {
+    private fun handleScreenCaptureSettingChange(isScreenCaptureAllowed: Boolean) {
         if (isScreenCaptureAllowed) {
             window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
         } else {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -265,6 +265,7 @@ class MainViewModel @Inject constructor(
     }
 
     private fun handleScreenCaptureUpdate(action: MainAction.Internal.ScreenCaptureUpdate) {
+        sendEvent(MainEvent.ScreenCaptureSettingChange(isAllowed = action.isScreenCaptureEnabled))
         mutableStateFlow.update { it.copy(isScreenCaptureAllowed = action.isScreenCaptureEnabled) }
     }
 
@@ -639,4 +640,9 @@ sealed class MainEvent {
     data class UpdateAppTheme(
         val osTheme: Int,
     ) : MainEvent()
+
+    /**
+     * Event indicating a change in the screen capture setting.
+     */
+    data class ScreenCaptureSettingChange(val isAllowed: Boolean) : MainEvent()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -84,7 +84,6 @@ class MainViewModel @Inject constructor(
 ) : BaseViewModel<MainState, MainEvent, MainAction>(
     initialState = MainState(
         theme = settingsRepository.appTheme,
-        isScreenCaptureAllowed = settingsRepository.isScreenCaptureAllowed,
         isErrorReportingDialogEnabled = featureFlagManager.getFeatureFlag(
             key = FlagKey.MobileErrorReporting,
         ),
@@ -266,7 +265,6 @@ class MainViewModel @Inject constructor(
 
     private fun handleScreenCaptureUpdate(action: MainAction.Internal.ScreenCaptureUpdate) {
         sendEvent(MainEvent.ScreenCaptureSettingChange(isAllowed = action.isScreenCaptureEnabled))
-        mutableStateFlow.update { it.copy(isScreenCaptureAllowed = action.isScreenCaptureEnabled) }
     }
 
     private fun handleAppThemeUpdated(action: MainAction.Internal.ThemeUpdate) {
@@ -494,7 +492,6 @@ class MainViewModel @Inject constructor(
 @Parcelize
 data class MainState(
     val theme: AppTheme,
-    val isScreenCaptureAllowed: Boolean,
     val isDynamicColorsEnabled: Boolean,
     private val isErrorReportingDialogEnabled: Boolean,
 ) : Parcelable {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -93,7 +93,7 @@ class SettingsDiskSourceImpl(
 
     private val mutableHasSeenGeneratorCoachMarkFlow = bufferedMutableSharedFlow<Boolean?>()
 
-    private val mutableScreenCaptureAllowedFlow = MutableSharedFlow<Boolean?>()
+    private val mutableScreenCaptureAllowedFlow = bufferedMutableSharedFlow<Boolean?>(replay = 1)
 
     private val mutableVaultRegisteredForExportFlow =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -243,7 +243,9 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
 
         viewModel.eventFlow.test {
-            // We skip the first 2 events because they are the default appTheme and appLanguage
+            // We skip the first 3 events because they are the
+            // default appTheme, appLanguage and ScreenCaptureUpdate
+            awaitItem()
             awaitItem()
             awaitItem()
 
@@ -294,7 +296,9 @@ class MainViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.eventFlow.test {
-                // We skip the first 2 events because they are the default appTheme and appLanguage
+                // We skip the first 3 events because they are the
+                // default appTheme, appLanguage and ScreenCaptureUpdate
+                awaitItem()
                 awaitItem()
                 awaitItem()
 
@@ -315,7 +319,9 @@ class MainViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             val cipherView = mockk<CipherView>()
             viewModel.eventFlow.test {
-                // We skip the first 2 events because they are the default appTheme and appLanguage
+                // We skip the first 3 events because they are the
+                // default appTheme, appLanguage and ScreenCaptureUpdate
+                awaitItem()
                 awaitItem()
                 awaitItem()
 
@@ -332,7 +338,9 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         val cipherView = mockk<CipherView>()
         viewModel.eventFlow.test {
-            // We skip the first 2 events because they are the default appTheme and appLanguage
+            // We skip the first 3 events because they are the
+            // default appTheme, appLanguage and ScreenCaptureUpdate
+            awaitItem()
             awaitItem()
             awaitItem()
 
@@ -365,7 +373,9 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
 
         viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
-            // We skip the first 2 events because they are the default appTheme and appLanguage
+            // We skip the first 3 events because they are the
+            // default appTheme, appLanguage and ScreenCaptureUpdate
+            eventFlow.awaitItem()
             eventFlow.awaitItem()
             eventFlow.awaitItem()
 
@@ -388,7 +398,9 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
 
         viewModel.eventFlow.test {
-            // We skip the first 2 events because they are the default appTheme and appLanguage
+            // We skip the first 3 events because they are the
+            // default appTheme, appLanguage and ScreenCaptureUpdate
+            awaitItem()
             awaitItem()
             awaitItem()
 
@@ -596,7 +608,9 @@ class MainViewModelTest : BaseViewModelTest() {
             } returns EmailTokenResult.Error(message = null, error = Throwable("Fail!"))
 
             viewModel.eventFlow.test {
-                // We skip the first 2 events because they are the default appTheme and appLanguage
+                // We skip the first 3 events because they are the
+                // default appTheme, appLanguage and ScreenCaptureUpdate
+                awaitItem()
                 awaitItem()
                 awaitItem()
 
@@ -630,7 +644,9 @@ class MainViewModelTest : BaseViewModelTest() {
             } returns EmailTokenResult.Error(message = expectedMessage, error = null)
 
             viewModel.eventFlow.test {
-                // We skip the first 2 events because they are the default appTheme and appLanguage
+                // We skip the first 3 events because they are the
+                // default appTheme, appLanguage and ScreenCaptureUpdate
+                awaitItem()
                 awaitItem()
                 awaitItem()
 
@@ -1023,7 +1039,9 @@ class MainViewModelTest : BaseViewModelTest() {
     fun `send NavigateToDebugMenu action when OpenDebugMenu action is sent`() = runTest {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
-            // We skip the first 2 events because they are the default appTheme and appLanguage
+            // We skip the first 3 events because they are the
+            // default appTheme, appLanguage and ScreenCaptureUpdate
+            awaitItem()
             awaitItem()
             awaitItem()
 
@@ -1115,6 +1133,23 @@ class MainViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(MainAction.AppSpecificLanguageUpdate(AppLanguage.SPANISH))
 
         verify { settingsRepository.appLanguage = AppLanguage.SPANISH }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ScreenCaptureUpdate should trigger the ScreenCaptureSettingChange event`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.eventFlow.test {
+            // We skip the first 3 events because they are the
+            // default appTheme, appLanguage and ScreenCaptureUpdate
+            awaitItem()
+            awaitItem()
+            awaitItem()
+
+            viewModel.trySendAction(MainAction.Internal.ScreenCaptureUpdate(true))
+            assertEquals(MainEvent.ScreenCaptureSettingChange(true), awaitItem())
+        }
     }
 
     private fun createViewModel(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -1022,20 +1022,6 @@ class MainViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `changes in the allowed screen capture value should update the state`() {
-        val viewModel = createViewModel()
-
-        assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
-
-        mutableScreenCaptureAllowedFlow.value = false
-
-        assertEquals(
-            DEFAULT_STATE.copy(isScreenCaptureAllowed = false),
-            viewModel.stateFlow.value,
-        )
-    }
-
-    @Test
     fun `send NavigateToDebugMenu action when OpenDebugMenu action is sent`() = runTest {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
@@ -1135,7 +1121,6 @@ class MainViewModelTest : BaseViewModelTest() {
         verify { settingsRepository.appLanguage = AppLanguage.SPANISH }
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `on ScreenCaptureUpdate should trigger the ScreenCaptureSettingChange event`() = runTest {
         val viewModel = createViewModel()
@@ -1177,7 +1162,6 @@ class MainViewModelTest : BaseViewModelTest() {
 
 private val DEFAULT_STATE: MainState = MainState(
     theme = AppTheme.DEFAULT,
-    isScreenCaptureAllowed = true,
     isErrorReportingDialogEnabled = false,
     isDynamicColorsEnabled = false,
 )


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22640

## 📔 Objective
When the screen capture setting was updated it only applied the effect after app restart. This solution updates the flags on MainActivity when the setting is updated

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
