### PR TITLE
PM-23293: Remove unused Toast events from the app

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.auth.feature.createaccount
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,7 +20,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
@@ -80,7 +78,6 @@ fun CreateAccountScreen(
     viewModel: CreateAccountViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     EventsEffect(viewModel) { event ->
         when (event) {
             is NavigateToPrivacyPolicy -> {
@@ -92,9 +89,6 @@ fun CreateAccountScreen(
             }
 
             is CreateAccountEvent.NavigateBack -> onNavigateBack.invoke()
-            is CreateAccountEvent.ShowToast -> {
-                Toast.makeText(context, event.text, Toast.LENGTH_SHORT).show()
-            }
 
             is CreateAccountEvent.NavigateToCaptcha -> {
                 intentManager.startCustomTabsActivity(uri = event.uri)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/createaccount/CreateAccountViewModel.kt
@@ -480,11 +480,6 @@ sealed class CreateAccountEvent {
     data object NavigateBack : CreateAccountEvent()
 
     /**
-     * Placeholder event for showing a toast. Can be removed once there are real events.
-     */
-    data class ShowToast(val text: String) : CreateAccountEvent()
-
-    /**
      * Navigates to the captcha verification screen.
      */
     data class NavigateToCaptcha(val uri: Uri) : CreateAccountEvent()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.auth.feature.login
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -23,7 +22,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -73,7 +71,6 @@ fun LoginScreen(
     keyboardController: SoftwareKeyboardController? = LocalSoftwareKeyboardController.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             LoginEvent.NavigateBack -> onNavigateBack()
@@ -99,10 +96,6 @@ fun LoginScreen(
                     event.password,
                     event.isNewDeviceVerification,
                 )
-            }
-
-            is LoginEvent.ShowToast -> {
-                Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginViewModel.kt
@@ -416,11 +416,6 @@ sealed class LoginEvent {
         val password: String?,
         val isNewDeviceVerification: Boolean = false,
     ) : LoginEvent()
-
-    /**
-     * Shows a toast with the given [message].
-     */
-    data class ShowToast(val message: String) : LoginEvent()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.auth.feature.startregistration
 
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -25,7 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
@@ -84,7 +82,6 @@ fun StartRegistrationScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val handler = rememberStartRegistrationHandler(viewModel = viewModel)
-    val context = LocalContext.current
     EventsEffect(viewModel) { event ->
         when (event) {
             is NavigateToPrivacyPolicy -> {
@@ -106,10 +103,6 @@ fun StartRegistrationScreen(
             }
 
             is StartRegistrationEvent.NavigateBack -> onNavigateBack.invoke()
-            is StartRegistrationEvent.ShowToast -> {
-                Toast.makeText(context, event.text, Toast.LENGTH_SHORT).show()
-            }
-
             is StartRegistrationEvent.NavigateToCompleteRegistration -> {
                 onNavigateToCompleteRegistration(
                     event.email,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationViewModel.kt
@@ -307,11 +307,6 @@ sealed class StartRegistrationEvent {
     data object NavigateBack : StartRegistrationEvent()
 
     /**
-     * Placeholder event for showing a toast. Can be removed once there are real events.
-     */
-    data class ShowToast(val text: String) : StartRegistrationEvent()
-
-    /**
      * Navigates to the complete registration screen.
      */
     data class NavigateToCompleteRegistration(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.auth.feature.trusteddevice
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -20,7 +19,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -59,7 +57,6 @@ fun TrustedDeviceScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val handlers = remember(viewModel) { TrustedDeviceHandlers.create(viewModel = viewModel) }
 
-    val context = LocalContext.current
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             is TrustedDeviceEvent.NavigateToApproveWithAdmin -> {
@@ -72,12 +69,6 @@ fun TrustedDeviceScreen(
 
             is TrustedDeviceEvent.NavigateToLockScreen -> {
                 onNavigateToLock(event.email)
-            }
-
-            is TrustedDeviceEvent.ShowToast -> {
-                Toast
-                    .makeText(context, event.message(context.resources), Toast.LENGTH_SHORT)
-                    .show()
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/trusteddevice/TrustedDeviceViewModel.kt
@@ -206,11 +206,6 @@ sealed class TrustedDeviceEvent {
     data class NavigateToLockScreen(
         val email: String,
     ) : TrustedDeviceEvent()
-
-    /**
-     * Displays the [message] as a toast.
-     */
-    data class ShowToast(val message: Text) : TrustedDeviceEvent()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.auth.feature.vaultunlock
 
-import android.widget.Toast
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -26,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -93,9 +91,6 @@ fun VaultUnlockScreen(
         LocalCredentialProviderCompletionManager.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
-
     LaunchedEffect(state.requiresBiometricsLogin) {
         if (state.requiresBiometricsLogin && !biometricsManager.isBiometricsSupported) {
             viewModel.trySendAction(VaultUnlockAction.BiometricsNoLongerSupported)
@@ -111,10 +106,6 @@ fun VaultUnlockScreen(
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
-            is VaultUnlockEvent.ShowToast -> {
-                Toast.makeText(context, event.text(resources), Toast.LENGTH_SHORT).show()
-            }
-
             is VaultUnlockEvent.PromptForBiometrics -> {
                 biometricsManager.promptBiometrics(
                     onSuccess = onBiometricsUnlockSuccess,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -552,13 +552,6 @@ data class VaultUnlockState(
  */
 sealed class VaultUnlockEvent {
     /**
-     * Displays a toast to the user.
-     */
-    data class ShowToast(
-        val text: Text,
-    ) : VaultUnlockEvent()
-
-    /**
      * Prompts the user for biometrics unlock.
      */
     data class PromptForBiometrics(val cipher: Cipher) : BackgroundEvent, VaultUnlockEvent()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity
 
 import android.content.res.Resources
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -93,8 +92,6 @@ fun AccountSecurityScreen(
     intentManager: IntentManager = LocalIntentManager.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
     var showBiometricsPrompt by rememberSaveable { mutableStateOf(false) }
     val unlockWithBiometricToggle: (cipher: Cipher) -> Unit = remember(viewModel) {
         {
@@ -139,10 +136,6 @@ fun AccountSecurityScreen(
                     onError = { showBiometricsPrompt = false },
                     cipher = event.cipher,
                 )
-            }
-
-            is AccountSecurityEvent.ShowToast -> {
-                Toast.makeText(context, event.text(resources), Toast.LENGTH_SHORT).show()
             }
 
             AccountSecurityEvent.NavigateToSetupUnlockScreen -> onNavigateToSetupUnlockScreen()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -644,13 +644,6 @@ sealed class AccountSecurityEvent {
     ) : AccountSecurityEvent()
 
     /**
-     * Displays a toast with the given [Text].
-     */
-    data class ShowToast(
-        val text: Text,
-    ) : AccountSecurityEvent()
-
-    /**
      * Navigate to the setup unlock screen.
      */
     data object NavigateToSetupUnlockScreen : AccountSecurityEvent()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.deleteaccount
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -25,7 +24,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -60,16 +58,9 @@ fun DeleteAccountScreen(
     onNavigateToDeleteAccountConfirmation: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             DeleteAccountEvent.NavigateBack -> onNavigateBack()
-
-            is DeleteAccountEvent.ShowToast -> {
-                Toast.makeText(context, event.message(resources), Toast.LENGTH_SHORT).show()
-            }
-
             DeleteAccountEvent.NavigateToDeleteAccountConfirmationScreen -> {
                 onNavigateToDeleteAccountConfirmation()
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
@@ -213,13 +213,6 @@ sealed class DeleteAccountEvent {
      * Navigates to the Delete Account Confirmation Screen.
      */
     data object NavigateToDeleteAccountConfirmationScreen : DeleteAccountEvent()
-
-    /**
-     * Displays the [message] in a toast.
-     */
-    data class ShowToast(
-        val message: Text,
-    ) : DeleteAccountEvent()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.deleteaccountconfirmation
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -51,15 +49,9 @@ fun DeleteAccountConfirmationScreen(
     onNavigateBack: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             DeleteAccountConfirmationEvent.NavigateBack -> onNavigateBack()
-
-            is DeleteAccountConfirmationEvent.ShowToast -> {
-                Toast.makeText(context, event.message(resources), Toast.LENGTH_SHORT).show()
-            }
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
@@ -226,13 +226,6 @@ sealed class DeleteAccountConfirmationEvent {
      * Navigates back.
      */
     data object NavigateBack : DeleteAccountConfirmationEvent()
-
-    /**
-     * Displays the [message] in a toast.
-     */
-    data class ShowToast(
-        val message: Text,
-    ) : DeleteAccountConfirmationEvent()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreen.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.pending
 import android.Manifest
 import android.annotation.SuppressLint
 import android.os.Build
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -34,7 +33,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -79,8 +77,6 @@ fun PendingRequestsScreen(
     onNavigateToLoginApproval: (fingerprint: String) -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
     val pullToRefreshState = rememberBitwardenPullToRefreshState(
         isEnabled = state.isPullToRefreshEnabled,
         isRefreshing = state.isRefreshing,
@@ -93,10 +89,6 @@ fun PendingRequestsScreen(
             PendingRequestsEvent.NavigateBack -> onNavigateBack()
             is PendingRequestsEvent.NavigateToLoginApproval -> {
                 onNavigateToLoginApproval(event.fingerprint)
-            }
-
-            is PendingRequestsEvent.ShowToast -> {
-                Toast.makeText(context, event.message(resources), Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.util.toFormattedDateTimeStyle
 import com.bitwarden.core.util.isOverFiveMinutesOld
 import com.bitwarden.ui.platform.base.BaseViewModel
-import com.bitwarden.ui.util.Text
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequest
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequestsUpdatesResult
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -282,13 +281,6 @@ sealed class PendingRequestsEvent {
      */
     data class NavigateToLoginApproval(
         val fingerprint: String,
-    ) : PendingRequestsEvent()
-
-    /**
-     * Displays the [message] in a toast.
-     */
-    data class ShowToast(
-        val message: Text,
     ) : PendingRequestsEvent()
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.autofill
 
 import android.content.res.Resources
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -35,6 +34,7 @@ import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.badge.NotificationBadge
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.model.TooltipData
+import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.x8bit.bitwarden.R
@@ -48,7 +48,6 @@ import com.x8bit.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenTextRow
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
-import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.browser.BrowserAutofillSettingsCard
 import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.handlers.AutoFillHandlers
@@ -73,7 +72,6 @@ fun AutoFillScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    val resources = context.resources
     var shouldShowAutofillFallbackDialog by rememberSaveable { mutableStateOf(false) }
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -87,10 +85,6 @@ fun AutoFillScreen(
                 val isSuccess = intentManager.startSystemAutofillSettingsActivity()
 
                 shouldShowAutofillFallbackDialog = !isSuccess
-            }
-
-            is AutoFillEvent.ShowToast -> {
-                Toast.makeText(context, event.text(resources), Toast.LENGTH_SHORT).show()
             }
 
             AutoFillEvent.NavigateToBlockAutoFill -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -370,13 +370,6 @@ sealed class AutoFillEvent {
     data object NavigateToSettings : AutoFillEvent()
 
     /**
-     * Displays a toast with the given [Text].
-     */
-    data class ShowToast(
-        val text: Text,
-    ) : AutoFillEvent()
-
-    /**
      * Navigate to the Autofill settings of the specified [browserPackage].
      */
     data class NavigateToBrowserAutofillSettings(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.folders
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -19,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -56,16 +54,12 @@ fun FoldersScreen(
     viewModel: FoldersViewModel = hiltViewModel(),
 ) {
     val state = viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             is FoldersEvent.NavigateBack -> onNavigateBack()
             is FoldersEvent.NavigateToAddFolderScreen -> onNavigateToAddFolderScreen()
-            is FoldersEvent.NavigateToEditFolderScreen ->
+            is FoldersEvent.NavigateToEditFolderScreen -> {
                 onNavigateToEditFolderScreen(event.folderId)
-
-            is FoldersEvent.ShowToast -> {
-                Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersViewModel.kt
@@ -180,11 +180,6 @@ sealed class FoldersEvent {
      * Navigates to the screen to edit a folder.
      */
     data class NavigateToEditFolderScreen(val folderId: String) : FoldersEvent()
-
-    /**
-     * Shows a toast with the given [message].
-     */
-    data class ShowToast(val message: String) : FoldersEvent()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.vault
 
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -19,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -61,16 +59,11 @@ fun VaultSettingsScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
     val snackbarHostState = rememberBitwardenSnackbarHostState()
-    val context = LocalContext.current
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             VaultSettingsEvent.NavigateBack -> onNavigateBack()
             VaultSettingsEvent.NavigateToExportVault -> onNavigateToExportVault()
             VaultSettingsEvent.NavigateToFolders -> onNavigateToFolders()
-            is VaultSettingsEvent.ShowToast -> {
-                Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
-            }
-
             is VaultSettingsEvent.NavigateToImportVault -> {
                 if (state.isNewImportLoginsFlowEnabled) {
                     onNavigateToImportLogins()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsViewModel.kt
@@ -182,13 +182,6 @@ sealed class VaultSettingsEvent {
     data object NavigateToFolders : VaultSettingsEvent()
 
     /**
-     * Shows a toast with the given [message].
-     */
-    data class ShowToast(
-        val message: String,
-    ) : VaultSettingsEvent()
-
-    /**
      * Shows a snackbar with the given [data].
      */
     data class ShowSnackbar(val data: BitwardenSnackbarData) : VaultSettingsEvent(), BackgroundEvent

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.tools.feature.generator.passwordhistory
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,7 +20,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -52,16 +50,10 @@ fun PasswordHistoryScreen(
     viewModel: PasswordHistoryViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
-
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             PasswordHistoryEvent.NavigateBack -> onNavigateBack.invoke()
-
-            is PasswordHistoryEvent.ShowToast -> {
-                Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
-            }
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModel.kt
@@ -227,14 +227,6 @@ data class PasswordHistoryState(
  * Defines the set of events that can occur in the password history screen.
  */
 sealed class PasswordHistoryEvent {
-
-    /**
-     * Event to show a toast message.
-     *
-     * @property message The message to be displayed in the toast.
-     */
-    data class ShowToast(val message: String) : PasswordHistoryEvent()
-
     /**
      * Event to navigate back to the previous screen.
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -84,12 +83,6 @@ fun ManualCodeEntryScreen(
                 intent.data = Uri.parse("package:" + context.packageName)
 
                 intentManager.startActivity(intent = intent)
-            }
-
-            is ManualCodeEntryEvent.ShowToast -> {
-                Toast
-                    .makeText(context, event.message.invoke(context.resources), Toast.LENGTH_SHORT)
-                    .show()
             }
 
             is ManualCodeEntryEvent.NavigateToQrCodeScreen -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryViewModel.kt
@@ -123,11 +123,6 @@ sealed class ManualCodeEntryEvent {
      * Navigate to the app settings.
      */
     data object NavigateToAppSettings : ManualCodeEntryEvent()
-
-    /**
-     * Show a toast with the given [message].
-     */
-    data class ShowToast(val message: Text) : ManualCodeEntryEvent()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.ui.vault.feature.qrcodescan
 
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import android.widget.Toast
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
@@ -85,20 +84,12 @@ fun QrCodeScanScreen(
         { viewModel.trySendAction(QrCodeScanAction.QrCodeScanReceive(it)) }
     }
 
-    val context = LocalContext.current
-
     val onEnterKeyManuallyClick = remember(viewModel) {
         { viewModel.trySendAction(QrCodeScanAction.ManualEntryTextClick) }
     }
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
-            is QrCodeScanEvent.ShowToast -> {
-                Toast
-                    .makeText(context, event.message.invoke(context.resources), Toast.LENGTH_SHORT)
-                    .show()
-            }
-
             is QrCodeScanEvent.NavigateBack -> {
                 onNavigateBack.invoke()
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanViewModel.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.ui.vault.feature.qrcodescan
 
 import android.net.Uri
 import com.bitwarden.ui.platform.base.BaseViewModel
-import com.bitwarden.ui.util.Text
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.TotpCodeResult
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -128,11 +127,6 @@ sealed class QrCodeScanEvent {
      * Navigate to manual code entry screen.
      */
     data object NavigateToManualCodeEntry : QrCodeScanEvent()
-
-    /**
-     * Show a toast with the given [message].
-     */
-    data class ShowToast(val message: Text) : QrCodeScanEvent()
 }
 
 /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
@@ -1,6 +1,5 @@
 package com.bitwarden.authenticator.ui.auth.unlock
 
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,7 +20,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -51,18 +49,11 @@ fun UnlockScreen(
     biometricsManager: BiometricsManager = LocalBiometricsManager.current,
     onUnlocked: () -> Unit,
 ) {
-
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
     var showBiometricsPrompt by remember { mutableStateOf(true) }
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
-            is UnlockEvent.ShowToast -> {
-                Toast.makeText(context, event.message(resources), Toast.LENGTH_SHORT).show()
-            }
-
             UnlockEvent.NavigateToItemListing -> onUnlocked()
         }
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockViewModel.kt
@@ -118,13 +118,6 @@ sealed class UnlockEvent {
      * Navigates to the item listing screen.
      */
     data object NavigateToItemListing : UnlockEvent()
-
-    /**
-     * Displays a toast to the user.
-     */
-    data class ShowToast(
-        val message: Text,
-    ) : UnlockEvent()
 }
 
 /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
@@ -2,7 +2,6 @@ package com.bitwarden.authenticator.ui.authenticator.feature.qrcodescan
 
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import android.widget.Toast
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.Preview
@@ -90,15 +89,8 @@ fun QrCodeScanScreen(
         { viewModel.trySendAction(QrCodeScanAction.ManualEntryTextClick) }
     }
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
-            is QrCodeScanEvent.ShowToast -> {
-                Toast
-                    .makeText(context, event.message.invoke(context.resources), Toast.LENGTH_SHORT)
-                    .show()
-            }
-
             is QrCodeScanEvent.NavigateBack -> {
                 onNavigateBack.invoke()
             }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanViewModel.kt
@@ -13,7 +13,6 @@ import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.Defau
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.isBase32
-import com.bitwarden.ui.util.Text
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
@@ -256,11 +255,6 @@ sealed class QrCodeScanEvent {
      * Navigate to manual code entry screen.
      */
     data object NavigateToManualCodeEntry : QrCodeScanEvent()
-
-    /**
-     * Show a toast with the given [message].
-     */
-    data class ShowToast(val message: Text) : QrCodeScanEvent()
 }
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23293](https://bitwarden.atlassian.net/browse/PM-23293)

## 📔 Objective

This PR removes all Toast events that are never used from the apps.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23293]: https://bitwarden.atlassian.net/browse/PM-23293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ