### PR TITLE
PM-23320: Replace Export Vault screen toasts with snackbars

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModel.kt
@@ -21,6 +21,7 @@ import com.x8bit.bitwarden.data.vault.manager.FileManager
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.PasswordStrengthState
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
 import com.x8bit.bitwarden.ui.platform.feature.settings.exportvault.model.ExportVaultFormat
 import com.x8bit.bitwarden.ui.platform.feature.settings.exportvault.model.toExportFormat
 import com.x8bit.bitwarden.ui.platform.util.fileExtension
@@ -125,14 +126,14 @@ class ExportVaultViewModel @Inject constructor(
         mutableStateFlow.update {
             it.copy(dialogState = null)
         }
-        val toastMessage = when (val result = action.result) {
+        val message = when (val result = action.result) {
             is RequestOtpResult.Error -> {
                 result.message?.asText() ?: R.string.generic_error_message.asText()
             }
 
             RequestOtpResult.Success -> R.string.code_sent.asText()
         }
-        sendEvent(ExportVaultEvent.ShowToast(message = toastMessage))
+        sendEvent(ExportVaultEvent.ShowSnackbar(message = message))
     }
 
     /**
@@ -397,7 +398,7 @@ class ExportVaultViewModel @Inject constructor(
             return
         }
 
-        sendEvent(ExportVaultEvent.ShowToast(R.string.export_vault_success.asText()))
+        sendEvent(ExportVaultEvent.ShowSnackbar(R.string.export_vault_success.asText()))
     }
 
     private fun handleReceiveVerifyOneTimePasscodeResult(
@@ -508,7 +509,23 @@ sealed class ExportVaultEvent {
     /**
      * Shows a toast with the given [message].
      */
-    data class ShowToast(val message: Text) : ExportVaultEvent()
+    data class ShowSnackbar(
+        val data: BitwardenSnackbarData,
+    ) : ExportVaultEvent() {
+        constructor(
+            message: Text,
+            messageHeader: Text? = null,
+            actionLabel: Text? = null,
+            withDismissAction: Boolean = false,
+        ) : this(
+            data = BitwardenSnackbarData(
+                message = message,
+                messageHeader = messageHeader,
+                actionLabel = actionLabel,
+                withDismissAction = withDismissAction,
+            ),
+        )
+    }
 
     /**
      *  Navigates to select a location where to save the vault data with the [fileName].

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreenTest.kt
@@ -19,6 +19,7 @@ import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.assertNoDialogExists
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.PasswordStrengthState
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
 import com.x8bit.bitwarden.ui.platform.feature.settings.exportvault.model.ExportVaultFormat
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import io.mockk.every
@@ -60,6 +61,15 @@ class ExportVaultScreenTest : BitwardenComposeTest() {
         verify(exactly = 1) {
             intentManager.createDocumentIntent("test.json")
         }
+    }
+
+    @Test
+    fun `on ShowSnackbar should display snackbar content`() {
+        val message = "message"
+        val data = BitwardenSnackbarData(message = message.asText())
+        composeTestRule.onNodeWithText(text = message).assertDoesNotExist()
+        mutableEventFlow.tryEmit(ExportVaultEvent.ShowSnackbar(data = data))
+        composeTestRule.onNodeWithText(text = message).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
@@ -498,9 +498,7 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
                 )
                 assertEquals(DEFAULT_STATE, stateTurbine.awaitItem())
                 assertEquals(
-                    ExportVaultEvent.ShowToast(
-                        message = R.string.code_sent.asText(),
-                    ),
+                    ExportVaultEvent.ShowSnackbar(message = R.string.code_sent.asText()),
                     eventTurbine.awaitItem(),
                 )
             }
@@ -529,7 +527,7 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
                 )
                 assertEquals(DEFAULT_STATE, stateTurbine.awaitItem())
                 assertEquals(
-                    ExportVaultEvent.ShowToast(
+                    ExportVaultEvent.ShowSnackbar(
                         message = R.string.generic_error_message.asText(),
                     ),
                     eventTurbine.awaitItem(),
@@ -715,7 +713,7 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `ExportLocationReceive should emit ShowToast on success`() = runTest {
+    fun `ExportLocationReceive should emit ShowSnackbar on success`() = runTest {
         val exportData = "TestExportVaultData"
         val viewModel = createViewModel(
             DEFAULT_STATE.copy(
@@ -731,7 +729,7 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
             coVerify { fileManager.stringToUri(fileUri = any(), dataString = exportData) }
 
             assertEquals(
-                ExportVaultEvent.ShowToast(R.string.export_vault_success.asText()),
+                ExportVaultEvent.ShowSnackbar(R.string.export_vault_success.asText()),
                 awaitItem(),
             )
         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23320](https://bitwarden.atlassian.net/browse/PM-23320)

## 📔 Objective

This PR replaces the `ExportVaultScreen` toasts with Snackbars.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/cbd94627-afe7-47cf-b6f9-468921098068" width="300" /> | <img src="https://github.com/user-attachments/assets/c73c3fcb-c90a-4f73-9db2-5be05568cab6" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23320]: https://bitwarden.atlassian.net/browse/PM-23320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ