### PR TITLE
Disable MissingTranslation and ExtraTranslation lint checks in UI module

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -32,6 +32,12 @@ android {
         sourceCompatibility(libs.versions.jvmTarget.get())
         targetCompatibility(libs.versions.jvmTarget.get())
     }
+    lint {
+        disable += listOf(
+            "MissingTranslation",
+            "ExtraTranslation",
+        )
+    }
     testOptions {
         // Required for Robolectric
         unitTests.isIncludeAndroidResources = true


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This commit updates the `lint` configuration in the `ui/build.gradle.kts` file to disable the `MissingTranslation` and `ExtraTranslation` checks.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
