### PR TITLE
custom fields: hide or show move up or down actions depending on the items' index

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditAdditionalOptions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditAdditionalOptions.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -110,10 +110,10 @@ fun LazyListScope.vaultAddEditAdditionalOptions(
             }
         }
 
-        items(
+        itemsIndexed(
             items = commonState.customFieldData,
-            key = { "customField_${it.itemId}" },
-        ) { customItem ->
+            key = { _, customItem -> "customField_${customItem.itemId}" },
+        ) { index, customItem ->
             Column(
                 modifier = Modifier
                     .animateItem()
@@ -125,6 +125,8 @@ fun LazyListScope.vaultAddEditAdditionalOptions(
                     customField = customItem,
                     onCustomFieldValueChange = commonTypeHandlers.onCustomFieldValueChange,
                     onCustomFieldAction = commonTypeHandlers.onCustomFieldActionSelect,
+                    showMoveUpAction = index > 0,
+                    showMoveDownAction = index < commonState.customFieldData.lastIndex,
                     onHiddenVisibilityChanged = commonTypeHandlers.onHiddenFieldVisibilityChange,
                     supportedLinkedTypes = itemType.vaultLinkedFieldTypes,
                     cardStyle = CardStyle.Full,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomField.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomField.kt
@@ -34,6 +34,8 @@ import kotlinx.collections.immutable.toImmutableList
  * @param customField The field that is to be displayed.
  * @param onCustomFieldValueChange Invoked when the user changes the value.
  * @param onCustomFieldAction Invoked when the user chooses an action.
+ * @param showMoveUpAction Whether the [CustomFieldAction.MOVE_UP] is displayed in the action dialog.
+ * @param showMoveDownAction Whether the [CustomFieldAction.MOVE_DOWN] is displayed in the action dialog.
  * @param onHiddenVisibilityChanged Emits when the visibility of a hidden custom field changes.
  * @param cardStyle Indicates the type of card style to be applied.
  * @param modifier Modifier for the UI elements.
@@ -45,6 +47,8 @@ fun VaultAddEditCustomField(
     customField: VaultAddEditState.Custom,
     onCustomFieldValueChange: (VaultAddEditState.Custom) -> Unit,
     onCustomFieldAction: (CustomFieldAction, VaultAddEditState.Custom) -> Unit,
+    showMoveUpAction: Boolean,
+    showMoveDownAction: Boolean,
     onHiddenVisibilityChanged: (Boolean) -> Unit,
     cardStyle: CardStyle,
     modifier: Modifier = Modifier,
@@ -55,6 +59,13 @@ fun VaultAddEditCustomField(
 
     if (shouldShowChooserDialog) {
         CustomFieldActionDialog(
+            customFieldActions = CustomFieldAction.entries.filter { action ->
+                when (action) {
+                    CustomFieldAction.MOVE_UP -> showMoveUpAction
+                    CustomFieldAction.MOVE_DOWN -> showMoveDownAction
+                    else -> true
+                }
+            },
             onCustomFieldAction = { action ->
                 shouldShowChooserDialog = false
                 onCustomFieldAction(action, customField)
@@ -281,6 +292,7 @@ private fun CustomFieldLinkedField(
  */
 @Composable
 private fun CustomFieldActionDialog(
+    customFieldActions: List<CustomFieldAction> = CustomFieldAction.entries,
     onCustomFieldAction: (CustomFieldAction) -> Unit,
     onEditAction: () -> Unit,
     onDismissRequest: () -> Unit,
@@ -289,20 +301,18 @@ private fun CustomFieldActionDialog(
         title = stringResource(id = R.string.options),
         onDismissRequest = onDismissRequest,
     ) {
-        CustomFieldAction
-            .entries
-            .forEach { action ->
-                BitwardenBasicDialogRow(
-                    text = action.actionText.invoke(),
-                    onClick = {
-                        if (action == CustomFieldAction.EDIT) {
-                            onEditAction()
-                        } else {
-                            onCustomFieldAction(action)
-                        }
-                    },
-                )
-            }
+        customFieldActions.forEach { action ->
+            BitwardenBasicDialogRow(
+                text = action.actionText.invoke(),
+                onClick = {
+                    if (action == CustomFieldAction.EDIT) {
+                        onEditAction()
+                    } else {
+                        onCustomFieldAction(action)
+                    }
+                },
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -854,9 +854,6 @@ class VaultAddEditViewModel @Inject constructor(
                         .toMutableList()
 
                 val index = items.lastIndexOf(action.customField)
-                if (index == 0) {
-                    return
-                }
 
                 Collections.swap(items, index, index - 1)
 
@@ -875,9 +872,6 @@ class VaultAddEditViewModel @Inject constructor(
                         .toMutableList()
 
                 val index = items.indexOf(action.customField)
-                if (index == items.lastIndex) {
-                    return
-                }
 
                 Collections.swap(items, index, index + 1)
 


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Currently move up and down actions are displayed for all custom fields, although no action is triggered in some scenarios.
This PR hides the corresponding action, if it's not need for the specific field.
- When only one custom field is present no move actions are displayed
- When two fields are added only move down for the first or move up for the last is displayed
- When there are three or more items both actions are displayed for fields between the first and the last

## 📸 Screenshots

<img src="https://github.com/user-attachments/assets/f74ee248-87cd-44b8-a1bf-b090410d2e1f" width="250">
<img src="https://github.com/user-attachments/assets/5cffc202-3baa-40b0-8a2c-0e7623d653b6" width="250">
<img src="https://github.com/user-attachments/assets/d76ca22e-035f-48d2-b64d-f3dfb6fbd39c" width="250">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
