### PR TITLE
PM-23318: Replace OtherScreen toast with snackbar

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreen.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.other
 
 import android.content.res.Resources
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -36,6 +35,7 @@ import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.theme.BitwardenTheme
@@ -47,7 +47,8 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
-import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
+import com.x8bit.bitwarden.ui.platform.components.snackbar.rememberBitwardenSnackbarHostState
 import kotlinx.collections.immutable.toImmutableList
 
 /**
@@ -60,19 +61,11 @@ fun OtherScreen(
     viewModel: OtherViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
+    val snackbarHostState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             OtherEvent.NavigateBack -> onNavigateBack.invoke()
-            is OtherEvent.ShowToast -> {
-                Toast
-                    .makeText(
-                        context,
-                        event.message(context.resources),
-                        Toast.LENGTH_SHORT,
-                    )
-                    .show()
-            }
+            is OtherEvent.ShowSnackbar -> snackbarHostState.showSnackbar(snackbarData = event.data)
         }
     }
 
@@ -98,6 +91,9 @@ fun OtherScreen(
                     { viewModel.trySendAction(OtherAction.BackClick) }
                 },
             )
+        },
+        snackbarHost = {
+            BitwardenSnackbarHost(bitwardenHostState = snackbarHostState)
         },
     ) {
         OtherContent(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherViewModel.kt
@@ -12,6 +12,7 @@ import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManage
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
@@ -152,7 +153,7 @@ class OtherViewModel @Inject constructor(
     }
 
     private fun handleManualVaultSyncReceive() {
-        sendEvent(OtherEvent.ShowToast(R.string.syncing_complete.asText()))
+        sendEvent(OtherEvent.ShowSnackbar(R.string.syncing_complete.asText()))
     }
 }
 
@@ -203,9 +204,23 @@ sealed class OtherEvent {
     /**
      * Show a toast with the given message.
      */
-    data class ShowToast(
-        val message: Text,
-    ) : OtherEvent()
+    data class ShowSnackbar(
+        val data: BitwardenSnackbarData,
+    ) : OtherEvent() {
+        constructor(
+            message: Text,
+            messageHeader: Text? = null,
+            actionLabel: Text? = null,
+            withDismissAction: Boolean = false,
+        ) : this(
+            data = BitwardenSnackbarData(
+                message = message,
+                messageHeader = messageHeader,
+                actionLabel = actionLabel,
+                withDismissAction = withDismissAction,
+            ),
+        )
+    }
 }
 
 /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreenTest.kt
@@ -15,6 +15,7 @@ import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.assertNoDialogExists
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -82,6 +83,15 @@ class OtherScreenTest : BitwardenComposeTest() {
     fun `on back click should send BackClick`() {
         composeTestRule.onNodeWithContentDescription("Back").performClick()
         verify { viewModel.trySendAction(OtherAction.BackClick) }
+    }
+
+    @Test
+    fun `on ShowSnackbar should display snackbar content`() {
+        val message = "message"
+        val data = BitwardenSnackbarData(message = message.asText())
+        composeTestRule.onNodeWithText(text = message).assertDoesNotExist()
+        mutableEventFlow.tryEmit(OtherEvent.ShowSnackbar(data = data))
+        composeTestRule.onNodeWithText(text = message).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherViewModelTest.kt
@@ -185,13 +185,13 @@ class OtherViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `ManualVaultSyncReceive should emit ShowToast`() = runTest {
+    fun `ManualVaultSyncReceive should emit ShowSnackbar`() = runTest {
         val newSyncTime = Instant.parse("2023-10-27T12:00:00Z")
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             mutableVaultLastSyncStateFlow.tryEmit(newSyncTime)
             assertEquals(
-                OtherEvent.ShowToast(R.string.syncing_complete.asText()),
+                OtherEvent.ShowSnackbar(R.string.syncing_complete.asText()),
                 awaitItem(),
             )
         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23318](https://bitwarden.atlassian.net/browse/PM-23318)

## 📔 Objective

This PR replaces the Toast on the `OtherScreen` with a Snackbar.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/c1ed4b5f-18f5-4c7a-8ee5-671f374fe13d" width="300" /> | <img src="https://github.com/user-attachments/assets/ad4ad15c-ccbf-44c6-8bf0-be41903cd7dc" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23318]: https://bitwarden.atlassian.net/browse/PM-23318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ