### PR TITLE
PM-23549: Remove Authenticator app name localizations

### DIFF
--- a/authenticator/src/debug/res/values/strings_non_localized.xml
+++ b/authenticator/src/debug/res/values/strings_non_localized.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Authenticator Dev</string>
+</resources>

--- a/authenticator/src/main/res/values-af-rZA/strings.xml
+++ b/authenticator/src/main/res/values-af-rZA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-ar-rSA/strings.xml
+++ b/authenticator/src/main/res/values-ar-rSA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">المصادِق</string>
     <string name="biometrics_direction">المصادقة البيومترية</string>
     <string name="cancel">إلغاء</string>
     <string name="add_item">أضف عنصرا</string>

--- a/authenticator/src/main/res/values-az-rAZ/strings.xml
+++ b/authenticator/src/main/res/values-az-rAZ/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Kimlik doğrulayıcı</string>
     <string name="biometrics_direction">Biometrik doğrulama</string>
     <string name="cancel">İmtina</string>
     <string name="add_item">Element əlavə et</string>

--- a/authenticator/src/main/res/values-be-rBY/strings.xml
+++ b/authenticator/src/main/res/values-be-rBY/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Аўтэнтыфікатар</string>
     <string name="biometrics_direction">Біяметрычныя праверка</string>
     <string name="cancel">Скасаваць</string>
     <string name="add_item">Дадаць элемент</string>

--- a/authenticator/src/main/res/values-bg-rBG/strings.xml
+++ b/authenticator/src/main/res/values-bg-rBG/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-bn-rBD/strings.xml
+++ b/authenticator/src/main/res/values-bn-rBD/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">বাতিল করুন</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-bs-rBA/strings.xml
+++ b/authenticator/src/main/res/values-bs-rBA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-ca-rES/strings.xml
+++ b/authenticator/src/main/res/values-ca-rES/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Autenticador</string>
     <string name="biometrics_direction">Verificació biomètrica</string>
     <string name="cancel">Cancel·la</string>
     <string name="add_item">Afig element</string>

--- a/authenticator/src/main/res/values-cs-rCZ/strings.xml
+++ b/authenticator/src/main/res/values-cs-rCZ/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Ověřovací aplikace</string>
     <string name="biometrics_direction">Biometrické ověření</string>
     <string name="cancel">Zrušit</string>
     <string name="add_item">Přidat položku</string>

--- a/authenticator/src/main/res/values-cy-rGB/strings.xml
+++ b/authenticator/src/main/res/values-cy-rGB/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-da-rDK/strings.xml
+++ b/authenticator/src/main/res/values-da-rDK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometrisk godkendelse</string>
     <string name="cancel">Afbryd</string>
     <string name="add_item">Tilføj emne</string>

--- a/authenticator/src/main/res/values-de-rDE/strings.xml
+++ b/authenticator/src/main/res/values-de-rDE/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometrische Verifizierung</string>
     <string name="cancel">Abbrechen</string>
     <string name="add_item">Eintrag hinzufügen</string>

--- a/authenticator/src/main/res/values-el-rGR/strings.xml
+++ b/authenticator/src/main/res/values-el-rGR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Βιομετρική επαλήθευση</string>
     <string name="cancel">Ακύρωση</string>
     <string name="add_item">Προσθήκη στοιχείου</string>

--- a/authenticator/src/main/res/values-en-rGB/strings.xml
+++ b/authenticator/src/main/res/values-en-rGB/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-en-rIN/strings.xml
+++ b/authenticator/src/main/res/values-en-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-es-rES/strings.xml
+++ b/authenticator/src/main/res/values-es-rES/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Autenticador</string>
     <string name="biometrics_direction">Verificación biométrica</string>
     <string name="cancel">Cancelar</string>
     <string name="add_item">Añadir elemento</string>

--- a/authenticator/src/main/res/values-et-rEE/strings.xml
+++ b/authenticator/src/main/res/values-et-rEE/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Autentikaator</string>
     <string name="biometrics_direction">Biomeetriline tuvastamine</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Lisa kirje</string>

--- a/authenticator/src/main/res/values-eu-rES/strings.xml
+++ b/authenticator/src/main/res/values-eu-rES/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-fa-rIR/strings.xml
+++ b/authenticator/src/main/res/values-fa-rIR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-fi-rFI/strings.xml
+++ b/authenticator/src/main/res/values-fi-rFI/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Todentaja</string>
     <string name="biometrics_direction">Biometrinen todennus</string>
     <string name="cancel">Peruuta</string>
     <string name="add_item">Lisää kohde</string>

--- a/authenticator/src/main/res/values-fil-rPH/strings.xml
+++ b/authenticator/src/main/res/values-fil-rPH/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-fr-rFR/strings.xml
+++ b/authenticator/src/main/res/values-fr-rFR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Annuler</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-gl-rES/strings.xml
+++ b/authenticator/src/main/res/values-gl-rES/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Autenticador</string>
     <string name="biometrics_direction">Verifiación biométrica</string>
     <string name="cancel">Cancelar</string>
     <string name="add_item">Engadir elemento</string>

--- a/authenticator/src/main/res/values-hi-rIN/strings.xml
+++ b/authenticator/src/main/res/values-hi-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-hr-rHR/strings.xml
+++ b/authenticator/src/main/res/values-hr-rHR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Autentifikator</string>
     <string name="biometrics_direction">Biometrijska autentifikacija</string>
     <string name="cancel">Odustani</string>
     <string name="add_item">Dodaj stavku</string>

--- a/authenticator/src/main/res/values-hu-rHU/strings.xml
+++ b/authenticator/src/main/res/values-hu-rHU/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-in-rID/strings.xml
+++ b/authenticator/src/main/res/values-in-rID/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Autentikator</string>
     <string name="biometrics_direction">Verifikasi biometrik</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Tambahkan item</string>

--- a/authenticator/src/main/res/values-it-rIT/strings.xml
+++ b/authenticator/src/main/res/values-it-rIT/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Verifica biometrica</string>
     <string name="cancel">Annulla</string>
     <string name="add_item">Aggiungi elemento</string>

--- a/authenticator/src/main/res/values-iw-rIL/strings.xml
+++ b/authenticator/src/main/res/values-iw-rIL/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-ja-rJP/strings.xml
+++ b/authenticator/src/main/res/values-ja-rJP/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">生体認証</string>
     <string name="cancel">キャンセル</string>
     <string name="add_item">項目の追加</string>

--- a/authenticator/src/main/res/values-ka-rGE/strings.xml
+++ b/authenticator/src/main/res/values-ka-rGE/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-kn-rIN/strings.xml
+++ b/authenticator/src/main/res/values-kn-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-ko-rKR/strings.xml
+++ b/authenticator/src/main/res/values-ko-rKR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">취소</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-lt-rLT/strings.xml
+++ b/authenticator/src/main/res/values-lt-rLT/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-lv-rLV/strings.xml
+++ b/authenticator/src/main/res/values-lv-rLV/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-ml-rIN/strings.xml
+++ b/authenticator/src/main/res/values-ml-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-mr-rIN/strings.xml
+++ b/authenticator/src/main/res/values-mr-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">बायोमेट्रिक पडताळणी</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-my-rMM/strings.xml
+++ b/authenticator/src/main/res/values-my-rMM/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-nb-rNO/strings.xml
+++ b/authenticator/src/main/res/values-nb-rNO/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Avbryt</string>
     <string name="add_item">Legg til gjenstand</string>

--- a/authenticator/src/main/res/values-ne-rNP/strings.xml
+++ b/authenticator/src/main/res/values-ne-rNP/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-nl-rNL/strings.xml
+++ b/authenticator/src/main/res/values-nl-rNL/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometrische verificatie</string>
     <string name="cancel">Annuleren</string>
     <string name="add_item">Item toevoegen</string>

--- a/authenticator/src/main/res/values-nn-rNO/strings.xml
+++ b/authenticator/src/main/res/values-nn-rNO/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-or-rIN/strings.xml
+++ b/authenticator/src/main/res/values-or-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-pl-rPL/strings.xml
+++ b/authenticator/src/main/res/values-pl-rPL/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Weryfikacja biometryczna</string>
     <string name="cancel">Anuluj</string>
     <string name="add_item">Dodaj element</string>

--- a/authenticator/src/main/res/values-pt-rBR/strings.xml
+++ b/authenticator/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Autenticador</string>
     <string name="biometrics_direction">Verificação biométrica</string>
     <string name="cancel">Cancelar</string>
     <string name="add_item">Adicionar item</string>

--- a/authenticator/src/main/res/values-pt-rPT/strings.xml
+++ b/authenticator/src/main/res/values-pt-rPT/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Verificação biométrica</string>
     <string name="cancel">Cancelar</string>
     <string name="add_item">Adicionar item</string>

--- a/authenticator/src/main/res/values-ro-rRO/strings.xml
+++ b/authenticator/src/main/res/values-ro-rRO/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-ru-rRU/strings.xml
+++ b/authenticator/src/main/res/values-ru-rRU/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Аутентификатор</string>
     <string name="biometrics_direction">Биометрическая верификация</string>
     <string name="cancel">Отменить</string>
     <string name="add_item">Добавить элемент</string>
@@ -62,7 +61,7 @@
     <string name="secure_your_accounts_with_bitwarden_authenticator">Защитите свои учетные записи с помощью аутентификатора Bitwarden</string>
     <string name="get_verification_codes_for_all_your_accounts">Получите коды проверки для всех ваших учетных записей, поддерживающих 2-этапную проверку.</string>
     <string name="use_your_device_camera_to_scan_codes">Используйте камеру вашего устройства для сканирования кодов</string>
-    <string name="scan_the_qr_code_in_your_2_step_verification_settings_for_any_account">Сканируйте QR-код в настройках 
+    <string name="scan_the_qr_code_in_your_2_step_verification_settings_for_any_account">Сканируйте QR-код в настройках
 2-этапной верификации для любой учетной записи.</string>
     <string name="sign_in_using_unique_codes">Авторизуйтесь с помощью уникальных кодов</string>
     <string name="when_using_2_step_verification_youll_enter_your_username_and_password_and_a_code_generated_in_this_app">При использовании 2-этапной верификации вы введете свое имя пользователя, пароль и код, сгенерированный в этом приложении.</string>
@@ -80,7 +79,7 @@
     <string name="export_confirmation_title">Подтвердите экспорт</string>
     <string name="export_vault_warning">Этот экспорт содержит ваши данные в незашифрованном формате. Не следует хранить или отправлять экспортированный файл по незащищенным каналам (например, по электронной почте). Удалите его сразу после завершения работы.</string>
     <string name="file_format">Формат файла</string>
-    <string name="export_vault_failure">Возникла проблема с экспортом вашего хранилища. Если проблема сохраняется, вам нужно экспортировать из 
+    <string name="export_vault_failure">Возникла проблема с экспортом вашего хранилища. Если проблема сохраняется, вам нужно экспортировать из
 веб хранилища.</string>
     <string name="export_success">Данные успешно экспортированы</string>
     <string name="unlock_with">Разблокируйте с помощью %1$s</string>

--- a/authenticator/src/main/res/values-si-rLK/strings.xml
+++ b/authenticator/src/main/res/values-si-rLK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-sk-rSK/strings.xml
+++ b/authenticator/src/main/res/values-sk-rSK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-sl-rSI/strings.xml
+++ b/authenticator/src/main/res/values-sl-rSI/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-sr-rSP/strings.xml
+++ b/authenticator/src/main/res/values-sr-rSP/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Аутентификатор</string>
     <string name="biometrics_direction">Биометријска провера</string>
     <string name="cancel">Откажи</string>
     <string name="add_item">Додај ставку</string>

--- a/authenticator/src/main/res/values-sv-rSE/strings.xml
+++ b/authenticator/src/main/res/values-sv-rSE/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometrisk verifiering</string>
     <string name="cancel">Avbryt</string>
     <string name="add_item">Lägg till objekt</string>

--- a/authenticator/src/main/res/values-ta-rIN/strings.xml
+++ b/authenticator/src/main/res/values-ta-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-te-rIN/strings.xml
+++ b/authenticator/src/main/res/values-te-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-th-rTH/strings.xml
+++ b/authenticator/src/main/res/values-th-rTH/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values-tr-rTR/strings.xml
+++ b/authenticator/src/main/res/values-tr-rTR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Kimlik Doğrulayıcı</string>
     <string name="biometrics_direction">Biyometrik doğrulama</string>
     <string name="cancel">İptal</string>
     <string name="add_item">Öğe ekle</string>

--- a/authenticator/src/main/res/values-uk-rUA/strings.xml
+++ b/authenticator/src/main/res/values-uk-rUA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Автентифікатор</string>
     <string name="biometrics_direction">Біометрична перевірка</string>
     <string name="cancel">Скасувати</string>
     <string name="add_item">Додати запис</string>

--- a/authenticator/src/main/res/values-vi-rVN/strings.xml
+++ b/authenticator/src/main/res/values-vi-rVN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Xác minh sinh trắc học</string>
     <string name="cancel">Hủy bỏ</string>
     <string name="add_item">Thêm mục</string>

--- a/authenticator/src/main/res/values-zh-rCN/strings.xml
+++ b/authenticator/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">身份验证器</string>
     <string name="biometrics_direction">生物识别验证</string>
     <string name="cancel">取消</string>
     <string name="add_item">添加项目</string>

--- a/authenticator/src/main/res/values-zh-rTW/strings.xml
+++ b/authenticator/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel"></string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values/strings.xml
+++ b/authenticator/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Authenticator</string>
     <string name="biometrics_direction">Biometric verification</string>
     <string name="cancel">Cancel</string>
     <string name="add_item">Add item</string>

--- a/authenticator/src/main/res/values/strings_non_localized.xml
+++ b/authenticator/src/main/res/values/strings_non_localized.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">Authenticator</string>
+
     <string name="export_format_label_json">.json</string>
     <string name="export_format_label_csv">.csv</string>
     <string name="import_format_label_bitwarden_json">Bitwarden (.json)</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23549](https://bitwarden.atlassian.net/browse/PM-23549)

## 📔 Objective

This PR removes the localization for the `Authenticator` app name. The name is branded and should not be localized.

Additionally, I added a dev string so we can tell the difference between the prod and debug versions for the app (`Authenticator Dev`).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23549]: https://bitwarden.atlassian.net/browse/PM-23549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ