### PR TITLE
[PM-23122] Make `BitwardenTextRow`s in `PrivilegedAppsListScreen` unclickable

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/row/BitwardenTextRow.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/row/BitwardenTextRow.kt
@@ -39,6 +39,8 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  * @param textTestTag The optional test tag for the inner text component.
  * @param isEnabled Indicates if the row is enabled or not, a disabled row will not be clickable
  * and it's contents will be dimmed.
+ * @param clickable An optional override for whether the row is clickable or not. Defaults to
+ * [isEnabled].
  * @param withDivider Indicates if a divider should be drawn on the bottom of the row, defaults
  * to `false`.
  * @param tooltip The data required to display a tooltip.
@@ -54,6 +56,7 @@ fun BitwardenTextRow(
     description: String? = null,
     textTestTag: String? = null,
     isEnabled: Boolean = true,
+    clickable: Boolean = isEnabled,
     withDivider: Boolean = false,
     tooltip: TooltipData? = null,
     content: (@Composable () -> Unit)? = null,
@@ -65,7 +68,7 @@ fun BitwardenTextRow(
             .cardStyle(
                 cardStyle = cardStyle,
                 onClick = onClick,
-                clickEnabled = isEnabled,
+                clickEnabled = clickable,
                 paddingHorizontal = 16.dp,
             )
             .semantics(mergeDescendants = true) { },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/list/PrivilegedAppsListScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/list/PrivilegedAppsListScreen.kt
@@ -185,6 +185,7 @@ private fun PrivilegedAppsListContent(
                         R.string.trusted_by_x,
                         stringResource(item.trustAuthority.displayName),
                     ),
+                    clickable = false,
                     onClick = {},
                     cardStyle = state.installedApps
                         .toListItemCardStyle(index),
@@ -251,6 +252,7 @@ private fun PrivilegedAppsListContent(
                     BitwardenTextRow(
                         text = item.label,
                         onClick = {},
+                        clickable = false,
                         cardStyle = state.notInstalledUserTrustedApps
                             .toListItemCardStyle(index),
                         modifier = Modifier
@@ -303,6 +305,7 @@ private fun PrivilegedAppsListContent(
                     BitwardenTextRow(
                         text = item.label,
                         onClick = {},
+                        clickable = false,
                         cardStyle = state.notInstalledCommunityTrustedApps
                             .toListItemCardStyle(index),
                         modifier = Modifier
@@ -336,6 +339,7 @@ private fun PrivilegedAppsListContent(
                     BitwardenTextRow(
                         text = item.label,
                         onClick = {},
+                        clickable = false,
                         cardStyle = state.notInstalledGoogleTrustedApps
                             .toListItemCardStyle(index),
                         modifier = Modifier


### PR DESCRIPTION
## 🎟️ Tracking

PM-23122

## 📔 Objective

The `BitwardenTextRow` component now accepts a `clickable` parameter to override its click behavior independently of its `isEnabled` state.

This change is used in `PrivilegedAppsListScreen` to make the rows displaying privileged app information unclickable, while still appearing enabled.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
