### PR TITLE
[BWA-156] Allow TOTP syncing with Authenticator release APKs

### DIFF
--- a/app/src/release/res/values/manifest.xml
+++ b/app/src/release/res/values/manifest.xml
@@ -9,9 +9,8 @@
          Authenticator App release variant: -->
         <item>B06B54566AF2FBCC762700C8844B84EC410C230EACC3878FCF0248C0D9772A95</item>
 
-        <!-- These are the SHA-256 digest for one-off builds created from branches by the Github
-        Action of the Authenticator App release variant. Uncomment this to one off builds generated
-        from the Authenticator App repo. -->
-<!--        <item>52f393fb529fbf2ab5bb018bf17bf0f829d2fbebce099915aba42deab5a2fbb8</item>-->
+        <!-- These are the SHA-256 digest for APK signing key of the Authenticator App release
+        variant. -->
+        <item>52f393fb529fbf2ab5bb018bf17bf0f829d2fbebce099915aba42deab5a2fbb8</item>
     </string-array>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

BWA-156

## 📔 Objective

This change un-comments the sha256 digest of the release APK signing key so that it can sync TOTP codes with Bitwarden.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
