### PR TITLE
PM-23365: Create ToastManager to simplify displaying toasts from a Manager or ViewModel

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -1,8 +1,7 @@
 package com.x8bit.bitwarden.data.auth.manager
 
-import android.content.Context
-import android.widget.Toast
 import androidx.annotation.StringRes
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.manager.DispatcherManager
 import com.x8bit.bitwarden.R
@@ -27,15 +26,15 @@ import timber.log.Timber
  */
 @Suppress("LongParameterList")
 class UserLogoutManagerImpl(
-    private val context: Context,
     private val authDiskSource: AuthDiskSource,
     private val generatorDiskSource: GeneratorDiskSource,
     private val passwordHistoryDiskSource: PasswordHistoryDiskSource,
     private val pushDiskSource: PushDiskSource,
     private val settingsDiskSource: SettingsDiskSource,
+    private val toastManager: ToastManager,
     private val vaultDiskSource: VaultDiskSource,
-    dispatcherManager: DispatcherManager,
     private val vaultSdkSource: VaultSdkSource,
+    dispatcherManager: DispatcherManager,
 ) : UserLogoutManager {
     private val scope = CoroutineScope(dispatcherManager.unconfined)
     private val mainScope = CoroutineScope(dispatcherManager.main)
@@ -117,7 +116,7 @@ class UserLogoutManagerImpl(
     }
 
     private fun showToast(@StringRes message: Int) {
-        mainScope.launch { Toast.makeText(context, message, Toast.LENGTH_SHORT).show() }
+        mainScope.launch { toastManager.show(messageId = message) }
     }
 
     private fun switchUserIfAvailable(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/di/AuthManagerModule.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.auth.manager.di
 
 import android.content.Context
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.network.service.AccountsService
 import com.bitwarden.network.service.AuthRequestsService
@@ -107,23 +108,23 @@ object AuthManagerModule {
     @Provides
     @Singleton
     fun provideUserLogoutManager(
-        @ApplicationContext context: Context,
         authDiskSource: AuthDiskSource,
         generatorDiskSource: GeneratorDiskSource,
         passwordHistoryDiskSource: PasswordHistoryDiskSource,
         pushDiskSource: PushDiskSource,
         settingsDiskSource: SettingsDiskSource,
+        toastManager: ToastManager,
         vaultDiskSource: VaultDiskSource,
         vaultSdkSource: VaultSdkSource,
         dispatcherManager: DispatcherManager,
     ): UserLogoutManager =
         UserLogoutManagerImpl(
-            context = context,
             authDiskSource = authDiskSource,
             generatorDiskSource = generatorDiskSource,
             passwordHistoryDiskSource = passwordHistoryDiskSource,
             pushDiskSource = pushDiskSource,
             settingsDiskSource = settingsDiskSource,
+            toastManager = toastManager,
             vaultDiskSource = vaultDiskSource,
             vaultSdkSource = vaultSdkSource,
             dispatcherManager = dispatcherManager,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/di/AccessibilityModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/di/AccessibilityModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.PowerManager
 import android.view.accessibility.AccessibilityManager
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.data.manager.DispatcherManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityAutofillManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityAutofillManagerImpl
@@ -89,6 +90,7 @@ object AccessibilityModule {
         accessibilityAutofillManager: AccessibilityAutofillManager,
         launcherPackageNameManager: LauncherPackageNameManager,
         powerManager: PowerManager,
+        toastManager: ToastManager,
     ): BitwardenAccessibilityProcessor =
         BitwardenAccessibilityProcessorImpl(
             context = context,
@@ -96,6 +98,7 @@ object AccessibilityModule {
             accessibilityAutofillManager = accessibilityAutofillManager,
             launcherPackageNameManager = launcherPackageNameManager,
             powerManager = powerManager,
+            toastManager = toastManager,
         )
 
     @Singleton

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/processor/BitwardenAccessibilityProcessorImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/processor/BitwardenAccessibilityProcessorImpl.kt
@@ -5,6 +5,7 @@ import android.os.PowerManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.Toast
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityAutofillManager
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.LauncherPackageNameManager
@@ -26,6 +27,7 @@ class BitwardenAccessibilityProcessorImpl(
     private val accessibilityAutofillManager: AccessibilityAutofillManager,
     private val launcherPackageNameManager: LauncherPackageNameManager,
     private val powerManager: PowerManager,
+    private val toastManager: ToastManager,
 ) : BitwardenAccessibilityProcessor {
     override fun processAccessibilityEvent(
         event: AccessibilityEvent,
@@ -110,13 +112,10 @@ class BitwardenAccessibilityProcessorImpl(
                 )
             }
             ?: run {
-                Toast
-                    .makeText(
-                        context,
-                        R.string.autofill_tile_uri_not_found,
-                        Toast.LENGTH_LONG,
-                    )
-                    .show()
+                toastManager.show(
+                    messageId = R.string.autofill_tile_uri_not_found,
+                    duration = Toast.LENGTH_LONG,
+                )
             }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
@@ -93,7 +93,6 @@ object AutofillModule {
     @Singleton
     @Provides
     fun providesAutofillTotpManager(
-        @ApplicationContext context: Context,
         clock: Clock,
         clipboardManager: BitwardenClipboardManager,
         authRepository: AuthRepository,
@@ -101,7 +100,6 @@ object AutofillModule {
         vaultRepository: VaultRepository,
     ): AutofillTotpManager =
         AutofillTotpManagerImpl(
-            context = context,
             clock = clock,
             clipboardManager = clipboardManager,
             authRepository = authRepository,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerImpl.kt
@@ -1,7 +1,5 @@
 package com.x8bit.bitwarden.data.autofill.manager
 
-import android.content.Context
-import android.widget.Toast
 import com.bitwarden.ui.util.asText
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.R
@@ -16,7 +14,6 @@ import java.time.Clock
  * Default implementation of the [AutofillTotpManager].
  */
 class AutofillTotpManagerImpl(
-    private val context: Context,
     private val clock: Clock,
     private val clipboardManager: BitwardenClipboardManager,
     private val authRepository: AuthRepository,
@@ -39,13 +36,6 @@ class AutofillTotpManagerImpl(
                 text = totpResult.code,
                 toastDescriptorOverride = R.string.verification_code_totp.asText(),
             )
-            Toast
-                .makeText(
-                    context.applicationContext,
-                    R.string.verification_code_totp,
-                    Toast.LENGTH_LONG,
-                )
-                .show()
         }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
@@ -4,7 +4,6 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
-import android.widget.Toast
 import androidx.compose.ui.text.AnnotatedString
 import androidx.core.content.getSystemService
 import androidx.core.os.persistableBundleOf
@@ -12,6 +11,8 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.core.data.manager.toast.ToastManager
+import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.ui.platform.base.util.toAnnotatedString
 import com.bitwarden.ui.util.Text
 import com.x8bit.bitwarden.R
@@ -25,6 +26,7 @@ import java.util.concurrent.TimeUnit
 class BitwardenClipboardManagerImpl(
     private val context: Context,
     private val settingsRepository: SettingsRepository,
+    private val toastManager: ToastManager,
 ) : BitwardenClipboardManager {
     private val clipboardManager: ClipboardManager = requireNotNull(context.getSystemService())
 
@@ -45,14 +47,14 @@ class BitwardenClipboardManagerImpl(
                     )
                 },
         )
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+        if (isBuildVersionAtLeast(version = Build.VERSION_CODES.S_V2)) {
             val descriptor = toastDescriptorOverride
                 ?.let { context.resources.getString(R.string.value_has_been_copied, it) }
                 ?: context.resources.getString(
                     R.string.value_has_been_copied,
                     context.resources.getString(R.string.value),
                 )
-            Toast.makeText(context, descriptor, Toast.LENGTH_SHORT).show()
+            toastManager.show(message = descriptor)
         }
 
         val frequency = clearClipboardFrequencySeconds ?: return

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -3,6 +3,8 @@ package com.x8bit.bitwarden.data.platform.manager.di
 import android.app.Application
 import android.content.Context
 import androidx.core.content.getSystemService
+import com.bitwarden.core.data.manager.toast.ToastManager
+import com.bitwarden.core.data.manager.toast.ToastManagerImpl
 import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.data.manager.DispatcherManagerImpl
 import com.bitwarden.data.repository.ServerConfigRepository
@@ -189,9 +191,19 @@ object PlatformManagerModule {
     fun provideBitwardenClipboardManager(
         @ApplicationContext context: Context,
         settingsRepository: SettingsRepository,
+        toastManager: ToastManager,
     ): BitwardenClipboardManager = BitwardenClipboardManagerImpl(
-        context,
-        settingsRepository,
+        context = context,
+        settingsRepository = settingsRepository,
+        toastManager = toastManager,
+    )
+
+    @Provides
+    @Singleton
+    fun provideToastManager(
+        @ApplicationContext context: Context,
+    ): ToastManager = ToastManagerImpl(
+        context = context,
     )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.loginapproval
 
-import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -20,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -57,16 +55,10 @@ fun LoginApprovalScreen(
     onNavigateBack: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             LoginApprovalEvent.ExitApp -> exitManager.exitApplication()
             LoginApprovalEvent.NavigateBack -> onNavigateBack()
-
-            is LoginApprovalEvent.ShowToast -> {
-                Toast.makeText(context, event.message(resources), Toast.LENGTH_SHORT).show()
-            }
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.vault.feature.itemlisting
 
-import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -14,7 +13,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
@@ -96,8 +94,6 @@ fun VaultItemListingScreen(
     viewModel: VaultItemListingViewModel = hiltViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
     val userVerificationHandlers = remember(viewModel) {
         VaultItemListingUserVerificationHandlers.create(viewModel = viewModel)
     }
@@ -120,10 +116,6 @@ fun VaultItemListingScreen(
 
             is VaultItemListingEvent.ShowShareSheet -> {
                 intentManager.shareText(event.content)
-            }
-
-            is VaultItemListingEvent.ShowToast -> {
-                Toast.makeText(context, event.text(resources), Toast.LENGTH_SHORT).show()
             }
 
             is VaultItemListingEvent.NavigateToAddVaultItem -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -9,6 +9,7 @@ import androidx.credentials.provider.ProviderCreateCredentialRequest
 import androidx.credentials.provider.ProviderGetCredentialRequest
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.map
 import com.bitwarden.data.repository.util.baseIconUrl
@@ -142,6 +143,7 @@ class VaultItemListingViewModel @Inject constructor(
     private val networkConnectionManager: NetworkConnectionManager,
     private val featureFlagManager: FeatureFlagManager,
     private val relyingPartyParser: RelyingPartyParser,
+    private val toastManager: ToastManager,
     snackbarRelayManager: SnackbarRelayManager,
 ) : BaseViewModel<VaultItemListingState, VaultItemListingEvent, VaultItemListingsAction>(
     initialState = run {
@@ -1905,7 +1907,7 @@ class VaultItemListingViewModel @Inject constructor(
             is Fido2RegisterCredentialResult.Success -> {
                 // This must be a toast because we are finishing the activity and we want the
                 // user to have time to see the message.
-                sendEvent(VaultItemListingEvent.ShowToast(R.string.item_updated.asText()))
+                toastManager.show(messageId = R.string.item_updated)
                 sendEvent(
                     VaultItemListingEvent.CompleteFido2Registration(
                         RegisterFido2CredentialResult.Success(action.result.responseJson),
@@ -1920,7 +1922,7 @@ class VaultItemListingViewModel @Inject constructor(
     ) {
         // This must be a toast because we are finishing the activity and we want the
         // user to have time to see the message.
-        sendEvent(VaultItemListingEvent.ShowToast(R.string.an_error_has_occurred.asText()))
+        toastManager.show(messageId = R.string.an_error_has_occurred)
         sendEvent(
             VaultItemListingEvent.CompleteFido2Registration(
                 RegisterFido2CredentialResult.Error(
@@ -2887,13 +2889,6 @@ sealed class VaultItemListingEvent {
      * Show a share sheet with the given content.
      */
     data class ShowShareSheet(val content: String) : VaultItemListingEvent()
-
-    /**
-     * Show a toast with the given message.
-     *
-     * @property text the text to display.
-     */
-    data class ShowToast(val text: Text) : VaultItemListingEvent()
 
     /**
      * Show a snackbar to the user.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/processor/BitwardenAccessibilityProcessorTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/accessibility/processor/BitwardenAccessibilityProcessorTest.kt
@@ -6,6 +6,7 @@ import android.os.PowerManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.Toast
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.LoginView
 import com.x8bit.bitwarden.R
@@ -41,6 +42,9 @@ class BitwardenAccessibilityProcessorTest {
     }
     private val launcherPackageNameManager: LauncherPackageNameManager = mockk()
     private val powerManager: PowerManager = mockk()
+    private val toastManager: ToastManager = mockk {
+        every { show(messageId = any(), duration = Toast.LENGTH_LONG) } just runs
+    }
 
     private val bitwardenAccessibilityProcessor: BitwardenAccessibilityProcessor =
         BitwardenAccessibilityProcessorImpl(
@@ -49,6 +53,7 @@ class BitwardenAccessibilityProcessorTest {
             accessibilityAutofillManager = accessibilityAutofillManager,
             launcherPackageNameManager = launcherPackageNameManager,
             powerManager = powerManager,
+            toastManager = toastManager,
         )
 
     @BeforeEach
@@ -58,12 +63,6 @@ class BitwardenAccessibilityProcessorTest {
             AccessibilityNodeInfo::shouldSkipPackage,
         )
         mockkStatic(::createAutofillSelectionIntent)
-        mockkStatic(Toast::class)
-        every {
-            Toast
-                .makeText(context, R.string.autofill_tile_uri_not_found, Toast.LENGTH_LONG)
-                .show()
-        } just runs
     }
 
     @AfterEach
@@ -73,7 +72,6 @@ class BitwardenAccessibilityProcessorTest {
             AccessibilityNodeInfo::shouldSkipPackage,
         )
         unmockkStatic(::createAutofillSelectionIntent)
-        unmockkStatic(Toast::class)
     }
 
     @Test
@@ -252,9 +250,10 @@ class BitwardenAccessibilityProcessorTest {
             accessibilityAutofillManager.accessibilityAction
             accessibilityAutofillManager.accessibilityAction = null
             accessibilityParser.parseForUriOrPackageName(rootNode = node)
-            Toast
-                .makeText(context, R.string.autofill_tile_uri_not_found, Toast.LENGTH_LONG)
-                .show()
+            toastManager.show(
+                messageId = R.string.autofill_tile_uri_not_found,
+                duration = Toast.LENGTH_LONG,
+            )
         }
     }
 
@@ -305,9 +304,10 @@ class BitwardenAccessibilityProcessorTest {
             accessibilityAutofillManager.accessibilityAction = null
             accessibilityParser.parseForUriOrPackageName(rootNode = node)
             accessibilityParser.parseForFillableFields(rootNode = node, uri = uri)
-            Toast
-                .makeText(context, R.string.autofill_tile_uri_not_found, Toast.LENGTH_LONG)
-                .show()
+            toastManager.show(
+                messageId = R.string.autofill_tile_uri_not_found,
+                duration = Toast.LENGTH_LONG,
+            )
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalViewModelTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.loginap
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModelTest
@@ -62,6 +63,9 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
     }
     private val snackbarRelayManager: SnackbarRelayManager = mockk {
         every { sendSnackbarData(data = any(), relay = SnackbarRelay.LOGIN_APPROVAL) } just runs
+    }
+    private val toastManager: ToastManager = mockk {
+        every { show(messageId = any()) } just runs
     }
 
     @BeforeEach
@@ -327,11 +331,10 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 viewModel.trySendAction(LoginApprovalAction.ApproveRequestClick)
-                assertEquals(
-                    LoginApprovalEvent.ShowToast(R.string.login_approved.asText()),
-                    awaitItem(),
-                )
                 assertEquals(LoginApprovalEvent.ExitApp, awaitItem())
+            }
+            verify {
+                toastManager.show(messageId = R.string.login_approved)
             }
         }
 
@@ -397,11 +400,10 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 viewModel.trySendAction(LoginApprovalAction.DeclineRequestClick)
-                assertEquals(
-                    LoginApprovalEvent.ShowToast(R.string.log_in_denied.asText()),
-                    awaitItem(),
-                )
                 assertEquals(LoginApprovalEvent.ExitApp, awaitItem())
+            }
+            verify {
+                toastManager.show(messageId = R.string.log_in_denied)
             }
         }
 
@@ -441,6 +443,7 @@ class LoginApprovalViewModelTest : BaseViewModelTest() {
         authRepository = mockAuthRepository,
         specialCircumstanceManager = mockSpecialCircumstanceManager,
         snackbarRelayManager = snackbarRelayManager,
+        toastManager = toastManager,
         savedStateHandle = SavedStateHandle().apply {
             set("state", state)
             every { toLoginApprovalArgs() } returns LoginApprovalArgs(fingerprint = FINGERPRINT)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -14,6 +14,7 @@ import androidx.credentials.provider.ProviderGetCredentialRequest
 import androidx.credentials.provider.PublicKeyCredentialEntry
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.asFailure
@@ -158,6 +159,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     )
     private val clipboardManager: BitwardenClipboardManager = mockk {
         every { setText(text = any<String>(), toastDescriptorOverride = any<Text>()) } just runs
+    }
+    private val toastManager: ToastManager = mockk {
+        every { show(messageId = any()) } just runs
     }
 
     private val mutableUserStateFlow = MutableStateFlow<UserState?>(DEFAULT_USER_STATE)
@@ -3019,11 +3023,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 assertEquals(
-                    VaultItemListingEvent.ShowToast(R.string.an_error_has_occurred.asText()),
-                    awaitItem(),
-                )
-
-                assertEquals(
                     VaultItemListingEvent.CompleteFido2Registration(
                         RegisterFido2CredentialResult.Error(
                             R.string.passkey_registration_failed_due_to_an_internal_error.asText(),
@@ -3031,6 +3030,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     ),
                     awaitItem(),
                 )
+            }
+            verify {
+                toastManager.show(messageId = R.string.an_error_has_occurred)
             }
         }
 
@@ -3051,11 +3053,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 assertEquals(
-                    VaultItemListingEvent.ShowToast(R.string.item_updated.asText()),
-                    awaitItem(),
-                )
-
-                assertEquals(
                     VaultItemListingEvent.CompleteFido2Registration(
                         RegisterFido2CredentialResult.Success(
                             responseJson = "mockResponse",
@@ -3063,6 +3060,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     ),
                     awaitItem(),
                 )
+            }
+            verify {
+                toastManager.show(messageId = R.string.item_updated)
             }
         }
 
@@ -5322,6 +5322,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             privilegedAppRepository = privilegedAppRepository,
             featureFlagManager = featureFlagManager,
             snackbarRelayManager = snackbarRelayManager,
+            toastManager = toastManager,
             relyingPartyParser = relyingPartyParser,
         )
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
@@ -4,11 +4,11 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
-import android.widget.Toast
 import androidx.compose.ui.text.AnnotatedString
 import androidx.core.content.getSystemService
 import androidx.core.os.persistableBundleOf
 import com.bitwarden.authenticator.R
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.ui.platform.base.util.toAnnotatedString
 import com.bitwarden.ui.util.Text
 
@@ -17,6 +17,7 @@ import com.bitwarden.ui.util.Text
  */
 class BitwardenClipboardManagerImpl(
     private val context: Context,
+    private val toastManager: ToastManager,
 ) : BitwardenClipboardManager {
     private val clipboardManager: ClipboardManager = requireNotNull(context.getSystemService())
 
@@ -35,14 +36,12 @@ class BitwardenClipboardManagerImpl(
                 },
         )
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-            val descriptor = toastDescriptorOverride ?: text
-            Toast
-                .makeText(
-                    context,
-                    context.resources.getString(R.string.value_has_been_copied, descriptor),
-                    Toast.LENGTH_SHORT,
-                )
-                .show()
+            toastManager.show(
+                message = context.resources.getString(
+                    R.string.value_has_been_copied,
+                    toastDescriptorOverride ?: text,
+                ),
+            )
         }
     }
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/di/PlatformManagerModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/di/PlatformManagerModule.kt
@@ -20,6 +20,8 @@ import com.bitwarden.authenticator.data.platform.manager.imports.ImportManager
 import com.bitwarden.authenticator.data.platform.manager.imports.ImportManagerImpl
 import com.bitwarden.authenticator.data.platform.repository.DebugMenuRepository
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
+import com.bitwarden.core.data.manager.toast.ToastManager
+import com.bitwarden.core.data.manager.toast.ToastManagerImpl
 import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.data.manager.DispatcherManagerImpl
 import com.bitwarden.data.repository.ServerConfigRepository
@@ -41,7 +43,19 @@ object PlatformManagerModule {
     @Singleton
     fun provideBitwardenClipboardManager(
         @ApplicationContext context: Context,
-    ): BitwardenClipboardManager = BitwardenClipboardManagerImpl(context)
+        toastManager: ToastManager,
+    ): BitwardenClipboardManager = BitwardenClipboardManagerImpl(
+        context = context,
+        toastManager = toastManager,
+    )
+
+    @Provides
+    @Singleton
+    fun provideToastManager(
+        @ApplicationContext context: Context,
+    ): ToastManager = ToastManagerImpl(
+        context = context,
+    )
 
     @Provides
     @Singleton

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/toast/ToastManager.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/toast/ToastManager.kt
@@ -1,0 +1,19 @@
+package com.bitwarden.core.data.manager.toast
+
+import android.widget.Toast
+import androidx.annotation.StringRes
+
+/**
+ * Wrapper class for displaying a [Toast].
+ */
+interface ToastManager {
+    /**
+     * Displays a [Toast] with the given [message].
+     */
+    fun show(message: CharSequence, duration: Int = Toast.LENGTH_SHORT)
+
+    /**
+     * Displays a [Toast] with the given [messageId].
+     */
+    fun show(@StringRes messageId: Int, duration: Int = Toast.LENGTH_SHORT)
+}

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/toast/ToastManagerImpl.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/toast/ToastManagerImpl.kt
@@ -1,0 +1,19 @@
+package com.bitwarden.core.data.manager.toast
+
+import android.content.Context
+import android.widget.Toast
+
+/**
+ * The default implementation of the [ToastManager].
+ */
+class ToastManagerImpl(
+    private val context: Context,
+) : ToastManager {
+    override fun show(message: CharSequence, duration: Int) {
+        Toast.makeText(context, message, duration).show()
+    }
+
+    override fun show(messageId: Int, duration: Int) {
+        Toast.makeText(context, messageId, duration).show()
+    }
+}

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/toast/ToastManagerTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/toast/ToastManagerTest.kt
@@ -1,0 +1,68 @@
+package com.bitwarden.core.data.manager.toast
+
+import android.content.Context
+import android.widget.Toast
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ToastManagerTest {
+    private val context: Context = mockk()
+    private val toast: Toast = mockk {
+        every { show() } just runs
+    }
+    private val toastManager: ToastManager = ToastManagerImpl(
+        context = context,
+    )
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(Toast::class)
+        every { Toast.makeText(context, any<CharSequence>(), any()) } returns toast
+        every { Toast.makeText(context, any<Int>(), any()) } returns toast
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Toast::class)
+    }
+
+    @Test
+    fun `show with string should call show on Toast`() {
+        val message = "Test"
+        toastManager.show(message = message)
+        verify {
+            Toast.makeText(context, message, Toast.LENGTH_SHORT)
+            toast.show()
+        }
+
+        toastManager.show(message = message, Toast.LENGTH_LONG)
+        verify {
+            Toast.makeText(context, message, Toast.LENGTH_LONG)
+            toast.show()
+        }
+    }
+
+    @Test
+    fun `show with string resource should call show on Toast`() {
+        val messageId = 555
+        toastManager.show(messageId = messageId)
+        verify {
+            Toast.makeText(context, messageId, Toast.LENGTH_SHORT)
+            toast.show()
+        }
+
+        toastManager.show(messageId = messageId, Toast.LENGTH_LONG)
+        verify {
+            Toast.makeText(context, messageId, Toast.LENGTH_LONG)
+            toast.show()
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23365](https://bitwarden.atlassian.net/browse/PM-23365)

## 📔 Objective

This PR simplifies the usage of Toasts by wrapping the static functionality in a manager class. (this is great for tests too!)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23365]: https://bitwarden.atlassian.net/browse/PM-23365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ