### PR TITLE
[PM-21750] Only show dynamic colors option on Android 12+

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -27,6 +27,7 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
@@ -34,7 +35,6 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
-import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.x8bit.bitwarden.ui.platform.util.displayLabel
 import kotlinx.collections.immutable.toImmutableList
@@ -111,20 +111,22 @@ fun AppearanceScreen(
                     .fillMaxWidth(),
             )
             Spacer(modifier = Modifier.height(height = 8.dp))
-            BitwardenSwitch(
-                label = stringResource(id = R.string.dynamic_colors),
-                supportingText = stringResource(id = R.string.dynamic_colors_description),
-                isChecked = state.isDynamicColorsEnabled,
-                onCheckedChange = remember(viewModel) {
-                    { viewModel.trySendAction(AppearanceAction.DynamicColorsToggle(it)) }
-                },
-                cardStyle = CardStyle.Full,
-                modifier = Modifier
-                    .testTag("DynamicColorsSwitch")
-                    .fillMaxWidth()
-                    .standardHorizontalMargin(),
-            )
-            Spacer(modifier = Modifier.height(height = 8.dp))
+            if (state.isDynamicColorsSupported) {
+                BitwardenSwitch(
+                    label = stringResource(id = R.string.dynamic_colors),
+                    supportingText = stringResource(id = R.string.dynamic_colors_description),
+                    isChecked = state.isDynamicColorsEnabled,
+                    onCheckedChange = remember(viewModel) {
+                        { viewModel.trySendAction(AppearanceAction.DynamicColorsToggle(it)) }
+                    },
+                    cardStyle = CardStyle.Full,
+                    modifier = Modifier
+                        .testTag("DynamicColorsSwitch")
+                        .fillMaxWidth()
+                        .standardHorizontalMargin(),
+                )
+                Spacer(modifier = Modifier.height(height = 8.dp))
+            }
             BitwardenSwitch(
                 label = stringResource(id = R.string.show_website_icons),
                 supportingText = stringResource(id = R.string.show_website_icons_description),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
@@ -1,8 +1,10 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.appearance
 
+import android.os.Build
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -31,6 +33,7 @@ class AppearanceViewModel @Inject constructor(
             showWebsiteIcons = !settingsRepository.isIconLoadingDisabled,
             theme = settingsRepository.appTheme,
             isDynamicColorsEnabled = settingsRepository.isDynamicColorsEnabled,
+            isDynamicColorsSupported = isBuildVersionAtLeast(Build.VERSION_CODES.S),
             dialogState = null,
         ),
 ) {
@@ -42,11 +45,13 @@ class AppearanceViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
-        settingsRepository
+        if (state.isDynamicColorsSupported) {
+            settingsRepository
             .isDynamicColorsEnabledFlow
             .map { AppearanceAction.Internal.DynamicColorsStateUpdateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
+        }
     }
 
     override fun handleAction(action: AppearanceAction): Unit = when (action) {
@@ -139,6 +144,7 @@ data class AppearanceState(
     val language: AppLanguage,
     val showWebsiteIcons: Boolean,
     val theme: AppTheme,
+    val isDynamicColorsSupported: Boolean,
     val isDynamicColorsEnabled: Boolean,
     val dialogState: DialogState?,
 ) : Parcelable {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
@@ -47,10 +47,10 @@ class AppearanceViewModel @Inject constructor(
 
         if (state.isDynamicColorsSupported) {
             settingsRepository
-            .isDynamicColorsEnabledFlow
-            .map { AppearanceAction.Internal.DynamicColorsStateUpdateReceive(it) }
-            .onEach(::sendAction)
-            .launchIn(viewModelScope)
+                .isDynamicColorsEnabledFlow
+                .map { AppearanceAction.Internal.DynamicColorsStateUpdateReceive(it) }
+                .onEach(::sendAction)
+                .launchIn(viewModelScope)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-21750

## 📔 Objective

The dynamic colors option in Appearance settings will now only be displayed on devices running Android 12 (API 31) or higher, as this feature is not supported on older versions.

This change includes:
- Updating `AppearanceViewModel` to check the Android build version and set an `isDynamicColorsSupported` flag in the state.
- Conditionally rendering the "Dynamic colors" switch in `AppearanceScreen` based on the `isDynamicColorsSupported` flag.
- Updating tests to reflect this new behavior.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="365" alt="image" src="https://github.com/user-attachments/assets/c46c5303-f4f1-44d1-aad2-9da5f49145be" /> | <img width="365" alt="image" src="https://github.com/user-attachments/assets/226280dd-379f-49c0-93a6-bc57b21bb2e5" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
