### PR TITLE
[PM-23608] Add generateTotp overload with CipherListView parameter

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
@@ -35,6 +35,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.DeriveKeyConnectorRes
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.InitializeCryptoResult
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.RegisterFido2CredentialRequest
 import java.io.File
+import java.time.Instant
 
 /**
  * Source of vault information and functionality from the Bitwarden SDK.
@@ -403,6 +404,15 @@ interface VaultSdkSource {
         userId: String,
         totp: String,
         time: DateTime,
+    ): Result<TotpResponse>
+
+    /**
+     * Generate a verification code for the given [cipherListView] and [time].
+     */
+    suspend fun generateTotpForCipherListView(
+        userId: String,
+        cipherListView: CipherListView,
+        time: Instant,
     ): Result<TotpResponse>
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.time.Instant
 
 /**
  * Primary implementation of [VaultSdkSource] that serves as a convenience wrapper around a
@@ -447,6 +448,19 @@ class VaultSdkSourceImpl(
             .vault()
             .generateTotp(
                 key = totp,
+                time = time,
+            )
+    }
+
+    override suspend fun generateTotpForCipherListView(
+        userId: String,
+        cipherListView: CipherListView,
+        time: Instant,
+    ): Result<TotpResponse> = runCatchingWithLogs {
+        getClient(userId = userId)
+            .vault()
+            .generateTotpCipherView(
+                view = cipherListView,
                 time = time,
             )
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherListViewUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherListViewUtil.kt
@@ -1,0 +1,123 @@
+package com.x8bit.bitwarden.data.vault.datasource.sdk.model
+
+import com.bitwarden.vault.CardListView
+import com.bitwarden.vault.CipherListView
+import com.bitwarden.vault.CipherListViewType
+import com.bitwarden.vault.CipherPermissions
+import com.bitwarden.vault.CipherRepromptType
+import com.bitwarden.vault.CopyableCipherFields
+import com.bitwarden.vault.Fido2CredentialListView
+import com.bitwarden.vault.LocalDataView
+import com.bitwarden.vault.LoginListView
+import com.bitwarden.vault.LoginUriView
+import java.time.Instant
+import java.time.ZonedDateTime
+
+/**
+ * Default date time used for [ZonedDateTime] properties of mock objects.
+ */
+private const val DEFAULT_TIMESTAMP = "2023-10-27T12:00:00Z"
+
+/**
+ * Creates a mock [CipherListView] for testing. Defaults to a Login cipher. Set [type] to override
+ * the default behavior.
+ */
+@Suppress("LongParameterList")
+fun createMockCipherListView(
+    number: Int,
+    id: String = "mockId-$number",
+    organizationId: String? = "mockOrganizationId-$number",
+    folderId: String? = "mockId-$number",
+    type: CipherListViewType = CipherListViewType.Login(
+        createMockLoginListView(number = 1),
+    ),
+    reprompt: CipherRepromptType = CipherRepromptType.NONE,
+    name: String = "mockName-$number",
+    favorite: Boolean = false,
+    collectionIds: List<String> = listOf("mockId-$number"),
+    revisionDate: Instant = Instant.parse(DEFAULT_TIMESTAMP),
+    creationDate: Instant = Instant.parse(DEFAULT_TIMESTAMP),
+    attachments: UInt = 0U,
+    organizationUseTotp: Boolean = false,
+    edit: Boolean = false,
+    viewPassword: Boolean = false,
+    permissions: CipherPermissions? = createMockSdkCipherPermissions(),
+    localData: LocalDataView? = null,
+    key: String = "mockKey-$number",
+    subtitle: String = "mockSubtitle-$number",
+    hasOldAttachments: Boolean = false,
+    copyableFields: List<CopyableCipherFields> = emptyList(),
+    isDeleted: Boolean = false,
+): CipherListView = CipherListView(
+    id = id,
+    organizationId = organizationId,
+    folderId = folderId,
+    type = type,
+    reprompt = reprompt,
+    name = name,
+    favorite = favorite,
+    collectionIds = collectionIds,
+    revisionDate = revisionDate,
+    creationDate = creationDate,
+    deletedDate = if (isDeleted) Instant.parse(DEFAULT_TIMESTAMP) else null,
+    attachments = attachments,
+    organizationUseTotp = organizationUseTotp,
+    edit = edit,
+    viewPassword = viewPassword,
+    permissions = permissions,
+    localData = localData,
+    key = key,
+    subtitle = subtitle,
+    hasOldAttachments = hasOldAttachments,
+    copyableFields = copyableFields,
+)
+
+/**
+ * Creates a mock [LoginListView] for testing.
+ */
+@Suppress("LongParameterList")
+fun createMockLoginListView(
+    number: Int,
+    fido2Credentials: List<Fido2CredentialListView> = listOf(
+        createMockFido2CredentialListView(number = 1),
+    ),
+    hasFido2: Boolean = true,
+    username: String = "mockUsername-$number",
+    totp: String? = "mockTotp-$number",
+    uris: List<LoginUriView> = listOf(createMockUriView(number = 1)),
+): LoginListView = LoginListView(
+    fido2Credentials = fido2Credentials,
+    hasFido2 = hasFido2,
+    username = username,
+    totp = totp,
+    uris = uris,
+)
+
+/**
+ * Creates a mock [Fido2CredentialListView] for testing.
+ */
+@Suppress("LongParameterList")
+fun createMockFido2CredentialListView(
+    number: Int,
+    credentialId: String = "mockCredentialId-$number",
+    rpId: String = "mockRpId-$number",
+    userHandle: String = "mockUserHandle-$number",
+    userName: String = "mockUserName-$number",
+    userDisplayName: String = "mockUserDisplayName-$number",
+): Fido2CredentialListView = Fido2CredentialListView(
+    credentialId = credentialId,
+    rpId = rpId,
+    userHandle = userHandle,
+    userName = userName,
+    userDisplayName = userDisplayName,
+)
+
+/**
+ * Creates a mock [CardListView] for testing.
+ */
+fun createMockCardListView(
+    number: Int,
+    brand: String = "mockBrand-$number",
+): CardListView = CardListView(
+    brand = brand,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/TotpCodeManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/TotpCodeManagerTest.kt
@@ -45,7 +45,11 @@ class TotpCodeManagerTest {
     fun `getTotpCodeStateFlow should have loaded data with a valid values passed in`() = runTest {
         val totpResponse = TotpResponse("123456", 30u)
         coEvery {
-            vaultSdkSource.generateTotp(any(), any(), any())
+            vaultSdkSource.generateTotp(
+                userId = any(),
+                totp = any(),
+                time = any(),
+            )
         } returns totpResponse.asSuccess()
 
         val expected = createVerificationCodeItem()
@@ -61,7 +65,11 @@ class TotpCodeManagerTest {
         runTest {
             val totpResponse = TotpResponse("123456", 30u)
             coEvery {
-                vaultSdkSource.generateTotp(any(), any(), any())
+                vaultSdkSource.generateTotp(
+                    userId = any(),
+                    totp = any(),
+                    time = any(),
+                )
             } returns totpResponse.asSuccess()
 
             val cipherView = createMockCipherView(1).copy(
@@ -80,7 +88,11 @@ class TotpCodeManagerTest {
     fun `getTotpCodesStateFlow should have loaded data with empty list if unable to generate auth code`() =
         runTest {
             coEvery {
-                vaultSdkSource.generateTotp(any(), any(), any())
+                vaultSdkSource.generateTotp(
+                    userId = any(),
+                    totp = any(),
+                    time = any(),
+                )
             } returns Exception().asFailure()
 
             val cipherView = createMockCipherView(1).copy(
@@ -98,7 +110,11 @@ class TotpCodeManagerTest {
     fun `getTotpCodeStateFlow should have loaded item with valid data passed in`() = runTest {
         val totpResponse = TotpResponse("123456", 30u)
         coEvery {
-            vaultSdkSource.generateTotp(any(), any(), any())
+            vaultSdkSource.generateTotp(
+                userId = any(),
+                totp = any(),
+                time = any(),
+            )
         } returns totpResponse.asSuccess()
 
         val cipherView = createMockCipherView(
@@ -118,7 +134,11 @@ class TotpCodeManagerTest {
         runTest {
             val totpResponse = TotpResponse("123456", 30u)
             coEvery {
-                vaultSdkSource.generateTotp(any(), any(), any())
+                vaultSdkSource.generateTotp(
+                    userId = any(),
+                    totp = any(),
+                    time = any(),
+                )
             } returns totpResponse.asSuccess()
 
             val cipherView = createMockCipherView(1).copy(


### PR DESCRIPTION
## 🎟️ Tracking

PM-23608

## 📔 Objective

The `VaultSdkSource` and `VaultSdkSourceImpl` classes are updated to include a new overload for the `generateTotp` method. This overload accepts a `CipherListView` parameter instead of a `String` totp parameter.

This change also updates the corresponding unit tests to specify argument names.

Additionally, a new utility file `CipherListViewUtil.kt` is introduced to create mock `CipherListView` objects for testing purposes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
