### PR TITLE
PM-20152: Remove import logins flow feature flag

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -7,7 +7,6 @@ import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.model.CoachMarkTourType
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
-import com.x8bit.bitwarden.data.platform.manager.model.FlagKey
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,7 +30,6 @@ class FirstTimeActionManagerImpl @Inject constructor(
     private val authDiskSource: AuthDiskSource,
     private val settingsDiskSource: SettingsDiskSource,
     private val vaultDiskSource: VaultDiskSource,
-    private val featureFlagManager: FeatureFlagManager,
     private val autofillEnabledManager: AutofillEnabledManager,
 ) : FirstTimeActionManager {
 
@@ -101,16 +99,9 @@ class FirstTimeActionManagerImpl @Inject constructor(
             .activeUserIdChangesFlow
             .filterNotNull()
             .flatMapLatest {
-                combine(
-                    getShowImportLoginsSettingBadgeFlowInternal(userId = it),
-                    featureFlagManager.getFeatureFlagFlow(FlagKey.ImportLoginsFlow),
-                ) { showImportLogins, importLoginsEnabled ->
-                    val shouldShowImportLoginsSettings = showImportLogins && importLoginsEnabled
-                    listOf(shouldShowImportLoginsSettings)
-                }
-                    .map { list ->
-                        list.count { showImportLogins -> showImportLogins }
-                    }
+                getShowImportLoginsSettingBadgeFlowInternal(userId = it)
+                    .map { showImportLogins -> listOf(showImportLogins) }
+                    .map { list -> list.count { showImportLogins -> showImportLogins } }
             }
             .stateIn(
                 scope = unconfinedScope,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -353,14 +353,12 @@ object PlatformManagerModule {
         settingsDiskSource: SettingsDiskSource,
         vaultDiskSource: VaultDiskSource,
         dispatcherManager: DispatcherManager,
-        featureFlagManager: FeatureFlagManager,
         autofillEnabledManager: AutofillEnabledManager,
     ): FirstTimeActionManager = FirstTimeActionManagerImpl(
         authDiskSource = authDiskSource,
         settingsDiskSource = settingsDiskSource,
         vaultDiskSource = vaultDiskSource,
         dispatcherManager = dispatcherManager,
-        featureFlagManager = featureFlagManager,
         autofillEnabledManager = autofillEnabledManager,
     )
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt
@@ -22,7 +22,6 @@ sealed class FlagKey<out T : Any> {
         val activeFlags: List<FlagKey<*>> by lazy {
             listOf(
                 EmailVerification,
-                ImportLoginsFlow,
                 CredentialExchangeProtocolImport,
                 CredentialExchangeProtocolExport,
                 SingleTapPasskeyCreation,
@@ -39,14 +38,6 @@ sealed class FlagKey<out T : Any> {
      */
     data object EmailVerification : FlagKey<Boolean>() {
         override val keyName: String = "email-verification"
-        override val defaultValue: Boolean = false
-    }
-
-    /**
-     * Data object holding the feature flag key for the import logins feature.
-     */
-    data object ImportLoginsFlow : FlagKey<Boolean>() {
-        override val keyName: String = "import-logins-flow"
         override val defaultValue: Boolean = false
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -26,7 +26,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     }
 
     FlagKey.EmailVerification,
-    FlagKey.ImportLoginsFlow,
     FlagKey.CredentialExchangeProtocolImport,
     FlagKey.CredentialExchangeProtocolExport,
     FlagKey.CipherKeyEncryption,
@@ -77,7 +76,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
         -> this.keyName
 
     FlagKey.EmailVerification -> stringResource(BitwardenString.email_verification)
-    FlagKey.ImportLoginsFlow -> stringResource(BitwardenString.import_logins_flow)
     FlagKey.CredentialExchangeProtocolImport -> stringResource(BitwardenString.cxp_import)
     FlagKey.CredentialExchangeProtocolExport -> stringResource(BitwardenString.cxp_export)
     FlagKey.CipherKeyEncryption -> stringResource(BitwardenString.cipher_key_encryption)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.ui.platform.base.util.EventsEffect
@@ -34,13 +33,10 @@ import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.x8bit.bitwarden.ui.platform.components.card.actionCardExitAnimation
-import com.x8bit.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow
 import com.x8bit.bitwarden.ui.platform.components.row.BitwardenTextRow
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
 import com.x8bit.bitwarden.ui.platform.components.snackbar.rememberBitwardenSnackbarHostState
-import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 
 /**
  * Displays the vault settings screen.
@@ -54,7 +50,6 @@ fun VaultSettingsScreen(
     onNavigateToFolders: () -> Unit,
     onNavigateToImportLogins: () -> Unit,
     viewModel: VaultSettingsViewModel = hiltViewModel(),
-    intentManager: IntentManager = LocalIntentManager.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
@@ -64,14 +59,7 @@ fun VaultSettingsScreen(
             VaultSettingsEvent.NavigateBack -> onNavigateBack()
             VaultSettingsEvent.NavigateToExportVault -> onNavigateToExportVault()
             VaultSettingsEvent.NavigateToFolders -> onNavigateToFolders()
-            is VaultSettingsEvent.NavigateToImportVault -> {
-                if (state.isNewImportLoginsFlowEnabled) {
-                    onNavigateToImportLogins()
-                } else {
-                    intentManager.launchUri(event.url.toUri())
-                }
-            }
-
+            is VaultSettingsEvent.NavigateToImportVault -> onNavigateToImportLogins()
             is VaultSettingsEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)
         }
     }
@@ -105,7 +93,7 @@ fun VaultSettingsScreen(
         ) {
             Spacer(modifier = Modifier.height(12.dp))
             AnimatedVisibility(
-                visible = state.shouldShowImportCard,
+                visible = state.showImportActionCard,
                 label = "ImportLoginsActionCard",
                 exit = actionCardExitAnimation(),
             ) {
@@ -159,38 +147,18 @@ fun VaultSettingsScreen(
                     .fillMaxWidth(),
             )
 
-            if (state.isNewImportLoginsFlowEnabled) {
-                BitwardenTextRow(
-                    text = stringResource(BitwardenString.import_items),
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(VaultSettingsAction.ImportItemsClick) }
-                    },
-                    withDivider = false,
-                    cardStyle = CardStyle.Bottom,
-                    modifier = Modifier
-                        .testTag("ImportItemsLinkItemView")
-                        .standardHorizontalMargin()
-                        .fillMaxWidth(),
-                )
-            } else {
-                BitwardenExternalLinkRow(
-                    text = stringResource(BitwardenString.import_items),
-                    onConfirmClick = remember(viewModel) {
-                        { viewModel.trySendAction(VaultSettingsAction.ImportItemsClick) }
-                    },
-                    withDivider = false,
-                    dialogTitle = stringResource(id = BitwardenString.continue_to_web_app),
-                    dialogMessage = stringResource(
-                        id = BitwardenString.you_can_import_data_to_your_vault_on_x,
-                        state.importUrl,
-                    ),
-                    cardStyle = CardStyle.Bottom,
-                    modifier = Modifier
-                        .testTag("ImportItemsLinkItemView")
-                        .standardHorizontalMargin()
-                        .fillMaxWidth(),
-                )
-            }
+            BitwardenTextRow(
+                text = stringResource(BitwardenString.import_items),
+                onClick = remember(viewModel) {
+                    { viewModel.trySendAction(VaultSettingsAction.ImportItemsClick) }
+                },
+                withDivider = false,
+                cardStyle = CardStyle.Bottom,
+                modifier = Modifier
+                    .testTag("ImportItemsLinkItemView")
+                    .standardHorizontalMargin()
+                    .fillMaxWidth(),
+            )
             Spacer(modifier = Modifier.height(height = 16.dp))
             Spacer(modifier = Modifier.navigationBarsPadding())
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -164,14 +164,7 @@ class VaultViewModel @Inject constructor(
 
         authRepository
             .userStateFlow
-            .combine(
-                featureFlagManager.getFeatureFlagFlow(FlagKey.ImportLoginsFlow),
-            ) { userState, importLoginsEnabled ->
-                VaultAction.Internal.UserStateUpdateReceive(
-                    userState = userState,
-                    importLoginsFlowEnabled = importLoginsEnabled,
-                )
-            }
+            .map { VaultAction.Internal.UserStateUpdateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -805,8 +798,6 @@ class VaultViewModel @Inject constructor(
                 .any(),
         )
         val appBarTitle = vaultFilterData.toAppBarTitle()
-        val shouldShowImportActionCard = action.importLoginsFlowEnabled &&
-            firstTimeState.showImportLoginsCard
 
         mutableStateFlow.update {
             val accountSummaries = userState.toAccountSummaries()
@@ -818,7 +809,7 @@ class VaultViewModel @Inject constructor(
                 accountSummaries = accountSummaries,
                 vaultFilterData = vaultFilterData,
                 isPremium = userState.activeAccount.isPremium,
-                showImportActionCard = shouldShowImportActionCard,
+                showImportActionCard = firstTimeState.showImportLoginsCard,
             )
         }
     }
@@ -1704,7 +1695,6 @@ sealed class VaultAction {
          */
         data class UserStateUpdateReceive(
             val userState: UserState?,
-            val importLoginsFlowEnabled: Boolean,
         ) : Internal()
 
         /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FlagKeyTest.kt
@@ -14,10 +14,6 @@ class FlagKeyTest {
             "email-verification",
         )
         assertEquals(
-            FlagKey.ImportLoginsFlow.keyName,
-            "import-logins-flow",
-        )
-        assertEquals(
             FlagKey.CredentialExchangeProtocolImport.keyName,
             "cxp-import-mobile",
         )
@@ -56,7 +52,6 @@ class FlagKeyTest {
         assertTrue(
             listOf(
                 FlagKey.EmailVerification,
-                FlagKey.ImportLoginsFlow,
                 FlagKey.CredentialExchangeProtocolImport,
                 FlagKey.CredentialExchangeProtocolExport,
                 FlagKey.SingleTapPasskeyCreation,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -145,7 +145,6 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
 
 private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf(
     FlagKey.EmailVerification to true,
-    FlagKey.ImportLoginsFlow to true,
     FlagKey.CredentialExchangeProtocolImport to true,
     FlagKey.CredentialExchangeProtocolExport to true,
     FlagKey.SingleTapPasskeyCreation to true,
@@ -157,7 +156,6 @@ private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
 
 private val UPDATED_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf(
     FlagKey.EmailVerification to false,
-    FlagKey.ImportLoginsFlow to false,
     FlagKey.CredentialExchangeProtocolImport to false,
     FlagKey.CredentialExchangeProtocolExport to false,
     FlagKey.SingleTapPasskeyCreation to false,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
@@ -1,20 +1,15 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.vault
 
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.hasAnyAncestor
-import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.core.net.toUri
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -22,7 +17,6 @@ import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -36,14 +30,9 @@ class VaultSettingsScreenTest : BitwardenComposeTest() {
     private val mutableEventFlow = bufferedMutableSharedFlow<VaultSettingsEvent>()
     private val mutableStateFlow = MutableStateFlow(
         VaultSettingsState(
-            importUrl = "testUrl/#/tools/import",
-            isNewImportLoginsFlowEnabled = false,
             showImportActionCard = false,
         ),
     )
-    private val intentManager: IntentManager = mockk(relaxed = true) {
-        every { launchUri(any()) } just runs
-    }
 
     val viewModel = mockk<VaultSettingsViewModel>(relaxed = true) {
         every { eventFlow } returns mutableEventFlow
@@ -52,9 +41,7 @@ class VaultSettingsScreenTest : BitwardenComposeTest() {
 
     @Before
     fun setup() {
-        setContent(
-            intentManager = intentManager,
-        ) {
+        setContent {
             VaultSettingsScreen(
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
@@ -81,42 +68,6 @@ class VaultSettingsScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `import items click should display dialog and confirming should send ImportItemsClick`() {
-        composeTestRule.onNodeWithText("Import items").performClick()
-        composeTestRule
-            .onNodeWithText("Continue")
-            .assert(hasAnyAncestor(isDialog()))
-            .assertIsDisplayed()
-            .performClick()
-
-        verify {
-            viewModel.trySendAction(VaultSettingsAction.ImportItemsClick)
-        }
-    }
-
-    @Test
-    fun `import items click should display dialog & canceling should not send ImportItemsClick`() {
-        composeTestRule.onNodeWithText("Import items").performClick()
-        composeTestRule
-            .onNodeWithText("Cancel")
-            .assert(hasAnyAncestor(isDialog()))
-            .assertIsDisplayed()
-            .performClick()
-
-        verify(exactly = 0) {
-            viewModel.trySendAction(VaultSettingsAction.ImportItemsClick)
-        }
-    }
-
-    @Test
-    fun `import items click should display dialog with importUrl`() {
-        composeTestRule.onNodeWithText("Import items").performClick()
-        composeTestRule
-            .onNodeWithText(mutableStateFlow.value.importUrl, substring = true)
-            .assertIsDisplayed()
-    }
-
-    @Test
     fun `NavigateBack should call onNavigateBack`() {
         mutableEventFlow.tryEmit(VaultSettingsEvent.NavigateBack)
         assertTrue(onNavigateBackCalled)
@@ -135,43 +86,20 @@ class VaultSettingsScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `on NavigateToImportVault should invoke IntentManager not lambda`() {
-        val testUrl = "testUrl"
-        mutableEventFlow.tryEmit(VaultSettingsEvent.NavigateToImportVault(testUrl))
-        verify {
-            intentManager.launchUri(testUrl.toUri())
-        }
-        assertFalse(onNavigateToImportLoginsCalled)
-    }
-
-    @Test
-    fun `when new logins feature flag is enabled send action right when import items is clicked`() {
-        mutableStateFlow.update {
-            it.copy(isNewImportLoginsFlowEnabled = true)
-        }
+    fun `send action right when import items is clicked`() {
         composeTestRule.onNodeWithText("Import items").performClick()
         verify { viewModel.trySendAction(VaultSettingsAction.ImportItemsClick) }
     }
 
     @Test
-    fun `when new logins feature flag is enabled NavigateToImportVault should invoke lambda`() {
-        mutableStateFlow.update {
-            it.copy(isNewImportLoginsFlowEnabled = true)
-        }
-        val testUrl = "testUrl"
-        mutableEventFlow.tryEmit(VaultSettingsEvent.NavigateToImportVault(testUrl))
+    fun `NavigateToImportVault should invoke lambda`() {
+        mutableEventFlow.tryEmit(VaultSettingsEvent.NavigateToImportVault)
         assertTrue(onNavigateToImportLoginsCalled)
-        verify(exactly = 0) { intentManager.launchUri(testUrl.toUri()) }
     }
 
     @Test
     fun `when new show action card is true the import logins card should show`() {
-        mutableStateFlow.update {
-            it.copy(
-                showImportActionCard = true,
-                isNewImportLoginsFlowEnabled = true,
-            )
-        }
+        mutableStateFlow.update { it.copy(showImportActionCard = true) }
         composeTestRule
             .onNodeWithText("Import saved logins")
             .performScrollTo()
@@ -186,12 +114,7 @@ class VaultSettingsScreenTest : BitwardenComposeTest() {
 
     @Test
     fun `when action card is visible clicking the close icon should send correct action`() {
-        mutableStateFlow.update {
-            it.copy(
-                showImportActionCard = true,
-                isNewImportLoginsFlowEnabled = true,
-            )
-        }
+        mutableStateFlow.update { it.copy(showImportActionCard = true) }
         composeTestRule
             .onNodeWithContentDescription("Close")
             .performScrollTo()
@@ -203,12 +126,7 @@ class VaultSettingsScreenTest : BitwardenComposeTest() {
 
     @Test
     fun `when action card is visible get started button should send correct action`() {
-        mutableStateFlow.update {
-            it.copy(
-                showImportActionCard = true,
-                isNewImportLoginsFlowEnabled = true,
-            )
-        }
+        mutableStateFlow.update { it.copy(showImportActionCard = true) }
         composeTestRule
             .onNodeWithText("Get started")
             .performScrollTo()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -73,7 +73,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -172,13 +171,9 @@ class VaultViewModelTest : BaseViewModelTest() {
         every { trackEvent(event = any()) } just runs
     }
 
-    private val mutableImportLoginsFeatureFlow = MutableStateFlow(true)
     private val mutableRemoveCardPolicyFeatureFlow = MutableStateFlow(false)
     private val mutableSshKeyVaultItemsEnabledFlow = MutableStateFlow(false)
     private val featureFlagManager: FeatureFlagManager = mockk {
-        every {
-            getFeatureFlagFlow(FlagKey.ImportLoginsFlow)
-        } returns mutableImportLoginsFeatureFlow
         every {
             getFeatureFlagFlow(FlagKey.RemoveCardPolicy)
         } returns mutableRemoveCardPolicyFeatureFlow
@@ -2432,30 +2427,6 @@ class VaultViewModelTest : BaseViewModelTest() {
             )
         }
     }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `when feature flag ImportLoginsFlow is disabled, should show action card should always be false`() =
-        runTest {
-            mutableImportLoginsFeatureFlow.update { false }
-            val viewModel = createViewModel()
-            viewModel.stateFlow.test {
-                assertEquals(
-                    DEFAULT_STATE.copy(showImportActionCard = false),
-                    awaitItem(),
-                )
-                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                    accounts = DEFAULT_USER_STATE.accounts.map {
-                        it.copy(
-                            firstTimeState = DEFAULT_FIRST_TIME_STATE.copy(
-                                showImportLoginsCard = true,
-                            ),
-                        )
-                    },
-                )
-                expectNoEvents()
-            }
-        }
 
     @Suppress("MaxLineLength")
     @Test

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -672,7 +672,6 @@ Do you want to switch to this account?</string>
     <string name="continue_to_device_settings">Continue to device Settings?</string>
     <string name="two_step_login_description_long">Make your account more secure by setting up two-step login in the Bitwarden web app.</string>
     <string name="change_master_password_description_long">You can change your master password on the Bitwarden web app.</string>
-    <string name="you_can_import_data_to_your_vault_on_x">You can import data to your vault on %1$s.</string>
     <string name="learn_more_about_how_to_use_bitwarden_on_the_help_center">Learn more about how to use Bitwarden on the Help center.</string>
     <string name="privacy_policy_description_long">Check out our privacy policy on bitwarden.com.</string>
     <string name="explore_more_features_of_your_bitwarden_account_on_the_web_app">Explore more features of your Bitwarden account on the web app.</string>

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -9,7 +9,6 @@
 
     <!-- region Debug Menu -->
     <string name="email_verification">Email Verification</string>
-    <string name="import_logins_flow">Import Logins Flow</string>
     <string name="feature_flags">Feature Flags:</string>
     <string name="debug_menu">Debug Menu</string>
     <string name="reset_values">Reset values</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20152](https://bitwarden.atlassian.net/browse/PM-20152)

## 📔 Objective

This PR removes the import logins flow feature flat from the app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
