### PR TITLE
PM-19780: Authenticator source headers

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -516,14 +516,16 @@ private fun ItemListingContent(
 
                 when (state.sharedItems) {
                     is SharedCodesDisplayState.Codes -> {
-                        items(state.sharedItems.sections) { section ->
-                            BitwardenListHeaderText(
-                                label = section.label(),
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp),
-                            )
-                            section.codes.forEach {
+                        state.sharedItems.sections.forEach { section ->
+                            item {
+                                BitwardenListHeaderText(
+                                    label = section.label(),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp),
+                                )
+                            }
+                            items(section.codes) {
                                 VaultVerificationCodeItem(
                                     authCode = it.authCode,
                                     primaryLabel = it.title,
@@ -544,13 +546,15 @@ private fun ItemListingContent(
                         }
                     }
 
-                    SharedCodesDisplayState.Error -> item {
-                        Text(
-                            text = stringResource(R.string.shared_codes_error),
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            style = MaterialTheme.typography.bodySmall,
-                        )
+                    SharedCodesDisplayState.Error -> {
+                        item {
+                            Text(
+                                text = stringResource(R.string.shared_codes_error),
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
                     }
                 }
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchContent.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchContent.kt
@@ -2,14 +2,23 @@ package com.bitwarden.authenticator.ui.authenticator.feature.search
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.ui.authenticator.feature.model.SharedCodesDisplayState
+import com.bitwarden.authenticator.ui.authenticator.feature.model.VerificationCodeDisplayItem
 import com.bitwarden.authenticator.ui.authenticator.feature.search.handlers.SearchHandlers
+import com.bitwarden.authenticator.ui.platform.components.header.BitwardenListHeaderText
 
 /**
  * The content state for the item search screen.
@@ -21,30 +30,106 @@ fun ItemSearchContent(
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(modifier = modifier) {
+        if (viewState.hasLocalAndSharedItems) {
+            item {
+                BitwardenListHeaderText(
+                    label = stringResource(id = R.string.local_codes),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+            }
+        }
+
         items(viewState.itemList) {
             VaultVerificationCodeItem(
+                displayItem = it,
+                onCopyClick = searchHandlers.onItemClick,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(
-                        start = 16.dp,
-                        // There is some built-in padding to the menu button that makes up
-                        // the visual difference here.
-                        end = 12.dp,
-                    ),
-                authCode = it.authCode,
-                issuer = it.title,
-                periodSeconds = it.periodSeconds,
-                timeLeftSeconds = it.timeLeftSeconds,
-                alertThresholdSeconds = it.alertThresholdSeconds,
-                supportingLabel = it.subtitle,
-                startIcon = it.startIcon,
-                onCopyClick = { searchHandlers.onItemClick(it.authCode) },
-                onItemClick = { searchHandlers.onItemClick(it.authCode) },
+                    // There is some built-in padding to the menu button that
+                    // makes up the visual difference here.
+                    .padding(start = 16.dp, end = 12.dp),
             )
         }
 
+        if (viewState.hasLocalAndSharedItems) {
+            item {
+                Spacer(Modifier.height(height = 8.dp))
+            }
+        }
+
+        sharedCodes(
+            sharedItems = viewState.sharedItems,
+            onCopyClick = searchHandlers.onItemClick,
+        )
+
         item {
+            Spacer(modifier = Modifier.height(height = 16.dp))
             Spacer(modifier = Modifier.navigationBarsPadding())
         }
     }
+}
+
+private fun LazyListScope.sharedCodes(
+    sharedItems: SharedCodesDisplayState,
+    onCopyClick: (authCode: String) -> Unit,
+) {
+    when (sharedItems) {
+        is SharedCodesDisplayState.Codes -> {
+            sharedItems.sections.forEach { section ->
+                item {
+                    BitwardenListHeaderText(
+                        label = section.label(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                    )
+                }
+
+                items(section.codes) {
+                    VaultVerificationCodeItem(
+                        displayItem = it,
+                        onCopyClick = onCopyClick,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            // There is some built-in padding to the menu button that
+                            // makes up the visual difference here.
+                            .padding(start = 16.dp, end = 12.dp),
+                    )
+                }
+            }
+        }
+
+        SharedCodesDisplayState.Error -> {
+            item {
+                Text(
+                    text = stringResource(R.string.shared_codes_error),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VaultVerificationCodeItem(
+    displayItem: VerificationCodeDisplayItem,
+    onCopyClick: (authCode: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    VaultVerificationCodeItem(
+        authCode = displayItem.authCode,
+        issuer = displayItem.title,
+        periodSeconds = displayItem.periodSeconds,
+        timeLeftSeconds = displayItem.timeLeftSeconds,
+        alertThresholdSeconds = displayItem.alertThresholdSeconds,
+        supportingLabel = displayItem.subtitle,
+        startIcon = displayItem.startIcon,
+        onCopyClick = { onCopyClick(displayItem.authCode) },
+        onItemClick = { onCopyClick(displayItem.authCode) },
+        modifier = modifier,
+    )
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModel.kt
@@ -7,12 +7,12 @@ import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
-import com.bitwarden.authenticator.data.authenticator.repository.util.itemsOrEmpty
 import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.bitwarden.authenticator.ui.authenticator.feature.model.SharedCodesDisplayState
 import com.bitwarden.authenticator.ui.authenticator.feature.model.VerificationCodeDisplayItem
 import com.bitwarden.authenticator.ui.authenticator.feature.util.toDisplayItem
+import com.bitwarden.authenticator.ui.authenticator.feature.util.toSharedCodesDisplayState
 import com.bitwarden.core.data.repository.model.DataState
-import com.bitwarden.core.data.repository.util.SpecialCharWithPrecedenceComparator
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.removeDiacritics
 import com.bitwarden.ui.util.Text
@@ -85,8 +85,10 @@ class ItemSearchViewModel @Inject constructor(
         action: ItemSearchAction.Internal.AuthenticatorDataReceive,
     ) {
         action.localData.data?.let { localItems ->
-            val allItems = localItems + action.sharedData.itemsOrEmpty
-            updateStateWithAuthenticatorData(allItems)
+            updateStateWithAuthenticatorData(
+                localCodes = localItems,
+                sharedData = action.sharedData,
+            )
         }
     }
 
@@ -96,23 +98,24 @@ class ItemSearchViewModel @Inject constructor(
             .value
             .data
             ?.let { authenticatorData ->
-                val allItems = authenticatorData +
-                    authenticatorRepository.sharedCodesStateFlow.value.itemsOrEmpty
                 updateStateWithAuthenticatorData(
-                    authenticatorData = allItems,
+                    localCodes = authenticatorData,
+                    sharedData = authenticatorRepository.sharedCodesStateFlow.value,
                 )
             }
     }
 
     private fun updateStateWithAuthenticatorData(
-        authenticatorData: List<VerificationCodeItem>,
+        localCodes: List<VerificationCodeItem>,
+        sharedData: SharedVerificationCodesState,
     ) {
         mutableStateFlow.update { currentState ->
             currentState.copy(
-                searchTerm = currentState.searchTerm,
-                viewState = authenticatorData
-                    .filterAndOrganize(state.searchTerm)
-                    .toViewState(searchTerm = state.searchTerm),
+                viewState = toViewState(
+                    searchTerm = state.searchTerm,
+                    localCodes = localCodes,
+                    sharedData = sharedData,
+                ),
             )
         }
     }
@@ -135,55 +138,65 @@ class ItemSearchViewModel @Inject constructor(
     @Suppress("MagicNumber")
     private fun VerificationCodeItem.matchedSearch(searchTerm: String): SortPriority? {
         val term = searchTerm.removeDiacritics()
-        val itemName = otpAuthUriLabel?.removeDiacritics()
+        val itemName = otpAuthUriLabel.removeDiacritics()
         val itemId = id.takeIf { term.length > 8 }.orEmpty().removeDiacritics()
         val itemIssuer = issuer.orEmpty().removeDiacritics()
         return when {
-            itemName?.contains(other = term, ignoreCase = true) ?: false -> SortPriority.HIGH
+            itemName.contains(other = term, ignoreCase = true) -> SortPriority.HIGH
             itemId.contains(other = term, ignoreCase = true) -> SortPriority.LOW
             itemIssuer.contains(other = term, ignoreCase = true) -> SortPriority.LOW
             else -> null
         }
     }
 
-    private fun List<VerificationCodeItem>.toViewState(
+    private fun toViewState(
         searchTerm: String,
-    ): ItemSearchState.ViewState =
-        when {
-            searchTerm.isEmpty() -> {
-                ItemSearchState.ViewState.Empty(message = null)
-            }
+        localCodes: List<VerificationCodeItem>,
+        sharedData: SharedVerificationCodesState,
+    ): ItemSearchState.ViewState {
+        if (searchTerm.isEmpty()) {
+            return ItemSearchState.ViewState.Empty(message = null)
+        }
 
-            isNotEmpty() -> {
-                ItemSearchState.ViewState.Content(
-                    itemList = this
-                        .map {
-                            it.toDisplayItem(
-                                alertThresholdSeconds = 7,
-                                sharedVerificationCodesState = authenticatorRepository
-                                    .sharedCodesStateFlow
-                                    .value,
-                            )
-                        }
-                        .sortAlphabetically(),
-                )
-            }
+        val filteredLocalCodes = localCodes.filterAndOrganize(searchTerm = searchTerm)
+        val sharedItemsState = when (sharedData) {
+            SharedVerificationCodesState.Error -> SharedCodesDisplayState.Error
+            SharedVerificationCodesState.AppNotInstalled,
+            SharedVerificationCodesState.FeatureNotEnabled,
+            SharedVerificationCodesState.Loading,
+            SharedVerificationCodesState.OsVersionNotSupported,
+            SharedVerificationCodesState.SyncNotEnabled,
+                -> SharedCodesDisplayState.Codes(emptyList())
 
-            else -> {
+            is SharedVerificationCodesState.Success -> {
+                sharedData
+                    .copy(items = sharedData.items.filterAndOrganize(searchTerm = searchTerm))
+                    .toSharedCodesDisplayState(alertThresholdSeconds = 7)
+            }
+        }
+
+        return when {
+            filteredLocalCodes.isEmpty() && sharedItemsState.isEmpty() -> {
                 ItemSearchState.ViewState.Empty(
                     message = R.string.there_are_no_items_that_match_the_search.asText(),
                 )
             }
-        }
 
-    /**
-     * Sort a list of [VerificationCodeDisplayItem] by their titles alphabetically giving digits and
-     * special characters higher precedence.
-     */
-    private fun List<VerificationCodeDisplayItem>.sortAlphabetically() =
-        this.sortedWith { item1, item2 ->
-            SpecialCharWithPrecedenceComparator.compare(item1.title, item2.title)
+            else -> {
+                ItemSearchState.ViewState.Content(
+                    itemList = filteredLocalCodes.map {
+                        it.toDisplayItem(
+                            alertThresholdSeconds = 7,
+                            sharedVerificationCodesState = authenticatorRepository
+                                .sharedCodesStateFlow
+                                .value,
+                        )
+                    },
+                    sharedItems = sharedItemsState,
+                )
+            }
         }
+    }
     //endregion Utility Functions
 }
 
@@ -206,7 +219,13 @@ data class ItemSearchState(
         @Parcelize
         data class Content(
             val itemList: List<VerificationCodeDisplayItem>,
-        ) : ViewState()
+            val sharedItems: SharedCodesDisplayState,
+        ) : ViewState() {
+            /**
+             * Whether or not there should be a "Local codes" header shown above local codes.
+             */
+            val hasLocalAndSharedItems get() = !sharedItems.isEmpty() && itemList.isNotEmpty()
+        }
 
         /**
          * Show the empty state.

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/authenticator/manager/util/VerificationCodeItemUtil.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/authenticator/manager/util/VerificationCodeItemUtil.kt
@@ -7,23 +7,57 @@ import com.bitwarden.authenticator.data.authenticator.repository.model.Authentic
  * Creates a mock [VerificationCodeItem] for testing purposes.
  *
  * @param number A number used to generate unique values for the mock item.
- * @param favorite Whether the mock item should be marked as favorite. Defaults to false.
  * @return A [VerificationCodeItem] with mock data based on the provided number.
  */
+@Suppress("LongParameterList")
 fun createMockVerificationCodeItem(
     number: Int,
-    favorite: Boolean = false,
+    id: String = "mockId-$number",
+    code: String = "mockCode-$number",
+    periodSeconds: Int = 30,
+    timeLeftSeconds: Int = 120,
+    issueTime: Long = 0,
+    label: String = "mockLabel-$number",
+    issuer: String = "mockIssuer-$number",
+    source: AuthenticatorItem.Source = createMockLocalAuthenticatorItemSource(number = number),
 ): VerificationCodeItem =
     VerificationCodeItem(
-        code = "mockCode-$number",
-        periodSeconds = 30,
-        timeLeftSeconds = 120,
-        issueTime = 0,
-        id = "mockId-$number",
-        label = "mockLabel-$number",
-        issuer = "mockIssuer-$number",
-        source = AuthenticatorItem.Source.Local(
-            cipherId = "mockId-$number",
-            isFavorite = favorite,
-        ),
+        code = code,
+        periodSeconds = periodSeconds,
+        timeLeftSeconds = timeLeftSeconds,
+        issueTime = issueTime,
+        id = id,
+        label = label,
+        issuer = issuer,
+        source = source,
+    )
+
+/**
+ * Creates a mock [AuthenticatorItem.Source.Local] for testing purposes.
+ */
+fun createMockLocalAuthenticatorItemSource(
+    number: Int,
+    cipherId: String = "mockId-$number",
+    isFavorite: Boolean = false,
+): AuthenticatorItem.Source.Local =
+    AuthenticatorItem.Source.Local(
+        cipherId = cipherId,
+        isFavorite = isFavorite,
+    )
+
+/**
+ * Creates a mock [AuthenticatorItem.Source.Shared] for testing purposes.
+ */
+fun createMockSharedAuthenticatorItemSource(
+    number: Int,
+    userId: String = "mockUserId-$number",
+    nameOfUser: String? = "mockkNameOfUser-$number",
+    email: String = "mockEmail-$number",
+    environmentLabel: String = "mockkEnvironmentLabel-$number",
+): AuthenticatorItem.Source.Shared =
+    AuthenticatorItem.Source.Shared(
+        userId = userId,
+        nameOfUser = nameOfUser,
+        email = email,
+        environmentLabel = environmentLabel,
     )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModelTest.kt
@@ -1,50 +1,38 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.search
 
 import androidx.lifecycle.SavedStateHandle
+import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
+import com.bitwarden.authenticator.data.authenticator.manager.util.createMockSharedAuthenticatorItemSource
 import com.bitwarden.authenticator.data.authenticator.manager.util.createMockVerificationCodeItem
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
-import com.bitwarden.authenticator.data.authenticator.repository.model.AuthenticatorItem
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
-import com.bitwarden.authenticator.data.authenticator.repository.util.itemsOrEmpty
 import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClipboardManager
+import com.bitwarden.authenticator.ui.authenticator.feature.model.SharedCodesDisplayState
 import com.bitwarden.authenticator.ui.authenticator.feature.model.VerificationCodeDisplayItem
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.util.asText
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import kotlinx.coroutines.flow.MutableStateFlow
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class ItemSearchViewModelTest : BaseViewModelTest() {
 
     private val mutableAuthCodesStateFlow =
         MutableStateFlow<DataState<List<VerificationCodeItem>>>(DataState.Loading)
-    private val mutableSharedCodesFlow = MutableStateFlow(
-        SharedVerificationCodesState.Success(SHARED_ITEMS),
+    private val mutableSharedCodesFlow = MutableStateFlow<SharedVerificationCodesState>(
+        SharedVerificationCodesState.Success(items = SHARED_ITEMS),
     )
     private val mockAuthenticatorRepository = mockk<AuthenticatorRepository> {
         every { getLocalVerificationCodesFlow() } returns mutableAuthCodesStateFlow
         every { sharedCodesStateFlow } returns mutableSharedCodesFlow
     }
     private val mockClipboardManager = mockk<BitwardenClipboardManager>()
-
-    @BeforeEach
-    fun setup() {
-        mockkStatic(SharedVerificationCodesState::itemsOrEmpty)
-    }
-
-    @AfterEach
-    fun teardown() {
-        unmockkStatic(SharedVerificationCodesState::itemsOrEmpty)
-    }
 
     @Test
     fun `initial state is correct`() {
@@ -67,16 +55,17 @@ class ItemSearchViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             ItemSearchState.ViewState.Content(
-                itemList = SHARED_AND_LOCAL_DISPLAY_ITEMS,
+                itemList = LOCAL_DISPLAY_ITEMS,
+                sharedItems = SHARED_DISPLAY_ITEMS,
             ),
             viewModel.stateFlow.value.viewState,
         )
     }
 
     @Test
-    fun `state contains only local items when shared items are not available`() {
+    fun `state contains only local items when there are no shared items`() {
         val viewModel = createViewModel()
-        every { mutableSharedCodesFlow.value.itemsOrEmpty } returns emptyList()
+        mutableSharedCodesFlow.value = SharedVerificationCodesState.Success(items = emptyList())
         mutableAuthCodesStateFlow.value = DataState.Loaded(LOCAL_ITEMS)
 
         viewModel.trySendAction(
@@ -85,30 +74,40 @@ class ItemSearchViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             ItemSearchState.ViewState.Content(
-                itemList = listOf(SHARED_AND_LOCAL_DISPLAY_ITEMS[1]),
+                itemList = LOCAL_DISPLAY_ITEMS,
+                sharedItems = SharedCodesDisplayState.Codes(sections = emptyList()),
             ),
             viewModel.stateFlow.value.viewState,
         )
     }
 
-    private fun createItemSearchState(
-        viewState: ItemSearchState.ViewState = ItemSearchState.ViewState.Empty(message = null),
-    ) = ItemSearchState(
-        searchTerm = "",
-        viewState = viewState,
-    )
+    @Test
+    fun `state contains only local items when shared items are not available`() {
+        val viewModel = createViewModel()
+        mutableSharedCodesFlow.value = SharedVerificationCodesState.SyncNotEnabled
+        mutableAuthCodesStateFlow.value = DataState.Loaded(data = LOCAL_ITEMS)
 
-    private fun createViewModel(
-        initialState: ItemSearchState = createItemSearchState(),
-    ): ItemSearchViewModel {
-        return ItemSearchViewModel(
-            SavedStateHandle().apply {
-                set("state", initialState)
-            },
-            mockClipboardManager,
-            mockAuthenticatorRepository,
+        viewModel.trySendAction(ItemSearchAction.SearchTermChange(searchTerm = "I"))
+
+        assertEquals(
+            ItemSearchState.ViewState.Content(
+                itemList = LOCAL_DISPLAY_ITEMS.map { it.copy(showMoveToBitwarden = false) },
+                sharedItems = SharedCodesDisplayState.Codes(sections = emptyList()),
+            ),
+            viewModel.stateFlow.value.viewState,
         )
     }
+
+    private fun createViewModel(
+        initialState: ItemSearchState? = null,
+    ): ItemSearchViewModel =
+        ItemSearchViewModel(
+            savedStateHandle = SavedStateHandle().apply {
+                set("state", initialState)
+            },
+            clipboardManager = mockClipboardManager,
+            authenticatorRepository = mockAuthenticatorRepository,
+        )
 }
 
 private val LOCAL_ITEMS = listOf(
@@ -116,40 +115,38 @@ private val LOCAL_ITEMS = listOf(
 )
 
 private val SHARED_ITEMS = listOf(
-    VerificationCodeItem(
-        code = "123456",
-        periodSeconds = 60,
-        timeLeftSeconds = 30,
-        issueTime = 1,
-        issuer = "Issuer",
-        label = "accountName",
-        id = "123",
-        source = AuthenticatorItem.Source.Shared(
-            userId = "1",
-            nameOfUser = "John Test",
-            email = "test@test.com",
-            environmentLabel = "1234",
+    createMockVerificationCodeItem(
+        number = 2,
+        source = createMockSharedAuthenticatorItemSource(number = 2),
+    ),
+)
+
+private val SHARED_DISPLAY_ITEMS = SharedCodesDisplayState.Codes(
+    sections = listOf(
+        SharedCodesDisplayState.SharedCodesAccountSection(
+            label = R.string.shared_accounts_header.asText(
+                "mockEmail-2",
+                "mockkEnvironmentLabel-2",
+            ),
+            codes = listOf(
+                VerificationCodeDisplayItem(
+                    id = "mockId-2",
+                    title = "mockIssuer-2",
+                    subtitle = "mockLabel-2",
+                    timeLeftSeconds = 120,
+                    periodSeconds = 30,
+                    alertThresholdSeconds = 7,
+                    authCode = "mockCode-2",
+                    favorite = false,
+                    allowLongPressActions = false,
+                    showMoveToBitwarden = false,
+                ),
+            ),
         ),
     ),
 )
 
-private val SHARED_AND_LOCAL_DISPLAY_ITEMS = listOf(
-    VerificationCodeDisplayItem(
-        id = SHARED_ITEMS[0].id,
-        authCode = SHARED_ITEMS[0].code,
-        title = SHARED_ITEMS[0].issuer!!,
-        periodSeconds = SHARED_ITEMS[0].periodSeconds,
-        timeLeftSeconds = SHARED_ITEMS[0].timeLeftSeconds,
-        alertThresholdSeconds = 7,
-        startIcon = IconData.Local(
-            iconRes = BitwardenDrawable.ic_login_item,
-            testTag = "BitwardenIcon",
-        ),
-        subtitle = SHARED_ITEMS[0].label,
-        favorite = false,
-        allowLongPressActions = false,
-        showMoveToBitwarden = false,
-    ),
+private val LOCAL_DISPLAY_ITEMS = listOf(
     VerificationCodeDisplayItem(
         id = LOCAL_ITEMS[0].id,
         authCode = LOCAL_ITEMS[0].code,

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/VerificationCodeItemExtensionsTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/VerificationCodeItemExtensionsTest.kt
@@ -1,5 +1,7 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.util
 
+import com.bitwarden.authenticator.data.authenticator.manager.util.createMockLocalAuthenticatorItemSource
+import com.bitwarden.authenticator.data.authenticator.manager.util.createMockSharedAuthenticatorItemSource
 import com.bitwarden.authenticator.data.authenticator.manager.util.createMockVerificationCodeItem
 import com.bitwarden.authenticator.data.authenticator.repository.model.AuthenticatorItem
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
@@ -12,7 +14,10 @@ class VerificationCodeItemExtensionsTest {
     @Test
     fun `toDisplayItem should map Local items correctly`() {
         val alertThresholdSeconds = 7
-        val favoriteItem = createMockVerificationCodeItem(number = 1, favorite = true)
+        val favoriteItem = createMockVerificationCodeItem(
+            number = 1,
+            source = createMockLocalAuthenticatorItemSource(number = 1, isFavorite = true),
+        )
         val nonFavoriteItem = createMockVerificationCodeItem(number = 2)
 
         val expectedFavoriteItem = VerificationCodeDisplayItem(
@@ -134,15 +139,16 @@ class VerificationCodeItemExtensionsTest {
     @Test
     fun `toDisplayItem should map Shared items correctly`() {
         val alertThresholdSeconds = 7
-        val favoriteItem = createMockVerificationCodeItem(number = 1, favorite = true)
-            .copy(
-                source = AuthenticatorItem.Source.Shared(
-                    userId = "1",
-                    nameOfUser = "John Doe",
-                    email = "test@bitwarden.com",
-                    environmentLabel = "bitwarden.com",
-                ),
-            )
+        val favoriteItem = createMockVerificationCodeItem(
+            number = 1,
+            source = createMockSharedAuthenticatorItemSource(
+                number = 1,
+                userId = "1",
+                nameOfUser = "John Doe",
+                email = "test@bitwarden.com",
+                environmentLabel = "bitwarden.com",
+            ),
+        )
 
         val expectedFavoriteItem = VerificationCodeDisplayItem(
             id = favoriteItem.id,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19780](https://bitwarden.atlassian.net/browse/PM-19780)

## 📔 Objective

This PR adds headers to the Authenticator search screen indicating where the totp codes came from.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e9b312d0-3e1b-476a-bb18-e82289b037fc" width="300" /> | <img src="https://github.com/user-attachments/assets/3a2e3dbc-3cfc-4098-a8ae-b03e507b1c90" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19780]: https://bitwarden.atlassian.net/browse/PM-19780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ