### PR TITLE
[PM-22640] Re-added isScreenCaptureAllowed to the MainViewModel state

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
@@ -84,7 +84,7 @@ class MainActivity : AppCompatActivity() {
             val navController = rememberBitwardenNavController(name = "MainActivity")
             SetupEventsEffect(navController = navController)
             val state by mainViewModel.stateFlow.collectAsStateWithLifecycle()
-            handleScreenCaptureSettingChange(isScreenCaptureAllowed = state.isScreenCaptureAllowed)
+            updateScreenCapture(isScreenCaptureAllowed = state.isScreenCaptureAllowed)
             LocalManagerProvider(featureFlagsState = state.featureFlagsState) {
                 ObserveScreenDataEffect(
                     onDataUpdate = remember(mainViewModel) {
@@ -186,10 +186,6 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 is MainEvent.UpdateAppTheme -> AppCompatDelegate.setDefaultNightMode(event.osTheme)
-
-                is MainEvent.ScreenCaptureSettingChange -> {
-                    handleScreenCaptureSettingChange(isScreenCaptureAllowed = event.isAllowed)
-                }
             }
         }
     }
@@ -218,7 +214,7 @@ class MainActivity : AppCompatActivity() {
         recreate()
     }
 
-    private fun handleScreenCaptureSettingChange(isScreenCaptureAllowed: Boolean) {
+    private fun updateScreenCapture(isScreenCaptureAllowed: Boolean) {
         if (isScreenCaptureAllowed) {
             window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
         } else {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -265,7 +265,6 @@ class MainViewModel @Inject constructor(
     }
 
     private fun handleScreenCaptureUpdate(action: MainAction.Internal.ScreenCaptureUpdate) {
-        sendEvent(MainEvent.ScreenCaptureSettingChange(isAllowed = action.isScreenCaptureEnabled))
         mutableStateFlow.update { it.copy(isScreenCaptureAllowed = action.isScreenCaptureEnabled) }
     }
 
@@ -640,9 +639,4 @@ sealed class MainEvent {
     data class UpdateAppTheme(
         val osTheme: Int,
     ) : MainEvent()
-
-    /**
-     * Event indicating a change in the screen capture setting.
-     */
-    data class ScreenCaptureSettingChange(val isAllowed: Boolean) : MainEvent()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -93,7 +93,7 @@ class SettingsDiskSourceImpl(
 
     private val mutableHasSeenGeneratorCoachMarkFlow = bufferedMutableSharedFlow<Boolean?>()
 
-    private val mutableScreenCaptureAllowedFlow = bufferedMutableSharedFlow<Boolean?>(replay = 1)
+    private val mutableScreenCaptureAllowedFlow = bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableVaultRegisteredForExportFlow =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -243,9 +243,7 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
 
         viewModel.eventFlow.test {
-            // We skip the first 3 events because they are the
-            // default appTheme, appLanguage and ScreenCaptureUpdate
-            awaitItem()
+            // We skip the first 2 events because they are the default appTheme and appLanguage
             awaitItem()
             awaitItem()
 
@@ -296,9 +294,7 @@ class MainViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
 
             viewModel.eventFlow.test {
-                // We skip the first 3 events because they are the
-                // default appTheme, appLanguage and ScreenCaptureUpdate
-                awaitItem()
+                // We skip the first 2 events because they are the default appTheme and appLanguage
                 awaitItem()
                 awaitItem()
 
@@ -319,9 +315,7 @@ class MainViewModelTest : BaseViewModelTest() {
             val viewModel = createViewModel()
             val cipherView = mockk<CipherView>()
             viewModel.eventFlow.test {
-                // We skip the first 3 events because they are the
-                // default appTheme, appLanguage and ScreenCaptureUpdate
-                awaitItem()
+                // We skip the first 2 events because they are the default appTheme and appLanguage
                 awaitItem()
                 awaitItem()
 
@@ -338,9 +332,7 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         val cipherView = mockk<CipherView>()
         viewModel.eventFlow.test {
-            // We skip the first 3 events because they are the
-            // default appTheme, appLanguage and ScreenCaptureUpdate
-            awaitItem()
+            // We skip the first 2 events because they are the default appTheme and appLanguage
             awaitItem()
             awaitItem()
 
@@ -373,9 +365,7 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
 
         viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
-            // We skip the first 3 events because they are the
-            // default appTheme, appLanguage and ScreenCaptureUpdate
-            eventFlow.awaitItem()
+            // We skip the first 2 events because they are the default appTheme and appLanguage
             eventFlow.awaitItem()
             eventFlow.awaitItem()
 
@@ -398,9 +388,7 @@ class MainViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
 
         viewModel.eventFlow.test {
-            // We skip the first 3 events because they are the
-            // default appTheme, appLanguage and ScreenCaptureUpdate
-            awaitItem()
+            // We skip the first 2 events because they are the default appTheme and appLanguage
             awaitItem()
             awaitItem()
 
@@ -608,9 +596,7 @@ class MainViewModelTest : BaseViewModelTest() {
             } returns EmailTokenResult.Error(message = null, error = Throwable("Fail!"))
 
             viewModel.eventFlow.test {
-                // We skip the first 3 events because they are the
-                // default appTheme, appLanguage and ScreenCaptureUpdate
-                awaitItem()
+                // We skip the first 2 events because they are the default appTheme and appLanguage
                 awaitItem()
                 awaitItem()
 
@@ -644,9 +630,7 @@ class MainViewModelTest : BaseViewModelTest() {
             } returns EmailTokenResult.Error(message = expectedMessage, error = null)
 
             viewModel.eventFlow.test {
-                // We skip the first 3 events because they are the
-                // default appTheme, appLanguage and ScreenCaptureUpdate
-                awaitItem()
+                // We skip the first 2 events because they are the default appTheme and appLanguage
                 awaitItem()
                 awaitItem()
 
@@ -1039,9 +1023,7 @@ class MainViewModelTest : BaseViewModelTest() {
     fun `send NavigateToDebugMenu action when OpenDebugMenu action is sent`() = runTest {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
-            // We skip the first 3 events because they are the
-            // default appTheme, appLanguage and ScreenCaptureUpdate
-            awaitItem()
+            // We skip the first 2 events because they are the default appTheme and appLanguage
             awaitItem()
             awaitItem()
 
@@ -1133,22 +1115,6 @@ class MainViewModelTest : BaseViewModelTest() {
         viewModel.trySendAction(MainAction.AppSpecificLanguageUpdate(AppLanguage.SPANISH))
 
         verify { settingsRepository.appLanguage = AppLanguage.SPANISH }
-    }
-
-    @Test
-    fun `on ScreenCaptureUpdate should trigger the ScreenCaptureSettingChange event`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.eventFlow.test {
-            // We skip the first 3 events because they are the
-            // default appTheme, appLanguage and ScreenCaptureUpdate
-            awaitItem()
-            awaitItem()
-            awaitItem()
-
-            viewModel.trySendAction(MainAction.Internal.ScreenCaptureUpdate(true))
-            assertEquals(MainEvent.ScreenCaptureSettingChange(true), awaitItem())
-        }
     }
 
     private fun createViewModel(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22640

## 📔 Objective

`isScreenCaptureAllowed` needs to be present on the `MainViewModel` state in order to when `MainActivity` is recreated  it correctly updates the flags.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
