### PR TITLE
PM-23275: Update the display name for UK English

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/model/AppLanguage.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/model/AppLanguage.kt
@@ -53,7 +53,7 @@ enum class AppLanguage(
     ),
     ENGLISH_BRITISH(
         localeName = "en-GB",
-        text = "English (British)".asText(),
+        text = "English (United Kingdom)".asText(),
     ),
     SPANISH(
         localeName = "es",

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/appearance/model/AppLanguage.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/appearance/model/AppLanguage.kt
@@ -53,7 +53,7 @@ enum class AppLanguage(
     ),
     ENGLISH_BRITISH(
         localeName = "en-GB",
-        text = "English (British)".asText(),
+        text = "English (United Kingdom)".asText(),
     ),
     SPANISH(
         localeName = "es",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23275](https://bitwarden.atlassian.net/browse/PM-23275)

## 📔 Objective

This PR updates the displayed language names for UK English to match ISO 639-1 Standard.

    English (British) → English (United Kingdom)

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/8a7179d9-f382-40fd-b599-7f1dbc0164c9" width="300" /> | <img src="https://github.com/user-attachments/assets/30affc2a-379d-49dc-9c3f-acc3a01351f8" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23275]: https://bitwarden.atlassian.net/browse/PM-23275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ