### PR TITLE
PM-22213: Hide current access count when editing and there is not max access count

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
@@ -34,13 +34,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.bitwarden.ui.platform.components.animation.AnimateNullableContentVisibility
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedErrorButton
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
@@ -391,14 +391,26 @@ private fun AddEditSendOptions(
                         color = BitwardenTheme.colorScheme.text.secondary,
                         modifier = Modifier.fillMaxWidth(),
                     )
-                    state.common.currentAccessCount.takeUnless { isAddMode }?.let {
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = R.string.current_access_count.asText(it).invoke(),
-                            style = BitwardenTheme.typography.bodySmall,
-                            color = BitwardenTheme.colorScheme.text.secondary,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
+                    AnimateNullableContentVisibility(
+                        targetState = state
+                            .common
+                            .currentAccessCount
+                            ?.takeUnless { isAddMode || state.common.maxAccessCount == null },
+                        enter = fadeIn() + expandVertically(),
+                        exit = fadeOut() + shrinkVertically(),
+                    ) {
+                        Column {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                text = stringResource(
+                                    id = R.string.current_access_count,
+                                    formatArgs = arrayOf(it),
+                                ),
+                                style = BitwardenTheme.typography.bodySmall,
+                                color = BitwardenTheme.colorScheme.text.secondary,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
                     }
                 },
                 value = state.common.maxAccessCount,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22213](https://bitwarden.atlassian.net/browse/PM-22213)

## 📔 Objective

This PR hides the current access count field when editing a Send and the the maximum access count is 0 (or null).

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/9e84ec06-1488-438a-a351-1bb9c7a53beb" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
