### PR TITLE
PM-23322: Replace VaultItemScreen toasts with snackbars

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -141,7 +141,12 @@ class SearchViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
         snackbarRelayManager
-            .getSnackbarDataFlow(SnackbarRelay.SEND_DELETED, SnackbarRelay.SEND_UPDATED)
+            .getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_DELETED,
+                SnackbarRelay.CIPHER_RESTORED,
+                SnackbarRelay.SEND_DELETED,
+                SnackbarRelay.SEND_UPDATED,
+            )
             .map { SearchAction.Internal.SnackbarDataReceived(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelay.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelay.kt
@@ -9,6 +9,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 enum class SnackbarRelay {
+    CIPHER_DELETED,
+    CIPHER_RESTORED,
     LOGINS_IMPORTED,
     SEND_DELETED,
     SEND_UPDATED,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.vault.feature.item
 
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
@@ -14,7 +13,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -37,6 +35,8 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
+import com.x8bit.bitwarden.ui.platform.components.snackbar.rememberBitwardenSnackbarHostState
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
@@ -63,9 +63,6 @@ fun VaultItemScreen(
     onNavigateToPasswordHistory: (vaultItemId: String) -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
-
     val fileChooserLauncher = intentManager.getActivityResultLauncher { activityResult ->
         intentManager.getFileDataFromActivityResult(activityResult)
             ?.let {
@@ -75,7 +72,7 @@ fun VaultItemScreen(
             }
             ?: viewModel.trySendAction(VaultItemAction.Common.NoAttachmentFileLocationReceive)
     }
-
+    val snackbarHostState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             VaultItemEvent.NavigateBack -> onNavigateBack()
@@ -109,9 +106,7 @@ fun VaultItemScreen(
                 onNavigateToMoveToOrganization(event.itemId, true)
             }
 
-            is VaultItemEvent.ShowToast -> {
-                Toast.makeText(context, event.message(resources), Toast.LENGTH_SHORT).show()
-            }
+            is VaultItemEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)
 
             is VaultItemEvent.NavigateToSelectAttachmentSaveLocation -> {
                 fileChooserLauncher.launch(
@@ -247,6 +242,9 @@ fun VaultItemScreen(
                         .padding(bottom = 16.dp),
                 )
             }
+        },
+        snackbarHost = {
+            BitwardenSnackbarHost(bitwardenHostState = snackbarHostState)
         },
     ) {
         VaultItemContent(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -217,7 +217,12 @@ class VaultItemListingViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         snackbarRelayManager
-            .getSnackbarDataFlow(SnackbarRelay.SEND_DELETED, SnackbarRelay.SEND_UPDATED)
+            .getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_DELETED,
+                SnackbarRelay.CIPHER_RESTORED,
+                SnackbarRelay.SEND_DELETED,
+                SnackbarRelay.SEND_UPDATED,
+            )
             .map { VaultItemListingsAction.Internal.SnackbarDataReceived(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
@@ -2338,12 +2343,13 @@ data class VaultItemListingState(
      */
     val hasAddItemFabButton: Boolean
         get() = if (restrictItemTypesPolicyOrgIds.isNotEmpty() &&
-                itemListingType == VaultItemListingState.ItemListingType.Vault.Card) {
-                    false
-                } else {
-                    itemListingType.hasFab ||
-                        (viewState as? ViewState.NoItems)?.shouldShowAddButton == true
-                }
+            itemListingType == VaultItemListingState.ItemListingType.Vault.Card
+        ) {
+            false
+        } else {
+            itemListingType.hasFab ||
+                (viewState as? ViewState.NoItems)?.shouldShowAddButton == true
+        }
 
     /**
      * Whether or not this represents a listing screen for autofill.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -169,7 +169,11 @@ class VaultViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         snackbarRelayManager
-            .getSnackbarDataFlow(SnackbarRelay.LOGINS_IMPORTED)
+            .getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_DELETED,
+                SnackbarRelay.CIPHER_RESTORED,
+                SnackbarRelay.LOGINS_IMPORTED,
+            )
             .map { VaultAction.Internal.SnackbarDataReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -41,6 +41,9 @@ import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.DownloadAttachmentResult
 import com.x8bit.bitwarden.data.vault.repository.model.RestoreCipherResult
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
+import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
+import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.x8bit.bitwarden.ui.vault.feature.item.model.TotpCodeItemData
 import com.x8bit.bitwarden.ui.vault.feature.item.model.VaultItemLocation
 import com.x8bit.bitwarden.ui.vault.feature.item.util.createCommonContent
@@ -116,6 +119,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
     }
     private val featureFlagManager: FeatureFlagManager = mockk {
         every { getFeatureFlag(key = FlagKey.RestrictCipherItemDeletion) } returns false
+    }
+    private val snackbarRelayManager: SnackbarRelayManager = mockk {
+        every { sendSnackbarData(data = any(), relay = any()) } just runs
     }
 
     @BeforeEach
@@ -279,7 +285,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
         @Test
         @Suppress("MaxLineLength")
-        fun `ConfirmDeleteClick with DeleteCipherResult Success should should ShowToast and NavigateBack`() =
+        fun `ConfirmDeleteClick with DeleteCipherResult Success should should send snackbar data and NavigateBack`() =
             runTest {
                 every {
                     mockCipherView.toViewState(
@@ -313,12 +319,14 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
                 viewModel.eventFlow.test {
                     assertEquals(
-                        VaultItemEvent.ShowToast(R.string.item_soft_deleted.asText()),
-                        awaitItem(),
-                    )
-                    assertEquals(
                         VaultItemEvent.NavigateBack,
                         awaitItem(),
+                    )
+                }
+                verify {
+                    snackbarRelayManager.sendSnackbarData(
+                        data = BitwardenSnackbarData(message = R.string.item_soft_deleted.asText()),
+                        relay = SnackbarRelay.CIPHER_DELETED,
                     )
                 }
             }
@@ -411,12 +419,14 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
                 viewModel.eventFlow.test {
                     assertEquals(
-                        VaultItemEvent.ShowToast(R.string.item_deleted.asText()),
-                        awaitItem(),
-                    )
-                    assertEquals(
                         VaultItemEvent.NavigateBack,
                         awaitItem(),
+                    )
+                }
+                verify {
+                    snackbarRelayManager.sendSnackbarData(
+                        data = BitwardenSnackbarData(message = R.string.item_deleted.asText()),
+                        relay = SnackbarRelay.CIPHER_DELETED,
                     )
                 }
                 coVerify { vaultRepo.hardDeleteCipher(cipherId = VAULT_ITEM_ID) }
@@ -468,7 +478,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
         @Test
         @Suppress("MaxLineLength")
-        fun `ConfirmRestoreClick with RestoreCipherResult Success should should ShowToast and NavigateBack`() =
+        fun `ConfirmRestoreClick with RestoreCipherResult Success should should send snackbar data and NavigateBack`() =
             runTest {
                 every {
                     mockCipherView.toViewState(
@@ -503,12 +513,14 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
                 viewModel.eventFlow.test {
                     assertEquals(
-                        VaultItemEvent.ShowToast(R.string.item_restored.asText()),
-                        awaitItem(),
-                    )
-                    assertEquals(
                         VaultItemEvent.NavigateBack,
                         awaitItem(),
+                    )
+                }
+                verify {
+                    snackbarRelayManager.sendSnackbarData(
+                        data = BitwardenSnackbarData(message = R.string.item_restored.asText()),
+                        relay = SnackbarRelay.CIPHER_RESTORED,
                     )
                 }
             }
@@ -1075,7 +1087,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
         @Suppress("MaxLineLength")
         @Test
-        fun `on AttachmentFileLocationReceive success should hide loading dialog, copy file, delete file, and show toast`() =
+        fun `on AttachmentFileLocationReceive success should hide loading dialog, copy file, delete file, and show snackbar`() =
             runTest {
                 val file = mockk<File>()
                 val viewModel = createViewModel(state = DEFAULT_STATE, tempAttachmentFile = file)
@@ -1100,7 +1112,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
 
                 viewModel.eventFlow.test {
                     assertEquals(
-                        VaultItemEvent.ShowToast(R.string.save_attachment_success.asText()),
+                        VaultItemEvent.ShowSnackbar(R.string.save_attachment_success.asText()),
                         awaitItem(),
                     )
                 }
@@ -2436,6 +2448,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         environmentRepository = environmentRepository,
         settingsRepository = settingsRepository,
         featureFlagManager = featureFlagManager,
+        snackbarRelayManager = snackbarRelayManager,
     )
 
     private fun createViewState(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -43,7 +43,6 @@ import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
-import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.x8bit.bitwarden.ui.vault.components.model.CreateVaultItemType
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
@@ -86,7 +85,7 @@ class VaultViewModelTest : BaseViewModelTest() {
     private val mutableSnackbarDataFlow = bufferedMutableSharedFlow<BitwardenSnackbarData>()
     private val snackbarRelayManager: SnackbarRelayManager = mockk {
         every {
-            getSnackbarDataFlow(SnackbarRelay.LOGINS_IMPORTED)
+            getSnackbarDataFlow(relay = any(), relays = anyVararg())
         } returns mutableSnackbarDataFlow
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23322](https://bitwarden.atlassian.net/browse/PM-23322)

## 📔 Objective

This PR replaces all the Toasts on the `VaultItemScreen` with a Snackbar.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/013c1b46-d585-4ee4-9248-9ee758f1e639" width="300" /> | <img src="https://github.com/user-attachments/assets/e976aff7-c224-4ea3-884f-eba223691b76" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23322]: https://bitwarden.atlassian.net/browse/PM-23322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ