### PR TITLE
PM-19185: Persist pin after a soft-logout

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -80,6 +80,7 @@ class UserLogoutManagerImpl(
         // Save any data that will still need to be retained after otherwise clearing all dat
         val vaultTimeoutInMinutes = settingsDiskSource.getVaultTimeoutInMinutes(userId = userId)
         val vaultTimeoutAction = settingsDiskSource.getVaultTimeoutAction(userId = userId)
+        val pinProtectedUserKey = authDiskSource.getPinProtectedUserKey(userId = userId)
 
         switchUserIfAvailable(
             currentUserId = userId,
@@ -101,6 +102,10 @@ class UserLogoutManagerImpl(
                 vaultTimeoutAction = vaultTimeoutAction,
             )
         }
+        authDiskSource.storePinProtectedUserKey(
+            userId = userId,
+            pinProtectedUserKey = pinProtectedUserKey,
+        )
     }
 
     private fun clearData(userId: String) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -657,8 +657,8 @@ private fun SessionTimeoutActionRow(
 
     if (shouldShowLogoutActionConfirmationDialog) {
         BitwardenTwoButtonDialog(
-            title = stringResource(id = R.string.warning),
-            message = stringResource(id = R.string.vault_timeout_log_out_confirmation),
+            title = stringResource(id = R.string.vault_timeout_log_out_confirmation_title),
+            message = stringResource(id = R.string.vault_timeout_log_out_confirmation_message),
             confirmButtonText = stringResource(id = R.string.yes),
             dismissButtonText = stringResource(id = R.string.cancel),
             onConfirmClick = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,7 +101,8 @@
     <string name="one_minute">1 minute</string>
     <string name="four_hours">4 hours</string>
     <string name="immediately">Immediately</string>
-    <string name="vault_timeout_log_out_confirmation">Logging out will remove all access to your vault and requires online authentication after the timeout period. Are you sure you want to use this setting?</string>
+    <string name="vault_timeout_log_out_confirmation_title">Set session timeout to \"Log out\"?</string>
+    <string name="vault_timeout_log_out_confirmation_message">After the timeout period, you will be logged out. You will need to be connected to the internet to log in and access your vault again. Your settings and PIN saved on this device won\'t change.</string>
     <string name="logging_in">Logging in...</string>
     <string name="login_to_bitwarden">Log in to Bitwarden</string>
     <string name="master_password_confirmation_val_message">Password confirmation is not correct.</string>
@@ -341,7 +342,7 @@ Scanning will happen automatically.</string>
     <string name="pin">PIN</string>
     <string name="unlock">Unlock</string>
     <string name="thirty_minutes">30 minutes</string>
-    <string name="set_pin_description">Your PIN must be at least 4 characters. Your PIN settings will be reset if you ever fully log out of the application.</string>
+    <string name="set_pin_description">Your PIN must be at least 4 characters. Your PIN settings will be reset if you manually log out of the Bitwarden app.</string>
     <string name="logged_in_as_on">Logged in as %1$s on %2$s.</string>
     <string name="vault_locked_master_password">Your vault is locked. Verify your master password to continue.</string>
     <string name="vault_locked_pin">Your vault is locked. Verify your PIN code to continue.</string>

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
@@ -32,6 +32,7 @@ import java.time.ZonedDateTime
 class UserLogoutManagerTest {
     private val authDiskSource: AuthDiskSource = mockk {
         every { storeAccountTokens(userId = any(), accountTokens = null) } just runs
+        every { storePinProtectedUserKey(userId = any(), pinProtectedUserKey = any()) } just runs
         every { userState = any() } just runs
         every { clearData(any()) } just runs
     }
@@ -117,6 +118,7 @@ class UserLogoutManagerTest {
         val userId = USER_ID_1
         val vaultTimeoutInMinutes = 360
         val vaultTimeoutAction = VaultTimeoutAction.LOGOUT
+        val pinProtectedUserKey = "pinProtectedUserKey"
 
         every { authDiskSource.userState } returns MULTI_USER_STATE
         every {
@@ -125,10 +127,13 @@ class UserLogoutManagerTest {
         every {
             settingsDiskSource.getVaultTimeoutAction(userId = userId)
         } returns vaultTimeoutAction
+        every {
+            authDiskSource.getPinProtectedUserKey(userId = userId)
+        } returns pinProtectedUserKey
 
         userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
 
-        verify { authDiskSource.storeAccountTokens(userId = USER_ID_1, accountTokens = null) }
+        verify { authDiskSource.storeAccountTokens(userId = userId, accountTokens = null) }
         assertDataCleared(userId = userId)
 
         verify(exactly = 1) {
@@ -141,6 +146,18 @@ class UserLogoutManagerTest {
                 vaultTimeoutAction = vaultTimeoutAction,
             )
             toastManager.show(messageId = R.string.account_switched_automatically)
+            settingsDiskSource.storeVaultTimeoutInMinutes(
+                userId = userId,
+                vaultTimeoutInMinutes = vaultTimeoutInMinutes,
+            )
+            settingsDiskSource.storeVaultTimeoutAction(
+                userId = userId,
+                vaultTimeoutAction = vaultTimeoutAction,
+            )
+            authDiskSource.storePinProtectedUserKey(
+                userId = userId,
+                pinProtectedUserKey = pinProtectedUserKey,
+            )
         }
     }
 
@@ -149,6 +166,7 @@ class UserLogoutManagerTest {
         val userId = USER_ID_1
         val vaultTimeoutInMinutes = 360
         val vaultTimeoutAction = VaultTimeoutAction.LOGOUT
+        val pinProtectedUserKey = "pinProtectedUserKey"
 
         every { authDiskSource.userState } returns MULTI_USER_STATE
         every {
@@ -157,16 +175,31 @@ class UserLogoutManagerTest {
         every {
             settingsDiskSource.getVaultTimeoutAction(userId = userId)
         } returns vaultTimeoutAction
+        every {
+            authDiskSource.getPinProtectedUserKey(userId = userId)
+        } returns pinProtectedUserKey
 
         userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
 
         verify(exactly = 1) {
-            authDiskSource.storeAccountTokens(userId = USER_ID_1, accountTokens = null)
+            authDiskSource.storeAccountTokens(userId = userId, accountTokens = null)
             authDiskSource.userState = UserStateJson(
                 activeUserId = USER_ID_2,
                 accounts = MULTI_USER_STATE.accounts,
             )
             toastManager.show(messageId = R.string.account_switched_automatically)
+            settingsDiskSource.storeVaultTimeoutInMinutes(
+                userId = userId,
+                vaultTimeoutInMinutes = vaultTimeoutInMinutes,
+            )
+            settingsDiskSource.storeVaultTimeoutAction(
+                userId = userId,
+                vaultTimeoutAction = vaultTimeoutAction,
+            )
+            authDiskSource.storePinProtectedUserKey(
+                userId = userId,
+                pinProtectedUserKey = pinProtectedUserKey,
+            )
         }
     }
 
@@ -176,6 +209,7 @@ class UserLogoutManagerTest {
         val userId = USER_ID_1
         val vaultTimeoutInMinutes = 360
         val vaultTimeoutAction = VaultTimeoutAction.LOGOUT
+        val pinProtectedUserKey = "pinProtectedUserKey"
 
         every { authDiskSource.userState } returns MULTI_USER_STATE
         every {
@@ -184,16 +218,31 @@ class UserLogoutManagerTest {
         every {
             settingsDiskSource.getVaultTimeoutAction(userId = userId)
         } returns vaultTimeoutAction
+        every {
+            authDiskSource.getPinProtectedUserKey(userId = userId)
+        } returns pinProtectedUserKey
 
         userLogoutManager.softLogout(userId = userId, reason = LogoutReason.SecurityStamp)
 
         verify(exactly = 1) {
-            authDiskSource.storeAccountTokens(userId = USER_ID_1, accountTokens = null)
+            authDiskSource.storeAccountTokens(userId = userId, accountTokens = null)
             authDiskSource.userState = UserStateJson(
                 activeUserId = USER_ID_2,
                 accounts = MULTI_USER_STATE.accounts,
             )
             toastManager.show(messageId = R.string.login_expired)
+            settingsDiskSource.storeVaultTimeoutInMinutes(
+                userId = userId,
+                vaultTimeoutInMinutes = vaultTimeoutInMinutes,
+            )
+            settingsDiskSource.storeVaultTimeoutAction(
+                userId = userId,
+                vaultTimeoutAction = vaultTimeoutAction,
+            )
+            authDiskSource.storePinProtectedUserKey(
+                userId = userId,
+                pinProtectedUserKey = pinProtectedUserKey,
+            )
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreenTest.kt
@@ -257,7 +257,7 @@ class SetupUnlockScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText(
                 text = "Your PIN must be at least 4 characters. Your PIN settings will be reset " +
-                    "if you ever fully log out of the application.",
+                    "if you manually log out of the Bitwarden app.",
             )
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -352,7 +352,7 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText(
                 text = "Your PIN must be at least 4 characters. Your PIN settings will be reset " +
-                    "if you ever fully log out of the application.",
+                    "if you manually log out of the Bitwarden app.",
             )
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
@@ -1101,14 +1101,14 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText("Warning")
+            .onAllNodesWithText("Set session timeout to \"Log out\"?")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule
             .onAllNodesWithText(
-                "Logging out will remove all access to your vault and requires online " +
-                    "authentication after the timeout period. Are you sure you want to use this " +
-                    "setting?",
+                text = "After the timeout period, you will be logged out. You will need to be " +
+                    "connected to the internet to log in and access your vault again. Your " +
+                    "settings and PIN saved on this device won\'t change.",
             )
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
@@ -1140,7 +1140,7 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText("Warning")
+            .onAllNodesWithText("Set session timeout to \"Log out\"?")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule
@@ -1169,7 +1169,7 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
             .performClick()
 
         composeTestRule
-            .onAllNodesWithText("Warning")
+            .onAllNodesWithText("Set session timeout to \"Log out\"?")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
         composeTestRule


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19185](https://bitwarden.atlassian.net/browse/PM-19185?focusedCommentId=103980&sourceType=mention)

## 📔 Objective

This PR retains the PIN after a soft logout, allowing the user to re-login with a pin instead of a password. The UI has also had some copy updated in order to explain the functionality better.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19185]: https://bitwarden.atlassian.net/browse/PM-19185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ