### PR TITLE
[PM-23147] Update styles.xml

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,7 +6,7 @@
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionModeOverlay">true</item>
-        <item name="android:windowLayoutInDisplayCutoutMode">always</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">default</item>
         <item name="android:backgroundDimAmount">@dimen/dialogDimBackgroundAmount</item>
     </style>
 


### PR DESCRIPTION
`<item name="android:windowLayoutInDisplayCutoutMode">always</item>`

Android 10 (API level 29) compatibility issue. changed to default

## 🎟️ Tracking

https://github.com/bitwarden/android/issues/5442

## 📔 Objective

fix Android 10 compatibility issue 


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team


