### PR TITLE
[PM-23817] Move PM string to UI module and update Crowdin configuration

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/list/PrivilegedAppsListScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/list/PrivilegedAppsListScreen.kt
@@ -31,6 +31,7 @@ import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
@@ -194,7 +195,7 @@ private fun PrivilegedAppsListContent(
                         BitwardenStandardIconButton(
                             vectorIconRes = BitwardenDrawable.ic_delete,
                             contentDescription =
-                                stringResource(R.string.delete_x, item.packageName),
+                                stringResource(BitwardenString.delete_x, item.packageName),
                             onClick = remember(item) {
                                 { onDeleteClick(item) }
                             },

--- a/crowdin-bwpm.yml
+++ b/crowdin-bwpm.yml
@@ -1,10 +1,14 @@
 project_id_env: _CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_API_TOKEN
 preserve_hierarchy: true
-base_path: "app/src/main"
 files:
-  - source: "/res/values/strings.xml"
-    translation: "/res/values-%android_code%/%original_file_name%"
+  - source: "/app/src/main/res/values/strings.xml"
+    translation: "/app/src/main/res/values-%android_code%/%original_file_name%"
     dest: "/android/%original_file_name%"
+    update_option: update_as_unapproved
+    type: android
+  - source: "/ui/src/main/res/values/strings.xml"
+    translation: "/ui/src/main/res/values-%android_code%/%original_file_name%"
+    dest: "/android-ui/%original_file_name%"
     update_option: update_as_unapproved
     type: android

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -32,6 +32,12 @@ android {
         sourceCompatibility(libs.versions.jvmTarget.get())
         targetCompatibility(libs.versions.jvmTarget.get())
     }
+    lint {
+        disable += listOf(
+            "MissingTranslation",
+            "ExtraTranslation",
+        )
+    }
     testOptions {
         // Required for Robolectric
         unitTests.isIncludeAndroidResources = true

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/resource/BitwardenResources.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/resource/BitwardenResources.kt
@@ -4,3 +4,8 @@ package com.bitwarden.ui.platform.resource
  * A type alias for the drawable resources in the Bitwarden UI module.
  */
 typealias BitwardenDrawable = com.bitwarden.ui.R.drawable
+
+/**
+ * A type alias for the string resources in the Bitwarden UI module.
+ */
+typealias BitwardenString = com.bitwarden.ui.R.string

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="delete_x">Delete %s</string>
+</resources>


### PR DESCRIPTION
## 🎟️ Tracking

PM-23817

## 📔 Objective

This commit moves the `delete_x` string resource from the `app` module to the `ui` module.

The following changes were made:
- Added `strings.xml` to `ui/src/main/res/values/` and defined `delete_x` string.
- Updated `PrivilegedAppsListScreen.kt` to use `BitwardenString.delete_x` from the `ui` module.
- Added `BitwardenString` typealias in `BitwardenResources.kt` for string resources in the UI module.
- Updated `crowdin-bwpm.yml` to include the new path for UI module strings and adjusted the base path.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
