### PR TITLE
PM-24035: Add tooltip for website icons

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -21,12 +21,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.components.model.TooltipData
 import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
@@ -35,7 +37,9 @@ import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
 import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLanguage
+import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.util.displayLabel
 import kotlinx.collections.immutable.toImmutableList
 
@@ -48,11 +52,15 @@ import kotlinx.collections.immutable.toImmutableList
 fun AppearanceScreen(
     onNavigateBack: () -> Unit,
     viewModel: AppearanceViewModel = hiltViewModel(),
+    intentManager: IntentManager = LocalIntentManager.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             AppearanceEvent.NavigateBack -> onNavigateBack.invoke()
+            AppearanceEvent.NavigateToWebsiteIconsHelp -> {
+                intentManager.launchUri("https://bitwarden.com/help/website-icons/".toUri())
+            }
         }
     }
 
@@ -134,6 +142,12 @@ fun AppearanceScreen(
                 onCheckedChange = remember(viewModel) {
                     { viewModel.trySendAction(AppearanceAction.ShowWebsiteIconsToggle(it)) }
                 },
+                tooltip = TooltipData(
+                    onClick = remember(viewModel) {
+                        { viewModel.trySendAction(AppearanceAction.ShowWebsiteIconsTooltipClick) }
+                    },
+                    contentDescription = stringResource(id = R.string.show_website_icons_help),
+                ),
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .testTag("ShowWebsiteIconsSwitch")

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModel.kt
@@ -22,6 +22,7 @@ private const val KEY_STATE = "state"
 /**
  * View model for the appearance screen.
  */
+@Suppress("TooManyFunctions")
 @HiltViewModel
 class AppearanceViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
@@ -58,6 +59,7 @@ class AppearanceViewModel @Inject constructor(
         AppearanceAction.BackClick -> handleBackClicked()
         is AppearanceAction.LanguageChange -> handleLanguageChanged(action)
         is AppearanceAction.ShowWebsiteIconsToggle -> handleShowWebsiteIconsToggled(action)
+        AppearanceAction.ShowWebsiteIconsTooltipClick -> handleShowWebsiteIconsTooltipClick()
         is AppearanceAction.ThemeChange -> handleThemeChanged(action)
         is AppearanceAction.DynamicColorsToggle -> handleDynamicColorsToggled(action)
         AppearanceAction.DismissDialog -> handleDismissDialog()
@@ -68,6 +70,7 @@ class AppearanceViewModel @Inject constructor(
         is AppearanceAction.Internal.AppLanguageStateUpdateReceive -> {
             handleLanguageStateChange(action)
         }
+
         is AppearanceAction.Internal.DynamicColorsStateUpdateReceive -> {
             handleDynamicColorsStateChange(action)
         }
@@ -104,6 +107,10 @@ class AppearanceViewModel @Inject constructor(
 
         // Negate the boolean to properly update the settings repository
         settingsRepository.isIconLoadingDisabled = !action.showWebsiteIcons
+    }
+
+    private fun handleShowWebsiteIconsTooltipClick() {
+        sendEvent(AppearanceEvent.NavigateToWebsiteIconsHelp)
     }
 
     private fun handleThemeChanged(action: AppearanceAction.ThemeChange) {
@@ -170,6 +177,11 @@ sealed class AppearanceEvent {
      * Navigate back.
      */
     data object NavigateBack : AppearanceEvent()
+
+    /**
+     * Navigate to the website icons help URL.
+     */
+    data object NavigateToWebsiteIconsHelp : AppearanceEvent()
 }
 
 /**
@@ -194,6 +206,11 @@ sealed class AppearanceAction {
     data class ShowWebsiteIconsToggle(
         val showWebsiteIcons: Boolean,
     ) : AppearanceAction()
+
+    /**
+     * User clicked the website icons tooltip.
+     */
+    data object ShowWebsiteIconsTooltipClick : AppearanceAction()
 
     /**
      * Indicates that the user selected a new theme.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@ Scanning will happen automatically.</string>
     <string name="address">Address</string>
     <string name="expiration">Expiration</string>
     <string name="show_website_icons">Show website icons</string>
+    <string name="show_website_icons_help">Show website icons help</string>
     <string name="show_website_icons_description">Show a recognizable image next to each login</string>
     <string name="icons_url">Icons server URL</string>
     <string name="vault_is_locked">Vault is locked</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceViewModelTest.kt
@@ -137,6 +137,15 @@ class AppearanceViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `on ShowWebsiteIconsTooltipClick should emit NavigateToWebsiteIconsHelp`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(AppearanceAction.ShowWebsiteIconsTooltipClick)
+            assertEquals(AppearanceEvent.NavigateToWebsiteIconsHelp, awaitItem())
+        }
+    }
+
+    @Test
     fun `on ThemeChange should update state and set theme in SettingsRepository`() = runTest {
         val viewModel = createViewModel()
         viewModel.stateFlow.test {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24035](https://bitwarden.atlassian.net/browse/PM-24035)

## 📔 Objective

This PR adds a tooltip for the `Show website icons` options in the Appearance settings UI.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24035]: https://bitwarden.atlassian.net/browse/PM-24035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ