### PR TITLE
[PM-23546] Update 2FA verification code accept any length

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
@@ -247,7 +247,7 @@ private fun TwoFactorLoginScreenContent(
         Spacer(modifier = Modifier.height(height = 12.dp))
         Text(
             text = if (state.isNewDeviceVerification) {
-                R.string.enter_verification_code_new_device.asText(state.displayEmail).invoke()
+                R.string.enter_verification_code_new_device.asText().invoke()
             } else {
                 state.authMethod.description(
                     state.displayEmail,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -190,12 +190,10 @@ class TwoFactorLoginViewModel @Inject constructor(
      * Update the state with the new text and enable or disable the continue button.
      */
     private fun handleCodeInputChanged(action: TwoFactorLoginAction.CodeInputChanged) {
-        @Suppress("MagicNumber")
-        val minLength = if (state.isNewDeviceVerification) 8 else 6
         mutableStateFlow.update {
             it.copy(
                 codeInput = action.input,
-                isContinueButtonEnabled = action.input.length >= minLength,
+                isContinueButtonEnabled = action.input.isNotEmpty(),
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
     <string name="authenticator_app_title">Authenticator app</string>
     <string name="enter_verification_code_app">Enter the 6 digit verification code from your authenticator app.</string>
     <string name="enter_verification_code_email">Enter the 6 digit verification code that was emailed to %1$s.</string>
-    <string name="enter_verification_code_new_device">We don\'t recognize this device. Enter the 8 digit verification code that was emailed to %1$s.</string>
+    <string name="enter_verification_code_new_device">We don\'t recognize this device. Enter the code sent to your email to verify your identity.</string>
     <string name="recovery_code_title">Recovery code</string>
     <string name="remember">Remember</string>
     <string name="remember_email">Remember email</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -317,33 +317,6 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
-    fun `Continue buttons should only be enabled when code is 8 digit enough on isNewDeviceVerification`() {
-        val initialState = DEFAULT_STATE.copy(isNewDeviceVerification = true)
-        val viewModel = createViewModel(initialState)
-        viewModel.trySendAction(TwoFactorLoginAction.CodeInputChanged("123456"))
-
-        // 6 digit should be false when isNewDeviceVerification is true.
-        assertEquals(
-            initialState.copy(
-                codeInput = "123456",
-                isContinueButtonEnabled = false,
-            ),
-            viewModel.stateFlow.value,
-        )
-
-        // Set it to true.
-        viewModel.trySendAction(TwoFactorLoginAction.CodeInputChanged("12345678"))
-        assertEquals(
-            initialState.copy(
-                codeInput = "12345678",
-                isContinueButtonEnabled = true,
-            ),
-            viewModel.stateFlow.value,
-        )
-    }
-
-    @Test
     fun `ContinueButtonClick login returns success should update loadingDialogState`() = runTest {
         coEvery {
             authRepository.login(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23546

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Currently, the Android app is hardcoded to accept 8 digits for new device verification and 6 digits for 2fa verification. However, we are migrating our new device verification to use 6 digits.
To support this and any future changes, we should update this field to allow any length input. The correct code will work and anything else will return an “incorrect code” error.
Screen copy should also be updated to be length invariant: 
`We don't recognize this device. Enter the code sent to your email to verify your identity.`

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/3ae143bb-c0be-42c8-b71b-763f35faca4b


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
