### PR TITLE
PM-22972: Replace send Toasts with Snackbars

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.search
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,7 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -65,8 +63,6 @@ fun SearchScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val searchHandlers = remember(viewModel) { SearchHandlers.create(viewModel) }
-    val context = LocalContext.current
-
     RegisterScreenDataOnLifecycleEffect(
         appResumeStateManager = appResumeStateManager,
     ) {
@@ -116,11 +112,6 @@ fun SearchScreen(
             is SearchEvent.NavigateToUrl -> intentManager.launchUri(event.url.toUri())
             is SearchEvent.ShowShareSheet -> intentManager.shareText(event.content)
             is SearchEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)
-            is SearchEvent.ShowToast -> {
-                Toast
-                    .makeText(context, event.message(context.resources), Toast.LENGTH_SHORT)
-                    .show()
-            }
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -522,7 +522,7 @@ class SearchViewModel @Inject constructor(
 
             DeleteSendResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(SearchEvent.ShowToast(R.string.send_deleted.asText()))
+                sendEvent(SearchEvent.ShowSnackbar(R.string.send_deleted.asText()))
             }
         }
     }
@@ -561,7 +561,7 @@ class SearchViewModel @Inject constructor(
 
             is RemovePasswordSendResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(SearchEvent.ShowToast(R.string.password_removed.asText()))
+                sendEvent(SearchEvent.ShowSnackbar(R.string.password_removed.asText()))
             }
         }
     }
@@ -1293,14 +1293,21 @@ sealed class SearchEvent {
      */
     data class ShowSnackbar(
         val data: BitwardenSnackbarData,
-    ) : SearchEvent(), BackgroundEvent
-
-    /**
-     * Show a toast with the given [message].
-     */
-    data class ShowToast(
-        val message: Text,
-    ) : SearchEvent()
+    ) : SearchEvent(), BackgroundEvent {
+        constructor(
+            message: Text,
+            messageHeader: Text? = null,
+            actionLabel: Text? = null,
+            withDismissAction: Boolean = false,
+        ) : this(
+            data = BitwardenSnackbarData(
+                message = message,
+                messageHeader = messageHeader,
+                actionLabel = actionLabel,
+                withDismissAction = withDismissAction,
+            ),
+        )
+    }
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.tools.feature.send
 
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
@@ -13,7 +12,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
@@ -56,7 +54,7 @@ import kotlinx.collections.immutable.persistentListOf
 /**
  * UI for the send screen.
  */
-@Suppress("LongMethod", "CyclomaticComplexMethod")
+@Suppress("LongMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SendScreen(
@@ -70,7 +68,6 @@ fun SendScreen(
     appResumeStateManager: AppResumeStateManager = LocalAppResumeStateManager.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     val pullToRefreshState = rememberBitwardenPullToRefreshState(
         isEnabled = state.isPullToRefreshEnabled,
         isRefreshing = state.isRefreshing,
@@ -116,18 +113,8 @@ fun SendScreen(
                 intentManager.launchUri("https://bitwarden.com/products/send".toUri())
             }
 
-            is SendEvent.ShowShareSheet -> {
-                intentManager.shareText(event.url)
-            }
-
+            is SendEvent.ShowShareSheet -> intentManager.shareText(event.url)
             is SendEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)
-
-            is SendEvent.ShowToast -> {
-                Toast
-                    .makeText(context, event.message(context.resources), Toast.LENGTH_SHORT)
-                    .show()
-            }
-
             SendEvent.NavigateToFileSends -> onNavigateToSendFilesList()
             SendEvent.NavigateToTextSends -> onNavigateToSendTextList()
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -192,7 +192,7 @@ class SendViewModel @Inject constructor(
 
             DeleteSendResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(SendEvent.ShowToast(R.string.send_deleted.asText()))
+                sendEvent(SendEvent.ShowSnackbar(R.string.send_deleted.asText()))
             }
         }
     }
@@ -217,7 +217,7 @@ class SendViewModel @Inject constructor(
 
             is RemovePasswordSendResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(SendEvent.ShowToast(message = R.string.password_removed.asText()))
+                sendEvent(SendEvent.ShowSnackbar(message = R.string.password_removed.asText()))
             }
         }
     }
@@ -809,10 +809,19 @@ sealed class SendEvent {
      */
     data class ShowSnackbar(
         val data: BitwardenSnackbarData,
-    ) : SendEvent(), BackgroundEvent
-
-    /**
-     * Show a toast to the user.
-     */
-    data class ShowToast(val message: Text) : SendEvent()
+    ) : SendEvent(), BackgroundEvent {
+        constructor(
+            message: Text,
+            messageHeader: Text? = null,
+            actionLabel: Text? = null,
+            withDismissAction: Boolean = false,
+        ) : this(
+            data = BitwardenSnackbarData(
+                message = message,
+                messageHeader = messageHeader,
+                actionLabel = actionLabel,
+                withDismissAction = withDismissAction,
+            ),
+        )
+    }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1522,7 +1522,7 @@ class VaultItemListingViewModel @Inject constructor(
 
             DeleteSendResult.Success -> {
                 clearDialogState()
-                sendEvent(VaultItemListingEvent.ShowToast(R.string.send_deleted.asText()))
+                sendEvent(VaultItemListingEvent.ShowSnackbar(R.string.send_deleted.asText()))
             }
         }
     }
@@ -1548,9 +1548,7 @@ class VaultItemListingViewModel @Inject constructor(
 
             is RemovePasswordSendResult.Success -> {
                 clearDialogState()
-                sendEvent(
-                    VaultItemListingEvent.ShowToast(text = R.string.password_removed.asText()),
-                )
+                sendEvent(VaultItemListingEvent.ShowSnackbar(R.string.password_removed.asText()))
             }
         }
     }
@@ -1900,6 +1898,8 @@ class VaultItemListingViewModel @Inject constructor(
             }
 
             is Fido2RegisterCredentialResult.Success -> {
+                // This must be a toast because we are finishing the activity and we want the
+                // user to have time to see the message.
                 sendEvent(VaultItemListingEvent.ShowToast(R.string.item_updated.asText()))
                 sendEvent(
                     VaultItemListingEvent.CompleteFido2Registration(
@@ -1913,6 +1913,8 @@ class VaultItemListingViewModel @Inject constructor(
     private fun handleRegisterFido2CredentialResultErrorReceive(
         error: Fido2RegisterCredentialResult.Error,
     ) {
+        // This must be a toast because we are finishing the activity and we want the
+        // user to have time to see the message.
         sendEvent(VaultItemListingEvent.ShowToast(R.string.an_error_has_occurred.asText()))
         sendEvent(
             VaultItemListingEvent.CompleteFido2Registration(
@@ -2892,7 +2894,21 @@ sealed class VaultItemListingEvent {
      */
     data class ShowSnackbar(
         val data: BitwardenSnackbarData,
-    ) : VaultItemListingEvent(), BackgroundEvent
+    ) : VaultItemListingEvent(), BackgroundEvent {
+        constructor(
+            message: Text,
+            messageHeader: Text? = null,
+            actionLabel: Text? = null,
+            withDismissAction: Boolean = false,
+        ) : this(
+            data = BitwardenSnackbarData(
+                message = message,
+                messageHeader = messageHeader,
+                actionLabel = actionLabel,
+                withDismissAction = withDismissAction,
+            ),
+        )
+    }
 
     /**
      * Complete the current FIDO 2 credential registration process.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -811,7 +811,7 @@ class SearchViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `OverflowOptionClick Send DeleteClick with deleteSend success should emit ShowToast`() =
+    fun `OverflowOptionClick Send DeleteClick with deleteSend success should emit ShowSnackbar`() =
         runTest {
             val sendId = "sendId1234"
             coEvery { vaultRepository.deleteSend(sendId) } returns DeleteSendResult.Success
@@ -824,7 +824,7 @@ class SearchViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 assertEquals(
-                    SearchEvent.ShowToast(R.string.send_deleted.asText()),
+                    SearchEvent.ShowSnackbar(R.string.send_deleted.asText()),
                     awaitItem(),
                 )
             }
@@ -883,7 +883,7 @@ class SearchViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `OverflowOptionClick Send RemovePasswordClick with removePasswordSend success should emit ShowToast`() =
+    fun `OverflowOptionClick Send RemovePasswordClick with removePasswordSend success should emit ShowSnackbar`() =
         runTest {
             val sendId = "sendId1234"
             coEvery {
@@ -898,7 +898,7 @@ class SearchViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 assertEquals(
-                    SearchEvent.ShowToast(R.string.password_removed.asText()),
+                    SearchEvent.ShowSnackbar(R.string.password_removed.asText()),
                     awaitItem(),
                 )
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModelTest.kt
@@ -239,7 +239,7 @@ class SendViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `DeleteSendClick with deleteSend success should emit ShowToast`() = runTest {
+    fun `DeleteSendClick with deleteSend success should emit ShowSnackbar`() = runTest {
         val sendId = "sendId1234"
         val sendItem = mockk<SendState.ViewState.Content.SendItem> {
             every { id } returns sendId
@@ -249,7 +249,7 @@ class SendViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(SendAction.DeleteSendClick(sendItem))
-            assertEquals(SendEvent.ShowToast(R.string.send_deleted.asText()), awaitItem())
+            assertEquals(SendEvent.ShowSnackbar(R.string.send_deleted.asText()), awaitItem())
         }
     }
 
@@ -289,7 +289,7 @@ class SendViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `RemovePasswordClick with removePasswordSend success should emit ShowToast`() = runTest {
+    fun `RemovePasswordClick with removePasswordSend success should emit ShowSnackbar`() = runTest {
         val sendId = "sendId1234"
         val sendItem = mockk<SendState.ViewState.Content.SendItem> {
             every { id } returns sendId
@@ -301,7 +301,7 @@ class SendViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(SendAction.RemovePasswordClick(sendItem))
-            assertEquals(SendEvent.ShowToast(R.string.password_removed.asText()), awaitItem())
+            assertEquals(SendEvent.ShowSnackbar(R.string.password_removed.asText()), awaitItem())
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -1608,7 +1608,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `OverflowOptionClick Send DeleteClick with deleteSend success should emit ShowToast`() =
+    fun `OverflowOptionClick Send DeleteClick with deleteSend success should emit ShowSnackbar`() =
         runTest {
             val sendId = "sendId1234"
             coEvery { vaultRepository.deleteSend(sendId) } returns DeleteSendResult.Success
@@ -1621,7 +1621,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 assertEquals(
-                    VaultItemListingEvent.ShowToast(R.string.send_deleted.asText()),
+                    VaultItemListingEvent.ShowSnackbar(R.string.send_deleted.asText()),
                     awaitItem(),
                 )
             }
@@ -1682,7 +1682,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `OverflowOptionClick Send RemovePasswordClick with removePasswordSend success should emit ShowToast`() =
+    fun `OverflowOptionClick Send RemovePasswordClick with removePasswordSend success should emit ShowSnackbar`() =
         runTest {
             val sendId = "sendId1234"
             coEvery {
@@ -1697,7 +1697,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 assertEquals(
-                    VaultItemListingEvent.ShowToast(R.string.password_removed.asText()),
+                    VaultItemListingEvent.ShowSnackbar(R.string.password_removed.asText()),
                     awaitItem(),
                 )
             }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22972](https://bitwarden.atlassian.net/browse/PM-22972)

## 📔 Objective

This PR replaces all the Send based Toasts with Snackbars.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="" width="300" /> | <img src="" width="300" /> |
| <img src="" width="300" /> | <img src="" width="300" /> |
| <img src="" width="300" /> | <img src="" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
