### PR TITLE
PM-23690: Remove pre-login settings feature flag

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -35,7 +35,6 @@ sealed class FlagKey<out T : Any> {
                 MobileErrorReporting,
                 FlightRecorder,
                 RestrictCipherItemDeletion,
-                PreAuthSettings,
                 UserManagedPrivilegedApps,
                 RemoveCardPolicy,
             )
@@ -163,14 +162,6 @@ sealed class FlagKey<out T : Any> {
      */
     data object RestrictCipherItemDeletion : FlagKey<Boolean>() {
         override val keyName: String = "pm-15493-restrict-item-deletion-to-can-manage-permission"
-        override val defaultValue: Boolean = false
-    }
-
-    /**
-     * Data object holding the feature flag key to enable the settings menu before login.
-     */
-    data object PreAuthSettings : FlagKey<Boolean>() {
-        override val keyName: String = "enable-pm-prelogin-settings"
         override val defaultValue: Boolean = false
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
@@ -319,17 +319,15 @@ private fun LandingScreenContent(
                     .testTag("CreateAccountLabel"),
             )
         }
-        if (state.showSettingsButton) {
-            Spacer(modifier = Modifier.height(height = 8.dp))
-            BitwardenTextButton(
-                label = stringResource(id = R.string.app_settings),
-                onClick = onAppSettingsClick,
-                icon = rememberVectorPainter(id = BitwardenDrawable.ic_cog),
-                modifier = Modifier
-                    .standardHorizontalMargin()
-                    .fillMaxWidth(),
-            )
-        }
+        Spacer(modifier = Modifier.height(height = 8.dp))
+        BitwardenTextButton(
+            label = stringResource(id = R.string.app_settings),
+            onClick = onAppSettingsClick,
+            icon = rememberVectorPainter(id = BitwardenDrawable.ic_cog),
+            modifier = Modifier
+                .standardHorizontalMargin()
+                .fillMaxWidth(),
+        )
 
         Spacer(modifier = Modifier.height(height = 12.dp))
         Spacer(modifier = Modifier.navigationBarsPadding())

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModel.kt
@@ -54,7 +54,6 @@ class LandingViewModel @Inject constructor(
             selectedEnvironmentLabel = environmentRepository.environment.label,
             dialog = null,
             accountSummaries = authRepository.userStateFlow.value?.toAccountSummaries().orEmpty(),
-            showSettingsButton = featureFlagManager.getFeatureFlag(key = FlagKey.PreAuthSettings),
         ),
 ) {
 
@@ -108,11 +107,6 @@ class LandingViewModel @Inject constructor(
             .map { LandingAction.Internal.SnackbarDataReceived(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
-        featureFlagManager
-            .getFeatureFlagFlow(key = FlagKey.PreAuthSettings)
-            .map { LandingAction.Internal.PreAuthSettingFlagReceive(it) }
-            .onEach(::sendAction)
-            .launchIn(viewModelScope)
     }
 
     override fun handleAction(action: LandingAction) {
@@ -140,10 +134,6 @@ class LandingViewModel @Inject constructor(
             is LandingAction.Internal.UpdateEmailState -> handleInternalEmailStateUpdate(action)
             is LandingAction.Internal.UpdatedEnvironmentReceive -> {
                 handleUpdatedEnvironmentReceive(action)
-            }
-
-            is LandingAction.Internal.PreAuthSettingFlagReceive -> {
-                handlePreAuthSettingFlagReceive(action)
             }
 
             is LandingAction.Internal.SnackbarDataReceived -> handleSnackbarDataReceived(action)
@@ -271,12 +261,6 @@ class LandingViewModel @Inject constructor(
         }
     }
 
-    private fun handlePreAuthSettingFlagReceive(
-        action: LandingAction.Internal.PreAuthSettingFlagReceive,
-    ) {
-        mutableStateFlow.update { it.copy(showSettingsButton = action.isEnabled) }
-    }
-
     private fun handleSnackbarDataReceived(action: LandingAction.Internal.SnackbarDataReceived) {
         sendEvent(LandingEvent.ShowSnackbar(action.data))
     }
@@ -307,7 +291,6 @@ data class LandingState(
     val selectedEnvironmentLabel: String,
     val dialog: DialogState?,
     val accountSummaries: List<AccountSummary>,
-    val showSettingsButton: Boolean,
 ) : Parcelable {
     /**
      * Determines whether the app bar should be visible based on the presence of account summaries.
@@ -458,13 +441,6 @@ sealed class LandingAction {
      * Actions for internal use by the ViewModel.
      */
     sealed class Internal : LandingAction() {
-        /**
-         * Indicates that there has been a change to the pre-auth settings feature flag.
-         */
-        data class PreAuthSettingFlagReceive(
-            val isEnabled: Boolean,
-        ) : Internal()
-
         /**
          * Indicates that snackbar data has been received.
          */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
-import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 
 /**
  * Creates a list item for a [FlagKey].
@@ -40,7 +40,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.MobileErrorReporting,
     FlagKey.FlightRecorder,
     FlagKey.RestrictCipherItemDeletion,
-    FlagKey.PreAuthSettings,
     FlagKey.UserManagedPrivilegedApps,
     FlagKey.RemoveCardPolicy,
         -> {
@@ -102,9 +101,9 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.MobileErrorReporting -> stringResource(R.string.enable_error_reporting_dialog)
     FlagKey.FlightRecorder -> stringResource(R.string.enable_flight_recorder)
     FlagKey.RestrictCipherItemDeletion -> stringResource(R.string.restrict_item_deletion)
-    FlagKey.PreAuthSettings -> stringResource(R.string.enable_pre_auth_settings)
     FlagKey.UserManagedPrivilegedApps -> {
         stringResource(R.string.user_trusted_privileged_app_management)
     }
+
     FlagKey.RemoveCardPolicy -> stringResource(R.string.remove_card_policy)
 }

--- a/app/src/main/res/values/strings_non_localized.xml
+++ b/app/src/main/res/values/strings_non_localized.xml
@@ -26,7 +26,6 @@
     <string name="enable_error_reporting_dialog">Enable error reporting dialog</string>
     <string name="enable_flight_recorder">Enable flight recorder</string>
     <string name="restrict_item_deletion">Restrict item deletion</string>
-    <string name="enable_pre_auth_settings">Enabled pre-auth settings</string>
     <string name="generate_crash">Generate crash</string>
     <string name="generate_error_report">Generate error report</string>
     <string name="error_reports">Error reports</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -66,10 +66,6 @@ class FlagKeyTest {
             "pm-15493-restrict-item-deletion-to-can-manage-permission",
         )
         assertEquals(
-            FlagKey.PreAuthSettings.keyName,
-            "enable-pm-prelogin-settings",
-        )
-        assertEquals(
             FlagKey.UserManagedPrivilegedApps.keyName,
             "pm-18970-user-managed-privileged-apps",
         )
@@ -97,7 +93,6 @@ class FlagKeyTest {
                 FlagKey.MobileErrorReporting,
                 FlagKey.FlightRecorder,
                 FlagKey.RestrictCipherItemDeletion,
-                FlagKey.PreAuthSettings,
                 FlagKey.UserManagedPrivilegedApps,
                 FlagKey.RemoveCardPolicy,
             ).all {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreenTest.kt
@@ -284,20 +284,7 @@ class LandingScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `app settings button should be displayed according to state`() {
-        mutableStateFlow.update { it.copy(showSettingsButton = false) }
-        composeTestRule
-            .onNodeWithText(text = "App settings")
-            .assertDoesNotExist()
-        mutableStateFlow.update { it.copy(showSettingsButton = true) }
-        composeTestRule
-            .onNodeWithText(text = "App settings")
-            .assertExists()
-    }
-
-    @Test
     fun `on app settings click should send AppSettingsClick action`() {
-        mutableStateFlow.update { it.copy(showSettingsButton = true) }
         composeTestRule
             .onNodeWithText(text = "App settings")
             .performScrollTo()
@@ -527,5 +514,4 @@ private val DEFAULT_STATE = LandingState(
     selectedEnvironmentLabel = Environment.Us.label,
     dialog = null,
     accountSummaries = emptyList(),
-    showSettingsButton = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingViewModelTest.kt
@@ -51,7 +51,6 @@ class LandingViewModelTest : BaseViewModelTest() {
     }
     private val featureFlagManager: FeatureFlagManager = mockk(relaxed = true) {
         every { getFeatureFlag(FlagKey.EmailVerification) } returns false
-        every { getFeatureFlag(FlagKey.PreAuthSettings) } returns false
     }
 
     @Test
@@ -228,20 +227,6 @@ class LandingViewModelTest : BaseViewModelTest() {
         viewModel.eventFlow.test {
             viewModel.trySendAction(LandingAction.AppSettingsClick)
             assertEquals(LandingEvent.NavigateToSettings, awaitItem())
-        }
-    }
-
-    @Test
-    fun `PreAuthSettingFlagReceive should update the state accordingly`() = runTest {
-        val viewModel = createViewModel()
-        viewModel.stateFlow.test {
-            assertEquals(DEFAULT_STATE, awaitItem())
-
-            viewModel.trySendAction(LandingAction.Internal.PreAuthSettingFlagReceive(true))
-            assertEquals(DEFAULT_STATE.copy(showSettingsButton = true), awaitItem())
-
-            viewModel.trySendAction(LandingAction.Internal.PreAuthSettingFlagReceive(false))
-            assertEquals(DEFAULT_STATE.copy(showSettingsButton = false), awaitItem())
         }
     }
 
@@ -654,5 +639,4 @@ private val DEFAULT_STATE = LandingState(
     selectedEnvironmentLabel = Environment.Us.label,
     dialog = null,
     accountSummaries = emptyList(),
-    showSettingsButton = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -158,7 +158,6 @@ private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
     FlagKey.MobileErrorReporting to true,
     FlagKey.FlightRecorder to true,
     FlagKey.RestrictCipherItemDeletion to true,
-    FlagKey.PreAuthSettings to true,
     FlagKey.UserManagedPrivilegedApps to true,
     FlagKey.RemoveCardPolicy to true,
 )
@@ -178,7 +177,6 @@ private val UPDATED_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
     FlagKey.MobileErrorReporting to false,
     FlagKey.FlightRecorder to false,
     FlagKey.RestrictCipherItemDeletion to false,
-    FlagKey.PreAuthSettings to false,
     FlagKey.UserManagedPrivilegedApps to false,
     FlagKey.RemoveCardPolicy to false,
 )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23690](https://bitwarden.atlassian.net/browse/PM-23690)

## 📔 Objective

This PR removes the Pre-login Settings feature flag now that it is fully released.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23690]: https://bitwarden.atlassian.net/browse/PM-23690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ