### PR TITLE
Add generic logging to Autofill process

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FillResponseBuilderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FillResponseBuilderImpl.kt
@@ -10,6 +10,7 @@ import com.x8bit.bitwarden.data.autofill.util.buildDataset
 import com.x8bit.bitwarden.data.autofill.util.buildVaultItemDataset
 import com.x8bit.bitwarden.data.autofill.util.createTotpCopyIntentSender
 import com.x8bit.bitwarden.data.autofill.util.fillableAutofillIds
+import timber.log.Timber
 
 /**
  * The default implementation for [FillResponseBuilder]. This is a component for compiling fulfilled
@@ -22,12 +23,9 @@ class FillResponseBuilderImpl : FillResponseBuilder {
         saveInfo: SaveInfo?,
     ): FillResponse? =
         if (filledData.fillableAutofillIds.isNotEmpty()) {
+            Timber.w("Autofill request constructing FillResponse")
             val fillResponseBuilder = FillResponse.Builder()
-
-            saveInfo
-                ?.let { nonNullSaveInfo ->
-                    fillResponseBuilder.setSaveInfo(nonNullSaveInfo)
-                }
+            saveInfo?.let { nonNullSaveInfo -> fillResponseBuilder.setSaveInfo(nonNullSaveInfo) }
 
             filledData
                 .filledPartitions
@@ -52,12 +50,7 @@ class FillResponseBuilderImpl : FillResponseBuilder {
 
             fillResponseBuilder
                 // Add the Vault Item
-                .addDataset(
-                    filledData
-                        .buildVaultItemDataset(
-                            autofillAppInfo = autofillAppInfo,
-                        ),
-                )
+                .addDataset(filledData.buildVaultItemDataset(autofillAppInfo = autofillAppInfo))
                 .setIgnoredIds(*filledData.ignoreAutofillIds.toTypedArray())
                 .build()
         } else {
@@ -66,6 +59,7 @@ class FillResponseBuilderImpl : FillResponseBuilder {
             // with a presentation view. Neither of these make sense in the case where we have no
             // views to fill. What we are supposed to do when we cannot fulfill a request is
             // replace [FillResponse] with null in order to avoid this crash.
+            Timber.w("Autofill request has no fillable ids")
             null
         }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
@@ -9,6 +9,7 @@ import com.x8bit.bitwarden.data.autofill.model.FilledData
 import com.x8bit.bitwarden.data.autofill.model.FilledPartition
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProvider
 import com.x8bit.bitwarden.data.autofill.util.buildFilledItemOrNull
+import timber.log.Timber
 
 /**
  * The maximum amount of filled partitions the user will see. Viewing the rest will require opening
@@ -34,6 +35,7 @@ class FilledDataBuilderImpl(
     private val autofillCipherProvider: AutofillCipherProvider,
 ) : FilledDataBuilder {
     override suspend fun build(autofillRequest: AutofillRequest.Fillable): FilledData {
+        Timber.d("Autofill request constructing FilledData")
         val isVaultLocked = autofillCipherProvider.isVaultLocked()
 
         // Subtract one to make sure there is space for the vault item.
@@ -84,7 +86,7 @@ class FilledDataBuilderImpl(
                                 )
                             }
                     }
-                    ?: emptyList()
+                    .orEmpty()
             }
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/SaveInfoBuilderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/SaveInfoBuilderImpl.kt
@@ -4,6 +4,7 @@ import android.service.autofill.FillRequest
 import android.service.autofill.SaveInfo
 import com.x8bit.bitwarden.data.autofill.model.AutofillPartition
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import timber.log.Timber
 
 /**
  * The primary implementation of [SaveInfoBuilder].This is used for converting autofill data into
@@ -18,6 +19,7 @@ class SaveInfoBuilderImpl(
         fillRequest: FillRequest,
         packageName: String?,
     ): SaveInfo? {
+        Timber.d("Autofill request constructing SaveInfo -- ${fillRequest.id}")
         // Make sure that the save prompt is possible.
         val canPerformSaveRequest = autofillPartition.canPerformSaveRequest
         if (settingsRepository.isAutofillSavePromptDisabled || !canPerformSaveRequest) return null
@@ -26,6 +28,7 @@ class SaveInfoBuilderImpl(
         // in Compat mode since they show as masked values.
         val isInCompatMode = (fillRequest.flags or
             FillRequest.FLAG_COMPATIBILITY_MODE_REQUEST) == fillRequest.flags
+        Timber.d("Autofill request isInCompatMode=$isInCompatMode -- ${fillRequest.id}")
 
         // If login and compat mode, the password might be obfuscated,
         // in which case we should skip the save request.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/parser/AutofillParserImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/parser/AutofillParserImpl.kt
@@ -15,6 +15,7 @@ import com.x8bit.bitwarden.data.autofill.util.getMaxInlineSuggestionsCount
 import com.x8bit.bitwarden.data.autofill.util.toAutofillView
 import com.x8bit.bitwarden.data.autofill.util.website
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import timber.log.Timber
 
 /**
  * A list of URIs that should never be autofilled.
@@ -72,6 +73,7 @@ class AutofillParserImpl(
         autofillAppInfo: AutofillAppInfo,
         fillRequest: FillRequest?,
     ): AutofillRequest {
+        Timber.d("Parsing AssistStructure -- ${fillRequest?.id}")
         // Parse the `assistStructure` into internal models.
         val traversalDataList = assistStructure.traverse()
         // Take only the autofill views from the node that currently has focus.
@@ -133,6 +135,7 @@ class AutofillParserImpl(
 
         // Get inline information if available
         val isInlineAutofillEnabled = settingsRepository.isInlineAutofillEnabled
+        Timber.e("Autofill request isInlineEnabled=$isInlineAutofillEnabled -- ${fillRequest?.id}")
         val maxInlineSuggestionsCount = fillRequest.getMaxInlineSuggestionsCount(
             autofillAppInfo = autofillAppInfo,
             isInlineAutofillEnabled = isInlineAutofillEnabled,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorImpl.kt
@@ -53,8 +53,12 @@ class AutofillProcessorImpl(
         fillCallback: FillCallback,
         request: FillRequest,
     ) {
+        Timber.d("Begin processing Autofill fill request -- ${request.id}")
         // Set the listener so that any long running work is cancelled when it is no longer needed.
-        cancellationSignal.setOnCancelListener { job.cancel() }
+        cancellationSignal.setOnCancelListener {
+            Timber.d("Autofill job cancelled")
+            job.cancel()
+        }
         // Process the OS data and handle invoking the callback with the result.
         job.cancel()
         job = scope.launch {
@@ -122,6 +126,7 @@ class AutofillProcessorImpl(
         )
         when (autofillRequest) {
             is AutofillRequest.Fillable -> {
+                Timber.d("Autofill request is Fillable -- ${fillRequest.id}")
                 // Fulfill the [autofillRequest].
                 val filledData = filledDataBuilder.build(
                     autofillRequest = autofillRequest,
@@ -141,6 +146,7 @@ class AutofillProcessorImpl(
 
                 @Suppress("TooGenericExceptionCaught")
                 try {
+                    Timber.d("Autofill request success: Fillable -- ${fillRequest.id}")
                     fillCallback.onSuccess(response)
                 } catch (e: RuntimeException) {
                     // This is to catch any TransactionTooLargeExceptions that could occur here.
@@ -153,6 +159,7 @@ class AutofillProcessorImpl(
                 // If we are unable to fulfill the request, we should invoke the callback
                 // with null. This effectively disables autofill for this view set and
                 // allows the [AutofillService] to be unbound.
+                Timber.d("Autofill request success: Unfillable -- ${fillRequest.id}")
                 fillCallback.onSuccess(null)
             }
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/FilledItemExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/FilledItemExtensions.kt
@@ -1,17 +1,18 @@
 package com.x8bit.bitwarden.data.autofill.util
 
-import android.annotation.SuppressLint
+import android.os.Build
 import android.service.autofill.Dataset
 import android.service.autofill.Field
 import android.service.autofill.Presentations
 import android.widget.RemoteViews
+import androidx.annotation.RequiresApi
 import com.x8bit.bitwarden.data.autofill.model.FilledItem
 
 /**
  * Set up an overlay presentation for this [FilledItem] in the [datasetBuilder] for Android devices
  * running on API Tiramisu or greater.
  */
-@SuppressLint("NewApi")
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
 fun FilledItem.applyToDatasetPostTiramisu(
     datasetBuilder: Dataset.Builder,
     presentations: Presentations,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/FilledPartitionExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/FilledPartitionExtensions.kt
@@ -24,11 +24,7 @@ fun FilledPartition.buildDataset(
         autofillCipher = autofillCipher,
     )
     val datasetBuilder = Dataset.Builder()
-
-    authIntentSender
-        ?.let { intentSender ->
-            datasetBuilder.setAuthentication(intentSender)
-        }
+    authIntentSender?.let { intentSender -> datasetBuilder.setAuthentication(intentSender) }
 
     if (autofillAppInfo.isVersionAtLeast(version = Build.VERSION_CODES.TIRAMISU)) {
         applyToDatasetPostTiramisu(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/autofill/util/InlinePresentationSpecExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/autofill/util/InlinePresentationSpecExtensions.kt
@@ -18,6 +18,7 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.model.AutofillAppInfo
 import com.x8bit.bitwarden.data.autofill.model.AutofillCipher
 import com.x8bit.bitwarden.ui.autofill.iconTint
+import timber.log.Timber
 
 /**
  * Try creating an [InlinePresentation] for [autofillCipher] with this [InlinePresentationSpec]. If
@@ -84,7 +85,7 @@ private fun InlinePresentationSpec.createInlinePresentationOrNull(
     val isInlineCompatible = UiVersions
         .getVersions(style)
         .contains(UiVersions.INLINE_UI_VERSION_1)
-
+    Timber.d("Autofill request isInlineCompatible=$isInlineCompatible")
     if (!isInlineCompatible) return null
 
     val icon = Icon

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/builder/SaveInfoBuilderTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/builder/SaveInfoBuilderTest.kt
@@ -24,7 +24,9 @@ class SaveInfoBuilderTest {
 
     private val settingsRepository: SettingsRepository = mockk()
 
-    private val fillRequest: FillRequest = mockk()
+    private val fillRequest: FillRequest = mockk {
+        every { id } returns 55
+    }
     private val autofillIdOptional: AutofillId = mockk()
     private val autofillViewDataOptional = AutofillView.Data(
         autofillId = autofillIdOptional,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/parser/AutofillParserTests.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/parser/AutofillParserTests.kt
@@ -60,6 +60,7 @@ class AutofillParserTests {
         every { this@mockk.structure } returns assistStructure
     }
     private val fillRequest: FillRequest = mockk {
+        every { id } returns 55
         every { this@mockk.fillContexts } returns listOf(fillContext)
     }
     private val inlinePresentationSpecs: List<InlinePresentationSpec> = mockk()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillProcessorTest.kt
@@ -90,7 +90,9 @@ class AutofillProcessorTest {
     fun `processFillRequest should invoke callback with null when parse returns Unfillable`() {
         // Setup
         val autofillRequest = AutofillRequest.Unfillable
-        val fillRequest: FillRequest = mockk()
+        val fillRequest: FillRequest = mockk {
+            every { id } returns 55
+        }
         every { cancellationSignal.setOnCancelListener(any()) } just runs
         every {
             parser.parse(
@@ -124,7 +126,9 @@ class AutofillProcessorTest {
     fun `processFillRequest should invoke callback with filled response when has filledItems`() =
         runTest {
             // Setup
-            val fillRequest: FillRequest = mockk()
+            val fillRequest: FillRequest = mockk {
+                every { id } returns 55
+            }
             val filledData = FilledData(
                 filledPartitions = listOf(mockk()),
                 ignoreAutofillIds = emptyList(),
@@ -204,7 +208,9 @@ class AutofillProcessorTest {
     fun `processFillRequest should invoke callback with filled response when has filledItems and track exceptions thrown by callback`() =
         runTest {
             // Setup
-            val fillRequest: FillRequest = mockk()
+            val fillRequest: FillRequest = mockk {
+                every { id } returns 55
+            }
             val filledData = FilledData(
                 filledPartitions = listOf(mockk()),
                 ignoreAutofillIds = emptyList(),
@@ -466,7 +472,9 @@ class AutofillProcessorTest {
             every { packageName } returns PACKAGE_NAME
             every { partition } returns autofillPartition
         }
-        val fillRequest: FillRequest = mockk()
+        val fillRequest: FillRequest = mockk {
+            every { id } returns 55
+        }
         val saveInfo: SaveInfo = mockk()
         val filledData = FilledData(
             filledPartitions = listOf(mockk()),


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds some new logs to the Autofill processing logic to help with future bugs. These logs do not track any personal identify info and are fairly generic.

Additionally, a few small formatting changes were applied.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
