### PR TITLE
PM-23354: Replace Login Approval toasts with snackbar

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModel.kt
@@ -15,6 +15,9 @@ import com.x8bit.bitwarden.data.auth.manager.model.AuthRequestUpdatesResult
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
+import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
+import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -36,6 +39,7 @@ class LoginApprovalViewModel @Inject constructor(
     private val clock: Clock,
     private val authRepository: AuthRepository,
     private val specialCircumstanceManager: SpecialCircumstanceManager,
+    private val snackbarRelayManager: SnackbarRelayManager,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<LoginApprovalState, LoginApprovalEvent, LoginApprovalAction>(
     initialState = savedStateHandle[KEY_STATE]
@@ -182,8 +186,7 @@ class LoginApprovalViewModel @Inject constructor(
     ) {
         when (val result = action.result) {
             is AuthRequestResult.Success -> {
-                sendEvent(LoginApprovalEvent.ShowToast(R.string.login_approved.asText()))
-                sendClosingEvent()
+                sendClosingEvent(message = R.string.login_approved.asText())
             }
 
             is AuthRequestResult.Error -> {
@@ -246,8 +249,7 @@ class LoginApprovalViewModel @Inject constructor(
     ) {
         when (val result = action.result) {
             is AuthRequestResult.Success -> {
-                sendEvent(LoginApprovalEvent.ShowToast(R.string.log_in_denied.asText()))
-                sendClosingEvent()
+                sendClosingEvent(message = R.string.log_in_denied.asText())
             }
 
             is AuthRequestResult.Error -> {
@@ -264,14 +266,26 @@ class LoginApprovalViewModel @Inject constructor(
         }
     }
 
-    private fun sendClosingEvent() {
-        val event = if (state.specialCircumstance?.shouldFinishWhenComplete == true) {
-            LoginApprovalEvent.ExitApp
-        } else {
-            LoginApprovalEvent.NavigateBack
+    private fun sendClosingEvent(message: Text? = null) {
+        val shouldFinishWhenComplete = state.specialCircumstance?.shouldFinishWhenComplete == true
+        message?.let {
+            if (shouldFinishWhenComplete) {
+                // We are about to exit the app, so we need to use a Toast here.
+                sendEvent(LoginApprovalEvent.ShowToast(it))
+            } else {
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(message = it),
+                    relay = SnackbarRelay.LOGIN_APPROVAL,
+                )
+            }
         }
-
-        sendEvent(event)
+        sendEvent(
+            event = if (shouldFinishWhenComplete) {
+                LoginApprovalEvent.ExitApp
+            } else {
+                LoginApprovalEvent.NavigateBack
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreen.kt
@@ -61,6 +61,8 @@ import com.x8bit.bitwarden.ui.platform.components.content.BitwardenLoadingConten
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.model.rememberBitwardenPullToRefreshState
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
+import com.x8bit.bitwarden.ui.platform.components.snackbar.rememberBitwardenSnackbarHostState
 import com.x8bit.bitwarden.ui.platform.composition.LocalPermissionsManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
 
@@ -84,12 +86,15 @@ fun PendingRequestsScreen(
             { viewModel.trySendAction(PendingRequestsAction.RefreshPull) }
         },
     )
+    val snackbarHostState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             PendingRequestsEvent.NavigateBack -> onNavigateBack()
             is PendingRequestsEvent.NavigateToLoginApproval -> {
                 onNavigateToLoginApproval(event.fingerprint)
             }
+
+            is PendingRequestsEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)
         }
     }
 
@@ -142,6 +147,9 @@ fun PendingRequestsScreen(
             )
         },
         pullToRefreshState = pullToRefreshState,
+        snackbarHost = {
+            BitwardenSnackbarHost(bitwardenHostState = snackbarHostState)
+        },
     ) {
         when (val viewState = state.viewState) {
             is PendingRequestsState.ViewState.Content -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsViewModel.kt
@@ -5,11 +5,15 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.util.toFormattedDateTimeStyle
 import com.bitwarden.core.util.isOverFiveMinutesOld
+import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequest
 import com.x8bit.bitwarden.data.auth.manager.model.AuthRequestsUpdatesResult
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
+import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
+import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
@@ -32,6 +36,7 @@ private const val KEY_STATE = "state"
 class PendingRequestsViewModel @Inject constructor(
     private val clock: Clock,
     private val authRepository: AuthRepository,
+    snackbarRelayManager: SnackbarRelayManager,
     settingsRepository: SettingsRepository,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<PendingRequestsState, PendingRequestsEvent, PendingRequestsAction>(
@@ -50,6 +55,11 @@ class PendingRequestsViewModel @Inject constructor(
         settingsRepository
             .getPullToRefreshEnabledFlow()
             .map { PendingRequestsAction.Internal.PullToRefreshEnableReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+        snackbarRelayManager
+            .getSnackbarDataFlow(SnackbarRelay.LOGIN_APPROVAL)
+            .map { PendingRequestsAction.Internal.SnackbarDataReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
     }
@@ -117,6 +127,10 @@ class PendingRequestsViewModel @Inject constructor(
                 handlePullToRefreshEnableReceive(action)
             }
 
+            is PendingRequestsAction.Internal.SnackbarDataReceive -> {
+                handleSnackbarDataReceive(action)
+            }
+
             is PendingRequestsAction.Internal.AuthRequestsResultReceive -> {
                 handleAuthRequestsResultReceived(action)
             }
@@ -129,6 +143,12 @@ class PendingRequestsViewModel @Inject constructor(
         mutableStateFlow.update {
             it.copy(isPullToRefreshSettingEnabled = action.isPullToRefreshEnabled)
         }
+    }
+
+    private fun handleSnackbarDataReceive(
+        action: PendingRequestsAction.Internal.SnackbarDataReceive,
+    ) {
+        sendEvent(PendingRequestsEvent.ShowSnackbar(action.data))
     }
 
     private fun handleAuthRequestsResultReceived(
@@ -282,6 +302,13 @@ sealed class PendingRequestsEvent {
     data class NavigateToLoginApproval(
         val fingerprint: String,
     ) : PendingRequestsEvent()
+
+    /**
+     * Show a snackbar to the user.
+     */
+    data class ShowSnackbar(
+        val data: BitwardenSnackbarData,
+    ) : PendingRequestsEvent(), BackgroundEvent
 }
 
 /**
@@ -330,6 +357,13 @@ sealed class PendingRequestsAction {
          */
         data class PullToRefreshEnableReceive(
             val isPullToRefreshEnabled: Boolean,
+        ) : Internal()
+
+        /**
+         * Indicates that a snackbar data was received.
+         */
+        data class SnackbarDataReceive(
+            val data: BitwardenSnackbarData,
         ) : Internal()
 
         /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelay.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelay.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.Serializable
 enum class SnackbarRelay {
     CIPHER_DELETED,
     CIPHER_RESTORED,
+    LOGIN_APPROVAL,
     LOGINS_IMPORTED,
     SEND_DELETED,
     SEND_UPDATED,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreenTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.pending
 
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasClickAction
@@ -13,10 +14,12 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.util.isBuildVersionAtLeast
+import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.assertNoDialogExists
 import com.x8bit.bitwarden.data.platform.util.isFdroid
 import com.x8bit.bitwarden.data.util.advanceTimeByAndRunCurrent
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
+import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
 import com.x8bit.bitwarden.ui.platform.manager.permissions.FakePermissionManager
 import io.mockk.every
 import io.mockk.just
@@ -70,6 +73,15 @@ class PendingRequestsScreenTest : BitwardenComposeTest() {
     fun tearDown() {
         unmockkStatic(::isFdroid)
         unmockkStatic(::isBuildVersionAtLeast)
+    }
+
+    @Test
+    fun `on ShowSnackbar should display snackbar content`() {
+        val message = "message"
+        val data = BitwardenSnackbarData(message = message.asText())
+        composeTestRule.onNodeWithText(text = message).assertDoesNotExist()
+        mutableEventFlow.tryEmit(PendingRequestsEvent.ShowSnackbar(data = data))
+        composeTestRule.onNodeWithText(text = message).assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23354](https://bitwarden.atlassian.net/browse/PM-23354)

## 📔 Objective

This PR adds replaces the Pending Approval Toasts with Snackbars when possible.

Note that when approving a login via notification, the app closes after approving or denying the request. Because the app is closed, we still use a Toast in this scenario.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/27928a7f-7bc7-4fc4-a026-1d5353842b5d" width="300" /> | <img src="https://github.com/user-attachments/assets/89598fb2-6a9c-4ead-a162-d6be60951787" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23354]: https://bitwarden.atlassian.net/browse/PM-23354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ