### PR TITLE
[PM-24002] Copy Authenticator strings to `ui` module

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/clipboard/BitwardenClipboardManagerImpl.kt
@@ -7,9 +7,9 @@ import android.os.Build
 import androidx.compose.ui.text.AnnotatedString
 import androidx.core.content.getSystemService
 import androidx.core.os.persistableBundleOf
-import com.bitwarden.authenticator.R
 import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.ui.platform.base.util.toAnnotatedString
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 
 /**
@@ -38,7 +38,7 @@ class BitwardenClipboardManagerImpl(
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
             toastManager.show(
                 message = context.resources.getString(
-                    R.string.value_has_been_copied,
+                    BitwardenString.value_has_been_copied,
                     toastDescriptorOverride ?: text,
                 ),
             )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/BitwardenExportParser.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/BitwardenExportParser.kt
@@ -1,7 +1,6 @@
 package com.bitwarden.authenticator.data.platform.manager.imports.parsers
 
 import android.net.Uri
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemAlgorithm
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
@@ -9,6 +8,7 @@ import com.bitwarden.authenticator.data.authenticator.manager.TotpCodeManager
 import com.bitwarden.authenticator.data.authenticator.manager.model.ExportJsonData
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ExportParseResult
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportFileFormat
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -24,7 +24,9 @@ class BitwardenExportParser(
     override fun parse(byteArray: ByteArray): ExportParseResult {
         return when (fileFormat) {
             ImportFileFormat.BITWARDEN_JSON -> importJsonFile(byteArray)
-            else -> ExportParseResult.Error(R.string.import_bitwarden_unsupported_format.asText())
+            else -> ExportParseResult.Error(
+                BitwardenString.import_bitwarden_unsupported_format.asText(),
+            )
         }
     }
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/ExportParser.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/ExportParser.kt
@@ -1,8 +1,8 @@
 package com.bitwarden.authenticator.data.platform.manager.imports.parsers
 
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ExportParseResult
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
@@ -41,13 +41,13 @@ abstract class ExportParser {
         parse(byteArray = byteArray)
     } catch (error: MissingFieldException) {
         ExportParseResult.Error(
-            title = R.string.required_information_missing.asText(),
-            message = R.string.required_information_missing_message.asText(),
+            title = BitwardenString.required_information_missing.asText(),
+            message = BitwardenString.required_information_missing_message.asText(),
         )
     } catch (error: SerializationException) {
         ExportParseResult.Error(
-            title = R.string.file_could_not_be_processed.asText(),
-            message = R.string.file_could_not_be_processed_message.asText(),
+            title = BitwardenString.file_could_not_be_processed.asText(),
+            message = BitwardenString.file_could_not_be_processed_message.asText(),
         )
     } catch (error: IllegalArgumentException) {
         ExportParseResult.Error(message = error.message?.asText())

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/TwoFasExportParser.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/TwoFasExportParser.kt
@@ -1,11 +1,11 @@
 package com.bitwarden.authenticator.data.platform.manager.imports.parsers
 
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemAlgorithm
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ExportParseResult
 import com.bitwarden.authenticator.data.platform.manager.imports.model.TwoFasJsonExport
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -39,7 +39,7 @@ class TwoFasExportParser : ExportParser() {
 
         return if (!exportData.servicesEncrypted.isNullOrEmpty()) {
             ExportParseResult.Error(
-                message = R.string.import_2fas_password_protected_not_supported.asText(),
+                message = BitwardenString.import_2fas_password_protected_not_supported.asText(),
             )
         } else {
             ExportParseResult.Success(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorFilledTonalButton
 import com.bitwarden.authenticator.ui.platform.components.dialog.BasicDialogState
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenBasicDialog
@@ -36,6 +35,7 @@ import com.bitwarden.authenticator.ui.platform.composition.LocalBiometricsManage
 import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 
 /**
@@ -61,7 +61,7 @@ fun UnlockScreen(
     when (val dialog = state.dialog) {
         is UnlockState.Dialog.Error -> BitwardenBasicDialog(
             visibilityState = BasicDialogState.Shown(
-                title = R.string.an_error_has_occurred.asText(),
+                title = BitwardenString.an_error_has_occurred.asText(),
                 message = dialog.message,
             ),
             onDismissRequest = remember(viewModel) {
@@ -72,7 +72,7 @@ fun UnlockScreen(
         )
 
         UnlockState.Dialog.Loading -> BitwardenLoadingDialog(
-            visibilityState = LoadingDialogState.Shown(R.string.loading.asText()),
+            visibilityState = LoadingDialogState.Shown(BitwardenString.loading.asText()),
         )
 
         null -> Unit
@@ -124,11 +124,11 @@ fun UnlockScreen(
                         .fillMaxWidth(),
                     colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary),
                     painter = painterResource(id = BitwardenDrawable.ic_logo_horizontal),
-                    contentDescription = stringResource(R.string.bitwarden_authenticator),
+                    contentDescription = stringResource(BitwardenString.bitwarden_authenticator),
                 )
                 Spacer(modifier = Modifier.height(32.dp))
                 AuthenticatorFilledTonalButton(
-                    label = stringResource(id = R.string.use_biometrics_to_unlock),
+                    label = stringResource(id = BitwardenString.use_biometrics_to_unlock),
                     onClick = {
                         biometricsManager.promptBiometrics(
                             onSuccess = onBiometricsUnlock,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockViewModel.kt
@@ -3,10 +3,10 @@ package com.bitwarden.authenticator.ui.auth.unlock
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.platform.manager.BiometricsEncryptionManager
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -73,7 +73,7 @@ class UnlockViewModel @Inject constructor(
         mutableStateFlow.update {
             it.copy(
                 dialog = UnlockState.Dialog.Error(
-                    message = R.string.too_many_failed_biometric_attempts.asText(),
+                    message = BitwardenString.too_many_failed_biometric_attempts.asText(),
                 ),
             )
         }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemAlgorithm
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
 import com.bitwarden.authenticator.ui.authenticator.feature.edititem.model.EditItemData
@@ -65,6 +64,7 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import kotlinx.collections.immutable.toImmutableList
 
 /**
@@ -112,11 +112,11 @@ fun EditItemScreen(
         topBar = {
             AuthenticatorTopAppBar(
                 title = stringResource(
-                    id = R.string.edit_item,
+                    id = BitwardenString.edit,
                 ),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
-                navigationIconContentDescription = stringResource(id = R.string.close),
+                navigationIconContentDescription = stringResource(id = BitwardenString.close),
                 onNavigationIconClick = remember(viewModel) {
                     {
                         viewModel.trySendAction(EditItemAction.CancelClick)
@@ -124,7 +124,7 @@ fun EditItemScreen(
                 },
                 actions = {
                     AuthenticatorTextButton(
-                        label = stringResource(id = R.string.save),
+                        label = stringResource(id = BitwardenString.save),
                         onClick = remember(viewModel) {
                             { viewModel.trySendAction(EditItemAction.SaveClick) }
                         },
@@ -247,7 +247,7 @@ fun EditItemContent(
                 modifier = Modifier
                     .standardHorizontalMargin()
                     .fillMaxWidth(),
-                label = stringResource(id = R.string.information),
+                label = stringResource(id = BitwardenString.information),
             )
         }
 
@@ -258,7 +258,7 @@ fun EditItemContent(
                     .testTag(tag = "NameTextField")
                     .standardHorizontalMargin()
                     .fillMaxWidth(),
-                label = stringResource(id = R.string.name),
+                label = stringResource(id = BitwardenString.name),
                 value = viewState.itemData.issuer,
                 onValueChange = onIssuerNameTextChange,
                 singleLine = true,
@@ -272,7 +272,7 @@ fun EditItemContent(
                     .testTag(tag = "KeyTextField")
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
-                label = stringResource(id = R.string.key),
+                label = stringResource(id = BitwardenString.key),
                 value = viewState.itemData.totpCode,
                 onValueChange = onTotpCodeTextChange,
                 singleLine = true,
@@ -287,7 +287,7 @@ fun EditItemContent(
                     .testTag(tag = "UsernameTextField")
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
-                label = stringResource(id = R.string.username),
+                label = stringResource(id = BitwardenString.username),
                 value = viewState.itemData.username.orEmpty(),
                 onValueChange = onUsernameTextChange,
                 singleLine = true,
@@ -297,7 +297,7 @@ fun EditItemContent(
         item {
             Spacer(modifier = Modifier.height(16.dp))
             BitwardenSwitch(
-                label = stringResource(id = R.string.favorite),
+                label = stringResource(id = BitwardenString.favorite),
                 isChecked = viewState.itemData.favorite,
                 onCheckedChange = onToggleFavorite,
                 modifier = Modifier
@@ -332,7 +332,7 @@ fun EditItemContent(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = stringResource(R.string.advanced),
+                    text = stringResource(BitwardenString.advanced),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
                 )
@@ -340,9 +340,9 @@ fun EditItemContent(
                 Icon(
                     painter = rememberVectorPainter(id = BitwardenDrawable.ic_chevron_down),
                     contentDescription = if (viewState.isAdvancedOptionsExpanded) {
-                        stringResource(R.string.collapse_advanced_options)
+                        stringResource(BitwardenString.collapse_advanced_options)
                     } else {
-                        stringResource(R.string.expand_advanced_options)
+                        stringResource(BitwardenString.expand_advanced_options)
                     },
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier
@@ -386,7 +386,7 @@ private fun LazyListScope.advancedOptions(
                 .standardHorizontalMargin()
                 .fillMaxWidth()
                 .animateItem(),
-            label = stringResource(id = R.string.otp_type),
+            label = stringResource(id = BitwardenString.otp_type),
             options = typeOptionsWithStrings.values.toImmutableList(),
             selectedOption = viewState.itemData.type.name,
             onOptionSelected = { selectedOption ->
@@ -409,7 +409,7 @@ private fun LazyListScope.advancedOptions(
                 .standardHorizontalMargin()
                 .fillMaxWidth()
                 .animateItem(),
-            label = stringResource(id = R.string.algorithm),
+            label = stringResource(id = BitwardenString.algorithm),
             options = algorithmOptionsWithStrings.values.toImmutableList(),
             selectedOption = viewState.itemData.algorithm.name,
             onOptionSelected = { selectedOption ->
@@ -425,7 +425,7 @@ private fun LazyListScope.advancedOptions(
     item(key = "RefreshPeriodItemTypePicker") {
         val possibleRefreshPeriodOptions = AuthenticatorRefreshPeriodOption.entries
         val refreshPeriodOptionsWithStrings = possibleRefreshPeriodOptions.associateWith {
-            stringResource(id = R.string.refresh_period_seconds, it.seconds)
+            stringResource(id = BitwardenString.refresh_period_seconds, it.seconds)
         }
         Spacer(modifier = Modifier.height(8.dp))
         BitwardenMultiSelectButton(
@@ -434,10 +434,10 @@ private fun LazyListScope.advancedOptions(
                 .standardHorizontalMargin()
                 .fillMaxWidth()
                 .animateItem(),
-            label = stringResource(id = R.string.refresh_period),
+            label = stringResource(id = BitwardenString.refresh_period),
             options = refreshPeriodOptionsWithStrings.values.toImmutableList(),
             selectedOption = stringResource(
-                id = R.string.refresh_period_seconds,
+                id = BitwardenString.refresh_period_seconds,
                 viewState.itemData.refreshPeriod.seconds,
             ),
             onOptionSelected = remember(viewState) {
@@ -502,7 +502,7 @@ private fun DigitsCounterItem(
     modifier: Modifier = Modifier,
 ) {
     BitwardenStepper(
-        label = stringResource(id = R.string.number_of_digits),
+        label = stringResource(id = BitwardenString.number_of_digits),
         value = digits.coerceIn(minValue, maxValue),
         range = minValue..maxValue,
         onValueChange = onDigitsCounterChange,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemViewModel.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.toUpperCase
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemAlgorithm
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
@@ -18,6 +17,7 @@ import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.takeUntilLoaded
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.isBase32
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
@@ -87,8 +87,9 @@ class EditItemViewModel @Inject constructor(
             mutableStateFlow.update {
                 it.copy(
                     dialog = EditItemState.DialogState.Generic(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.validation_field_required.asText(R.string.name.asText()),
+                        title = BitwardenString.an_error_has_occurred.asText(),
+                        message = BitwardenString.validation_field_required
+                            .asText(BitwardenString.name.asText()),
                     ),
                 )
             }
@@ -97,8 +98,9 @@ class EditItemViewModel @Inject constructor(
             mutableStateFlow.update {
                 it.copy(
                     dialog = EditItemState.DialogState.Generic(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.validation_field_required.asText(R.string.key.asText()),
+                        title = BitwardenString.an_error_has_occurred.asText(),
+                        message = BitwardenString.validation_field_required
+                            .asText(BitwardenString.key.asText()),
                     ),
                 )
             }
@@ -107,8 +109,8 @@ class EditItemViewModel @Inject constructor(
             mutableStateFlow.update {
                 it.copy(
                     dialog = EditItemState.DialogState.Generic(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.key_is_invalid.asText(),
+                        title = BitwardenString.an_error_has_occurred.asText(),
+                        message = BitwardenString.key_is_invalid.asText(),
                     ),
                 )
             }
@@ -118,7 +120,7 @@ class EditItemViewModel @Inject constructor(
         mutableStateFlow.update {
             it.copy(
                 dialog = EditItemState.DialogState.Loading(
-                    R.string.saving.asText(),
+                    BitwardenString.saving.asText(),
                 ),
             )
         }
@@ -224,14 +226,14 @@ class EditItemViewModel @Inject constructor(
             CreateItemResult.Error -> mutableStateFlow.update {
                 it.copy(
                     dialog = EditItemState.DialogState.Generic(
-                        title = R.string.an_error_has_occurred.asText(),
-                        message = R.string.generic_error_message.asText(),
+                        title = BitwardenString.an_error_has_occurred.asText(),
+                        message = BitwardenString.generic_error_message.asText(),
                     ),
                 )
             }
 
             CreateItemResult.Success -> {
-                sendEvent(EditItemEvent.ShowToast(R.string.item_saved.asText()))
+                sendEvent(EditItemEvent.ShowToast(BitwardenString.item_saved.asText()))
                 sendEvent(EditItemEvent.NavigateBack)
             }
         }
@@ -244,7 +246,7 @@ class EditItemViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         viewState = EditItemState.ViewState.Error(
-                            message = R.string.generic_error_message.asText(),
+                            message = BitwardenString.generic_error_message.asText(),
                         ),
                     )
                 }
@@ -260,7 +262,7 @@ class EditItemViewModel @Inject constructor(
                             .data
                             ?.toViewState(expandAdvancedOptions)
                             ?: EditItemState.ViewState.Error(
-                                message = R.string.generic_error_message.asText(),
+                                message = BitwardenString.generic_error_message.asText(),
                             ),
                     )
                 }
@@ -278,9 +280,11 @@ class EditItemViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         viewState = EditItemState.ViewState.Error(
-                            message = R.string.internet_connection_required_title
+                            message = BitwardenString.internet_connection_required_title
                                 .asText()
-                                .concat(R.string.internet_connection_required_message.asText()),
+                                .concat(
+                                    BitwardenString.internet_connection_required_message.asText(),
+                                ),
                         ),
                     )
                 }
@@ -296,7 +300,7 @@ class EditItemViewModel @Inject constructor(
                             .data
                             ?.toViewState(expandAdvancedOptions)
                             ?: EditItemState.ViewState.Error(
-                                message = R.string.generic_error_message.asText(),
+                                message = BitwardenString.generic_error_message.asText(),
                             ),
                     )
                 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/FirstTimeSyncSnackbarHost.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/FirstTimeSyncSnackbarHost.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.bitwarden.authenticator.R
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Show a snackbar that says "Account synced from Bitwarden app" with a close action.
@@ -49,7 +49,7 @@ fun FirstTimeSyncSnackbarHost(
                     modifier = Modifier
                         .padding(16.dp)
                         .weight(1f, fill = true),
-                    text = stringResource(R.string.account_synced_from_bitwarden_app),
+                    text = stringResource(BitwardenString.account_synced_from_bitwarden_app),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.inverseOnSurface,
                 )
@@ -58,7 +58,7 @@ fun FirstTimeSyncSnackbarHost(
                 ) {
                     Icon(
                         painter = painterResource(id = BitwardenDrawable.ic_close),
-                        contentDescription = stringResource(id = R.string.close),
+                        contentDescription = stringResource(id = BitwardenString.close),
                         tint = MaterialTheme.colorScheme.inverseOnSurface,
                         modifier = Modifier
                             .size(24.dp),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.model.ItemListingExpandableFabAction
 import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.model.VaultDropdownMenuAction
 import com.bitwarden.authenticator.ui.authenticator.feature.model.SharedCodesDisplayState
@@ -88,6 +87,7 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.util.asText
 import kotlinx.coroutines.launch
@@ -315,7 +315,7 @@ private fun ItemListingDialogs(
         ItemListingState.DialogState.Loading -> {
             BitwardenLoadingDialog(
                 visibilityState = LoadingDialogState.Shown(
-                    text = R.string.syncing.asText(),
+                    text = BitwardenString.syncing.asText(),
                 ),
             )
         }
@@ -332,10 +332,10 @@ private fun ItemListingDialogs(
 
         is ItemListingState.DialogState.DeleteConfirmationPrompt -> {
             BitwardenTwoButtonDialog(
-                title = stringResource(id = R.string.delete),
+                title = stringResource(id = BitwardenString.delete),
                 message = dialog.message(),
-                confirmButtonText = stringResource(id = R.string.okay),
-                dismissButtonText = stringResource(id = R.string.cancel),
+                confirmButtonText = stringResource(id = BitwardenString.okay),
+                dismissButtonText = stringResource(id = BitwardenString.cancel),
                 onConfirmClick = {
                     onConfirmDeleteClick(dialog.itemId)
                 },
@@ -373,11 +373,11 @@ private fun ItemListingContent(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             AuthenticatorMediumTopAppBar(
-                title = stringResource(id = R.string.verification_codes),
+                title = stringResource(id = BitwardenString.verification_codes),
                 scrollBehavior = scrollBehavior,
                 actions = {
                     AuthenticatorSearchActionItem(
-                        contentDescription = stringResource(id = R.string.search_codes),
+                        contentDescription = stringResource(id = BitwardenString.search_codes),
                         onClick = onNavigateToSearch,
                     )
                 },
@@ -388,22 +388,26 @@ private fun ItemListingContent(
                 modifier = Modifier
                     .semantics { testTag = "AddItemButton" }
                     .padding(bottom = 16.dp),
-                label = R.string.add_item.asText(),
+                label = BitwardenString.add_item.asText(),
                 items = listOf(
                     ItemListingExpandableFabAction.ScanQrCode(
-                        label = R.string.scan_a_qr_code.asText(),
+                        label = BitwardenString.scan_a_qr_code.asText(),
                         icon = IconResource(
                             iconPainter = painterResource(id = BitwardenDrawable.ic_camera),
-                            contentDescription = stringResource(id = R.string.scan_a_qr_code),
+                            contentDescription = stringResource(
+                                id = BitwardenString.scan_a_qr_code,
+                            ),
                             testTag = "ScanQRCodeButton",
                         ),
                         onScanQrCodeClick = onScanQrCodeClick,
                     ),
                     ItemListingExpandableFabAction.EnterSetupKey(
-                        label = R.string.enter_key_manually.asText(),
+                        label = BitwardenString.enter_key_manually.asText(),
                         icon = IconResource(
                             iconPainter = painterResource(id = BitwardenDrawable.ic_keyboard),
-                            contentDescription = stringResource(id = R.string.enter_key_manually),
+                            contentDescription = stringResource(
+                                id = BitwardenString.enter_key_manually,
+                            ),
                             testTag = "EnterSetupKeyButton",
                         ),
                         onEnterSetupKeyClick = onEnterSetupKeyClick,
@@ -412,7 +416,7 @@ private fun ItemListingContent(
                 expandableFabIcon = ExpandableFabIcon(
                     iconData = IconResource(
                         iconPainter = painterResource(id = BitwardenDrawable.ic_plus),
-                        contentDescription = stringResource(id = R.string.add_item),
+                        contentDescription = stringResource(id = BitwardenString.add_item),
                         testTag = "AddItemButton",
                     ),
                     iconRotation = 45f,
@@ -444,7 +448,7 @@ private fun ItemListingContent(
             if (state.favoriteItems.isNotEmpty()) {
                 item(key = "favorites_header") {
                     BitwardenListHeaderTextWithSupportLabel(
-                        label = stringResource(id = R.string.favorites),
+                        label = stringResource(id = BitwardenString.favorites),
                         supportingLabel = state.favoriteItems.count().toString(),
                         modifier = Modifier
                             .fillMaxWidth()
@@ -494,13 +498,20 @@ private fun ItemListingContent(
             if (state.shouldShowLocalHeader) {
                 item(key = "local_items_header") {
                     AuthenticatorExpandingHeader(
-                        label = stringResource(id = R.string.local_codes, state.itemList.size),
+                        label = stringResource(
+                            id = BitwardenString.local_codes,
+                            state.itemList.size,
+                        ),
                         isExpanded = isLocalHeaderExpanded,
                         onClick = { isLocalHeaderExpanded = !isLocalHeaderExpanded },
                         onClickLabel = if (isLocalHeaderExpanded) {
-                            stringResource(R.string.local_items_are_expanded_click_to_collapse)
+                            stringResource(
+                                BitwardenString.local_items_are_expanded_click_to_collapse,
+                            )
                         } else {
-                            stringResource(R.string.local_items_are_collapsed_click_to_expand)
+                            stringResource(
+                                BitwardenString.local_items_are_collapsed_click_to_expand,
+                            )
                         },
                         modifier = Modifier
                             .fillMaxWidth()
@@ -546,9 +557,11 @@ private fun ItemListingContent(
                                     onSectionExpandedClick(section)
                                 },
                                 onClickLabel = if (section.isExpanded) {
-                                    stringResource(R.string.items_expanded_click_to_collapse)
+                                    stringResource(BitwardenString.items_expanded_click_to_collapse)
                                 } else {
-                                    stringResource(R.string.items_are_collapsed_click_to_expand)
+                                    stringResource(
+                                        BitwardenString.items_are_collapsed_click_to_expand,
+                                    )
                                 },
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -586,7 +599,7 @@ private fun ItemListingContent(
                 SharedCodesDisplayState.Error -> {
                     item(key = "shared_codes_error") {
                         Text(
-                            text = stringResource(R.string.shared_codes_error),
+                            text = stringResource(BitwardenString.shared_codes_error),
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             style = MaterialTheme.typography.bodySmall,
                             modifier = Modifier
@@ -634,7 +647,7 @@ fun EmptyItemListingContent(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             AuthenticatorTopAppBar(
-                title = stringResource(id = R.string.verification_codes),
+                title = stringResource(id = BitwardenString.verification_codes),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = null,
                 actions = { },
@@ -645,22 +658,26 @@ fun EmptyItemListingContent(
                 modifier = Modifier
                     .semantics { testTag = "AddItemButton" }
                     .padding(bottom = 16.dp),
-                label = R.string.add_item.asText(),
+                label = BitwardenString.add_item.asText(),
                 items = listOf(
                     ItemListingExpandableFabAction.ScanQrCode(
-                        label = R.string.scan_a_qr_code.asText(),
+                        label = BitwardenString.scan_a_qr_code.asText(),
                         icon = IconResource(
                             iconPainter = painterResource(id = BitwardenDrawable.ic_camera),
-                            contentDescription = stringResource(id = R.string.scan_a_qr_code),
+                            contentDescription = stringResource(
+                                id = BitwardenString.scan_a_qr_code,
+                            ),
                             testTag = "ScanQRCodeButton",
                         ),
                         onScanQrCodeClick = onScanQrCodeClick,
                     ),
                     ItemListingExpandableFabAction.EnterSetupKey(
-                        label = R.string.enter_key_manually.asText(),
+                        label = BitwardenString.enter_key_manually.asText(),
                         icon = IconResource(
                             iconPainter = painterResource(id = BitwardenDrawable.ic_keyboard),
-                            contentDescription = stringResource(id = R.string.enter_key_manually),
+                            contentDescription = stringResource(
+                                id = BitwardenString.enter_key_manually,
+                            ),
                             testTag = "EnterSetupKeyButton",
                         ),
                         onEnterSetupKeyClick = onEnterSetupKeyClick,
@@ -669,7 +686,7 @@ fun EmptyItemListingContent(
                 expandableFabIcon = ExpandableFabIcon(
                     iconData = IconResource(
                         iconPainter = painterResource(id = BitwardenDrawable.ic_plus),
-                        contentDescription = stringResource(id = R.string.add_item),
+                        contentDescription = stringResource(id = BitwardenString.add_item),
                         testTag = "AddItemButton",
                     ),
                     iconRotation = 45f,
@@ -723,21 +740,21 @@ fun EmptyItemListingContent(
                         },
                     ),
                     contentDescription = stringResource(
-                        id = R.string.empty_item_list,
+                        id = BitwardenString.empty_item_list,
                     ),
                     contentScale = ContentScale.Fit,
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(
-                    text = stringResource(id = R.string.you_dont_have_items_to_display),
+                    text = stringResource(id = BitwardenString.you_dont_have_items_to_display),
                     style = Typography.titleMedium,
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(
                     textAlign = TextAlign.Center,
-                    text = stringResource(id = R.string.empty_item_list_instruction),
+                    text = stringResource(id = BitwardenString.empty_item_list_instruction),
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
@@ -745,7 +762,7 @@ fun EmptyItemListingContent(
                     modifier = Modifier
                         .semantics { testTag = "AddCodeButton" }
                         .fillMaxWidth(),
-                    label = stringResource(R.string.add_code),
+                    label = stringResource(BitwardenString.add_code),
                     onClick = onAddCodeClick,
                 )
             }
@@ -761,9 +778,9 @@ private fun DownloadBitwardenActionCard(
 ) = BitwardenActionCard(
     modifier = modifier,
     actionIcon = rememberVectorPainter(BitwardenDrawable.ic_shield),
-    actionText = stringResource(R.string.download_bitwarden_card_message),
-    callToActionText = stringResource(R.string.download_now),
-    titleText = stringResource(R.string.download_bitwarden_card_title),
+    actionText = stringResource(BitwardenString.download_bitwarden_card_message),
+    callToActionText = stringResource(BitwardenString.download_now),
+    titleText = stringResource(BitwardenString.download_bitwarden_card_title),
     onCardClicked = onDownloadBitwardenClick,
     trailingContent = {
         IconButton(
@@ -771,7 +788,7 @@ private fun DownloadBitwardenActionCard(
         ) {
             Icon(
                 painter = painterResource(id = BitwardenDrawable.ic_close),
-                contentDescription = stringResource(id = R.string.close),
+                contentDescription = stringResource(id = BitwardenString.close),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
                     .size(24.dp),
@@ -812,7 +829,7 @@ private fun SyncWithBitwardenActionCard(
                 )
                 Spacer(Modifier.width(width = 16.dp))
                 Text(
-                    text = stringResource(id = R.string.sync_with_the_bitwarden_app),
+                    text = stringResource(id = BitwardenString.sync_with_the_bitwarden_app),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
@@ -822,7 +839,7 @@ private fun SyncWithBitwardenActionCard(
             IconButton(onClick = onDismissClick) {
                 Icon(
                     painter = painterResource(id = BitwardenDrawable.ic_close),
-                    contentDescription = stringResource(id = R.string.close),
+                    contentDescription = stringResource(id = BitwardenString.close),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(size = 24.dp),
                 )
@@ -830,7 +847,7 @@ private fun SyncWithBitwardenActionCard(
             Spacer(Modifier.width(width = 4.dp))
         }
         Text(
-            text = stringResource(id = R.string.sync_with_bitwarden_action_card_message),
+            text = stringResource(id = BitwardenString.sync_with_bitwarden_action_card_message),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier
@@ -840,14 +857,14 @@ private fun SyncWithBitwardenActionCard(
         )
         Spacer(Modifier.height(height = 16.dp))
         AuthenticatorFilledButton(
-            label = stringResource(id = R.string.take_me_to_app_settings),
+            label = stringResource(id = BitwardenString.take_me_to_app_settings),
             onClick = onAppSettingsClick,
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth(),
         )
         AuthenticatorTextButton(
-            label = stringResource(id = R.string.learn_more),
+            label = stringResource(id = BitwardenString.learn_more),
             onClick = onLearnMoreClick,
             modifier = Modifier
                 .padding(horizontal = 16.dp)

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
@@ -3,7 +3,6 @@ package com.bitwarden.authenticator.ui.authenticator.feature.itemlisting
 import android.net.Uri
 import android.os.Parcelable
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemAlgorithm
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
@@ -28,6 +27,7 @@ import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -189,8 +189,8 @@ class ItemListingViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialog = ItemListingState.DialogState.Error(
-                            title = R.string.something_went_wrong.asText(),
-                            message = R.string.please_try_again.asText(),
+                            title = BitwardenString.something_went_wrong.asText(),
+                            message = BitwardenString.please_try_again.asText(),
                         ),
                     )
                 }
@@ -202,7 +202,9 @@ class ItemListingViewModel @Inject constructor(
         mutableStateFlow.update {
             it.copy(
                 dialog = ItemListingState.DialogState.DeleteConfirmationPrompt(
-                    message = R.string.do_you_really_want_to_permanently_delete_cipher.asText(),
+                    message = BitwardenString
+                        .do_you_really_want_to_permanently_delete_this_cannot_be_undone
+                        .asText(),
                     itemId = itemId,
                 ),
             )
@@ -273,8 +275,8 @@ class ItemListingViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialog = ItemListingState.DialogState.Error(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.generic_error_message.asText(),
+                            title = BitwardenString.an_error_has_occurred.asText(),
+                            message = BitwardenString.generic_error_message.asText(),
                         ),
                     )
                 }
@@ -286,7 +288,7 @@ class ItemListingViewModel @Inject constructor(
                 }
                 sendEvent(
                     ItemListingEvent.ShowToast(
-                        message = R.string.item_deleted.asText(),
+                        message = BitwardenString.item_deleted.asText(),
                     ),
                 )
             }
@@ -303,8 +305,8 @@ class ItemListingViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialog = ItemListingState.DialogState.Error(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.authenticator_key_read_error.asText(),
+                            title = BitwardenString.an_error_has_occurred.asText(),
+                            message = BitwardenString.authenticator_key_read_error.asText(),
                         ),
                     )
                 }
@@ -313,7 +315,7 @@ class ItemListingViewModel @Inject constructor(
             CreateItemResult.Success -> {
                 sendEvent(
                     event = ItemListingEvent.ShowToast(
-                        message = R.string.verification_code_added.asText(),
+                        message = BitwardenString.verification_code_added.asText(),
                     ),
                 )
             }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/VaultVerificationCodeItem.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/VaultVerificationCodeItem.kt
@@ -32,13 +32,13 @@ import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.model.VaultDropdownMenuAction
 import com.bitwarden.authenticator.ui.platform.components.indicator.BitwardenCircularCountdownIndicator
 import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
 import com.bitwarden.ui.platform.components.icon.BitwardenIcon
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * The verification code item displayed to the user.
@@ -158,7 +158,7 @@ fun VaultVerificationCodeItem(
         ) {
             DropdownMenuItem(
                 text = {
-                    Text(text = stringResource(id = R.string.copy))
+                    Text(text = stringResource(id = BitwardenString.copy))
                 },
                 onClick = {
                     shouldShowDropdownMenu = false
@@ -167,14 +167,14 @@ fun VaultVerificationCodeItem(
                 leadingIcon = {
                     Icon(
                         painter = painterResource(id = BitwardenDrawable.ic_copy),
-                        contentDescription = stringResource(id = R.string.copy),
+                        contentDescription = stringResource(id = BitwardenString.copy),
                     )
                 },
             )
             HorizontalDivider()
             DropdownMenuItem(
                 text = {
-                    Text(text = stringResource(id = R.string.edit_item))
+                    Text(text = stringResource(id = BitwardenString.edit))
                 },
                 onClick = {
                     shouldShowDropdownMenu = false
@@ -183,7 +183,7 @@ fun VaultVerificationCodeItem(
                 leadingIcon = {
                     Icon(
                         painter = painterResource(id = BitwardenDrawable.ic_edit_item),
-                        contentDescription = stringResource(R.string.edit_item),
+                        contentDescription = stringResource(BitwardenString.edit),
                     )
                 },
             )
@@ -191,7 +191,7 @@ fun VaultVerificationCodeItem(
                 HorizontalDivider()
                 DropdownMenuItem(
                     text = {
-                        Text(text = stringResource(id = R.string.copy_to_bitwarden_vault))
+                        Text(text = stringResource(id = BitwardenString.copy_to_bitwarden_vault))
                     },
                     onClick = {
                         shouldShowDropdownMenu = false
@@ -201,7 +201,7 @@ fun VaultVerificationCodeItem(
                         Icon(
                             painter = painterResource(id = BitwardenDrawable.ic_arrow_right),
                             contentDescription = stringResource(
-                                id = R.string.copy_to_bitwarden_vault,
+                                id = BitwardenString.copy_to_bitwarden_vault,
                             ),
                         )
                     },
@@ -210,7 +210,7 @@ fun VaultVerificationCodeItem(
             HorizontalDivider()
             DropdownMenuItem(
                 text = {
-                    Text(text = stringResource(id = R.string.delete_item))
+                    Text(text = stringResource(id = BitwardenString.delete_item))
                 },
                 onClick = {
                     shouldShowDropdownMenu = false
@@ -219,7 +219,7 @@ fun VaultVerificationCodeItem(
                 leadingIcon = {
                     Icon(
                         painter = painterResource(id = BitwardenDrawable.ic_delete_item),
-                        contentDescription = stringResource(id = R.string.delete_item),
+                        contentDescription = stringResource(id = BitwardenString.delete_item),
                     )
                 },
             )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.appbar.AuthenticatorTopAppBar
 import com.bitwarden.authenticator.ui.platform.components.dialog.BasicDialogState
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenBasicDialog
@@ -56,6 +55,7 @@ import com.bitwarden.ui.platform.base.util.annotatedStringResource
 import com.bitwarden.ui.platform.base.util.spanStyleOf
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * The screen to manually add a totp code.
@@ -110,9 +110,11 @@ fun ManualCodeEntryScreen(
 
     if (shouldShowPermissionDialog) {
         BitwardenTwoButtonDialog(
-            message = stringResource(id = R.string.enable_camera_permission_to_use_the_scanner),
-            confirmButtonText = stringResource(id = R.string.settings),
-            dismissButtonText = stringResource(id = R.string.no_thanks),
+            message = stringResource(
+                id = BitwardenString.enable_camera_permission_to_use_the_scanner,
+            ),
+            confirmButtonText = stringResource(id = BitwardenString.settings),
+            dismissButtonText = stringResource(id = BitwardenString.no_thanks),
             onConfirmClick = remember(viewModel) {
                 { viewModel.trySendAction(ManualCodeEntryAction.SettingsClick) }
             },
@@ -133,9 +135,9 @@ fun ManualCodeEntryScreen(
         modifier = Modifier.fillMaxSize(),
         topBar = {
             AuthenticatorTopAppBar(
-                title = stringResource(id = R.string.create_verification_code),
+                title = stringResource(id = BitwardenString.create_verification_code),
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
-                navigationIconContentDescription = stringResource(id = R.string.close),
+                navigationIconContentDescription = stringResource(id = BitwardenString.close),
                 onNavigationIconClick = remember(viewModel) {
                     { viewModel.trySendAction(ManualCodeEntryAction.CloseClick) }
                 },
@@ -183,7 +185,7 @@ private fun ManualCodeEntryContent(
 ) {
     Column(modifier = modifier.verticalScroll(state = rememberScrollState())) {
         Text(
-            text = stringResource(id = R.string.enter_key_manually),
+            text = stringResource(id = BitwardenString.enter_key_manually),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier
                 .fillMaxWidth()
@@ -192,7 +194,7 @@ private fun ManualCodeEntryContent(
 
         Spacer(modifier = Modifier.height(height = 8.dp))
         BitwardenTextField(
-            label = stringResource(id = R.string.name),
+            label = stringResource(id = BitwardenString.name),
             value = state.issuer,
             onValueChange = onNameChange,
             modifier = Modifier
@@ -203,7 +205,7 @@ private fun ManualCodeEntryContent(
         Spacer(modifier = Modifier.height(height = 8.dp))
         BitwardenPasswordField(
             singleLine = false,
-            label = stringResource(id = R.string.key),
+            label = stringResource(id = BitwardenString.key),
             value = state.code,
             onValueChange = onKeyChange,
             capitalization = KeyboardCapitalization.Characters,
@@ -224,7 +226,7 @@ private fun ManualCodeEntryContent(
         )
         Spacer(modifier = Modifier.height(height = 8.dp))
         Text(
-            text = stringResource(id = R.string.cannot_add_authenticator_key),
+            text = stringResource(id = BitwardenString.cannot_add_authenticator_key),
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier
                 .fillMaxWidth()
@@ -245,10 +247,10 @@ private fun ScanQrCodeText(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val accessibilityString = stringResource(id = R.string.scan_qr_code)
+    val accessibilityString = stringResource(id = BitwardenString.scan_qr_code)
     Text(
         text = annotatedStringResource(
-            id = R.string.scan_qr_code,
+            id = BitwardenString.scan_qr_code,
             emphasisHighlightStyle = spanStyleOf(
                 color = MaterialTheme.colorScheme.primary,
                 textStyle = MaterialTheme.typography.bodyMedium,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
@@ -3,7 +3,6 @@ package com.bitwarden.authenticator.ui.authenticator.feature.manualcodeentry
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
 import com.bitwarden.authenticator.data.authenticator.manager.TotpCodeManager
@@ -15,6 +14,7 @@ import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.Defau
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.isBase32
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -95,17 +95,17 @@ class ManualCodeEntryViewModel @Inject constructor(
             .replace(" ", "")
             .replace(TotpCodeManager.STEAM_CODE_PREFIX, "")
         if (sanitizedCode.isBlank()) {
-            showErrorDialog(R.string.key_is_required.asText())
+            showErrorDialog(BitwardenString.key_is_required.asText())
             return
         }
 
         if (!sanitizedCode.isBase32()) {
-            showErrorDialog(R.string.key_is_invalid.asText())
+            showErrorDialog(BitwardenString.key_is_invalid.asText())
             return
         }
 
         if (state.issuer.isBlank()) {
-            showErrorDialog(R.string.name_is_required.asText())
+            showErrorDialog(BitwardenString.name_is_required.asText())
             return
         }
 
@@ -127,8 +127,8 @@ class ManualCodeEntryViewModel @Inject constructor(
             mutableStateFlow.update {
                 it.copy(
                     dialog = ManualCodeEntryState.DialogState.Error(
-                        title = R.string.something_went_wrong.asText(),
-                        message = R.string.please_try_again.asText(),
+                        title = BitwardenString.something_went_wrong.asText(),
+                        message = BitwardenString.please_try_again.asText(),
                     ),
                 )
             }
@@ -159,7 +159,7 @@ class ManualCodeEntryViewModel @Inject constructor(
             )
             sendEvent(
                 event = ManualCodeEntryEvent.ShowToast(
-                    message = R.string.verification_code_added.asText(),
+                    message = BitwardenString.verification_code_added.asText(),
                 ),
             )
             sendEvent(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/SaveManualCodeButtons.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/SaveManualCodeButtons.kt
@@ -6,10 +6,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorFilledButton
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorFilledTonalButton
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorOutlinedButton
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Displays save buttons for saving a manually entered code.
@@ -29,7 +29,7 @@ fun SaveManualCodeButtons(
     when (state) {
         ManualCodeEntryState.ButtonState.LocalOnly -> {
             AuthenticatorFilledTonalButton(
-                label = stringResource(id = R.string.add_code),
+                label = stringResource(id = BitwardenString.add_code),
                 onClick = onSaveLocallyClick,
                 modifier = modifier.testTag(tag = "AddCodeButton"),
             )
@@ -38,12 +38,12 @@ fun SaveManualCodeButtons(
         ManualCodeEntryState.ButtonState.SaveLocallyPrimary -> {
             Column(modifier = modifier) {
                 AuthenticatorFilledButton(
-                    label = stringResource(id = R.string.save_here),
+                    label = stringResource(id = BitwardenString.save_here),
                     onClick = onSaveLocallyClick,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 AuthenticatorOutlinedButton(
-                    label = stringResource(R.string.save_to_bitwarden),
+                    label = stringResource(BitwardenString.save_to_bitwarden),
                     onClick = onSaveToBitwardenClick,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -53,12 +53,12 @@ fun SaveManualCodeButtons(
         ManualCodeEntryState.ButtonState.SaveToBitwardenPrimary -> {
             Column(modifier = modifier) {
                 AuthenticatorFilledButton(
-                    label = stringResource(id = R.string.save_to_bitwarden),
+                    label = stringResource(id = BitwardenString.save_to_bitwarden),
                     onClick = onSaveToBitwardenClick,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 AuthenticatorOutlinedButton(
-                    label = stringResource(R.string.save_here),
+                    label = stringResource(BitwardenString.save_here),
                     onClick = onSaveLocallyClick,
                     modifier = Modifier.fillMaxWidth(),
                 )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/navbar/AuthenticatorNavBarScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/navbar/AuthenticatorNavBarScreen.kt
@@ -42,7 +42,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.ItemListingGraphRoute
 import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.ItemListingRoute
 import com.bitwarden.authenticator.ui.authenticator.feature.itemlisting.itemListingGraph
@@ -55,6 +54,7 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.max
 import com.bitwarden.ui.platform.base.util.toDp
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.RootTransitionProviders
 import com.bitwarden.ui.platform.util.toObjectNavigationRoute
 import kotlinx.coroutines.flow.launchIn
@@ -309,8 +309,8 @@ private sealed class AuthenticatorNavBarTab : Parcelable {
     data object VerificationCodes : AuthenticatorNavBarTab() {
         override val iconResSelected get() = BitwardenDrawable.ic_verification_codes_filled
         override val iconRes get() = BitwardenDrawable.ic_verification_codes
-        override val labelRes get() = R.string.verification_codes
-        override val contentDescriptionRes get() = R.string.verification_codes
+        override val labelRes get() = BitwardenString.verification_codes
+        override val contentDescriptionRes get() = BitwardenString.verification_codes
         override val route get() = ItemListingRoute.toObjectNavigationRoute()
         override val testTag get() = "VerificationCodesTab"
     }
@@ -322,8 +322,8 @@ private sealed class AuthenticatorNavBarTab : Parcelable {
     data object Settings : AuthenticatorNavBarTab() {
         override val iconResSelected get() = BitwardenDrawable.ic_settings_solid
         override val iconRes get() = BitwardenDrawable.ic_settings
-        override val labelRes get() = R.string.settings
-        override val contentDescriptionRes get() = R.string.settings
+        override val labelRes get() = BitwardenString.settings
+        override val contentDescriptionRes get() = BitwardenString.settings
         override val route get() = SettingsGraphRoute.toObjectNavigationRoute()
         override val testTag get() = "SettingsTab"
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/ChooseSaveLocationDialog.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/ChooseSaveLocationDialog.kt
@@ -25,11 +25,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorTextButton
 import com.bitwarden.authenticator.ui.platform.components.toggle.BitwardenWideSwitch
 import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
 import com.bitwarden.authenticator.ui.platform.components.util.maxDialogWidth
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Displays a dialog asking the user where they would like to save a new QR code.
@@ -70,7 +70,7 @@ fun ChooseSaveLocationDialog(
                 modifier = Modifier
                     .padding(horizontal = 24.dp)
                     .fillMaxWidth(),
-                text = stringResource(R.string.verification_code_created),
+                text = stringResource(BitwardenString.verification_code_created),
                 color = MaterialTheme.colorScheme.onSurface,
                 style = MaterialTheme.typography.headlineSmall,
             )
@@ -80,14 +80,14 @@ fun ChooseSaveLocationDialog(
                     .weight(1f, fill = false)
                     .padding(horizontal = 24.dp)
                     .fillMaxWidth(),
-                text = stringResource(R.string.choose_save_location_message),
+                text = stringResource(BitwardenString.choose_save_location_message),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 style = MaterialTheme.typography.bodyMedium,
             )
             Spacer(Modifier.height(16.dp))
             BitwardenWideSwitch(
                 modifier = Modifier.padding(horizontal = 16.dp),
-                label = stringResource(R.string.save_option_as_default),
+                label = stringResource(BitwardenString.save_option_as_default),
                 isChecked = isSaveAsDefaultChecked,
                 onCheckedChange = { isSaveAsDefaultChecked = !isSaveAsDefaultChecked },
             )
@@ -99,14 +99,14 @@ fun ChooseSaveLocationDialog(
                 AuthenticatorTextButton(
                     modifier = Modifier
                         .padding(horizontal = 4.dp),
-                    label = stringResource(R.string.save_here),
+                    label = stringResource(BitwardenString.save_here),
                     labelTextColor = MaterialTheme.colorScheme.primary,
                     onClick = { onSaveHereClick.invoke(isSaveAsDefaultChecked) },
                 )
                 AuthenticatorTextButton(
                     modifier = Modifier
                         .padding(horizontal = 4.dp),
-                    label = stringResource(R.string.save_to_bitwarden),
+                    label = stringResource(BitwardenString.save_to_bitwarden),
                     labelTextColor = MaterialTheme.colorScheme.primary,
                     onClick = { onTakeMeToBitwardenClick.invoke(isSaveAsDefaultChecked) },
                 )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.authenticator.feature.qrcodescan.util.QrCodeAnalyzer
 import com.bitwarden.authenticator.ui.authenticator.feature.qrcodescan.util.QrCodeAnalyzerImpl
 import com.bitwarden.authenticator.ui.platform.components.appbar.AuthenticatorTopAppBar
@@ -65,6 +64,7 @@ import com.bitwarden.ui.platform.base.util.annotatedStringResource
 import com.bitwarden.ui.platform.base.util.spanStyleOf
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import java.util.concurrent.Executors
 import kotlin.coroutines.resume
@@ -118,9 +118,9 @@ fun QrCodeScanScreen(
         modifier = Modifier.fillMaxSize(),
         topBar = {
             AuthenticatorTopAppBar(
-                title = stringResource(id = R.string.scan_qr_code),
+                title = stringResource(id = BitwardenString.scan_qr_code),
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
-                navigationIconContentDescription = stringResource(id = R.string.close),
+                navigationIconContentDescription = stringResource(id = BitwardenString.close),
                 onNavigationIconClick = remember(viewModel) {
                     { viewModel.trySendAction(QrCodeScanAction.CloseClick) }
                 },
@@ -168,8 +168,8 @@ private fun QrCodeScanDialogs(
         QrCodeScanState.DialogState.SaveToBitwardenError -> {
             BitwardenBasicDialog(
                 visibilityState = BasicDialogState.Shown(
-                    title = R.string.something_went_wrong.asText(),
-                    message = R.string.please_try_again.asText(),
+                    title = BitwardenString.something_went_wrong.asText(),
+                    message = BitwardenString.please_try_again.asText(),
                 ),
                 onDismissRequest = onDismissRequest,
             )
@@ -204,7 +204,7 @@ private fun PortraitQRCodeContent(
                 .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                text = stringResource(id = R.string.point_your_camera_at_the_qr_code),
+                text = stringResource(id = BitwardenString.point_your_camera_at_the_qr_code),
                 textAlign = TextAlign.Center,
                 color = Color.White,
                 style = MaterialTheme.typography.bodyMedium,
@@ -245,7 +245,7 @@ private fun LandscapeQRCodeContent(
                 .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                text = stringResource(id = R.string.point_your_camera_at_the_qr_code),
+                text = stringResource(id = BitwardenString.point_your_camera_at_the_qr_code),
                 textAlign = TextAlign.Center,
                 color = Color.White,
                 style = MaterialTheme.typography.bodySmall,
@@ -438,10 +438,10 @@ private fun BottomClickableText(
     onEnterCodeManuallyClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val enterKeyText = stringResource(id = R.string.enter_key_manually)
+    val enterKeyText = stringResource(id = BitwardenString.enter_key_manually)
     Text(
         text = annotatedStringResource(
-            id = R.string.cannot_scan_qr_code_enter_key_manually,
+            id = BitwardenString.cannot_scan_qr_code_enter_key_manually,
             linkHighlightStyle = spanStyleOf(
                 color = LocalNonMaterialColors.current.qrCodeClickableText,
                 textStyle = MaterialTheme.typography.bodyMedium,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchContent.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchContent.kt
@@ -14,11 +14,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.authenticator.feature.model.SharedCodesDisplayState
 import com.bitwarden.authenticator.ui.authenticator.feature.model.VerificationCodeDisplayItem
 import com.bitwarden.authenticator.ui.authenticator.feature.search.handlers.SearchHandlers
 import com.bitwarden.authenticator.ui.platform.components.header.BitwardenListHeaderText
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * The content state for the item search screen.
@@ -104,7 +104,7 @@ private fun LazyListScope.sharedCodes(
         SharedCodesDisplayState.Error -> {
             item {
                 Text(
-                    text = stringResource(R.string.shared_codes_error),
+                    text = stringResource(BitwardenString.shared_codes_error),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodySmall,
                     modifier = Modifier.padding(horizontal = 16.dp),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.authenticator.feature.search.handlers.SearchHandlers
 import com.bitwarden.authenticator.ui.platform.components.appbar.AuthenticatorSearchTopAppBar
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
@@ -26,6 +25,7 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.bottomDivider
 import com.bitwarden.ui.platform.components.appbar.NavigationIcon
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * The search screen for authenticator items.
@@ -63,12 +63,12 @@ fun ItemSearchScreen(
                     .semantics { testTag = "SearchFieldEntry" }
                     .bottomDivider(),
                 searchTerm = state.searchTerm,
-                placeholder = stringResource(id = R.string.search_codes),
+                placeholder = stringResource(id = BitwardenString.search_codes),
                 onSearchTermChange = searchHandlers.onSearchTermChange,
                 scrollBehavior = scrollBehavior,
                 navigationIcon = NavigationIcon(
                     navigationIcon = painterResource(id = BitwardenDrawable.ic_back),
-                    navigationIconContentDescription = stringResource(id = R.string.back),
+                    navigationIconContentDescription = stringResource(id = BitwardenString.back),
                     onNavigationIconClick = searchHandlers.onBackClick,
                 ),
             )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModel.kt
@@ -3,7 +3,6 @@ package com.bitwarden.authenticator.ui.authenticator.feature.search
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
@@ -15,6 +14,7 @@ import com.bitwarden.authenticator.ui.authenticator.feature.util.toSharedCodesDi
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.removeDiacritics
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -70,7 +70,7 @@ class ItemSearchViewModel @Inject constructor(
                 clipboardManager.setText(action.authCode)
                 sendEvent(
                     event = ItemSearchEvent.ShowToast(
-                        message = R.string.value_has_been_copied.asText(action.authCode),
+                        message = BitwardenString.value_has_been_copied.asText(action.authCode),
                     ),
                 )
             }
@@ -178,7 +178,7 @@ class ItemSearchViewModel @Inject constructor(
         return when {
             filteredLocalCodes.isEmpty() && sharedItemsState.isEmpty() -> {
                 ItemSearchState.ViewState.Empty(
-                    message = R.string.there_are_no_items_that_match_the_search.asText(),
+                    message = BitwardenString.there_are_no_items_that_match_the_search.asText(),
                 )
             }
 
@@ -224,7 +224,7 @@ data class ItemSearchState(
             /**
              * The header to display for the local codes.
              */
-            val localListHeader: Text get() = R.string.local_codes.asText(itemList.size)
+            val localListHeader: Text get() = BitwardenString.local_codes.asText(itemList.size)
 
             /**
              * Whether or not there should be a "Local codes" header shown above local codes.

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/VaultVerificationCodeItem.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/VaultVerificationCodeItem.kt
@@ -22,12 +22,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.indicator.BitwardenCircularCountdownIndicator
 import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
 import com.bitwarden.ui.platform.components.icon.BitwardenIcon
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * The verification code item displayed to the user.
@@ -117,7 +117,7 @@ fun VaultVerificationCodeItem(
         ) {
             Icon(
                 painter = painterResource(id = BitwardenDrawable.ic_copy),
-                contentDescription = stringResource(id = R.string.copy),
+                contentDescription = stringResource(id = BitwardenString.copy),
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(24.dp),
             )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/SharedVerificationCodesStateExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/SharedVerificationCodesStateExtensions.kt
@@ -1,10 +1,10 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.util
 
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.repository.model.AuthenticatorItem
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
 import com.bitwarden.authenticator.ui.authenticator.feature.model.SharedCodesDisplayState
 import com.bitwarden.authenticator.ui.authenticator.feature.model.VerificationCodeDisplayItem
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 
 /**
@@ -34,7 +34,7 @@ fun SharedVerificationCodesState.Success.toSharedCodesDisplayState(
         .map {
             SharedCodesDisplayState.SharedCodesAccountSection(
                 id = it.key.userId,
-                label = R.string.shared_accounts_header.asText(
+                label = BitwardenString.shared_accounts_header.asText(
                     it.key.email,
                     it.key.environmentLabel,
                     it.value.size,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/appbar/AuthenticatorSearchTopAppBar.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/appbar/AuthenticatorSearchTopAppBar.kt
@@ -24,10 +24,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.input.ImeAction
-import com.bitwarden.authenticator.R
 import com.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.bitwarden.ui.platform.components.appbar.NavigationIcon
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Represents a Bitwarden styled [TopAppBar] that assumes the following components:
@@ -88,7 +88,7 @@ fun AuthenticatorSearchTopAppBar(
                     ) {
                         Icon(
                             painter = painterResource(id = BitwardenDrawable.ic_close),
-                            contentDescription = stringResource(id = R.string.clear),
+                            contentDescription = stringResource(id = BitwardenString.clear),
                         )
                     }
                 },

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/appbar/AuthenticatorTopAppBar.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/appbar/AuthenticatorTopAppBar.kt
@@ -19,11 +19,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
 import com.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.bitwarden.ui.platform.components.appbar.NavigationIcon
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Represents a Bitwarden styled [TopAppBar] that assumes the following components:
@@ -128,7 +128,7 @@ private fun AuthenticatorTopAppBar_preview() {
                 ),
             navigationIcon = NavigationIcon(
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
-                navigationIconContentDescription = stringResource(id = R.string.close),
+                navigationIconContentDescription = stringResource(id = BitwardenString.close),
                 onNavigationIconClick = { },
             ),
         )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/card/BitwardenActionCard.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/card/BitwardenActionCard.kt
@@ -24,9 +24,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bitwarden.authenticator.R
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * A reusable card for displaying actions to the user.
@@ -121,7 +121,7 @@ private fun ActionCardWithTrailingPreview() {
             ) {
                 Icon(
                     painter = painterResource(id = BitwardenDrawable.ic_close),
-                    contentDescription = stringResource(id = R.string.close),
+                    contentDescription = stringResource(id = BitwardenString.close),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier
                         .size(24.dp),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/content/BitwardenErrorContent.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/content/BitwardenErrorContent.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorTextButton
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * A Bitwarden-themed, re-usable error state.
@@ -47,7 +47,7 @@ fun BitwardenErrorContent(
         onTryAgainClick?.let {
             Spacer(modifier = Modifier.height(16.dp))
             AuthenticatorTextButton(
-                label = stringResource(id = R.string.try_again),
+                label = stringResource(id = BitwardenString.try_again),
                 onClick = it,
                 modifier = Modifier.padding(horizontal = 16.dp),
             )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenBasicDialog.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenBasicDialog.kt
@@ -7,9 +7,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorTextButton
 import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import kotlinx.parcelize.Parcelize
@@ -32,7 +32,7 @@ fun BitwardenBasicDialog(
             onDismissRequest = onDismissRequest,
             confirmButton = {
                 AuthenticatorTextButton(
-                    label = stringResource(id = R.string.okay),
+                    label = stringResource(id = BitwardenString.okay),
                     onClick = onDismissRequest,
                 )
             },

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenSelectionDialog.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/dialog/BitwardenSelectionDialog.kt
@@ -22,9 +22,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorTextButton
 import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Displays a dialog with a title and "Cancel" button.
@@ -43,7 +43,7 @@ import com.bitwarden.authenticator.ui.platform.components.util.maxDialogHeight
 fun BitwardenSelectionDialog(
     title: String,
     subtitle: String? = null,
-    dismissLabel: String = stringResource(R.string.cancel),
+    dismissLabel: String = stringResource(BitwardenString.cancel),
     onDismissRequest: () -> Unit,
     onDismissActionClick: () -> Unit = onDismissRequest,
     selectionItems: @Composable ColumnScope.() -> Unit = {},

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/fab/ExpandableFloatingActionButton.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/fab/ExpandableFloatingActionButton.kt
@@ -33,10 +33,10 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.bitwarden.authenticator.R
-import com.bitwarden.ui.util.Text
 import com.bitwarden.authenticator.ui.platform.components.model.IconResource
 import com.bitwarden.authenticator.ui.platform.theme.Typography
+import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.util.Text
 
 /**
  * A FAB that expands, when clicked, to display a collection of options that can be clicked.
@@ -62,7 +62,7 @@ fun <T : ExpandableFabOption> ExpandableFloatingActionButton(
         } else {
             0f
         },
-        label = stringResource(R.string.add_item_rotation),
+        label = stringResource(BitwardenString.add_item_rotation),
     )
     Column(
         modifier = modifier.wrapContentSize(),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/field/BitwardenPasswordField.kt
@@ -28,9 +28,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.util.nonLetterColorVisualTransformation
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Represents a Bitwarden-styled password field that hoists show/hide password state to the caller.
@@ -110,7 +110,8 @@ fun BitwardenPasswordField(
                 }
 
                 @StringRes
-                val contentDescriptionRes = if (showPassword) R.string.hide else R.string.show
+                val contentDescriptionRes =
+                    if (showPassword) BitwardenString.hide else BitwardenString.show
                 Icon(
                     modifier = Modifier.semantics { showPasswordTestTag?.let { testTag = it } },
                     painter = painterResource(id = painterRes),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/BitwardenListItem.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/BitwardenListItem.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.bitwarden.authenticator.ui.platform.components.dialog.row.BitwardenBasicDialogRow
 import com.bitwarden.authenticator.ui.platform.components.model.IconResource
@@ -39,6 +38,7 @@ import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
 import com.bitwarden.ui.platform.components.icon.BitwardenIcon
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -137,7 +137,7 @@ fun BitwardenListItem(
             ) {
                 Icon(
                     painter = painterResource(id = BitwardenDrawable.ic_more_horizontal),
-                    contentDescription = stringResource(id = R.string.options),
+                    contentDescription = stringResource(id = BitwardenString.options),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(24.dp),
                 )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/row/BitwardenExternalLinkRow.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/row/BitwardenExternalLinkRow.kt
@@ -10,12 +10,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.authenticator.ui.platform.theme.AuthenticatorTheme
 import com.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Represents a row of text that can be clicked on and contains an external link.
@@ -41,8 +41,8 @@ fun BitwardenExternalLinkRow(
     withDivider: Boolean = true,
     dialogTitle: String,
     dialogMessage: String,
-    dialogConfirmButtonText: String = stringResource(id = R.string.continue_text),
-    dialogDismissButtonText: String = stringResource(id = R.string.cancel),
+    dialogConfirmButtonText: String = stringResource(id = BitwardenString.continue_text),
+    dialogDismissButtonText: String = stringResource(id = BitwardenString.cancel),
 ) {
     var shouldShowDialog by rememberSaveable { mutableStateOf(false) }
     BitwardenTextRow(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.platform.manager.model.FlagKey
 import com.bitwarden.authenticator.ui.platform.components.appbar.AuthenticatorTopAppBar
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorFilledButton
@@ -35,6 +34,7 @@ import com.bitwarden.ui.platform.components.appbar.NavigationIcon
 import com.bitwarden.ui.platform.components.divider.BitwardenHorizontalDivider
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Top level screen for the debug menu.
@@ -60,11 +60,11 @@ fun DebugMenuScreen(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             AuthenticatorTopAppBar(
-                title = stringResource(R.string.debug_menu),
+                title = stringResource(BitwardenString.debug_menu),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(BitwardenDrawable.ic_back),
-                    navigationIconContentDescription = stringResource(id = R.string.back),
+                    navigationIconContentDescription = stringResource(id = BitwardenString.back),
                     onNavigationIconClick = remember(viewModel) {
                         {
                             viewModel.trySendAction(DebugMenuAction.NavigateBack)
@@ -109,7 +109,7 @@ private fun FeatureFlagContent(
     ) {
         Spacer(modifier = Modifier.height(8.dp))
         BitwardenListHeaderText(
-            label = stringResource(R.string.feature_flags),
+            label = stringResource(BitwardenString.feature_flags),
             modifier = Modifier.standardHorizontalMargin(),
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -130,7 +130,7 @@ private fun FeatureFlagContent(
         }
         Spacer(modifier = Modifier.height(12.dp))
         AuthenticatorFilledButton(
-            label = stringResource(R.string.reset_values),
+            label = stringResource(BitwardenString.reset_values),
             onClick = onResetValues,
             modifier = Modifier
                 .standardHorizontalMargin()

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -3,9 +3,9 @@ package com.bitwarden.authenticator.ui.platform.feature.debugmenu.components
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.platform.manager.model.FlagKey
 import com.bitwarden.authenticator.ui.platform.components.toggle.BitwardenWideSwitch
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Creates a list item for a [FlagKey].
@@ -61,5 +61,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
         -> this.keyName
 
     FlagKey.BitwardenAuthenticationEnabled ->
-        stringResource(R.string.bitwarden_authentication_enabled)
+        stringResource(BitwardenString.bitwarden_authentication_enabled)
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.appbar.AuthenticatorMediumTopAppBar
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.bitwarden.authenticator.ui.platform.components.dialog.BitwardenSelectionRow
@@ -70,6 +69,7 @@ import com.bitwarden.ui.platform.base.util.spanStyleOf
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 
@@ -140,7 +140,7 @@ fun SettingsScreen(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             AuthenticatorMediumTopAppBar(
-                title = stringResource(id = R.string.settings),
+                title = stringResource(id = BitwardenString.settings),
                 scrollBehavior = scrollBehavior,
             )
         },
@@ -263,7 +263,7 @@ private fun SecuritySettings(
 
     BitwardenListHeaderText(
         modifier = Modifier.padding(horizontal = 16.dp),
-        label = stringResource(id = R.string.security),
+        label = stringResource(id = BitwardenString.security),
     )
     Spacer(modifier = Modifier.height(8.dp))
     UnlockWithBiometricsRow(
@@ -297,11 +297,11 @@ private fun VaultSettings(
 ) {
     BitwardenListHeaderText(
         modifier = Modifier.padding(horizontal = 16.dp),
-        label = stringResource(id = R.string.data),
+        label = stringResource(id = BitwardenString.data),
     )
     Spacer(modifier = Modifier.height(8.dp))
     BitwardenTextRow(
-        text = stringResource(id = R.string.import_vault),
+        text = stringResource(id = BitwardenString.import_vault),
         onClick = onImportClick,
         modifier = modifier
             .semantics { testTag = "Import" },
@@ -319,7 +319,7 @@ private fun VaultSettings(
     )
     Spacer(modifier = Modifier.height(8.dp))
     BitwardenTextRow(
-        text = stringResource(id = R.string.export),
+        text = stringResource(id = BitwardenString.export),
         onClick = onExportClick,
         modifier = modifier
             .semantics { testTag = "Export" },
@@ -337,21 +337,21 @@ private fun VaultSettings(
     )
     Spacer(modifier = Modifier.height(8.dp))
     BitwardenExternalLinkRow(
-        text = stringResource(R.string.backup),
+        text = stringResource(BitwardenString.backup),
         onConfirmClick = onBackupClick,
         modifier = modifier
             .semantics { testTag = "Backup" },
-        dialogTitle = stringResource(R.string.data_backup_title),
-        dialogMessage = stringResource(R.string.data_backup_message),
-        dialogConfirmButtonText = stringResource(R.string.learn_more),
-        dialogDismissButtonText = stringResource(R.string.okay),
+        dialogTitle = stringResource(BitwardenString.data_backup_title),
+        dialogMessage = stringResource(BitwardenString.data_backup_message),
+        dialogConfirmButtonText = stringResource(BitwardenString.learn_more),
+        dialogDismissButtonText = stringResource(BitwardenString.okay),
     )
     if (shouldShowSyncWithBitwardenApp) {
         Spacer(modifier = Modifier.height(8.dp))
         BitwardenTextRow(
-            text = stringResource(id = R.string.sync_with_bitwarden_app),
+            text = stringResource(id = BitwardenString.sync_with_bitwarden_app),
             description = annotatedStringResource(
-                id = R.string.learn_more_link,
+                id = BitwardenString.learn_more_link,
                 style = spanStyleOf(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textStyle = MaterialTheme.typography.bodyMedium,
@@ -396,7 +396,7 @@ private fun DefaultSaveOptionSelectionRow(
     var shouldShowDefaultSaveOptionDialog by remember { mutableStateOf(false) }
 
     BitwardenTextRow(
-        text = stringResource(id = R.string.default_save_option),
+        text = stringResource(id = BitwardenString.default_save_option),
         onClick = { shouldShowDefaultSaveOptionDialog = true },
         modifier = modifier,
         withDivider = true,
@@ -411,9 +411,9 @@ private fun DefaultSaveOptionSelectionRow(
     var dialogSelection by remember { mutableStateOf(currentSelection) }
     if (shouldShowDefaultSaveOptionDialog) {
         BitwardenSelectionDialog(
-            title = stringResource(id = R.string.default_save_option),
-            subtitle = stringResource(id = R.string.default_save_options_subtitle),
-            dismissLabel = stringResource(id = R.string.confirm),
+            title = stringResource(id = BitwardenString.default_save_option),
+            subtitle = stringResource(id = BitwardenString.default_save_options_subtitle),
+            dismissLabel = stringResource(id = BitwardenString.confirm),
             onDismissRequest = { shouldShowDefaultSaveOptionDialog = false },
             onDismissActionClick = {
                 onSaveOptionUpdated(dialogSelection)
@@ -445,8 +445,8 @@ private fun UnlockWithBiometricsRow(
     BitwardenWideSwitch(
         modifier = modifier,
         label = stringResource(
-            id = R.string.unlock_with,
-            stringResource(id = R.string.biometrics),
+            id = BitwardenString.unlock_with,
+            stringResource(id = BitwardenString.biometrics),
         ),
         isChecked = isChecked || showBiometricsPrompt,
         onCheckedChange = { toggled ->
@@ -479,7 +479,7 @@ private fun AppearanceSettings(
 ) {
     BitwardenListHeaderText(
         modifier = Modifier.padding(horizontal = 16.dp),
-        label = stringResource(id = R.string.appearance),
+        label = stringResource(id = BitwardenString.appearance),
     )
     ThemeSelectionRow(
         currentSelection = state.appearance.theme,
@@ -499,7 +499,7 @@ private fun ThemeSelectionRow(
     var shouldShowThemeSelectionDialog by remember { mutableStateOf(false) }
 
     BitwardenTextRow(
-        text = stringResource(id = R.string.theme),
+        text = stringResource(id = BitwardenString.theme),
         onClick = { shouldShowThemeSelectionDialog = true },
         modifier = modifier,
         withDivider = true,
@@ -518,7 +518,7 @@ private fun ThemeSelectionRow(
 
     if (shouldShowThemeSelectionDialog) {
         BitwardenSelectionDialog(
-            title = stringResource(id = R.string.theme),
+            title = stringResource(id = BitwardenString.theme),
             onDismissRequest = { shouldShowThemeSelectionDialog = false },
         ) {
             AppTheme.entries.forEach { option ->
@@ -549,10 +549,10 @@ private fun HelpSettings(
 ) {
     BitwardenListHeaderText(
         modifier = Modifier.padding(horizontal = 16.dp),
-        label = stringResource(id = R.string.help),
+        label = stringResource(id = BitwardenString.help),
     )
     BitwardenTextRow(
-        text = stringResource(id = R.string.launch_tutorial),
+        text = stringResource(id = BitwardenString.launch_tutorial),
         onClick = onTutorialClick,
         modifier = modifier
             .semantics { testTag = "LaunchTutorial" },
@@ -560,13 +560,13 @@ private fun HelpSettings(
     )
     Spacer(modifier = Modifier.height(8.dp))
     BitwardenExternalLinkRow(
-        text = stringResource(id = R.string.bitwarden_help_center),
+        text = stringResource(id = BitwardenString.bitwarden_help_center),
         onConfirmClick = onHelpCenterClick,
         modifier = modifier
             .semantics { testTag = "BitwardenHelpCenter" },
-        dialogTitle = stringResource(id = R.string.continue_to_help_center),
+        dialogTitle = stringResource(id = BitwardenString.continue_to_help_center),
         dialogMessage = stringResource(
-            id = R.string.learn_more_about_how_to_use_bitwarden_on_the_help_center,
+            BitwardenString.learn_more_about_how_to_use_bitwarden_authenticator_on_the_help_center,
         ),
     )
 }
@@ -584,24 +584,24 @@ private fun AboutSettings(
 ) {
     BitwardenListHeaderText(
         modifier = modifier.padding(horizontal = 16.dp),
-        label = stringResource(id = R.string.about),
+        label = stringResource(id = BitwardenString.about),
     )
     BitwardenWideSwitch(
         modifier = modifier
             .padding(horizontal = 16.dp)
             .semantics { testTag = "SubmitCrashLogs" },
-        label = stringResource(id = R.string.submit_crash_logs),
+        label = stringResource(id = BitwardenString.submit_crash_logs),
         isChecked = state.isSubmitCrashLogsEnabled,
         onCheckedChange = onSubmitCrashLogsCheckedChange,
     )
     BitwardenExternalLinkRow(
-        text = stringResource(id = R.string.privacy_policy),
+        text = stringResource(id = BitwardenString.privacy_policy),
         modifier = modifier
             .semantics { testTag = "PrivacyPolicy" },
         onConfirmClick = onPrivacyPolicyClick,
-        dialogTitle = stringResource(id = R.string.continue_to_privacy_policy),
+        dialogTitle = stringResource(id = BitwardenString.continue_to_privacy_policy),
         dialogMessage = stringResource(
-            id = R.string.privacy_policy_description_long,
+            id = BitwardenString.privacy_policy_description_long,
         ),
     )
     CopyRow(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModel.kt
@@ -6,7 +6,6 @@ import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.authenticator.BuildConfig
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
 import com.bitwarden.authenticator.data.authenticator.repository.util.isSyncWithBitwardenEnabled
@@ -19,6 +18,7 @@ import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.authenticatorbridge.manager.model.AccountSyncState
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
@@ -135,7 +135,7 @@ class SettingsViewModel @Inject constructor(
         if (action.enabled) {
             mutableStateFlow.update {
                 it.copy(
-                    dialog = SettingsState.Dialog.Loading(R.string.saving.asText()),
+                    dialog = SettingsState.Dialog.Loading(BitwardenString.saving.asText()),
                     isUnlockWithBiometricsEnabled = true,
                 )
             }
@@ -336,7 +336,7 @@ class SettingsViewModel @Inject constructor(
                 isUnlockWithBiometricsEnabled = unlockWithBiometricsEnabled,
                 isSubmitCrashLogsEnabled = isSubmitCrashLogsEnabled,
                 dialog = null,
-                version = R.string.version
+                version = BitwardenString.version
                     .asText()
                     .concat(": ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})".asText()),
                 copyrightInfo = copyrightInfo,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/appearance/model/AppLanguage.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/appearance/model/AppLanguage.kt
@@ -1,6 +1,6 @@
 package com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model
 
-import com.bitwarden.authenticator.R
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 
@@ -13,7 +13,7 @@ enum class AppLanguage(
 ) {
     DEFAULT(
         localeName = null,
-        text = R.string.default_system.asText(),
+        text = BitwardenString.default_system.asText(),
     ),
     AFRIKAANS(
         localeName = "af",

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.appbar.AuthenticatorTopAppBar
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorFilledTonalButton
 import com.bitwarden.authenticator.ui.platform.components.dialog.BasicDialogState
@@ -44,6 +43,7 @@ import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.authenticator.ui.platform.util.displayLabel
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import kotlinx.collections.immutable.toImmutableList
 
 /**
@@ -95,12 +95,12 @@ fun ExportScreen(
     }
     if (shouldShowConfirmationPrompt) {
         BitwardenTwoButtonDialog(
-            title = stringResource(id = R.string.export_confirmation_title),
+            title = stringResource(id = BitwardenString.export_confirmation_title),
             message = stringResource(
-                id = R.string.export_vault_warning,
+                id = BitwardenString.export_vault_warning,
             ),
-            confirmButtonText = stringResource(id = R.string.export),
-            dismissButtonText = stringResource(id = R.string.cancel),
+            confirmButtonText = stringResource(id = BitwardenString.export),
+            dismissButtonText = stringResource(id = BitwardenString.cancel),
             onConfirmClick = {
                 shouldShowConfirmationPrompt = false
                 confirmExportClick()
@@ -143,10 +143,10 @@ fun ExportScreen(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             AuthenticatorTopAppBar(
-                title = stringResource(id = R.string.export),
+                title = stringResource(id = BitwardenString.export),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
-                navigationIconContentDescription = stringResource(id = R.string.close),
+                navigationIconContentDescription = stringResource(id = BitwardenString.close),
                 onNavigationIconClick = remember(viewModel) {
                     {
                         viewModel.trySendAction(ExportAction.CloseButtonClick)
@@ -183,7 +183,7 @@ private fun ExportScreenContent(
     ) {
         val resources = LocalContext.current.resources
         BitwardenMultiSelectButton(
-            label = stringResource(id = R.string.file_format),
+            label = stringResource(id = BitwardenString.file_format),
             options = ExportVaultFormat.entries.map { it.displayLabel() }.toImmutableList(),
             selectedOption = state.exportVaultFormat.displayLabel(),
             onOptionSelected = { selectedOptionLabel ->
@@ -201,7 +201,7 @@ private fun ExportScreenContent(
         Spacer(modifier = Modifier.height(8.dp))
 
         AuthenticatorFilledTonalButton(
-            label = stringResource(id = R.string.export),
+            label = stringResource(id = BitwardenString.export),
             onClick = onExportClick,
             modifier = Modifier
                 .semantics { testTag = "ExportVaultButton" }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportViewModel.kt
@@ -2,13 +2,13 @@ package com.bitwarden.authenticator.ui.platform.feature.settings.export
 
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.model.ExportDataResult
 import com.bitwarden.authenticator.ui.platform.feature.settings.export.model.ExportVaultFormat
 import com.bitwarden.authenticator.ui.platform.util.fileExtension
 import com.bitwarden.core.data.util.toFormattedPattern
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -120,8 +120,8 @@ class ExportViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = ExportState.DialogState.Error(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.export_vault_failure.asText(),
+                            title = BitwardenString.an_error_has_occurred.asText(),
+                            message = BitwardenString.export_vault_failure.asText(),
                         ),
                     )
                 }
@@ -129,7 +129,7 @@ class ExportViewModel @Inject constructor(
 
             is ExportDataResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(ExportEvent.ShowToast(R.string.export_success.asText()))
+                sendEvent(ExportEvent.ShowToast(BitwardenString.export_success.asText()))
             }
         }
     }
@@ -152,7 +152,7 @@ data class ExportState(
          * Displays a loading dialog with an optional [message].
          */
         data class Loading(
-            val message: Text = R.string.loading.asText(),
+            val message: Text = BitwardenString.loading.asText(),
         ) : DialogState()
 
         /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportFileFormat
 import com.bitwarden.authenticator.ui.platform.components.appbar.AuthenticatorTopAppBar
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorFilledTonalButton
@@ -40,6 +39,7 @@ import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.authenticator.ui.platform.util.displayLabel
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import kotlinx.collections.immutable.toImmutableList
 
 /**
@@ -88,11 +88,11 @@ fun ImportingScreen(
             BitwardenTwoButtonDialog(
                 title = dialog.title?.invoke(),
                 message = dialog.message.invoke(),
-                confirmButtonText = stringResource(id = R.string.get_help),
+                confirmButtonText = stringResource(id = BitwardenString.get_help),
                 onConfirmClick = {
                     intentManager.launchUri("https://bitwarden.com/help".toUri())
                 },
-                dismissButtonText = stringResource(id = R.string.cancel),
+                dismissButtonText = stringResource(id = BitwardenString.cancel),
                 onDismissClick = {
                     viewModel.trySendAction(ImportAction.DialogDismiss)
                 },
@@ -120,10 +120,10 @@ fun ImportingScreen(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             AuthenticatorTopAppBar(
-                title = stringResource(id = R.string.import_vault),
+                title = stringResource(id = BitwardenString.import_vault),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
-                navigationIconContentDescription = stringResource(id = R.string.close),
+                navigationIconContentDescription = stringResource(id = BitwardenString.close),
                 onNavigationIconClick = remember(viewModel) {
                     {
                         viewModel.trySendAction(ImportAction.CloseButtonClick)
@@ -164,7 +164,7 @@ private fun ImportScreenContent(
     ) {
         val resources = LocalContext.current.resources
         BitwardenMultiSelectButton(
-            label = stringResource(id = R.string.file_format),
+            label = stringResource(id = BitwardenString.file_format),
             options = ImportFileFormat.entries.map { it.displayLabel() }.toImmutableList(),
             selectedOption = state.importFileFormat.displayLabel(),
             onOptionSelected = { selectedOptionLabel ->
@@ -182,7 +182,7 @@ private fun ImportScreenContent(
         Spacer(modifier = Modifier.height(8.dp))
 
         AuthenticatorFilledTonalButton(
-            label = stringResource(id = R.string.import_vault),
+            label = stringResource(id = BitwardenString.import_vault),
             onClick = onImportClick,
             modifier = Modifier
                 .semantics { testTag = "ImportVaultButton" }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingViewModel.kt
@@ -2,12 +2,12 @@ package com.bitwarden.authenticator.ui.platform.feature.settings.importing
 
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportDataResult
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportFileFormat
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -100,8 +100,9 @@ class ImportingViewModel @Inject constructor(
                 mutableStateFlow.update {
                     it.copy(
                         dialogState = ImportState.DialogState.Error(
-                            title = result.title ?: R.string.an_error_has_occurred.asText(),
-                            message = result.message ?: R.string.import_vault_failure.asText(),
+                            title = result.title ?: BitwardenString.an_error_has_occurred.asText(),
+                            message = result.message
+                                ?: BitwardenString.import_vault_failure.asText(),
                         ),
                     )
                 }
@@ -111,7 +112,7 @@ class ImportingViewModel @Inject constructor(
                 mutableStateFlow.update { it.copy(dialogState = null) }
                 sendEvent(
                     ImportEvent.ShowToast(
-                        message = R.string.import_success.asText(),
+                        message = BitwardenString.import_success.asText(),
                     ),
                 )
                 sendEvent(ImportEvent.NavigateBack)
@@ -139,7 +140,7 @@ data class ImportState(
          * Represents a loading dialog with the given [message].
          */
         data class Loading(
-            val message: Text = R.string.loading.asText(),
+            val message: Text = BitwardenString.loading.asText(),
         ) : DialogState()
 
         /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorFilledTonalButton
 import com.bitwarden.authenticator.ui.platform.components.button.AuthenticatorTextButton
 import com.bitwarden.authenticator.ui.platform.components.scaffold.BitwardenScaffold
@@ -49,6 +48,7 @@ import com.bitwarden.authenticator.ui.platform.util.isPortrait
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.bitwarden.ui.platform.resource.BitwardenString
 import kotlinx.coroutines.launch
 
 /**
@@ -165,7 +165,7 @@ private fun TutorialScreenContent(
 
         AuthenticatorTextButton(
             isEnabled = !state.isLastPage,
-            label = stringResource(id = R.string.skip),
+            label = stringResource(id = BitwardenString.skip),
             onClick = skipClick,
             modifier = Modifier
                 .standardHorizontalMargin()

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialViewModel.kt
@@ -1,9 +1,9 @@
 package com.bitwarden.authenticator.ui.platform.feature.tutorial
 
 import android.os.Parcelable
-import com.bitwarden.authenticator.R
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
@@ -93,8 +93,8 @@ data class TutorialState(
         @Parcelize
         data object IntroSlide : TutorialSlide() {
             override val image: Int get() = BitwardenDrawable.ic_tutorial_verification_codes
-            override val title: Int get() = R.string.secure_your_accounts_with_bitwarden_authenticator
-            override val message: Int get() = R.string.get_verification_codes_for_all_your_accounts
+            override val title: Int get() = BitwardenString.secure_your_accounts_with_bitwarden_authenticator
+            override val message: Int get() = BitwardenString.get_verification_codes_for_all_your_accounts
         }
 
         /**
@@ -103,8 +103,8 @@ data class TutorialState(
         @Parcelize
         data object QrScannerSlide : TutorialSlide() {
             override val image: Int get() = BitwardenDrawable.ic_tutorial_qr_scanner
-            override val title: Int get() = R.string.use_your_device_camera_to_scan_codes
-            override val message: Int get() = R.string.scan_the_qr_code_in_your_2_step_verification_settings_for_any_account
+            override val title: Int get() = BitwardenString.use_your_device_camera_to_scan_codes
+            override val message: Int get() = BitwardenString.scan_the_qr_code_in_your_2_step_verification_settings_for_any_account
         }
 
         /**
@@ -113,8 +113,8 @@ data class TutorialState(
         @Parcelize
         data object UniqueCodesSlide : TutorialSlide() {
             override val image: Int get() = BitwardenDrawable.ic_tutorial_2fa
-            override val title: Int get() = R.string.sign_in_using_unique_codes
-            override val message: Int get() = R.string.when_using_2_step_verification_youll_enter_your_username_and_password_and_a_code_generated_in_this_app
+            override val title: Int get() = BitwardenString.sign_in_using_unique_codes
+            override val message: Int get() = BitwardenString.when_using_2_step_verification_youll_enter_your_username_and_password_and_a_code_generated_in_this_app
         }
     }
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
@@ -7,7 +7,7 @@ import androidx.biometric.BiometricManager.Authenticators
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
-import com.bitwarden.authenticator.R
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * Default implementation of the [BiometricsManager] to manage biometrics within the app.
@@ -89,8 +89,8 @@ class BiometricsManagerImpl(
         )
 
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
-            .setTitle(activity.getString(R.string.bitwarden_authenticator))
-            .setDescription(activity.getString(R.string.biometrics_direction))
+            .setTitle(activity.getString(BitwardenString.bitwarden_authenticator))
+            .setDescription(activity.getString(BitwardenString.biometrics_direction))
             .setAllowedAuthenticators(allowedAuthenticators)
             .build()
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import com.bitwarden.annotation.OmitFromCoverage
-import com.bitwarden.authenticator.R
+import com.bitwarden.ui.platform.resource.BitwardenString
 
 /**
  * The default implementation of the [IntentManager] for simplifying the handling of Android
@@ -56,7 +56,7 @@ class IntentManagerImpl(
             Intent(Intent.ACTION_OPEN_DOCUMENT)
                 .addCategory(Intent.CATEGORY_OPENABLE)
                 .setType(mimeType),
-            ContextCompat.getString(context, R.string.file_source),
+            ContextCompat.getString(context, BitwardenString.file_source),
         )
 
         return chooserIntent

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/AppThemeExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/AppThemeExtensions.kt
@@ -1,7 +1,7 @@
 package com.bitwarden.authenticator.ui.platform.util
 
-import com.bitwarden.authenticator.R
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 
@@ -10,7 +10,7 @@ import com.bitwarden.ui.util.asText
  */
 val AppTheme.displayLabel: Text
     get() = when (this) {
-        AppTheme.DEFAULT -> R.string.default_system.asText()
-        AppTheme.DARK -> R.string.dark.asText()
-        AppTheme.LIGHT -> R.string.light.asText()
+        AppTheme.DEFAULT -> BitwardenString.default_system.asText()
+        AppTheme.DARK -> BitwardenString.dark.asText()
+        AppTheme.LIGHT -> BitwardenString.light.asText()
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/DefaultSaveOptionExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/DefaultSaveOptionExtensions.kt
@@ -1,16 +1,16 @@
 package com.bitwarden.authenticator.ui.platform.util
 
-import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 
 /**
  * Returns a human-readable display label for the given [DefaultSaveOption].
  */
 val DefaultSaveOption.displayLabel: Text
     get() = when (this) {
-        DefaultSaveOption.NONE -> R.string.none.asText()
-        DefaultSaveOption.LOCAL -> R.string.save_here.asText()
-        DefaultSaveOption.BITWARDEN_APP -> R.string.save_to_bitwarden.asText()
+        DefaultSaveOption.NONE -> BitwardenString.none.asText()
+        DefaultSaveOption.LOCAL -> BitwardenString.save_here.asText()
+        DefaultSaveOption.BITWARDEN_APP -> BitwardenString.save_to_bitwarden.asText()
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/ExportFormatExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/ExportFormatExtensions.kt
@@ -1,17 +1,17 @@
 package com.bitwarden.authenticator.ui.platform.util
 
-import com.bitwarden.authenticator.R
+import com.bitwarden.authenticator.ui.platform.feature.settings.export.model.ExportVaultFormat
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.bitwarden.authenticator.ui.platform.feature.settings.export.model.ExportVaultFormat
 
 /**
  *  Provides a human-readable label for the export format.
  */
 val ExportVaultFormat.displayLabel: Text
     get() = when (this) {
-        ExportVaultFormat.JSON -> R.string.export_format_label_json.asText()
-        ExportVaultFormat.CSV -> R.string.export_format_label_csv.asText()
+        ExportVaultFormat.JSON -> BitwardenString.json_extension.asText()
+        ExportVaultFormat.CSV -> BitwardenString.csv_extension.asText()
     }
 
 /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/ImportFormatExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/ImportFormatExtensions.kt
@@ -1,7 +1,7 @@
 package com.bitwarden.authenticator.ui.platform.util
 
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportFileFormat
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 
@@ -10,8 +10,19 @@ import com.bitwarden.ui.util.asText
  */
 val ImportFileFormat.displayLabel: Text
     get() = when (this) {
-        ImportFileFormat.BITWARDEN_JSON -> R.string.import_format_label_bitwarden_json.asText()
-        ImportFileFormat.TWO_FAS_JSON -> R.string.import_format_label_2fas_json.asText()
-        ImportFileFormat.LAST_PASS_JSON -> R.string.import_format_label_lastpass_json.asText()
-        ImportFileFormat.AEGIS -> R.string.import_format_label_aegis_json.asText()
+        ImportFileFormat.BITWARDEN_JSON -> {
+            BitwardenString.import_format_label_bitwarden_json.asText()
+        }
+
+        ImportFileFormat.TWO_FAS_JSON -> {
+            BitwardenString.import_format_label_2fas_json.asText()
+        }
+
+        ImportFileFormat.LAST_PASS_JSON -> {
+            BitwardenString.import_format_label_lastpass_json.asText()
+        }
+
+        ImportFileFormat.AEGIS -> {
+            BitwardenString.import_format_label_aegis_json.asText()
+        }
     }

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemViewModelTest.kt
@@ -2,7 +2,6 @@ package com.bitwarden.authenticator.ui.authenticator.feature.edititem
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemAlgorithm
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
@@ -11,6 +10,7 @@ import com.bitwarden.authenticator.data.authenticator.repository.model.CreateIte
 import com.bitwarden.authenticator.ui.authenticator.feature.edititem.model.EditItemData
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
 import io.mockk.coEvery
@@ -227,8 +227,9 @@ class EditItemViewModelTest : BaseViewModelTest() {
         assertEquals(
             state.copy(
                 dialog = EditItemState.DialogState.Generic(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.validation_field_required.asText(R.string.name.asText()),
+                    title = BitwardenString.an_error_has_occurred.asText(),
+                    message = BitwardenString.validation_field_required
+                        .asText(BitwardenString.name.asText()),
                 ),
             ),
             viewModel.stateFlow.value,
@@ -250,8 +251,9 @@ class EditItemViewModelTest : BaseViewModelTest() {
         assertEquals(
             state.copy(
                 dialog = EditItemState.DialogState.Generic(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.validation_field_required.asText(R.string.key.asText()),
+                    title = BitwardenString.an_error_has_occurred.asText(),
+                    message = BitwardenString.validation_field_required
+                        .asText(BitwardenString.key.asText()),
                 ),
             ),
             viewModel.stateFlow.value,
@@ -273,8 +275,8 @@ class EditItemViewModelTest : BaseViewModelTest() {
         assertEquals(
             state.copy(
                 dialog = EditItemState.DialogState.Generic(
-                    title = R.string.an_error_has_occurred.asText(),
-                    message = R.string.key_is_invalid.asText(),
+                    title = BitwardenString.an_error_has_occurred.asText(),
+                    message = BitwardenString.key_is_invalid.asText(),
                 ),
             ),
             viewModel.stateFlow.value,
@@ -298,7 +300,7 @@ class EditItemViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     state.copy(
                         dialog = EditItemState.DialogState.Loading(
-                            message = R.string.saving.asText(),
+                            message = BitwardenString.saving.asText(),
                         ),
                     ),
                     awaitItem(),
@@ -306,8 +308,8 @@ class EditItemViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     state.copy(
                         dialog = EditItemState.DialogState.Generic(
-                            title = R.string.an_error_has_occurred.asText(),
-                            message = R.string.generic_error_message.asText(),
+                            title = BitwardenString.an_error_has_occurred.asText(),
+                            message = BitwardenString.generic_error_message.asText(),
                         ),
                     ),
                     awaitItem(),
@@ -346,13 +348,13 @@ class EditItemViewModelTest : BaseViewModelTest() {
             assertEquals(
                 state.copy(
                     dialog = EditItemState.DialogState.Loading(
-                        message = R.string.saving.asText(),
+                        message = BitwardenString.saving.asText(),
                     ),
                 ),
                 stateFlow.awaitItem(),
             )
             assertEquals(
-                EditItemEvent.ShowToast(R.string.item_saved.asText()),
+                EditItemEvent.ShowToast(BitwardenString.item_saved.asText()),
                 eventFlow.awaitItem(),
             )
             assertEquals(EditItemEvent.NavigateBack, eventFlow.awaitItem())
@@ -397,7 +399,7 @@ class EditItemViewModelTest : BaseViewModelTest() {
             assertEquals(
                 DEFAULT_STATE.copy(
                     viewState = EditItemState.ViewState.Error(
-                        message = R.string.generic_error_message.asText(),
+                        message = BitwardenString.generic_error_message.asText(),
                     ),
                 ),
                 awaitItem(),
@@ -422,9 +424,9 @@ class EditItemViewModelTest : BaseViewModelTest() {
             assertEquals(
                 DEFAULT_STATE.copy(
                     viewState = EditItemState.ViewState.Error(
-                        message = R.string.internet_connection_required_title
+                        message = BitwardenString.internet_connection_required_title
                             .asText()
-                            .concat(R.string.internet_connection_required_message.asText()),
+                            .concat(BitwardenString.internet_connection_required_message.asText()),
                     ),
                 ),
                 awaitItem(),
@@ -435,7 +437,7 @@ class EditItemViewModelTest : BaseViewModelTest() {
             assertEquals(
                 DEFAULT_STATE.copy(
                     viewState = EditItemState.ViewState.Error(
-                        message = R.string.generic_error_message.asText(),
+                        message = BitwardenString.generic_error_message.asText(),
                     ),
                 ),
                 awaitItem(),

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.itemlisting
 
 import app.cash.turbine.test
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
@@ -19,6 +18,7 @@ import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import io.mockk.every
 import io.mockk.just
@@ -406,8 +406,8 @@ class ItemListingViewModelTest : BaseViewModelTest() {
     fun `on CopyToBitwardenClick should show error dialog when startAddTotpLoginItemFlow returns false`() {
         val expectedState = DEFAULT_STATE.copy(
             dialog = ItemListingState.DialogState.Error(
-                title = R.string.something_went_wrong.asText(),
-                message = R.string.please_try_again.asText(),
+                title = BitwardenString.something_went_wrong.asText(),
+                message = BitwardenString.please_try_again.asText(),
             ),
         )
         val expectedUriString = "expectedUriString"
@@ -486,7 +486,9 @@ class ItemListingViewModelTest : BaseViewModelTest() {
 
         val expectedState = DEFAULT_STATE.copy(
             dialog = ItemListingState.DialogState.DeleteConfirmationPrompt(
-                message = R.string.do_you_really_want_to_permanently_delete_cipher.asText(),
+                message = BitwardenString
+                    .do_you_really_want_to_permanently_delete_this_cannot_be_undone
+                    .asText(),
                 itemId = LOCAL_CODE.id,
             ),
         )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModelTest.kt
@@ -2,7 +2,6 @@ package com.bitwarden.authenticator.ui.authenticator.feature.manualcodeentry
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemEntity
 import com.bitwarden.authenticator.data.authenticator.datasource.disk.entity.AuthenticatorItemType
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
@@ -12,6 +11,7 @@ import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -191,7 +191,7 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
             }
             viewModel.eventFlow.test {
                 assertEquals(
-                    ManualCodeEntryEvent.ShowToast(R.string.verification_code_added.asText()),
+                    ManualCodeEntryEvent.ShowToast(BitwardenString.verification_code_added.asText()),
                     awaitItem(),
                 )
                 assertEquals(
@@ -243,8 +243,8 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
                 code = "ABCD",
                 issuer = "mockIssuer",
                 dialog = ManualCodeEntryState.DialogState.Error(
-                    title = R.string.something_went_wrong.asText(),
-                    message = R.string.please_try_again.asText(),
+                    title = BitwardenString.something_went_wrong.asText(),
+                    message = BitwardenString.please_try_again.asText(),
                 ),
             )
             assertEquals(expectedState, viewModel.stateFlow.value)
@@ -302,7 +302,7 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             ManualCodeEntryState.DialogState.Error(
-                message = R.string.key_is_required.asText(),
+                message = BitwardenString.key_is_required.asText(),
             ),
             viewModel.stateFlow.value.dialog,
         )
@@ -320,7 +320,7 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             ManualCodeEntryState.DialogState.Error(
-                message = R.string.key_is_invalid.asText(),
+                message = BitwardenString.key_is_invalid.asText(),
             ),
             viewModel.stateFlow.value.dialog,
         )
@@ -339,7 +339,7 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             ManualCodeEntryState.DialogState.Error(
-                message = R.string.name_is_required.asText(),
+                message = BitwardenString.name_is_required.asText(),
             ),
             viewModel.stateFlow.value.dialog,
         )
@@ -415,7 +415,7 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel(
             initialState = DEFAULT_STATE.copy(
                 dialog = ManualCodeEntryState.DialogState.Error(
-                    message = R.string.key_is_required.asText(),
+                    message = BitwardenString.key_is_required.asText(),
                 ),
             ),
         )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.search
 
 import androidx.lifecycle.SavedStateHandle
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
 import com.bitwarden.authenticator.data.authenticator.manager.util.createMockSharedAuthenticatorItemSource
 import com.bitwarden.authenticator.data.authenticator.manager.util.createMockVerificationCodeItem
@@ -14,6 +13,7 @@ import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import io.mockk.every
 import io.mockk.mockk
@@ -125,7 +125,7 @@ private val SHARED_DISPLAY_ITEMS = SharedCodesDisplayState.Codes(
     sections = listOf(
         SharedCodesDisplayState.SharedCodesAccountSection(
             id = "mockUserId-2",
-            label = R.string.shared_accounts_header.asText(
+            label = BitwardenString.shared_accounts_header.asText(
                 "mockEmail-2",
                 "mockkEnvironmentLabel-2",
                 1,

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/SharedVerificationCodesStateTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/SharedVerificationCodesStateTest.kt
@@ -1,11 +1,11 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.util
 
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.manager.model.VerificationCodeItem
 import com.bitwarden.authenticator.data.authenticator.repository.model.AuthenticatorItem
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
 import com.bitwarden.authenticator.ui.authenticator.feature.model.SharedCodesDisplayState
 import com.bitwarden.authenticator.ui.authenticator.feature.model.VerificationCodeDisplayItem
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -62,7 +62,7 @@ class SharedVerificationCodesStateTest {
             sections = listOf(
                 SharedCodesDisplayState.SharedCodesAccountSection(
                     id = "user1",
-                    label = R.string.shared_accounts_header.asText(
+                    label = BitwardenString.shared_accounts_header.asText(
                         "John@test.com",
                         "bitwarden.com",
                         1,
@@ -85,7 +85,7 @@ class SharedVerificationCodesStateTest {
                 ),
                 SharedCodesDisplayState.SharedCodesAccountSection(
                     id = "user1",
-                    label = R.string.shared_accounts_header.asText(
+                    label = BitwardenString.shared_accounts_header.asText(
                         "Jane@test.com",
                         "bitwarden.eu",
                         1,
@@ -154,7 +154,7 @@ class SharedVerificationCodesStateTest {
             sections = listOf(
                 SharedCodesDisplayState.SharedCodesAccountSection(
                     id = "user1",
-                    label = R.string.shared_accounts_header.asText(
+                    label = BitwardenString.shared_accounts_header.asText(
                         "John@test.com",
                         "bitwarden.com",
                         1,
@@ -177,7 +177,7 @@ class SharedVerificationCodesStateTest {
                 ),
                 SharedCodesDisplayState.SharedCodesAccountSection(
                     id = "user1",
-                    label = R.string.shared_accounts_header.asText(
+                    label = BitwardenString.shared_accounts_header.asText(
                         "Jane@test.com",
                         "bitwarden.eu",
                         1,

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.core.net.toUri
 import com.bitwarden.authenticator.BuildConfig
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.base.AuthenticatorComposeTest
 import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
@@ -19,6 +18,7 @@ import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsMana
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
 import io.mockk.every
@@ -197,7 +197,7 @@ private val DEFAULT_STATE = SettingsState(
     showDefaultSaveOptionRow = true,
     defaultSaveOption = DEFAULT_SAVE_OPTION,
     dialog = null,
-    version = R.string.version.asText()
+    version = BitwardenString.version.asText()
         .concat(": ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})".asText()),
     copyrightInfo = "© Bitwarden Inc. 2015-2024".asText(),
 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -3,7 +3,6 @@ package com.bitwarden.authenticator.ui.platform.feature.settings
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.authenticator.BuildConfig
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
 import com.bitwarden.authenticator.data.authenticator.repository.util.isSyncWithBitwardenEnabled
@@ -16,6 +15,7 @@ import com.bitwarden.authenticatorbridge.manager.model.AccountSyncState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
 import io.mockk.every
@@ -228,7 +228,7 @@ private val DEFAULT_STATE = SettingsState(
     showDefaultSaveOptionRow = false,
     defaultSaveOption = DEFAULT_SAVE_OPTION,
     dialog = null,
-    version = R.string.version.asText()
+    version = BitwardenString.version.asText()
         .concat(": ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})".asText()),
     copyrightInfo = "© Bitwarden Inc. 2015-2024".asText(),
 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/util/DefaultSaveOptionExtensionsTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/util/DefaultSaveOptionExtensionsTest.kt
@@ -1,7 +1,7 @@
 package com.bitwarden.authenticator.ui.platform.util
 
-import com.bitwarden.authenticator.R
 import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -12,9 +12,9 @@ class DefaultSaveOptionExtensionsTest {
     fun `displayLabel should map to correct labels`() {
         DefaultSaveOption.entries.forEach {
             val expected = when (it) {
-                DefaultSaveOption.BITWARDEN_APP -> R.string.save_to_bitwarden.asText()
-                DefaultSaveOption.LOCAL -> R.string.save_here.asText()
-                DefaultSaveOption.NONE -> R.string.none.asText()
+                DefaultSaveOption.BITWARDEN_APP -> BitwardenString.save_to_bitwarden.asText()
+                DefaultSaveOption.LOCAL -> BitwardenString.save_here.asText()
+                DefaultSaveOption.NONE -> BitwardenString.none.asText()
             }
             assertEquals(
                 expected,

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="about">About</string>
     <string name="add_folder">Add folder</string>
     <string name="add_item">Add Item</string>
@@ -531,7 +531,7 @@ Scanning will happen automatically.</string>
     <string name="verification_codes">Verification codes</string>
     <string name="premium_subscription_required">Premium subscription required</string>
     <string name="cannot_add_authenticator_key_scan_qr_code">Cannot add authenticator key? <annotation link="scanQrCode">Scan QR Code</annotation></string>
-    <string name="scan_qr_code">Scan QR Code</string>
+    <string name="scan_qr_code"><annotation link="scanQrCode">Scan QR code</annotation></string>
     <string name="cannot_scan_qr_code_enter_key_manually">Cannot scan QR code? <annotation link="enterKeyManually">Enter key manually</annotation></string>
     <string name="authenticator_key_scanner">Authenticator key</string>
     <string name="authenticator_key_help">Authenticator key help</string>
@@ -993,4 +993,88 @@ Do you want to switch to this account?</string>
     <string name="delete_x">Delete %s</string>
     <string name="failed_to_decrypt_cipher_contact_support">Failed to decrypt cipher. Contact support.</string>
     <string name="decryption_error">Decryption error</string>
+    <string name="add_item_rotation">Add Item Rotation</string>
+    <string name="scan_a_qr_code">Scan a QR code</string>
+    <string name="cannot_add_authenticator_key">Cannot add authenticator key?</string>
+    <string name="enable_camera_permission_to_use_the_scanner">Enable camera permission to use the scanner</string>
+    <string name="empty_item_list">Empty Item Listing</string>
+    <string name="you_dont_have_items_to_display">You don\'t have any items to display.</string>
+    <string name="empty_item_list_instruction">Add a new code to secure your accounts.</string>
+    <string name="add_code">Add code</string>
+    <string name="verification_code_added">Verification code added</string>
+    <string name="refresh_period">Refresh period</string>
+    <string name="algorithm">Algorithm</string>
+    <string name="advanced">Advanced</string>
+    <string name="collapse_advanced_options">Collapse advanced options</string>
+    <string name="number_of_digits">Number of digits</string>
+    <string name="refresh_period_seconds" tools:ignore="PluralsCandidate">%d seconds</string>
+    <string name="item_saved">Item saved</string>
+    <string name="information">Information</string>
+    <string name="otp_type">OTP type</string>
+    <string name="search_codes">Search codes</string>
+    <string name="secure_your_accounts_with_bitwarden_authenticator">Secure your accounts with Bitwarden Authenticator</string>
+    <string name="get_verification_codes_for_all_your_accounts">Get verification codes for all your accounts that support 2-step verification.</string>
+    <string name="use_your_device_camera_to_scan_codes">Use your device camera to scan codes</string>
+    <string name="scan_the_qr_code_in_your_2_step_verification_settings_for_any_account">Scan the QR code in your 2-step verification settings for any account.</string>
+    <string name="sign_in_using_unique_codes">Sign in using unique codes</string>
+    <string name="when_using_2_step_verification_youll_enter_your_username_and_password_and_a_code_generated_in_this_app">When using 2-step verification, you\'ll enter your username and password and a code generated in this app.</string>
+    <string name="skip">Skip</string>
+    <string name="help">Help</string>
+    <string name="launch_tutorial">Launch tutorial</string>
+    <string name="delete_item">Delete item</string>
+    <string name="do_you_really_want_to_permanently_delete_this_cannot_be_undone">Do you really want to permanently delete? This cannot be undone.</string>
+    <string name="data">Data</string>
+    <string name="export">Export</string>
+    <string name="export_confirmation_title">Confirm export</string>
+    <string name="export_success">Data exported successfully</string>
+    <string name="security">Security</string>
+    <string name="too_many_failed_biometric_attempts">Too many failed biometrics attempts.</string>
+    <string name="version">Version</string>
+    <string name="learn_more_about_how_to_use_bitwarden_authenticator_on_the_help_center">Learn more about how to use Bitwarden Authenticator on the Help Center.</string>
+    <string name="key">Key</string>
+    <string name="create_verification_code">Create Verification code</string>
+    <string name="key_is_required">Key is required.</string>
+    <string name="name_is_required">Name is required.</string>
+    <string name="import_vault_failure">There was a problem importing your vault.</string>
+    <string name="import_vault">Import</string>
+    <string name="import_success">Vault import successful</string>
+    <string name="key_is_invalid">Key is invalid.</string>
+    <string name="backup">Backup</string>
+    <string name="data_backup_title">Data backup</string>
+    <string name="data_backup_message">Bitwarden Authenticator data is backed up and can be restored with your regularly scheduled device backups.</string>
+    <string name="import_2fas_password_protected_not_supported">Importing from 2FAS password protected files is not supported. Try again with an exported file that is not password protected.</string>
+    <string name="import_bitwarden_unsupported_format">Importing Bitwarden CSV files is not supported. Try again with an exported JSON file.</string>
+    <string name="download_bitwarden_card_title">Download the Bitwarden app</string>
+    <string name="download_bitwarden_card_message">Store all of your logins and sync verification codes directly with the Authenticator app.</string>
+    <string name="download_now">Download now</string>
+    <string name="sync_with_bitwarden_app">Sync with Bitwarden app</string>
+    <string name="learn_more_link"><annotation link="learnMore">Learn more</annotation></string>
+    <string name="shared_codes_error">Unable to sync codes from the Bitwarden app. Make sure both apps are up-to-date. You can still access your existing codes in the Bitwarden app.</string>
+    <string name="shared_accounts_header">%1$s | %2$s (%3$d)</string>
+    <string name="sync_with_the_bitwarden_app">Sync with the Bitwarden app</string>
+    <string name="sync_with_bitwarden_action_card_message">In order to view all of your verification codes, you’ll need to allow for syncing on all of your accounts.</string>
+    <string name="take_me_to_app_settings">Take me to the app settings</string>
+    <string name="something_went_wrong">Something went wrong</string>
+    <string name="please_try_again">Please try again</string>
+    <string name="copy_to_bitwarden_vault">Copy to Bitwarden vault</string>
+    <string name="default_save_option">Default save option</string>
+    <string name="save_to_bitwarden">Save to Bitwarden</string>
+    <string name="save_here">Save here</string>
+    <string name="none">None</string>
+    <string name="default_save_options_subtitle">Select where you would like to save new verification codes.</string>
+    <string name="verification_code_created">Verification code created</string>
+    <string name="choose_save_location_message">Save this authenticator key here, or add it to a login in your Bitwarden app.</string>
+    <string name="save_option_as_default">Save option as default</string>
+    <string name="account_synced_from_bitwarden_app">Account synced from Bitwarden app</string>
+    <string name="local_codes">Local codes (%1$d)</string>
+    <string name="required_information_missing">Required Information Missing</string>
+    <string name="required_information_missing_message">"Required info is missing (e.g., ‘services’ or ‘secret’). Check your file and try again. Visit bitwarden.com/help for support"</string>
+    <string name="file_could_not_be_processed">"File Could Not Be Processed"</string>
+    <string name="file_could_not_be_processed_message">"File could not be processed. Ensure it’s valid JSON and try again. Need help? Visit bitwarden.com/help"</string>
+    <string name="get_help">Get Help</string>
+    <string name="expand_advanced_options">Expand advanced options</string>
+    <string name="local_items_are_expanded_click_to_collapse">Local items are expanded, click to collapse.</string>
+    <string name="local_items_are_collapsed_click_to_expand">Local items are collapsed, click to expand.</string>
+    <string name="items_expanded_click_to_collapse">Items are expanded, click to collapse.</string>
+    <string name="items_are_collapsed_click_to_expand">Items are collapsed, click to expand.</string>
 </resources>

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="bitwarden_authenticator">Bitwarden Authenticator</string>
     <string name="csv_extension" translatable="false">.csv</string>
     <string name="duo_title" translatable="false">Duo</string>
     <string name="duo_org_title" translatable="false">Duo (%1$s)</string>
     <string name="json_extension" translatable="false">.json</string>
     <string name="json_extension_formatted" translatable="false">.json (%1$s)</string>
 
-    <!-- Debug Menu -->
+    <!-- region Debug Menu -->
     <string name="email_verification">Email Verification</string>
     <string name="import_logins_flow">Import Logins Flow</string>
     <string name="feature_flags">Feature Flags:</string>
@@ -29,5 +30,11 @@
     <string name="error_reports">Error reports</string>
     <string name="user_trusted_privileged_app_management">User-trusted privileged app management</string>
     <string name="remove_card_policy">Remove Card Policy</string>
-    <!-- /Debug Menu -->
+    <string name="bitwarden_authentication_enabled">Bitwarden authentication enabled</string>
+    <string name="import_format_label_bitwarden_json">Bitwarden (.json)</string>
+    <string name="import_format_label_2fas_json">2FAS (no password)</string>
+    <string name="import_format_label_lastpass_json">LastPass (.json)</string>
+    <string name="import_format_label_aegis_json">Aegis (.json)</string>
+
+    <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

PM-24002

## 📔 Objective

Move all Authenticator string resources to the `ui` module.

A subsequent PR will remove strings in the `authenticator` module. A two-step approach is being taken to ensure translations are not lost during the move.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
