### PR TITLE
PM-24004: Push notification for sync should bypass 30 minute interval

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -314,7 +314,7 @@ class VaultRepositoryImpl(
 
         pushManager
             .fullSyncFlow
-            .onEach { syncIfNecessary() }
+            .onEach { sync(forced = false) }
             .launchIn(unconfinedScope)
 
         pushManager

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -3275,7 +3275,7 @@ class VaultRepositoryTest {
     }
 
     @Test
-    fun `fullSyncFlow emission should trigger sync if necessary`() {
+    fun `fullSyncFlow emission should trigger unforced sync`() {
         val userId = "mockId-1"
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         every {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24004](https://bitwarden.atlassian.net/browse/PM-24004)

## 📔 Objective

This PR changes the full sync notification to call `sync(force = false)` instead of `syncIfNecessary()`, this small changes bypasses the 30 minute interval check to ensure we sync if something has changed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24004]: https://bitwarden.atlassian.net/browse/PM-24004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ