### PR TITLE
PM-23910: Disallow file sends for non-premium users

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -838,11 +838,26 @@ class VaultItemListingViewModel @Inject constructor(
             }
 
             is VaultItemListingState.ItemListingType.Send -> {
-                sendEvent(
-                    VaultItemListingEvent.NavigateToAddSendItem(
-                        sendType = itemListingType.toSendItemType(),
-                    ),
-                )
+                when (val sendType = itemListingType.toSendItemType()) {
+                    SendItemType.FILE -> {
+                        if (state.isPremium) {
+                            sendEvent(VaultItemListingEvent.NavigateToAddSendItem(sendType))
+                        } else {
+                            mutableStateFlow.update {
+                                it.copy(
+                                    dialogState = VaultItemListingState.DialogState.Error(
+                                        title = R.string.send.asText(),
+                                        message = R.string.send_file_premium_required.asText(),
+                                    ),
+                                )
+                            }
+                        }
+                    }
+
+                    SendItemType.TEXT -> {
+                        sendEvent(VaultItemListingEvent.NavigateToAddSendItem(sendType))
+                    }
+                }
             }
         }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -881,4 +881,5 @@ private val DEFAULT_STATE = AddEditSendState(
     baseWebSendUrl = "https://vault.bitwarden.com/#/send/",
     policyDisablesSend = false,
     sendType = SendItemType.TEXT,
+    isPremium = true,
 )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23910](https://bitwarden.atlassian.net/browse/PM-23910)

## 📔 Objective

This PR ensures that Files Sends cannot be created without a premium account.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23910]: https://bitwarden.atlassian.net/browse/PM-23910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ