### PR TITLE
PM-19776: Change 'Move to Bitwarden' to 'Copy to Bitwarden vault'

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
@@ -119,7 +119,7 @@ class ItemListingViewModel @Inject constructor(
             }
 
             is ItemListingAction.ItemClick -> {
-                handleCopyItemClick(action.authCode)
+                handleCopyCodeClick(action.authCode)
             }
 
             is ItemListingAction.DialogDismiss -> {
@@ -164,7 +164,7 @@ class ItemListingViewModel @Inject constructor(
         sendEvent(ItemListingEvent.NavigateToAppSettings)
     }
 
-    private fun handleCopyItemClick(authCode: String) {
+    private fun handleCopyCodeClick(authCode: String) {
         clipboardManager.setText(authCode)
     }
 
@@ -172,7 +172,7 @@ class ItemListingViewModel @Inject constructor(
         sendEvent(ItemListingEvent.NavigateToEditItem(itemId))
     }
 
-    private fun handleMoveToBitwardenClick(itemId: String) {
+    private fun handleCopyToBitwardenClick(itemId: String) {
         viewModelScope.launch {
             val item = authenticatorRepository
                 .getItemStateFlow(itemId)
@@ -521,9 +521,9 @@ class ItemListingViewModel @Inject constructor(
 
     private fun handleDropdownMenuClick(action: ItemListingAction.DropdownMenuClick) {
         when (action.menuAction) {
-            VaultDropdownMenuAction.COPY -> handleCopyItemClick(action.item.authCode)
+            VaultDropdownMenuAction.COPY_CODE -> handleCopyCodeClick(action.item.authCode)
             VaultDropdownMenuAction.EDIT -> handleEditItemClick(action.item.id)
-            VaultDropdownMenuAction.MOVE -> handleMoveToBitwardenClick(action.item.id)
+            VaultDropdownMenuAction.COPY_TO_BITWARDEN -> handleCopyToBitwardenClick(action.item.id)
             VaultDropdownMenuAction.DELETE -> handleDeleteItemClick(action.item.id)
         }
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/VaultVerificationCodeItem.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/VaultVerificationCodeItem.kt
@@ -161,7 +161,7 @@ fun VaultVerificationCodeItem(
                 },
                 onClick = {
                     shouldShowDropdownMenu = false
-                    onDropdownMenuClick(VaultDropdownMenuAction.COPY)
+                    onDropdownMenuClick(VaultDropdownMenuAction.COPY_CODE)
                 },
                 leadingIcon = {
                     Icon(
@@ -190,16 +190,18 @@ fun VaultVerificationCodeItem(
                 HorizontalDivider()
                 DropdownMenuItem(
                     text = {
-                        Text(text = stringResource(id = R.string.move_to_bitwarden))
+                        Text(text = stringResource(id = R.string.copy_to_bitwarden_vault))
                     },
                     onClick = {
                         shouldShowDropdownMenu = false
-                        onDropdownMenuClick(VaultDropdownMenuAction.MOVE)
+                        onDropdownMenuClick(VaultDropdownMenuAction.COPY_TO_BITWARDEN)
                     },
                     leadingIcon = {
                         Icon(
                             painter = painterResource(id = R.drawable.ic_arrow_right),
-                            contentDescription = stringResource(id = R.string.move_to_bitwarden),
+                            contentDescription = stringResource(
+                                id = R.string.copy_to_bitwarden_vault,
+                            ),
                         )
                     },
                 )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/model/VaultDropdownMenuAction.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/model/VaultDropdownMenuAction.kt
@@ -4,8 +4,8 @@ package com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.model
  * Enum representing the available actions in the Vault dropdown menu.
  */
 enum class VaultDropdownMenuAction {
-    COPY,
+    COPY_CODE,
+    COPY_TO_BITWARDEN,
     EDIT,
-    MOVE,
     DELETE,
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/SharedVerificationCodesStateExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/SharedVerificationCodesStateExtensions.kt
@@ -23,7 +23,7 @@ fun SharedVerificationCodesState.Success.toSharedCodesDisplayState(
             it.toDisplayItem(
                 alertThresholdSeconds = alertThresholdSeconds,
                 // Always map based on Error state, because shared codes will never
-                // show "Move to Bitwarden" action.
+                // show "Copy to Bitwarden vault" action.
                 sharedVerificationCodesState = SharedVerificationCodesState.Error,
             ),
         )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/VerificationCodeItemExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/util/VerificationCodeItemExtensions.kt
@@ -30,10 +30,10 @@ fun VerificationCodeItem.toDisplayItem(
     },
     favorite = (source as? AuthenticatorItem.Source.Local)?.isFavorite ?: false,
     showMoveToBitwarden = when (source) {
-        // Shared items should never show Move to Bitwarden action:
+        // Shared items should never show "Copy to Bitwarden vault" action:
         is AuthenticatorItem.Source.Shared -> false
 
-        // Local items should only show Move to Bitwarden if we are successfully syncing: =
+        // Local items should only show "Copy to Bitwarden vault" if we are successfully syncing: =
         is AuthenticatorItem.Source.Local -> when (sharedVerificationCodesState) {
             SharedVerificationCodesState.AppNotInstalled,
             SharedVerificationCodesState.Error,

--- a/authenticator/src/main/res/values/strings.xml
+++ b/authenticator/src/main/res/values/strings.xml
@@ -124,7 +124,7 @@
     <string name="take_me_to_app_settings">Take me to the app settings</string>
     <string name="something_went_wrong">Something went wrong</string>
     <string name="please_try_again">Please try again</string>
-    <string name="move_to_bitwarden">Move to Bitwarden</string>
+    <string name="copy_to_bitwarden_vault">Copy to Bitwarden vault</string>
     <string name="default_save_option">Default save option</string>
     <string name="save_to_bitwarden">Save to Bitwarden</string>
     <string name="save_here">Save here</string>

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
@@ -346,7 +346,7 @@ class ItemListingScreenTest : AuthenticatorComposeTest() {
     }
 
     @Test
-    fun `clicking Move to Bitwarden should send MoveToBitwardenClick`() {
+    fun `clicking Copy to Bitwarden vault should send DropdownMenuClick with COPY_TO_BITWARDEN`() {
         mutableStateFlow.value = DEFAULT_STATE.copy(
             viewState = ItemListingState.ViewState.Content(
                 actionCard = ItemListingState.ActionCardState.None,
@@ -360,21 +360,22 @@ class ItemListingScreenTest : AuthenticatorComposeTest() {
             .performTouchInput { longClick() }
 
         composeTestRule
-            .onNodeWithText("Move to Bitwarden")
+            .onNodeWithText(text = "Copy to Bitwarden vault")
             .performClick()
 
         verify {
             viewModel.trySendAction(
                 ItemListingAction.DropdownMenuClick(
-                    menuAction = VaultDropdownMenuAction.MOVE,
+                    menuAction = VaultDropdownMenuAction.COPY_TO_BITWARDEN,
                     item = LOCAL_CODE,
                 ),
             )
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `Move to Bitwarden long press action should not show when showMoveToBitwarden is false`() {
+    fun `Copy to Bitwarden vault long press action should not show when showMoveToBitwarden is false`() {
         mutableStateFlow.value = DEFAULT_STATE.copy(
             viewState = ItemListingState.ViewState.Content(
                 actionCard = ItemListingState.ActionCardState.None,
@@ -388,7 +389,7 @@ class ItemListingScreenTest : AuthenticatorComposeTest() {
             .performTouchInput { longClick() }
 
         composeTestRule
-            .onNodeWithText("Move to Bitwarden")
+            .onNodeWithText(text = "Copy to Bitwarden vault")
             .assertDoesNotExist()
     }
 

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModelTest.kt
@@ -378,7 +378,7 @@ class ItemListingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `on MoveToBitwardenClick receive should call startAddTotpLoginItemFlow`() {
+    fun `on CopyToBitwardenClick receive should call startAddTotpLoginItemFlow`() {
         val expectedUriString = "expectedUriString"
         val entity: AuthenticatorItemEntity = mockk {
             every { toOtpAuthUriString() } returns expectedUriString
@@ -394,7 +394,7 @@ class ItemListingViewModelTest : BaseViewModelTest() {
 
         viewModel.trySendAction(
             ItemListingAction.DropdownMenuClick(
-                menuAction = VaultDropdownMenuAction.MOVE,
+                menuAction = VaultDropdownMenuAction.COPY_TO_BITWARDEN,
                 item = LOCAL_CODE,
             ),
         )
@@ -403,7 +403,7 @@ class ItemListingViewModelTest : BaseViewModelTest() {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `on MoveToBitwardenClick should show error dialog when startAddTotpLoginItemFlow returns false`() {
+    fun `on CopyToBitwardenClick should show error dialog when startAddTotpLoginItemFlow returns false`() {
         val expectedState = DEFAULT_STATE.copy(
             dialog = ItemListingState.DialogState.Error(
                 title = R.string.something_went_wrong.asText(),
@@ -423,7 +423,10 @@ class ItemListingViewModelTest : BaseViewModelTest() {
 
         val viewModel = createViewModel()
         viewModel.trySendAction(
-            ItemListingAction.DropdownMenuClick(VaultDropdownMenuAction.MOVE, LOCAL_CODE),
+            ItemListingAction.DropdownMenuClick(
+                menuAction = VaultDropdownMenuAction.COPY_TO_BITWARDEN,
+                item = LOCAL_CODE,
+            ),
         )
         assertEquals(
             expectedState,
@@ -442,7 +445,7 @@ class ItemListingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `should copy text to clipboard when DropdownMenuClick COPY is triggered`() = runTest {
+    fun `should copy text to clipboard when DropdownMenuClick COPY_CODE is triggered`() = runTest {
         val viewModel = createViewModel()
 
         every { clipboardManager.setText(text = LOCAL_CODE.authCode) } just runs
@@ -450,7 +453,7 @@ class ItemListingViewModelTest : BaseViewModelTest() {
         viewModel.eventFlow.test {
             viewModel.trySendAction(
                 ItemListingAction.DropdownMenuClick(
-                    menuAction = VaultDropdownMenuAction.COPY,
+                    menuAction = VaultDropdownMenuAction.COPY_CODE,
                     item = LOCAL_CODE,
                 ),
             )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19776](https://bitwarden.atlassian.net/browse/PM-19776)

## 📔 Objective

This PR updates the `Move to Bitwarden` text to say `Copy to Bitwarden vault`.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/97f69527-9401-4dd2-abc7-d155735d8153" width="300" /> | <img src="https://github.com/user-attachments/assets/4dd98d83-cb70-4f18-893f-3cf7ff9e01b6" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19776]: https://bitwarden.atlassian.net/browse/PM-19776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ