### PR TITLE
 PM-24182: Fix crash in Android 13

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/util/ParcelableRouteSerializer.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/util/ParcelableRouteSerializer.kt
@@ -1,9 +1,9 @@
 package com.bitwarden.ui.platform.util
 
-import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.Base64
+import androidx.core.os.ParcelCompat
 import com.bitwarden.annotation.OmitFromCoverage
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
@@ -105,7 +105,7 @@ open class ParcelableRouteSerializer<T : Parcelable>(
                 }
             }
             encodedString
-                ?.toParcelable<T>()
+                ?.toParcelable()
                 ?: throw IllegalStateException("Invalid decoding for ${kClass.qualifiedName}.")
         }
 
@@ -137,15 +137,11 @@ open class ParcelableRouteSerializer<T : Parcelable>(
         }
         val value = try {
             @Suppress("UNCHECKED_CAST")
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                parcel.readParcelable(
-                    ParcelableRouteSerializer::class.java.classLoader,
-                    kClass.java,
-                )
-            } else {
-                @Suppress("DEPRECATION")
-                parcel.readParcelable(ParcelableRouteSerializer::class.java.classLoader)
-            } as T?
+            ParcelCompat.readParcelable(
+                parcel,
+                ParcelableRouteSerializer::class.java.classLoader,
+                kClass.java,
+            ) as T?
         } catch (_: IllegalArgumentException) {
             null
         } catch (_: IllegalStateException) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24182](https://bitwarden.atlassian.net/browse/PM-24182)

## 📔 Objective

🍒 This PR fixes a crash that only occurs on API 33 (Upside Down Cake).

Using ParcelCompat handles the checks internally and does not use the newer `readParcelable` API until API 34 when this bug was fixed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24182]: https://bitwarden.atlassian.net/browse/PM-24182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ