### PR TITLE
[PM-23604] Add 'getCipher' helper method

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManager.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.vault.manager
 
 import android.net.Uri
 import com.bitwarden.vault.CipherView
+import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.CreateAttachmentResult
 import com.x8bit.bitwarden.data.vault.repository.model.CreateCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteAttachmentResult
@@ -50,6 +51,11 @@ interface CipherManager {
         cipherView: CipherView,
         attachmentId: String,
     ): DownloadAttachmentResult
+
+    /**
+     * Attempt to retrieve a decrypted cipher based on the [cipherId].
+     */
+    suspend fun getCipher(cipherId: String): GetCipherResult
 
     /**
      * Attempt to delete a cipher.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/model/GetCipherResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/model/GetCipherResult.kt
@@ -1,0 +1,29 @@
+package com.x8bit.bitwarden.data.vault.manager.model
+
+import com.bitwarden.vault.CipherView
+
+/**
+ * Models result of getting a cipher.
+ */
+sealed class GetCipherResult {
+    /**
+     * Cipher retrieved successfully.
+     *
+     * @param cipherView The cipher retrieved.
+     */
+    data class Success(
+        val cipherView: CipherView,
+    ) : GetCipherResult()
+
+    /**
+     * Cipher not found.
+     */
+    data object CipherNotFound : GetCipherResult()
+
+    /**
+     * Generic error while retrieving cipher.
+     */
+    data class Failure(
+        val error: Throwable,
+    ) : GetCipherResult()
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-23604

## 📔 Objective

This PR adds a `getCipher` helper method for retrieving a cipher by ID.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
