### PR TITLE
PM-23692: Remove auth sync feature flag from password manager

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -138,13 +138,11 @@ object PlatformManagerModule {
         addTotpItemFromAuthenticatorManager: AddTotpItemFromAuthenticatorManager,
         @ApplicationContext context: Context,
         dispatcherManager: DispatcherManager,
-        featureFlagManager: FeatureFlagManager,
     ): AuthenticatorBridgeProcessor = AuthenticatorBridgeProcessorImpl(
         authenticatorBridgeRepository = authenticatorBridgeRepository,
         addTotpItemFromAuthenticatorManager = addTotpItemFromAuthenticatorManager,
         context = context,
         dispatcherManager = dispatcherManager,
-        featureFlagManager = featureFlagManager,
     )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -21,7 +21,6 @@ sealed class FlagKey<out T : Any> {
          */
         val activeFlags: List<FlagKey<*>> by lazy {
             listOf(
-                AuthenticatorSync,
                 EmailVerification,
                 ImportLoginsFlow,
                 CredentialExchangeProtocolImport,
@@ -38,14 +37,6 @@ sealed class FlagKey<out T : Any> {
                 RemoveCardPolicy,
             )
         }
-    }
-
-    /**
-     * Data object holding the key for syncing with the Bitwarden Authenticator app.
-     */
-    data object AuthenticatorSync : FlagKey<Boolean>() {
-        override val keyName: String = "enable-pm-bwa-sync"
-        override val defaultValue: Boolean = false
     }
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/processor/AuthenticatorBridgeProcessorImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/processor/AuthenticatorBridgeProcessorImpl.kt
@@ -18,8 +18,6 @@ import com.bitwarden.authenticatorbridge.util.toSymmetricEncryptionKeyData
 import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.data.manager.DispatcherManager
 import com.x8bit.bitwarden.data.auth.manager.AddTotpItemFromAuthenticatorManager
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.AuthenticatorBridgeRepository
 import com.x8bit.bitwarden.data.platform.util.createAddTotpItemFromAuthenticatorIntent
 import com.x8bit.bitwarden.ui.vault.util.getTotpDataOrNull
@@ -33,7 +31,6 @@ import timber.log.Timber
 class AuthenticatorBridgeProcessorImpl(
     private val authenticatorBridgeRepository: AuthenticatorBridgeRepository,
     private val addTotpItemFromAuthenticatorManager: AddTotpItemFromAuthenticatorManager,
-    private val featureFlagManager: FeatureFlagManager,
     dispatcherManager: DispatcherManager,
     context: Context,
 ) : AuthenticatorBridgeProcessor {
@@ -44,12 +41,9 @@ class AuthenticatorBridgeProcessorImpl(
 
     override val binder: IAuthenticatorBridgeService.Stub?
         get() {
-            return if (
-                !featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) ||
-                !isBuildVersionAtLeast(Build.VERSION_CODES.S)
-            ) {
-                // If the feature flag is not enabled, OR if version is below Android 12,
-                // return a null binder which will no-op all service calls
+            return if (!isBuildVersionAtLeast(Build.VERSION_CODES.S)) {
+                // If version is below Android 12, return a null binder which will no-op all
+                // service calls
                 null
             } else {
                 // Otherwise, return real binder implementation:

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -25,7 +25,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
         Unit
     }
 
-    FlagKey.AuthenticatorSync,
     FlagKey.EmailVerification,
     FlagKey.ImportLoginsFlow,
     FlagKey.CredentialExchangeProtocolImport,
@@ -82,7 +81,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.DummyString,
         -> this.keyName
 
-    FlagKey.AuthenticatorSync -> stringResource(R.string.authenticator_sync)
     FlagKey.EmailVerification -> stringResource(R.string.email_verification)
     FlagKey.ImportLoginsFlow -> stringResource(R.string.import_logins_flow)
     FlagKey.CredentialExchangeProtocolImport -> stringResource(R.string.cxp_import)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -17,10 +17,8 @@ import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.UserFingerprintResult
 import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
 import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
@@ -51,7 +49,6 @@ class AccountSecurityViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val environmentRepository: EnvironmentRepository,
     private val biometricsEncryptionManager: BiometricsEncryptionManager,
-    private val featureFlagManager: FeatureFlagManager,
     private val firstTimeActionManager: FirstTimeActionManager,
     policyManager: PolicyManager,
     savedStateHandle: SavedStateHandle,
@@ -74,9 +71,7 @@ class AccountSecurityViewModel @Inject constructor(
                 ?.activeAccount
                 ?.hasMasterPassword != false,
             isUnlockWithPinEnabled = settingsRepository.isUnlockWithPinEnabled,
-            shouldShowEnableAuthenticatorSync =
-                featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) &&
-                    isBuildVersionAtLeast(Build.VERSION_CODES.S),
+            shouldShowEnableAuthenticatorSync = isBuildVersionAtLeast(Build.VERSION_CODES.S),
             userId = userId,
             vaultTimeout = settingsRepository.vaultTimeout,
             vaultTimeoutAction = settingsRepository.vaultTimeoutAction,
@@ -121,13 +116,6 @@ class AccountSecurityViewModel @Inject constructor(
                 )
             }
             .onEach(::sendAction)
-            .launchIn(viewModelScope)
-
-        featureFlagManager
-            .getFeatureFlagFlow(FlagKey.AuthenticatorSync)
-            .onEach {
-                trySendAction(AccountSecurityAction.Internal.AuthenticatorSyncFeatureFlagUpdate(it))
-            }
             .launchIn(viewModelScope)
 
         firstTimeActionManager
@@ -374,10 +362,6 @@ class AccountSecurityViewModel @Inject constructor(
 
     private fun handleInternalAction(action: AccountSecurityAction.Internal) {
         when (action) {
-            is AccountSecurityAction.Internal.AuthenticatorSyncFeatureFlagUpdate -> {
-                handleAuthenticatorSyncFeatureFlagUpdate(action)
-            }
-
             is AccountSecurityAction.Internal.BiometricsKeyResultReceive -> {
                 handleBiometricsKeyResultReceive(action)
             }
@@ -444,18 +428,6 @@ class AccountSecurityViewModel @Inject constructor(
         mutableStateFlow.update {
             it.copy(
                 shouldShowUnlockActionCard = action.showUnlockBadge,
-            )
-        }
-    }
-
-    private fun handleAuthenticatorSyncFeatureFlagUpdate(
-        action: AccountSecurityAction.Internal.AuthenticatorSyncFeatureFlagUpdate,
-    ) {
-        val shouldShowAuthenticatorSync =
-            action.isEnabled && isBuildVersionAtLeast(Build.VERSION_CODES.S)
-        mutableStateFlow.update {
-            it.copy(
-                shouldShowEnableAuthenticatorSync = shouldShowAuthenticatorSync,
             )
         }
     }
@@ -777,13 +749,6 @@ sealed class AccountSecurityAction {
      * Models actions that can be sent by the view model itself.
      */
     sealed class Internal : AccountSecurityAction() {
-
-        /**
-         * The feature flag value for authenticator syncing was updated.
-         */
-        data class AuthenticatorSyncFeatureFlagUpdate(
-            val isEnabled: Boolean,
-        ) : Internal()
 
         /**
          * A biometrics key result has been received.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -10,10 +10,6 @@ class FlagKeyTest {
     @Test
     fun `Feature flags have the correct key name set`() {
         assertEquals(
-            FlagKey.AuthenticatorSync.keyName,
-            "enable-pm-bwa-sync",
-        )
-        assertEquals(
             FlagKey.EmailVerification.keyName,
             "email-verification",
         )
@@ -75,7 +71,6 @@ class FlagKeyTest {
     fun `All feature flags have the correct default value set`() {
         assertTrue(
             listOf(
-                FlagKey.AuthenticatorSync,
                 FlagKey.EmailVerification,
                 FlagKey.ImportLoginsFlow,
                 FlagKey.CredentialExchangeProtocolImport,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/processor/AuthenticatorBridgeProcessorTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/processor/AuthenticatorBridgeProcessorTest.kt
@@ -21,8 +21,6 @@ import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
 import com.x8bit.bitwarden.data.auth.manager.AddTotpItemFromAuthenticatorManagerImpl
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.repository.AuthenticatorBridgeRepository
 import com.x8bit.bitwarden.data.platform.util.createAddTotpItemFromAuthenticatorIntent
 import com.x8bit.bitwarden.ui.vault.model.TotpData
@@ -49,7 +47,6 @@ import org.junit.jupiter.api.Test
 
 class AuthenticatorBridgeProcessorTest {
 
-    private val featureFlagManager = mockk<FeatureFlagManager>()
     private val addTotpItemFromAuthenticatorManager = AddTotpItemFromAuthenticatorManagerImpl()
     private val authenticatorBridgeRepository = mockk<AuthenticatorBridgeRepository>()
     private val context = mockk<Context> {
@@ -64,7 +61,6 @@ class AuthenticatorBridgeProcessorTest {
             addTotpItemFromAuthenticatorManager = addTotpItemFromAuthenticatorManager,
             authenticatorBridgeRepository = authenticatorBridgeRepository,
             context = context,
-            featureFlagManager = featureFlagManager,
             dispatcherManager = FakeDispatcherManager(),
         )
         mockkStatic(::createAddTotpItemFromAuthenticatorIntent)
@@ -91,30 +87,16 @@ class AuthenticatorBridgeProcessorTest {
     }
 
     @Test
-    fun `when AuthenticatorSync feature flag is off, should return null binder`() {
+    fun `when running Android level greater than S, should return non-null binder`() {
         mockkStatic(::isBuildVersionAtLeast)
         every { isBuildVersionAtLeast(Build.VERSION_CODES.S) } returns true
-        every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
-        assertNull(bridgeServiceProcessor.binder)
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `when AuthenticatorSync feature flag is on and running Android level greater than S, should return non-null binder`() {
-        mockkStatic(::isBuildVersionAtLeast)
-        every { isBuildVersionAtLeast(Build.VERSION_CODES.S) } returns true
-        every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns true
         assertNotNull(bridgeServiceProcessor.binder)
     }
 
     @Test
-    fun `when below Android level S, should never return a binder regardless of feature flag`() {
+    fun `when below Android level S, should never return a binder`() {
         mockkStatic(::isBuildVersionAtLeast)
         every { isBuildVersionAtLeast(Build.VERSION_CODES.S) } returns false
-        every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns false
-        assertNull(bridgeServiceProcessor.binder)
-
-        every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns true
         assertNull(bridgeServiceProcessor.binder)
     }
 
@@ -310,7 +292,6 @@ class AuthenticatorBridgeProcessorTest {
     private fun getDefaultBinder(): IAuthenticatorBridgeService.Stub {
         mockkStatic(::isBuildVersionAtLeast)
         every { isBuildVersionAtLeast(Build.VERSION_CODES.S) } returns true
-        every { featureFlagManager.getFeatureFlag(FlagKey.AuthenticatorSync) } returns true
         return bridgeServiceProcessor.binder!!
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -144,7 +144,6 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
 }
 
 private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf(
-    FlagKey.AuthenticatorSync to true,
     FlagKey.EmailVerification to true,
     FlagKey.ImportLoginsFlow to true,
     FlagKey.CredentialExchangeProtocolImport to true,
@@ -162,7 +161,6 @@ private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
 )
 
 private val UPDATED_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf(
-    FlagKey.AuthenticatorSync to false,
     FlagKey.EmailVerification to false,
     FlagKey.ImportLoginsFlow to false,
     FlagKey.CredentialExchangeProtocolImport to false,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23692](https://bitwarden.atlassian.net/browse/PM-23692)

## 📔 Objective

This PR removes the Authenticator Sync feature flag from the Password Manager app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23692]: https://bitwarden.atlassian.net/browse/PM-23692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ