### PR TITLE
[PM-24204] Correct TOTP generation to use cipherId instead of totpCode

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerImpl.kt
@@ -24,11 +24,12 @@ class AutofillTotpManagerImpl(
         if (settingsRepository.isAutoCopyTotpDisabled) return
         val isPremium = authRepository.userStateFlow.value?.activeAccount?.isPremium == true
         if (!isPremium && !cipherView.organizationUseTotp) return
-        val totpCode = cipherView.login?.totp ?: return
+        cipherView.login?.totp ?: return
+        val cipherId = cipherView.id ?: return
 
         val totpResult = vaultRepository.generateTotp(
             time = clock.instant(),
-            totpCode = totpCode,
+            cipherId = cipherId,
         )
 
         if (totpResult is GenerateTotpResult.Success) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.data.vault.datasource.sdk
 
-import com.bitwarden.core.DateTime
 import com.bitwarden.core.DerivePinKeyResponse
 import com.bitwarden.core.InitOrgCryptoRequest
 import com.bitwarden.core.InitUserCryptoMethod
@@ -372,15 +371,6 @@ interface VaultSdkSource {
         userId: String,
         passwordHistoryList: List<PasswordHistory>,
     ): Result<List<PasswordHistoryView>>
-
-    /**
-     * Generate a verification code and the period using the totp code.
-     */
-    suspend fun generateTotp(
-        userId: String,
-        totp: String,
-        time: DateTime,
-    ): Result<TotpResponse>
 
     /**
      * Generate a verification code for the given [cipherListView] and [time].

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.data.vault.datasource.sdk
 
-import com.bitwarden.core.DateTime
 import com.bitwarden.core.DeriveKeyConnectorRequest
 import com.bitwarden.core.DerivePinKeyResponse
 import com.bitwarden.core.InitOrgCryptoRequest
@@ -415,19 +414,6 @@ class VaultSdkSourceImpl(
             .vault()
             .passwordHistory()
             .decryptList(list = passwordHistoryList)
-    }
-
-    override suspend fun generateTotp(
-        userId: String,
-        totp: String,
-        time: DateTime,
-    ): Result<TotpResponse> = runCatchingWithLogs {
-        getClient(userId = userId)
-            .vault()
-            .generateTotp(
-                key = totp,
-                time = time,
-            )
     }
 
     override suspend fun generateTotpForCipherListView(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
@@ -225,7 +225,7 @@ interface VaultRepository : CipherManager, VaultLockManager {
     /**
      * Attempt to get the verification code and the period.
      */
-    suspend fun generateTotp(totpCode: String, time: DateTime): GenerateTotpResult
+    suspend fun generateTotp(cipherId: String, time: DateTime): GenerateTotpResult
 
     /**
      * Attempt to delete a send.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -414,7 +414,7 @@ class SearchViewModel @Inject constructor(
         action: ListingItemOverflowAction.VaultAction.CopyTotpClick,
     ) {
         viewModelScope.launch {
-            val result = vaultRepo.generateTotp(action.totpCode, clock.instant())
+            val result = vaultRepo.generateTotp(action.cipherId, clock.instant())
             sendAction(SearchAction.Internal.GenerateTotpResultReceive(result))
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1239,7 +1239,7 @@ class VaultItemListingViewModel @Inject constructor(
         action: ListingItemOverflowAction.VaultAction.CopyTotpClick,
     ) {
         viewModelScope.launch {
-            val result = vaultRepository.generateTotp(action.totpCode, clock.instant())
+            val result = vaultRepository.generateTotp(action.cipherId, clock.instant())
             sendAction(VaultItemListingsAction.Internal.GenerateTotpResultReceive(result))
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
@@ -136,7 +136,7 @@ sealed class ListingItemOverflowAction : Parcelable {
          */
         @Parcelize
         data class CopyTotpClick(
-            val totpCode: String,
+            val cipherId: String,
             override val requiresPasswordReprompt: Boolean,
         ) : VaultAction() {
             override val title: Text get() = BitwardenString.copy_totp.asText()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensions.kt
@@ -39,7 +39,7 @@ fun CipherListView.toOverflowActions(
                 this.login?.totp
                     ?.let {
                         ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                            totpCode = it,
+                            cipherId = cipherId,
                             requiresPasswordReprompt = hasMasterPassword,
                         )
                     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -634,7 +634,7 @@ class VaultViewModel @Inject constructor(
         action: ListingItemOverflowAction.VaultAction.CopyTotpClick,
     ) {
         viewModelScope.launch {
-            val result = vaultRepository.generateTotp(action.totpCode, clock.instant())
+            val result = vaultRepository.generateTotp(action.cipherId, clock.instant())
             sendAction(VaultAction.Internal.GenerateTotpResultReceive(result))
         }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillTotpManagerTest.kt
@@ -128,7 +128,7 @@ class AutofillTotpManagerTest {
             }
             every { loginView.totp } returns TOTP_CODE
             coEvery {
-                vaultRepository.generateTotp(time = FIXED_CLOCK.instant(), totpCode = TOTP_CODE)
+                vaultRepository.generateTotp(time = FIXED_CLOCK.instant(), cipherId = "cipherId")
             } returns generateTotpResult
 
             autofillTotpManager.tryCopyTotpToClipboard(cipherView = cipherView)
@@ -141,7 +141,7 @@ class AutofillTotpManagerTest {
                 settingsRepository.isAutoCopyTotpDisabled
             }
             coVerify(exactly = 1) {
-                vaultRepository.generateTotp(time = FIXED_CLOCK.instant(), totpCode = TOTP_CODE)
+                vaultRepository.generateTotp(time = FIXED_CLOCK.instant(), cipherId = "cipherId")
             }
         }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
@@ -69,9 +69,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.security.MessageDigest
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 
 @Suppress("LargeClass")
 class VaultSdkSourceTest {
@@ -978,30 +975,6 @@ class VaultSdkSourceTest {
         }
 
     @Test
-    fun `generateTotp should call SDK and return a Result with correct data`() = runTest {
-        val userId = "userId"
-        val totpResponse = TotpResponse("TestCode", 30u)
-        coEvery { clientVault.generateTotp(any(), any()) } returns totpResponse
-
-        val time = FIXED_CLOCK.instant()
-        val result = vaultSdkSource.generateTotp(
-            userId = userId,
-            totp = "Totp",
-            time = time,
-        )
-
-        assertEquals(totpResponse.asSuccess(), result)
-        coVerify {
-            clientVault.generateTotp(
-                key = "Totp",
-                time = time,
-            )
-        }
-
-        coVerify { sdkClientManager.getOrCreateClient(userId = userId) }
-    }
-
-    @Test
     fun `generateTotpForCipherListView should call SDK and return a Result with correct data`() =
         runTest {
             val userId = "userId"
@@ -1421,8 +1394,4 @@ private val DEFAULT_FIDO_2_AUTH_REQUEST = AuthenticateFido2CredentialRequest(
     ),
     isUserVerificationSupported = true,
     selectedCipherView = createMockCipherView(number = 1),
-)
-private val FIXED_CLOCK: Clock = Clock.fixed(
-    Instant.parse("2023-10-27T12:00:00Z"),
-    ZoneOffset.UTC,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/TotpCodeManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/TotpCodeManagerTest.kt
@@ -143,10 +143,10 @@ class TotpCodeManagerTest {
         runTest {
             val totpResponse = TotpResponse("123456", 30u)
             coEvery {
-                vaultSdkSource.generateTotp(
+                vaultSdkSource.generateTotpForCipherListView(
                     userId = any(),
-                    totp = any(),
                     time = any(),
+                    cipherListView = any(),
                 )
             } returns totpResponse.asSuccess()
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -2740,7 +2740,7 @@ class VaultRepositoryTest {
             fakeAuthDiskSource.userState = null
 
             val result = vaultRepository.generateTotp(
-                totpCode = "totpCode",
+                cipherId = "totpCode",
                 time = DateTime.now(),
             )
 
@@ -2753,13 +2753,16 @@ class VaultRepositoryTest {
     @Test
     fun `generateTotp should return a success result on getting a code`() = runTest {
         val totpResponse = TotpResponse("Testcode", 30u)
+        val userId = "mockId-1"
         coEvery {
-            vaultSdkSource.generateTotp(any(), any(), any())
+            vaultSdkSource.generateTotpForCipherListView(any(), any(), any())
         } returns totpResponse.asSuccess()
         fakeAuthDiskSource.userState = MOCK_USER_STATE
+        setVaultToUnlocked(userId = userId)
+        setupDataStateFlow(userId = userId)
 
         val result = vaultRepository.generateTotp(
-            totpCode = "testCode",
+            cipherId = "mockId-1",
             time = DateTime.now(),
         )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -1007,7 +1007,7 @@ class SearchViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 SearchAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                        totpCode = totpCode,
+                        cipherId = totpCode,
                         requiresPasswordReprompt = false,
                     ),
                 ),
@@ -1035,7 +1035,7 @@ class SearchViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 SearchAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                        totpCode = totpCode,
+                        cipherId = totpCode,
                         requiresPasswordReprompt = false,
                     ),
                 ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
@@ -52,7 +52,7 @@ fun createMockDisplayItemForCipher(
                         cipherId = "mockId-$number",
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                        totpCode = "mockTotp-$number",
+                        cipherId = "mockId-$number",
                         requiresPasswordReprompt = true,
                     ),
                     ListingItemOverflowAction.VaultAction.ViewClick(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -1954,7 +1954,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 VaultItemListingsAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                        totpCode = totpCode,
+                        cipherId = totpCode,
                         requiresPasswordReprompt = false,
                     ),
                 ),
@@ -1982,7 +1982,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 VaultItemListingsAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                        totpCode = totpCode,
+                        cipherId = totpCode,
                         requiresPasswordReprompt = false,
                     ),
                 ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -62,7 +62,7 @@ fun createMockDisplayItemForCipher(
                         cipherId = "mockId-$number",
                     ),
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                        totpCode = "mockTotp-$number",
+                        cipherId = "mockId-$number",
                         requiresPasswordReprompt = requiresPasswordReprompt,
                     ),
                     ListingItemOverflowAction.VaultAction.ViewClick(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensionsTest.kt
@@ -45,7 +45,7 @@ class CipherListViewExtensionsTest {
                     cipherId = id,
                 ),
                 ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                    totpCode = totpCode,
+                    cipherId = id,
                     requiresPasswordReprompt = false,
                 ),
                 ListingItemOverflowAction.VaultAction.ViewClick(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1931,7 +1931,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 VaultAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                        totpCode = totpCode,
+                        cipherId = totpCode,
                         requiresPasswordReprompt = false,
                     ),
                 ),
@@ -1959,7 +1959,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(
                 VaultAction.OverflowOptionClick(
                     ListingItemOverflowAction.VaultAction.CopyTotpClick(
-                        totpCode = totpCode,
+                        cipherId = totpCode,
                         requiresPasswordReprompt = false,
                     ),
                 ),


### PR DESCRIPTION
## 🎟️ Tracking

PM-24204
PM-24206

## 📔 Objective

This commit modifies the TOTP generation logic across the application to utilize `cipherId` instead of the raw `totpCode`. This change enhances security and aligns with best practices by avoiding the direct handling of TOTP codes where possible.

Key changes include:
- Updated `VaultRepository` and `VaultSdkSource` to accept `cipherId` for TOTP generation. The `generateTotp` method in `VaultSdkSource` that accepted a `totp` string has been removed.
- `VaultRepositoryImpl` now retrieves the `CipherListView` using the provided `cipherId` to pass to `VaultSdkSource.generateTotpForCipherListView`.
- ViewModels (`SearchViewModel`, `VaultViewModel`, `VaultItemListingViewModel`) and `AutofillTotpManagerImpl` now pass `cipherId` to `VaultRepository.generateTotp`.
- `ListingItemOverflowAction.VaultAction.CopyTotpClick` now holds `cipherId` instead of `totpCode`.
- `CipherListViewExtensions` updated to pass `cipherId` when creating `CopyTotpClick` action.
- Relevant test cases across `ViewModel` tests, `Repository` tests, `Manager` tests, and `DataSource` tests have been updated to reflect these changes, ensuring `cipherId` is used for TOTP generation and mock interactions.

## 📸 Screenshots

https://github.com/user-attachments/assets/fb274dee-fff9-41d3-91b5-3af6a447194f

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
