### PR TITLE
PM-23693: Remove Authenticator Sync flag from Authenticator app

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorBridgeModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorBridgeModule.kt
@@ -4,19 +4,14 @@ import android.content.Context
 import com.bitwarden.authenticator.BuildConfig
 import com.bitwarden.authenticator.data.auth.datasource.disk.AuthDiskSource
 import com.bitwarden.authenticator.data.authenticator.repository.util.SymmetricKeyStorageProviderImpl
-import com.bitwarden.authenticator.data.platform.manager.FeatureFlagManager
-import com.bitwarden.authenticator.data.platform.manager.model.FlagKey
 import com.bitwarden.authenticatorbridge.factory.AuthenticatorBridgeFactory
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
-import com.bitwarden.authenticatorbridge.manager.model.AccountSyncState
 import com.bitwarden.authenticatorbridge.provider.SymmetricKeyStorageProvider
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Singleton
 
 /**
@@ -38,23 +33,11 @@ object AuthenticatorBridgeModule {
     fun provideAuthenticatorBridgeManager(
         factory: AuthenticatorBridgeFactory,
         symmetricKeyStorageProvider: SymmetricKeyStorageProvider,
-        featureFlagManager: FeatureFlagManager,
     ): AuthenticatorBridgeManager =
-        if (featureFlagManager.getFeatureFlag(FlagKey.PasswordManagerSync)) {
-            factory.getAuthenticatorBridgeManager(
-                connectionType = BuildConfig.AUTHENTICATOR_BRIDGE_CONNECTION_TYPE,
-                symmetricKeyStorageProvider = symmetricKeyStorageProvider,
-            )
-        } else {
-            // If feature flag is not enabled, return no-op bridge manager so we never
-            // connect to bridge service:
-            object : AuthenticatorBridgeManager {
-                override val accountSyncStateFlow: StateFlow<AccountSyncState>
-                    get() = MutableStateFlow(AccountSyncState.Loading)
-
-                override fun startAddTotpLoginItemFlow(totpUri: String): Boolean = false
-            }
-        }
+        factory.getAuthenticatorBridgeManager(
+            connectionType = BuildConfig.AUTHENTICATOR_BRIDGE_CONNECTION_TYPE,
+            symmetricKeyStorageProvider = symmetricKeyStorageProvider,
+        )
 
     @Provides
     fun providesSymmetricKeyStorageProvider(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorRepositoryModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/di/AuthenticatorRepositoryModule.kt
@@ -5,7 +5,6 @@ import com.bitwarden.authenticator.data.authenticator.manager.FileManager
 import com.bitwarden.authenticator.data.authenticator.manager.TotpCodeManager
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepositoryImpl
-import com.bitwarden.authenticator.data.platform.manager.FeatureFlagManager
 import com.bitwarden.authenticator.data.platform.manager.imports.ImportManager
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
@@ -28,7 +27,6 @@ object AuthenticatorRepositoryModule {
     fun provideAuthenticatorRepository(
         authenticatorBridgeManager: AuthenticatorBridgeManager,
         authenticatorDiskSource: AuthenticatorDiskSource,
-        featureFlagManager: FeatureFlagManager,
         dispatcherManager: DispatcherManager,
         fileManager: FileManager,
         importManager: ImportManager,
@@ -37,7 +35,6 @@ object AuthenticatorRepositoryModule {
     ): AuthenticatorRepository = AuthenticatorRepositoryImpl(
         authenticatorBridgeManager = authenticatorBridgeManager,
         authenticatorDiskSource = authenticatorDiskSource,
-        featureFlagManager = featureFlagManager,
         dispatcherManager = dispatcherManager,
         fileManager = fileManager,
         importManager = importManager,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/model/FlagKey.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/model/FlagKey.kt
@@ -22,7 +22,6 @@ sealed class FlagKey<out T : Any> {
         val activeFlags: List<FlagKey<*>> by lazy {
             listOf(
                 BitwardenAuthenticationEnabled,
-                PasswordManagerSync,
             )
         }
     }
@@ -32,14 +31,6 @@ sealed class FlagKey<out T : Any> {
      */
     data object BitwardenAuthenticationEnabled : FlagKey<Boolean>() {
         override val keyName: String = "bitwarden-authentication-enabled"
-        override val defaultValue: Boolean = false
-    }
-
-    /**
-     * Indicates whether syncing with the main Bitwarden password manager app should be enabled..
-     */
-    data object PasswordManagerSync : FlagKey<Boolean>() {
-        override val keyName: String = "enable-pm-bwa-sync"
         override val defaultValue: Boolean = false
     }
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -147,7 +147,6 @@ private fun FeatureFlagContent_preview() {
         FeatureFlagContent(
             featureFlagMap = mapOf(
                 FlagKey.BitwardenAuthenticationEnabled to true,
-                FlagKey.PasswordManagerSync to false,
             ),
             onValueChange = { _, _ -> },
             onResetValues = { },

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -23,7 +23,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
         -> Unit
 
     FlagKey.BitwardenAuthenticationEnabled,
-    FlagKey.PasswordManagerSync,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
         key = flagKey as FlagKey<Boolean>,
@@ -63,6 +62,4 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
 
     FlagKey.BitwardenAuthenticationEnabled ->
         stringResource(R.string.bitwarden_authentication_enabled)
-
-    FlagKey.PasswordManagerSync -> stringResource(R.string.password_manager_sync)
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -351,7 +351,7 @@ private fun VaultSettings(
         BitwardenTextRow(
             text = stringResource(id = R.string.sync_with_bitwarden_app),
             description = annotatedStringResource(
-                id = R.string.this_feature_is_not_not_yet_available_for_self_hosted_users,
+                id = R.string.learn_more_link,
                 style = spanStyleOf(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textStyle = MaterialTheme.typography.bodyMedium,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModel.kt
@@ -10,9 +10,7 @@ import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
 import com.bitwarden.authenticator.data.authenticator.repository.util.isSyncWithBitwardenEnabled
-import com.bitwarden.authenticator.data.platform.manager.FeatureFlagManager
 import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClipboardManager
-import com.bitwarden.authenticator.data.platform.manager.model.FlagKey
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticator.data.platform.repository.model.BiometricsKeyResult
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
@@ -49,7 +47,6 @@ class SettingsViewModel @Inject constructor(
     private val authenticatorBridgeManager: AuthenticatorBridgeManager,
     private val settingsRepository: SettingsRepository,
     private val clipboardManager: BitwardenClipboardManager,
-    featureFlagManager: FeatureFlagManager,
 ) : BaseViewModel<SettingsState, SettingsEvent, SettingsAction>(
     initialState = savedStateHandle[KEY_STATE]
         ?: createInitialState(
@@ -58,8 +55,6 @@ class SettingsViewModel @Inject constructor(
             appTheme = settingsRepository.appTheme,
             unlockWithBiometricsEnabled = settingsRepository.isUnlockWithBiometricsEnabled,
             isSubmitCrashLogsEnabled = settingsRepository.isCrashLoggingEnabled,
-            isSyncWithBitwardenFeatureEnabled =
-            featureFlagManager.getFeatureFlag(FlagKey.PasswordManagerSync),
             accountSyncState = authenticatorBridgeManager.accountSyncStateFlow.value,
             defaultSaveOption = settingsRepository.defaultSaveOption,
             sharedAccountsState = authenticatorRepository.sharedCodesStateFlow.value,
@@ -323,13 +318,12 @@ class SettingsViewModel @Inject constructor(
             unlockWithBiometricsEnabled: Boolean,
             isSubmitCrashLogsEnabled: Boolean,
             accountSyncState: AccountSyncState,
-            isSyncWithBitwardenFeatureEnabled: Boolean,
             sharedAccountsState: SharedVerificationCodesState,
         ): SettingsState {
             val currentYear = Year.now(clock)
             val copyrightInfo = "© Bitwarden Inc. 2015-$currentYear".asText()
-            // Show sync with Bitwarden row if feature is enabled and the OS is supported:
-            val shouldShowSyncWithBitwarden = isSyncWithBitwardenFeatureEnabled &&
+            // Show sync with Bitwarden row if the OS is supported:
+            val shouldShowSyncWithBitwarden =
                 accountSyncState != AccountSyncState.OsVersionNotSupported
             // Show default save options only if the user had enabled sync with Bitwarden:
             // (They can enable it via the "Sync with Bitwarden" row.

--- a/authenticator/src/main/res/values/strings.xml
+++ b/authenticator/src/main/res/values/strings.xml
@@ -115,7 +115,7 @@
     <string name="download_bitwarden_card_message">Store all of your logins and sync verification codes directly with the Authenticator app.</string>
     <string name="download_now">Download now</string>
     <string name="sync_with_bitwarden_app">Sync with Bitwarden app</string>
-    <string name="this_feature_is_not_not_yet_available_for_self_hosted_users">This feature is not yet available for self-hosted users. <annotation link="learnMore">Learn more</annotation></string>
+    <string name="learn_more_link"><annotation link="learnMore">Learn more</annotation></string>
     <string name="shared_codes_error">Unable to sync codes from the Bitwarden app. Make sure both apps are up-to-date. You can still access your existing codes in the Bitwarden app.</string>
     <string name="shared_accounts_header">%1$s | %2$s (%3$d)</string>
     <string name="sync_with_the_bitwarden_app">Sync with the Bitwarden app</string>

--- a/authenticator/src/main/res/values/strings_non_localized.xml
+++ b/authenticator/src/main/res/values/strings_non_localized.xml
@@ -14,6 +14,5 @@
     <string name="debug_menu">Debug Menu</string>
     <string name="reset_values">Reset values</string>
     <string name="bitwarden_authentication_enabled">Bitwarden authentication enabled</string>
-    <string name="password_manager_sync">Password manager sync</string>
 
 </resources>

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
@@ -73,7 +73,7 @@ class FeatureFlagManagerTest {
         )
 
         val flagValue = manager.getFeatureFlag(
-            key = FlagKey.PasswordManagerSync,
+            key = FlagKey.DummyBoolean,
             forceRefresh = false,
         )
         assertFalse(flagValue)
@@ -169,7 +169,7 @@ class FeatureFlagManagerTest {
         fakeServerConfigRepository.serverConfigValue = null
 
         val flagValue = manager.getFeatureFlag(
-            key = FlagKey.PasswordManagerSync,
+            key = FlagKey.DummyBoolean,
             forceRefresh = false,
         )
 

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/FlagKeyTest.kt
@@ -12,10 +12,6 @@ class FlagKeyTest {
             FlagKey.BitwardenAuthenticationEnabled.keyName,
             "bitwarden-authentication-enabled",
         )
-        assertEquals(
-            FlagKey.PasswordManagerSync.keyName,
-            "enable-pm-bwa-sync",
-        )
     }
 
     @Test
@@ -23,7 +19,6 @@ class FlagKeyTest {
         assertTrue(
             listOf(
                 FlagKey.BitwardenAuthenticationEnabled,
-                FlagKey.PasswordManagerSync,
             ).all {
                 !it.defaultValue
             },

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/repository/DebugMenuRepositoryTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/repository/DebugMenuRepositoryTest.kt
@@ -99,10 +99,6 @@ class DebugMenuRepositoryTest {
             debugMenuRepository.resetFeatureFlagOverrides()
             verify(exactly = 1) {
                 mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
-                    FlagKey.PasswordManagerSync,
-                    FlagKey.PasswordManagerSync.defaultValue,
-                )
-                mockFeatureFlagOverrideDiskSource.saveFeatureFlag(
                     FlagKey.BitwardenAuthenticationEnabled,
                     FlagKey.BitwardenAuthenticationEnabled.defaultValue,
                 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
@@ -52,7 +52,7 @@ class DebugMenuScreenTest : AuthenticatorComposeTest() {
     @Test
     fun `feature flag content should not display if the state is empty`() {
         composeTestRule
-            .onNodeWithText("Password manager sync", ignoreCase = true)
+            .onNodeWithText("Bitwarden authentication enabled", ignoreCase = true)
             .assertDoesNotExist()
     }
 
@@ -61,13 +61,13 @@ class DebugMenuScreenTest : AuthenticatorComposeTest() {
         mutableStateFlow.tryEmit(
             DebugMenuState(
                 featureFlags = mapOf(
-                    FlagKey.PasswordManagerSync to true,
+                    FlagKey.BitwardenAuthenticationEnabled to true,
                 ),
             ),
         )
 
         composeTestRule
-            .onNodeWithText("Password manager sync", ignoreCase = true)
+            .onNodeWithText("Bitwarden authentication enabled", ignoreCase = true)
             .assertExists()
     }
 
@@ -76,18 +76,18 @@ class DebugMenuScreenTest : AuthenticatorComposeTest() {
         mutableStateFlow.tryEmit(
             DebugMenuState(
                 featureFlags = mapOf(
-                    FlagKey.PasswordManagerSync to true,
+                    FlagKey.BitwardenAuthenticationEnabled to true,
                 ),
             ),
         )
         composeTestRule
-            .onNodeWithText("Password manager sync", ignoreCase = true)
+            .onNodeWithText("Bitwarden authentication enabled", ignoreCase = true)
             .performClick()
 
         verify {
             viewModel.trySendAction(
                 DebugMenuAction.UpdateFeatureFlag(
-                    FlagKey.PasswordManagerSync,
+                    FlagKey.BitwardenAuthenticationEnabled,
                     false,
                 ),
             )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -64,9 +64,11 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
     fun `handleUpdateFeatureFlag should update the feature flag via the repository`() {
         val viewModel = createViewModel()
         viewModel.trySendAction(
-            DebugMenuAction.UpdateFeatureFlag(FlagKey.PasswordManagerSync, false),
+            DebugMenuAction.UpdateFeatureFlag(FlagKey.BitwardenAuthenticationEnabled, false),
         )
-        verify { mockDebugMenuRepository.updateFeatureFlag(FlagKey.PasswordManagerSync, false) }
+        verify {
+            mockDebugMenuRepository.updateFeatureFlag(FlagKey.BitwardenAuthenticationEnabled, false)
+        }
     }
 
     private fun createViewModel(): DebugMenuViewModel = DebugMenuViewModel(
@@ -77,12 +79,10 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
 
 private val DEFAULT_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.BitwardenAuthenticationEnabled to true,
-    FlagKey.PasswordManagerSync to true,
 )
 
 private val UPDATED_MAP_VALUE: Map<FlagKey<Any>, Any> = mapOf(
     FlagKey.BitwardenAuthenticationEnabled to false,
-    FlagKey.PasswordManagerSync to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -7,9 +7,7 @@ import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
 import com.bitwarden.authenticator.data.authenticator.repository.util.isSyncWithBitwardenEnabled
-import com.bitwarden.authenticator.data.platform.manager.FeatureFlagManager
 import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClipboardManager
-import com.bitwarden.authenticator.data.platform.manager.model.FlagKey
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
@@ -58,9 +56,6 @@ class SettingsViewModelTest : BaseViewModelTest() {
         every { isCrashLoggingEnabled } returns true
     }
     private val clipboardManager: BitwardenClipboardManager = mockk()
-    private val featureFlagManager: FeatureFlagManager = mockk {
-        every { getFeatureFlag(FlagKey.PasswordManagerSync) } returns true
-    }
 
     @BeforeEach
     fun setup() {
@@ -74,25 +69,7 @@ class SettingsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
-    fun `initialState should be correct when saved state is null and password manager feature flag is off`() {
-        every {
-            featureFlagManager.getFeatureFlag(FlagKey.PasswordManagerSync)
-        } returns false
-        val viewModel = createViewModel(savedState = null)
-        val expectedState = DEFAULT_STATE.copy(
-            showSyncWithBitwarden = false,
-            showDefaultSaveOptionRow = false,
-        )
-        assertEquals(
-            expectedState,
-            viewModel.stateFlow.value,
-        )
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `initialState should be correct when saved state is null and password manager feature flag is on but OS version is too low`() {
+    fun `initialState should be correct when saved state is null but OS version is too low`() {
         every {
             authenticatorBridgeManager.accountSyncStateFlow
         } returns MutableStateFlow(AccountSyncState.OsVersionNotSupported)
@@ -108,14 +85,10 @@ class SettingsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    @Suppress("MaxLineLength")
-    fun `initialState should be correct when saved state is null and password manager feature flag is on and OS version is supported`() {
+    fun `initialState should be correct when saved state is null and OS version is supported`() {
         every {
             authenticatorBridgeManager.accountSyncStateFlow
         } returns MutableStateFlow(AccountSyncState.Loading)
-        every {
-            featureFlagManager.getFeatureFlag(FlagKey.PasswordManagerSync)
-        } returns true
         val viewModel = createViewModel(savedState = null)
         val expectedState = DEFAULT_STATE.copy(
             showSyncWithBitwarden = true,
@@ -233,7 +206,6 @@ class SettingsViewModelTest : BaseViewModelTest() {
         authenticatorRepository = authenticatorRepository,
         settingsRepository = settingsRepository,
         clipboardManager = clipboardManager,
-        featureFlagManager = featureFlagManager,
     )
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23693](https://bitwarden.atlassian.net/browse/PM-23693)

## 📔 Objective

This PR removes the Authenticator Sync feature flag from the Authenticator app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23693]: https://bitwarden.atlassian.net/browse/PM-23693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ