### PR TITLE
[PM-24205] Fix Fido2CredentialStore to save new credentials correctly (#5601)

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/di/VaultSdkModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/di/VaultSdkModule.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.vault.datasource.sdk.di
 
 import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.sdk.Fido2CredentialStore
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.SdkClientManager
 import com.x8bit.bitwarden.data.platform.manager.sdk.SdkRepositoryFactory
@@ -50,8 +51,12 @@ object VaultSdkModule {
     @Provides
     @Singleton
     fun providesFido2CredentialStore(
+        authRepository: AuthRepository,
+        vaultSdkSource: VaultSdkSource,
         vaultRepository: VaultRepository,
     ): Fido2CredentialStore = Fido2CredentialStoreImpl(
+        authRepository = authRepository,
+        vaultSdkSource = vaultSdkSource,
         vaultRepository = vaultRepository,
     )
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-24205
Cherry-picking #5601 

## 📔 Objective

Fixes a bug that failed to create a new login cipher for passkey registration. The patch refactors how `Fido2CredentialStoreImpl` save credentials to utilize `VaultSdkSource` for decrypting the `Cipher` before saving it. This change ensures that new ciphers are saved correctly.

Key changes:
- `Fido2CredentialStoreImpl` now depends on `AuthRepository` and `VaultSdkSource`.
- The `saveCredential` method in `Fido2CredentialStoreImpl` now uses `vaultSdkSource.decryptCipher` to decrypt the `EncryptionContext.cipher` before updating or creating the cipher in `VaultRepository`.
- `NoActiveUserException` is thrown if there is no active user when attempting to decrypt.
- The `VaultSdkModule` has been updated to provide the new dependencies to `Fido2CredentialStoreImpl`.

## 📸 Screenshots

https://github.com/user-attachments/assets/bf7ce3bd-d33c-472e-965f-2b8cebff7e34

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
