### PR TITLE
PM-23136: Only apply 'always' display cutout mode on API 30 and up

### DIFF
--- a/app/src/main/res/values-v30/values.xml
+++ b/app/src/main/res/values-v30/values.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Always -->
+    <integer name="displayCutoutMode">3</integer>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,7 +6,7 @@
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionModeOverlay">true</item>
-        <item name="android:windowLayoutInDisplayCutoutMode">always</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">@integer/displayCutoutMode</item>
         <item name="android:backgroundDimAmount">@dimen/dialogDimBackgroundAmount</item>
     </style>
 

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="dialogDimBackgroundAmount" format="float">0.55</dimen>
+    <!-- default -->
+    <integer name="displayCutoutMode">0</integer>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23136](https://bitwarden.atlassian.net/browse/PM-23136)

## 📔 Objective

This PR fixes a crash on Android 10 caused by using the `always` `windowLayoutInDisplayCutoutMode`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23136]: https://bitwarden.atlassian.net/browse/PM-23136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ