### PR TITLE
[PM-23710] Fixed logic to getServerConfig and added new test on Authenticator

### DIFF
--- a/data/src/main/kotlin/com/bitwarden/data/repository/ServerConfigRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/repository/ServerConfigRepositoryImpl.kt
@@ -35,11 +35,11 @@ internal class ServerConfigRepositoryImpl(
     override suspend fun getServerConfig(forceRefresh: Boolean): ServerConfig? {
         val localConfig = configDiskSource.serverConfig
         val needsRefresh = localConfig == null ||
-            Instant
-                .ofEpochMilli(localConfig.lastSync)
-                .isAfter(
-                    clock.instant().plusSeconds(MINIMUM_CONFIG_SYNC_INTERVAL_SEC),
-                )
+            clock.instant().isAfter(
+                Instant
+                    .ofEpochMilli(localConfig.lastSync)
+                    .plusSeconds(MINIMUM_CONFIG_SYNC_INTERVAL_SEC),
+            )
 
         if (needsRefresh || forceRefresh) {
             configService


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23710
Related to #5496 

## 📔 Objective

Fix the needs refresh validation on `ServerConfigRepository.getServerConfig` and added new test to verify if serverConfig is updated when sync interval is reached.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
