### PR TITLE
Fix `unmockkStatic` usage in `SdkCipherRepositoryTest`

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkCipherRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkCipherRepositoryTest.kt
@@ -13,6 +13,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -41,7 +42,7 @@ class SdkCipherRepositoryTest {
 
     @AfterEach
     fun tearDown() {
-        mockkStatic(
+        unmockkStatic(
             SyncResponseJson.Cipher::toEncryptedSdkCipher,
             Cipher::toEncryptedNetworkCipherResponse,
         )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

The `tearDown` method in `SdkCipherRepositoryTest` was incorrectly calling `mockkStatic` instead of `unmockkStatic` when cleaning up mocks. This commit corrects the method call to ensure proper test teardown.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
