### PR TITLE
PM-19780: Fix incorrect sub header on authenticator search screen

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchContent.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchContent.kt
@@ -33,7 +33,7 @@ fun ItemSearchContent(
         if (viewState.hasLocalAndSharedItems) {
             item {
                 BitwardenListHeaderText(
-                    label = stringResource(id = R.string.local_codes),
+                    label = viewState.localListHeader(),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchScreen.kt
@@ -1,7 +1,6 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.search
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -75,29 +74,24 @@ fun ItemSearchScreen(
             )
         },
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
-        ) {
-            val innerModifier = Modifier
-                .fillMaxSize()
+        when (val viewState = state.viewState) {
+            is ItemSearchState.ViewState.Content -> {
+                ItemSearchContent(
+                    viewState = viewState,
+                    searchHandlers = searchHandlers,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues = innerPadding),
+                )
+            }
 
-            when (val viewState = state.viewState) {
-                is ItemSearchState.ViewState.Content -> {
-                    ItemSearchContent(
-                        viewState = viewState,
-                        searchHandlers = searchHandlers,
-                        modifier = innerModifier,
-                    )
-                }
-
-                is ItemSearchState.ViewState.Empty -> {
-                    ItemSearchEmptyContent(
-                        viewState = viewState,
-                        modifier = innerModifier,
-                    )
-                }
+            is ItemSearchState.ViewState.Empty -> {
+                ItemSearchEmptyContent(
+                    viewState = viewState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues = innerPadding),
+                )
             }
         }
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModel.kt
@@ -222,6 +222,11 @@ data class ItemSearchState(
             val sharedItems: SharedCodesDisplayState,
         ) : ViewState() {
             /**
+             * The header to display for the local codes.
+             */
+            val localListHeader: Text get() = R.string.local_codes.asText(itemList.size)
+
+            /**
              * Whether or not there should be a "Local codes" header shown above local codes.
              */
             val hasLocalAndSharedItems get() = !sharedItems.isEmpty() && itemList.isNotEmpty()


### PR DESCRIPTION
## 🎟️ Tracking

PM-19780

## 📔 Objective

This PR update the `Local codes` subheader on the search screen to properly display the number of local items.

The root column has also been updated to simplify the layout.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/7a4075df-9065-4106-9d9f-127a124f5026" width="300" /> | <img src="https://github.com/user-attachments/assets/9d9f629e-c8b9-4125-8b02-da3116dec457" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
