### PR TITLE
Allow asterisk in email validation

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StringExtensions.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StringExtensions.kt
@@ -45,14 +45,14 @@ fun String?.orZeroWidthSpace(): String = this.orNullIfBlank() ?: ZERO_WIDTH_CHAR
  *
  * This validates that the email is valid by asserting that:
  * * The string starts with a string of characters including periods, underscores, percent symbols,
- * plus's, minus's, forward slash's, and alphanumeric characters.
+ * plus's, minus's, forward slash's, asterisks, and alphanumeric characters.
  * * Followed by an '@' symbol.
  * * Followed by a string of characters including periods, minus's, and alphanumeric characters.
  * * Followed by a period.
  * * Followed by at least 2 more alphanumeric characters.
  */
 fun String.isValidEmail(): Boolean =
-    this.matches(regex = "^[A-Za-z0-9._%+-/]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$".toRegex())
+    this.matches(regex = "^[A-Za-z0-9._%+-/*]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$".toRegex())
 
 /**
  * Returns `true` if the given [String] is a non-blank, valid URI and `false` otherwise.

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/base/util/StringExtensionsTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/base/util/StringExtensionsTest.kt
@@ -28,6 +28,7 @@ class StringExtensionsTest {
             "test.test@test.test.com" to true,
             "test/test@test.test.com" to true,
             "test.test@test/test.com" to false,
+            "test*test@test.com" to true,
         )
         invalidEmails.forEach {
             assertEquals(it.first.isValidEmail(), it.second)


### PR DESCRIPTION
## 🎟️ Tracking

PM-23844
Resolves #5535

## 📔 Objective

The email validation regex in `StringExtensions.kt` is updated to allow the asterisk character (*) in the local part of an email address.

The `isValidEmail` function's KDoc is also updated to reflect this change.

## 📸 Screenshot


https://github.com/user-attachments/assets/7f53c1f5-cd58-4252-b8d9-2bd947ce0dec



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
