### PR TITLE
[PM-23132] Update capitalization and wording in privileged apps strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -973,13 +973,13 @@ Do you want to switch to this account?</string>
     <string name="passkey_operation_failed_because_browser_x_is_not_trusted">Passkey operation failed because browser (%1$s) is not recognized. Select \"Trust\" to add %1$s to the list of locally trusted applications.</string>
     <string name="passkey_operation_failed_because_the_browser_is_not_trusted">Passkey operation failed because the browser is not trusted.</string>
     <string name="trust">Trust</string>
-    <string name="trusted_by_you_learn_more">These are applications or browsers that Bitwarden does not trust by default, but You trust to perform passkey operations.</string>
+    <string name="trusted_by_you_learn_more">These are applications or browsers that Bitwarden does not trust by default, but you trust to perform passkey operations.</string>
     <string name="trusted_by_community_learn_more">These are applications not included in the Google Play Store, but Bitwarden trusts to perform passkey operations after community members use and report them as safe.</string>
     <string name="trusted_by_google_learn_more">These are applications Google considers safe and are available in Google\'s Play Store.</string>
     <string name="trusted_by_you">Trusted by You</string>
     <string name="trusted_by_the_community">Trusted by the Community</string>
     <string name="trusted_by_google">Trusted by Google</string>
-    <string name="privileged_apps_description">To protect users from phishing attempts, by default, Bitwarden only completes passkey operations through web browsers trusted by Google or the Bitwarden community.</string>
+    <string name="privileged_apps_description">To protect users from phishing attempts, by default, Bitwarden only completes passkey operations through applications or web browsers trusted by Google or the Bitwarden community.</string>
     <string name="about_privileged_applications">About privileged applications</string>
     <string name="learn_more_about_privileged_apps">Learn more about privileged apps</string>
     <string name="privileged_apps">Privileged apps</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/about/AboutPrivilegedAppsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/about/AboutPrivilegedAppsScreenTest.kt
@@ -36,8 +36,8 @@ class AboutPrivilegedAppsScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(
                 "To protect users from phishing attempts, by default, Bitwarden only completes " +
-                    "passkey operations through web browsers trusted by Google or the Bitwarden " +
-                    "community.",
+                    "passkey operations through applications or web browsers trusted by Google " +
+                    "or the Bitwarden community.",
             )
             .assertIsDisplayed()
 
@@ -48,7 +48,7 @@ class AboutPrivilegedAppsScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(
                 "These are applications or browsers that Bitwarden does not trust by default, " +
-                    "but You trust to perform passkey operations.",
+                    "but you trust to perform passkey operations.",
             )
             .assertIsDisplayed()
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-23132

## 📔 Objective

- Capitalization of "You" in `trusted_by_you_learn_more` is changed to "you".
- The `privileged_apps_description` string is updated to include "applications or" before "web browsers".

## 📸 Screenshots

| Header | Header |
|--------|--------|
| <img width="482" alt="image" src="https://github.com/user-attachments/assets/06da1714-e7e9-4f31-9f91-b378546b957a" /> | <img width="489" alt="image" src="https://github.com/user-attachments/assets/eb6e811e-aff6-41b6-b781-3786a9ae62ad" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
