### PR TITLE
PM-14063: SDK persistance state

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -246,7 +246,7 @@ class FirstTimeActionManagerImpl @Inject constructor(
         return authDiskSource
             .getShowImportLoginsFlow(userId)
             .combine(
-                vaultDiskSource.getCiphers(userId),
+                vaultDiskSource.getCiphersFlow(userId),
             ) { showImportLogins, ciphers ->
                 showImportLogins ?: true && ciphers.isEmpty()
             }
@@ -260,7 +260,7 @@ class FirstTimeActionManagerImpl @Inject constructor(
         return settingsDiskSource
             .getShowImportLoginsSettingBadgeFlow(userId)
             .combine(
-                vaultDiskSource.getCiphers(userId),
+                vaultDiskSource.getCiphersFlow(userId),
             ) { showImportLogins, ciphers ->
                 showImportLogins ?: false && ciphers.isEmpty()
             }
@@ -297,7 +297,7 @@ class FirstTimeActionManagerImpl @Inject constructor(
             .flatMapLatest { activeUserId ->
                 combine(
                     flow = this,
-                    flow2 = vaultDiskSource.getCiphers(activeUserId),
+                    flow2 = vaultDiskSource.getCiphersFlow(activeUserId),
                 ) { receiverCurrentValue, ciphers ->
                     receiverCurrentValue && ciphers.none {
                         it.login != null && it.organizationId == null

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -69,6 +69,8 @@ import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManage
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.restriction.RestrictionManager
 import com.x8bit.bitwarden.data.platform.manager.restriction.RestrictionManagerImpl
+import com.x8bit.bitwarden.data.platform.manager.sdk.SdkRepositoryFactory
+import com.x8bit.bitwarden.data.platform.manager.sdk.SdkRepositoryFactoryImpl
 import com.x8bit.bitwarden.data.platform.processor.AuthenticatorBridgeProcessor
 import com.x8bit.bitwarden.data.platform.processor.AuthenticatorBridgeProcessorImpl
 import com.x8bit.bitwarden.data.platform.repository.AuthenticatorBridgeRepository
@@ -245,9 +247,11 @@ object PlatformManagerModule {
     fun provideSdkClientManager(
         featureFlagManager: FeatureFlagManager,
         nativeLibraryManager: NativeLibraryManager,
+        sdkRepositoryFactory: SdkRepositoryFactory,
     ): SdkClientManager = SdkClientManagerImpl(
         featureFlagManager = featureFlagManager,
         nativeLibraryManager = nativeLibraryManager,
+        sdkRepoFactory = sdkRepositoryFactory,
     )
 
     @Provides
@@ -384,6 +388,14 @@ object PlatformManagerModule {
         settingsDiskSource = settingsDiskSource,
         autofillEnabledManager = autofillEnabledManager,
         accessibilityEnabledManager = accessibilityEnabledManager,
+    )
+
+    @Provides
+    @Singleton
+    fun provideSdkRepositoryFactory(
+        vaultDiskSource: VaultDiskSource,
+    ): SdkRepositoryFactory = SdkRepositoryFactoryImpl(
+        vaultDiskSource = vaultDiskSource,
     )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactory.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactory.kt
@@ -1,0 +1,13 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk
+
+import com.bitwarden.sdk.CipherRepository
+
+/**
+ * Creates and manages sdk repositories.
+ */
+interface SdkRepositoryFactory {
+    /**
+     * Retrieves or creates a [CipherRepository] for use with the Bitwarden SDK.
+     */
+    fun getCipherRepository(userId: String): CipherRepository
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryImpl.kt
@@ -1,0 +1,20 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk
+
+import com.bitwarden.sdk.CipherRepository
+import com.x8bit.bitwarden.data.platform.manager.sdk.repository.SdkCipherRepository
+import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
+
+/**
+ * The default implementation for the [SdkRepositoryFactory].
+ */
+class SdkRepositoryFactoryImpl(
+    private val vaultDiskSource: VaultDiskSource,
+) : SdkRepositoryFactory {
+    override fun getCipherRepository(
+        userId: String,
+    ): CipherRepository =
+        SdkCipherRepository(
+            userId = userId,
+            vaultDiskSource = vaultDiskSource,
+        )
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkCipherRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkCipherRepository.kt
@@ -1,0 +1,43 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk.repository
+
+import com.bitwarden.sdk.CipherRepository
+import com.bitwarden.vault.Cipher
+import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedNetworkCipherResponse
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipher
+import timber.log.Timber
+
+/**
+ * A user-scoped implementation of a Bitwarden SDK [CipherRepository].
+ */
+class SdkCipherRepository(
+    private val userId: String,
+    private val vaultDiskSource: VaultDiskSource,
+) : CipherRepository {
+    override suspend fun get(id: String): Cipher? =
+        vaultDiskSource
+            .getCipher(userId = userId, cipherId = id)
+            ?.toEncryptedSdkCipher()
+
+    override suspend fun has(id: String): Boolean = this.get(id = id) != null
+
+    override suspend fun list(): List<Cipher> =
+        vaultDiskSource
+            .getCiphers(userId = userId)
+            .map { it.toEncryptedSdkCipher() }
+
+    override suspend fun remove(id: String) {
+        vaultDiskSource.deleteCipher(userId = userId, cipherId = id)
+    }
+
+    override suspend fun set(id: String, value: Cipher) {
+        if (id != value.id) {
+            Timber.e("SDK Cipher 'set' operation: ID's do not match")
+            return
+        }
+        vaultDiskSource.saveCipher(
+            userId = userId,
+            cipher = value.toEncryptedNetworkCipherResponse(encryptedFor = userId),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
@@ -95,7 +95,7 @@ class AuthenticatorBridgeRepositoryImpl(
 
                 // Vault is unlocked, query vault disk source for totp logins:
                 val totpUris = vaultDiskSource
-                    .getCiphers(userId)
+                    .getCiphersFlow(userId)
                     .first()
                     // Filter out any ciphers without a totp item and also deleted ciphers
                     .filter { it.login?.totp != null && it.deletedDate == null }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
@@ -20,6 +20,16 @@ interface VaultDiskSource {
     fun getCiphersFlow(userId: String): Flow<List<SyncResponseJson.Cipher>>
 
     /**
+     * Retrieves all ciphers from the data source for a given [userId].
+     */
+    suspend fun getCiphers(userId: String): List<SyncResponseJson.Cipher>
+
+    /**
+     * Retrieves a cipher from the data source for a given [userId] and [cipherId].
+     */
+    suspend fun getCipher(userId: String, cipherId: String): SyncResponseJson.Cipher?
+
+    /**
      * Deletes a cipher from the data source for the given [userId] and [cipherId].
      */
     suspend fun deleteCipher(userId: String, cipherId: String)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
@@ -15,9 +15,9 @@ interface VaultDiskSource {
     suspend fun saveCipher(userId: String, cipher: SyncResponseJson.Cipher)
 
     /**
-     * Retrieves all ciphers from the data source for a given [userId].
+     * Retrieves all ciphers from the data source for a given [userId] as a [Flow].
      */
-    fun getCiphers(userId: String): Flow<List<SyncResponseJson.Cipher>>
+    fun getCiphersFlow(userId: String): Flow<List<SyncResponseJson.Cipher>>
 
     /**
      * Deletes a cipher from the data source for the given [userId] and [cipherId].
@@ -72,13 +72,13 @@ interface VaultDiskSource {
     /**
      * Replaces all [vault] data for a given [userId] with the new `vault`.
      *
-     * This will always cause the [getCiphers], [getCollections], and [getFolders] functions to
+     * This will always cause the [getCiphersFlow], [getCollections], and [getFolders] functions to
      * re-emit even if the underlying data has not changed.
      */
     suspend fun replaceVaultData(userId: String, vault: SyncResponseJson)
 
     /**
-     * Trigger re-emissions from the [getCiphers], [getCollections], [getFolders], and [getSends]
+     * Trigger re-emissions from the [getCiphersFlow], [getCollections], [getFolders], and [getSends]
      * functions.
      */
     suspend fun resyncVaultData(userId: String)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -59,13 +59,13 @@ class VaultDiskSourceImpl(
         )
     }
 
-    override fun getCiphers(
+    override fun getCiphersFlow(
         userId: String,
     ): Flow<List<SyncResponseJson.Cipher>> =
         merge(
             forceCiphersFlow,
             ciphersDao
-                .getAllCiphers(userId = userId)
+                .getAllCiphersFlow(userId = userId)
                 .map { entities ->
                     withContext(context = dispatcherManager.default) {
                         entities
@@ -296,7 +296,7 @@ class VaultDiskSourceImpl(
 
     override suspend fun resyncVaultData(userId: String) {
         coroutineScope {
-            val deferredCiphers = async { getCiphers(userId = userId).first() }
+            val deferredCiphers = async { getCiphersFlow(userId = userId).first() }
             val deferredCollections = async { getCollections(userId = userId).first() }
             val deferredFolders = async { getFolders(userId = userId).first() }
             val deferredSends = async { getSends(userId = userId).first() }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/CiphersDao.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/CiphersDao.kt
@@ -30,6 +30,23 @@ interface CiphersDao {
     ): Flow<List<CipherEntity>>
 
     /**
+     * Retrieves all ciphers from the database for a given [userId].
+     */
+    @Query("SELECT * FROM ciphers WHERE user_id = :userId")
+    suspend fun getAllCiphers(
+        userId: String,
+    ): List<CipherEntity>
+
+    /**
+     * Retrieves a cipher from the database for a given [userId] and [cipherId].
+     */
+    @Query("SELECT * FROM ciphers WHERE user_id = :userId AND id = :cipherId LIMIT 1")
+    suspend fun getCipher(
+        userId: String,
+        cipherId: String,
+    ): CipherEntity?
+
+    /**
      * Deletes all the stored ciphers associated with the given [userId]. This will return the
      * number of rows deleted by this query.
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/CiphersDao.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/CiphersDao.kt
@@ -22,10 +22,10 @@ interface CiphersDao {
     suspend fun insertCiphers(ciphers: List<CipherEntity>)
 
     /**
-     * Retrieves all ciphers from the database for a given [userId].
+     * Retrieves all ciphers from the database for a given [userId] as a [Flow].
      */
     @Query("SELECT * FROM ciphers WHERE user_id = :userId")
-    fun getAllCiphers(
+    fun getAllCiphersFlow(
         userId: String,
     ): Flow<List<CipherEntity>>
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -922,7 +922,7 @@ class VaultRepositoryImpl(
     }
 
     private suspend fun clearFolderIdFromCiphers(folderId: String, userId: String) {
-        vaultDiskSource.getCiphers(userId).firstOrNull()?.forEach {
+        vaultDiskSource.getCiphersFlow(userId).firstOrNull()?.forEach {
             if (it.folderId == folderId) {
                 vaultDiskSource.saveCipher(
                     userId, it.copy(folderId = null),
@@ -941,7 +941,7 @@ class VaultRepositoryImpl(
             .map { it.toEncryptedSdkFolder() }
 
         val ciphers = vaultDiskSource
-            .getCiphers(userId)
+            .getCiphersFlow(userId)
             .firstOrNull()
             .orEmpty()
             .map { it.toEncryptedSdkCipher() }
@@ -1067,7 +1067,7 @@ class VaultRepositoryImpl(
         userId: String,
     ): Flow<DataState<List<CipherView>>> =
         vaultDiskSource
-            .getCiphers(userId = userId)
+            .getCiphersFlow(userId = userId)
             .onStart { mutableCiphersStateFlow.updateToPendingOrLoading() }
             .map {
                 waitUntilUnlocked(userId = userId)
@@ -1088,7 +1088,7 @@ class VaultRepositoryImpl(
         userId: String,
     ): Flow<DataState<List<CipherListView>>> =
         vaultDiskSource
-            .getCiphers(userId = userId)
+            .getCiphersFlow(userId = userId)
             .onStart { mutableCiphersListViewStateFlow.updateToPendingOrLoading() }
             .map {
                 waitUntilUnlocked(userId = userId)
@@ -1488,7 +1488,7 @@ class VaultRepositoryImpl(
                                 )
                                 vaultDiskSource.resyncVaultData(userId = userId)
                                 val itemsAvailable = vaultDiskSource
-                                    .getCiphers(userId)
+                                    .getCiphersFlow(userId)
                                     .firstOrNull()
                                     ?.isNotEmpty() == true
                                 return SyncVaultDataResult.Success(itemsAvailable = itemsAvailable)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -33,7 +33,7 @@ class FirstTimeActionManagerTest {
     private val fakeSettingsDiskSource = FakeSettingsDiskSource()
     private val mutableCiphersListFlow = MutableStateFlow(emptyList<SyncResponseJson.Cipher>())
     private val vaultDiskSource = mockk<VaultDiskSource> {
-        every { getCiphers(any()) } returns mutableCiphersListFlow
+        every { getCiphersFlow(any()) } returns mutableCiphersListFlow
     }
 
     private val mutableImportLoginsFlow = MutableStateFlow(false)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerTest.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager
 
 import com.bitwarden.core.util.isBuildVersionAtLeast
+import com.x8bit.bitwarden.data.platform.manager.sdk.SdkRepositoryFactory
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -17,6 +18,9 @@ class SdkClientManagerTest {
 
     private val mockNativeLibraryManager = mockk<NativeLibraryManager> {
         every { loadLibrary(any()) } returns Result.success(Unit)
+    }
+    private val sdkRepoFactory: SdkRepositoryFactory = mockk {
+        every { getCipherRepository(userId = any()) } returns mockk()
     }
 
     @BeforeEach
@@ -82,5 +86,6 @@ class SdkClientManagerTest {
         clientProvider = { mockk(relaxed = true) },
         nativeLibraryManager = mockNativeLibraryManager,
         featureFlagManager = mockk(),
+        sdkRepoFactory = sdkRepoFactory,
     )
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryTests.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryTests.kt
@@ -1,0 +1,30 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk
+
+import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class SdkRepositoryFactoryTests {
+
+    private val vaultDiskSource: VaultDiskSource = mockk()
+
+    private val sdkRepoFactory: SdkRepositoryFactory = SdkRepositoryFactoryImpl(
+        vaultDiskSource = vaultDiskSource,
+    )
+
+    @Test
+    fun `getCipherRepository should create a new client`() {
+        val userId = "userId"
+        val firstClient = sdkRepoFactory.getCipherRepository(userId = userId)
+
+        // Additional calls for the same userId should create a repo
+        val secondClient = sdkRepoFactory.getCipherRepository(userId = userId)
+        assertNotEquals(firstClient, secondClient)
+
+        // Additional calls for different userIds should return a different repo
+        val otherUserId = "otherUserId"
+        val thirdClient = sdkRepoFactory.getCipherRepository(userId = otherUserId)
+        assertNotEquals(firstClient, thirdClient)
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkCipherRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkCipherRepositoryTest.kt
@@ -1,0 +1,190 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk.repository
+
+import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.sdk.CipherRepository
+import com.bitwarden.vault.Cipher
+import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedNetworkCipherResponse
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipher
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SdkCipherRepositoryTest {
+
+    private val vaultDiskSource: VaultDiskSource = mockk()
+
+    private val sdkCipherRepository: CipherRepository = SdkCipherRepository(
+        userId = USER_ID,
+        vaultDiskSource = vaultDiskSource,
+    )
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(
+            SyncResponseJson.Cipher::toEncryptedSdkCipher,
+            Cipher::toEncryptedNetworkCipherResponse,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockkStatic(
+            SyncResponseJson.Cipher::toEncryptedSdkCipher,
+            Cipher::toEncryptedNetworkCipherResponse,
+        )
+    }
+
+    @Test
+    fun `get should return null when not present`() = runTest {
+        val cipherId = "cipherId"
+        coEvery { vaultDiskSource.getCipher(userId = USER_ID, cipherId = cipherId) } returns null
+
+        val result = sdkCipherRepository.get(id = cipherId)
+
+        assertNull(result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getCipher(userId = USER_ID, cipherId = cipherId)
+        }
+    }
+
+    @Test
+    fun `get should return an encrypted sdk cipher when present`() = runTest {
+        val cipherId = "cipherId"
+        val expected = mockk<Cipher>()
+        val responseCipher = mockk<SyncResponseJson.Cipher> {
+            every { toEncryptedSdkCipher() } returns expected
+        }
+        coEvery {
+            vaultDiskSource.getCipher(userId = USER_ID, cipherId = cipherId)
+        } returns responseCipher
+
+        val result = sdkCipherRepository.get(id = cipherId)
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getCipher(userId = USER_ID, cipherId = cipherId)
+        }
+    }
+
+    @Test
+    fun `has should return false when not present`() = runTest {
+        val cipherId = "cipherId"
+        coEvery { vaultDiskSource.getCipher(userId = USER_ID, cipherId = cipherId) } returns null
+
+        val result = sdkCipherRepository.has(id = cipherId)
+
+        assertFalse(result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getCipher(userId = USER_ID, cipherId = cipherId)
+        }
+    }
+
+    @Test
+    fun `get should return true when present`() = runTest {
+        val cipherId = "cipherId"
+        val responseCipher = mockk<SyncResponseJson.Cipher> {
+            every { toEncryptedSdkCipher() } returns mockk<Cipher>()
+        }
+        coEvery {
+            vaultDiskSource.getCipher(userId = USER_ID, cipherId = cipherId)
+        } returns responseCipher
+
+        val result = sdkCipherRepository.has(id = cipherId)
+
+        assertTrue(result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getCipher(userId = USER_ID, cipherId = cipherId)
+        }
+    }
+
+    @Test
+    fun `list should return empty list when nothing present`() = runTest {
+        coEvery { vaultDiskSource.getCiphers(userId = USER_ID) } returns emptyList()
+
+        val result = sdkCipherRepository.list()
+
+        assertEquals(emptyList<Cipher>(), result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getCiphers(userId = USER_ID)
+        }
+    }
+
+    @Test
+    fun `list should return encrypted sdk cipher list when present`() = runTest {
+        val expectedCipher = mockk<Cipher>()
+        val expected = listOf(expectedCipher)
+        val responseCipher = mockk<SyncResponseJson.Cipher> {
+            every { toEncryptedSdkCipher() } returns expectedCipher
+        }
+        coEvery { vaultDiskSource.getCiphers(userId = USER_ID) } returns listOf(responseCipher)
+
+        val result = sdkCipherRepository.list()
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getCiphers(userId = USER_ID)
+        }
+    }
+
+    @Test
+    fun `remove should call deleteCipher on the vaultDiskSource`() = runTest {
+        val cipherId = "cipherId"
+        coEvery { vaultDiskSource.deleteCipher(userId = USER_ID, cipherId = cipherId) } just runs
+
+        sdkCipherRepository.remove(id = cipherId)
+
+        coVerify(exactly = 1) {
+            vaultDiskSource.deleteCipher(userId = USER_ID, cipherId = cipherId)
+        }
+    }
+
+    @Test
+    fun `set should do nothing if the ids don't match`() = runTest {
+        val cipherId = "cipherId"
+        val cipher = mockk<Cipher> {
+            every { id } returns "differentCipherId"
+        }
+
+        sdkCipherRepository.set(id = cipherId, value = cipher)
+
+        coVerify(exactly = 0) {
+            vaultDiskSource.saveCipher(userId = any(), cipher = any())
+        }
+    }
+
+    @Test
+    fun `set should call saveCipher on vaultDiskSource if ids match`() = runTest {
+        val cipherId = "cipherId"
+        val responseCipher = mockk<SyncResponseJson.Cipher>()
+        val cipher = mockk<Cipher> {
+            every { id } returns cipherId
+            every {
+                toEncryptedNetworkCipherResponse(encryptedFor = USER_ID)
+            } returns responseCipher
+        }
+        coEvery {
+            vaultDiskSource.saveCipher(userId = USER_ID, cipher = responseCipher)
+        } just runs
+
+        sdkCipherRepository.set(id = cipherId, value = cipher)
+
+        coVerify(exactly = 1) {
+            vaultDiskSource.saveCipher(userId = USER_ID, cipher = responseCipher)
+        }
+    }
+}
+
+private const val USER_ID: String = "userId"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
@@ -98,8 +98,8 @@ class AuthenticatorBridgeRepositoryTest {
 
         // Add some ciphers to vaultDiskSource for each user,
         // and setup mock decryption for them:
-        every { vaultDiskSource.getCiphers(USER_1_ID) } returns flowOf(USER_1_CIPHERS)
-        every { vaultDiskSource.getCiphers(USER_2_ID) } returns flowOf(USER_2_CIPHERS)
+        every { vaultDiskSource.getCiphersFlow(USER_1_ID) } returns flowOf(USER_1_CIPHERS)
+        every { vaultDiskSource.getCiphersFlow(USER_2_ID) } returns flowOf(USER_2_CIPHERS)
         mockkStatic(SyncResponseJson.Cipher::toEncryptedSdkCipher)
         every {
             USER_1_TOTP_CIPHER.toEncryptedSdkCipher()
@@ -137,8 +137,8 @@ class AuthenticatorBridgeRepositoryTest {
             )
             verify { authRepository.userStateFlow }
             verify { vaultRepository.vaultUnlockDataStateFlow }
-            verify { vaultDiskSource.getCiphers(USER_1_ID) }
-            verify { vaultDiskSource.getCiphers(USER_2_ID) }
+            verify { vaultDiskSource.getCiphersFlow(USER_1_ID) }
+            verify { vaultDiskSource.getCiphersFlow(USER_2_ID) }
             verify { vaultRepository.isVaultUnlocked(USER_1_ID) }
             verify { vaultRepository.isVaultUnlocked(USER_2_ID) }
             coVerify {
@@ -186,7 +186,7 @@ class AuthenticatorBridgeRepositoryTest {
             }
             verify { vaultRepository.vaultUnlockDataStateFlow }
             verify { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) }
-            verify { vaultDiskSource.getCiphers(USER_2_ID) }
+            verify { vaultDiskSource.getCiphersFlow(USER_2_ID) }
             coVerify { vaultSdkSource.decryptCipher(USER_2_ID, USER_2_ENCRYPTED_SDK_TOTP_CIPHER) }
         }
 
@@ -206,7 +206,7 @@ class AuthenticatorBridgeRepositoryTest {
                 sharedAccounts,
             )
             verify { vaultRepository.vaultUnlockDataStateFlow }
-            verify { vaultDiskSource.getCiphers(USER_1_ID) }
+            verify { vaultDiskSource.getCiphersFlow(USER_1_ID) }
             verify { vaultRepository.isVaultUnlocked(USER_1_ID) }
             coVerify { vaultSdkSource.decryptCipher(USER_1_ID, USER_1_ENCRYPTED_SDK_TOTP_CIPHER) }
             verify { authRepository.userStateFlow }
@@ -226,7 +226,7 @@ class AuthenticatorBridgeRepositoryTest {
             }
             verify { vaultRepository.vaultUnlockDataStateFlow }
             verify { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) }
-            verify { vaultDiskSource.getCiphers(USER_2_ID) }
+            verify { vaultDiskSource.getCiphersFlow(USER_2_ID) }
             coVerify { vaultSdkSource.decryptCipher(USER_2_ID, USER_2_ENCRYPTED_SDK_TOTP_CIPHER) }
         }
 
@@ -261,7 +261,7 @@ class AuthenticatorBridgeRepositoryTest {
             }
             verify { vaultRepository.vaultUnlockDataStateFlow }
             verify { vaultRepository.lockVault(USER_2_ID, isUserInitiated = false) }
-            verify { vaultDiskSource.getCiphers(USER_2_ID) }
+            verify { vaultDiskSource.getCiphersFlow(USER_2_ID) }
             coVerify { vaultSdkSource.decryptCipher(USER_2_ID, USER_2_ENCRYPTED_SDK_TOTP_CIPHER) }
         }
 
@@ -284,7 +284,7 @@ class AuthenticatorBridgeRepositoryTest {
             // None of these calls should happen until after user 1's vault state is not UNLOCKING:
             verify(exactly = 0) {
                 vaultRepository.isVaultUnlocked(userId = USER_1_ID)
-                vaultDiskSource.getCiphers(USER_1_ID)
+                vaultDiskSource.getCiphersFlow(USER_1_ID)
             }
 
             // Then move out of UNLOCKING state, and things should proceed as normal:
@@ -296,8 +296,8 @@ class AuthenticatorBridgeRepositoryTest {
             deferred.await()
 
             verify { authRepository.userStateFlow }
-            verify { vaultDiskSource.getCiphers(USER_1_ID) }
-            verify { vaultDiskSource.getCiphers(USER_2_ID) }
+            verify { vaultDiskSource.getCiphersFlow(USER_1_ID) }
+            verify { vaultDiskSource.getCiphersFlow(USER_2_ID) }
             verify { vaultRepository.isVaultUnlocked(USER_1_ID) }
             verify { vaultRepository.isVaultUnlocked(USER_2_ID) }
             verify { vaultRepository.vaultUnlockDataStateFlow }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -80,12 +80,12 @@ class VaultDiskSourceTest {
     }
 
     @Test
-    fun `getCiphers should emit all CiphersDao updates`() = runTest {
+    fun `getCiphersFlow should emit all CiphersDao updates`() = runTest {
         val cipherEntities = listOf(CIPHER_ENTITY)
         val ciphers = listOf(CIPHER_1)
 
         vaultDiskSource
-            .getCiphers(USER_ID)
+            .getCiphersFlow(USER_ID)
             .test {
                 assertEquals(emptyList<SyncResponseJson.Cipher>(), awaitItem())
                 ciphersDao.insertCiphers(cipherEntities)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -94,6 +94,29 @@ class VaultDiskSourceTest {
     }
 
     @Test
+    fun `getCiphers should return all CiphersDao ciphers`() = runTest {
+        val cipherEntities = listOf(CIPHER_ENTITY)
+        val ciphers = listOf(CIPHER_1)
+
+        val result1 = vaultDiskSource.getCiphers(USER_ID)
+        assertEquals(emptyList<SyncResponseJson.Cipher>(), result1)
+        ciphersDao.insertCiphers(cipherEntities)
+        val result2 = vaultDiskSource.getCiphers(USER_ID)
+        assertEquals(ciphers, result2)
+    }
+
+    @Test
+    fun `getCipher should return CiphersDao cipher`() = runTest {
+        val cipherEntities = listOf(CIPHER_ENTITY)
+
+        val result1 = vaultDiskSource.getCipher(userId = USER_ID, cipherId = CIPHER_ENTITY.id)
+        assertNull(result1)
+        ciphersDao.insertCiphers(cipherEntities)
+        val result2 = vaultDiskSource.getCipher(userId = USER_ID, cipherId = CIPHER_ENTITY.id)
+        assertEquals(CIPHER_1, result2)
+    }
+
+    @Test
     fun `DeleteCipher should call deleteCipher`() = runTest {
         assertFalse(ciphersDao.deleteCipherCalled)
         ciphersDao.storedCiphers.add(CIPHER_ENTITY)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeCiphersDao.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeCiphersDao.kt
@@ -35,7 +35,7 @@ class FakeCiphersDao : CiphersDao {
         return count
     }
 
-    override fun getAllCiphers(userId: String): Flow<List<CipherEntity>> =
+    override fun getAllCiphersFlow(userId: String): Flow<List<CipherEntity>> =
         ciphersFlow.map { ciphers -> ciphers.filter { it.userId == userId } }
 
     override suspend fun insertCiphers(ciphers: List<CipherEntity>) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeCiphersDao.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeCiphersDao.kt
@@ -38,6 +38,12 @@ class FakeCiphersDao : CiphersDao {
     override fun getAllCiphersFlow(userId: String): Flow<List<CipherEntity>> =
         ciphersFlow.map { ciphers -> ciphers.filter { it.userId == userId } }
 
+    override suspend fun getAllCiphers(userId: String): List<CipherEntity> =
+        storedCiphers.filter { it.userId == userId }
+
+    override suspend fun getCipher(userId: String, cipherId: String): CipherEntity? =
+        storedCiphers.find { it.userId == userId && it.id == cipherId }
+
     override suspend fun insertCiphers(ciphers: List<CipherEntity>) {
         storedCiphers.addAll(ciphers)
         ciphersFlow.tryEmit(ciphers.toList())

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -173,7 +173,7 @@ class VaultRepositoryTest {
         MutableStateFlow(listOf(createMockCipher(1)))
     private val vaultDiskSource: VaultDiskSource = mockk {
         coEvery { resyncVaultData(any()) } just runs
-        every { getCiphers(any()) } returns mutableGetCiphersFlow
+        every { getCiphersFlow(any()) } returns mutableGetCiphersFlow
     }
     private val totpCodeManager: TotpCodeManager = mockk()
     private val vaultSdkSource: VaultSdkSource = mockk {
@@ -533,7 +533,7 @@ class VaultRepositoryTest {
             val mutableCiphersStateFlow =
                 bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>(replay = 1)
             every {
-                vaultDiskSource.getCiphers(userId = MOCK_USER_STATE.activeUserId)
+                vaultDiskSource.getCiphersFlow(userId = MOCK_USER_STATE.activeUserId)
             } returns mutableCiphersStateFlow
             coEvery {
                 vaultSdkSource.decryptCipherList(
@@ -566,7 +566,7 @@ class VaultRepositoryTest {
         val mutableCiphersStateFlow =
             bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>(replay = 1)
         every {
-            vaultDiskSource.getCiphers(userId = MOCK_USER_STATE.activeUserId)
+            vaultDiskSource.getCiphersFlow(userId = MOCK_USER_STATE.activeUserId)
         } returns mutableCiphersStateFlow
         coEvery {
             vaultSdkSource.decryptCipherList(
@@ -2811,7 +2811,7 @@ class VaultRepositoryTest {
                 )
 
             coEvery {
-                vaultDiskSource.getCiphers(MOCK_USER_STATE.activeUserId)
+                vaultDiskSource.getCiphersFlow(MOCK_USER_STATE.activeUserId)
             } returns mutableCiphersStateFlow
 
             coEvery {
@@ -4141,7 +4141,7 @@ class VaultRepositoryTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         coEvery { vaultDiskSource.deleteFolder(userId = userId, folderId = folderId) } just runs
         coEvery {
-            vaultDiskSource.getCiphers(userId)
+            vaultDiskSource.getCiphersFlow(userId)
         } returns flowOf()
 
         mutableSyncFolderDeleteFlow.tryEmit(
@@ -4150,7 +4150,7 @@ class VaultRepositoryTest {
 
         coVerify {
             vaultDiskSource.deleteFolder(userId = userId, folderId = folderId)
-            vaultDiskSource.getCiphers(userId)
+            vaultDiskSource.getCiphersFlow(userId)
         }
     }
 
@@ -4393,7 +4393,7 @@ class VaultRepositoryTest {
             val orgCipher = createMockCipher(3).copy(deletedDate = null)
 
             coEvery {
-                vaultDiskSource.getCiphers(userId)
+                vaultDiskSource.getCiphersFlow(userId)
             } returns flowOf(listOf(userCipher, deletedCipher, orgCipher))
 
             coEvery {
@@ -4430,7 +4430,7 @@ class VaultRepositoryTest {
             val userId = "mockId-1"
 
             coEvery {
-                vaultDiskSource.getCiphers(userId)
+                vaultDiskSource.getCiphersFlow(userId)
             } returns flowOf(listOf(createMockCipher(1)))
 
             coEvery {
@@ -4793,7 +4793,7 @@ class VaultRepositoryTest {
         foldersFlow: Flow<List<SyncResponseJson.Folder>> = bufferedMutableSharedFlow(),
         sendsFlow: Flow<List<SyncResponseJson.Send>> = bufferedMutableSharedFlow(),
     ) {
-        coEvery { vaultDiskSource.getCiphers(MOCK_USER_STATE.activeUserId) } returns ciphersFlow
+        coEvery { vaultDiskSource.getCiphersFlow(MOCK_USER_STATE.activeUserId) } returns ciphersFlow
         coEvery {
             vaultDiskSource.getCollections(MOCK_USER_STATE.activeUserId)
         } returns collectionsFlow


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14063](https://bitwarden.atlassian.net/browse/PM-14063)

## 📔 Objective

This PR adds the persistence state for the SDK Ciphers Repository.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14063]: https://bitwarden.atlassian.net/browse/PM-14063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ