### PR TITLE
PM-24245: Remove the restrict-item-deletion-to-can-manage-permission feature flag

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -30,7 +30,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CredentialExchangeProtocolImport,
     FlagKey.CredentialExchangeProtocolExport,
     FlagKey.CipherKeyEncryption,
-    FlagKey.RestrictCipherItemDeletion,
     FlagKey.UserManagedPrivilegedApps,
     FlagKey.RemoveCardPolicy,
         -> {
@@ -78,7 +77,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.CredentialExchangeProtocolImport -> stringResource(BitwardenString.cxp_import)
     FlagKey.CredentialExchangeProtocolExport -> stringResource(BitwardenString.cxp_export)
     FlagKey.CipherKeyEncryption -> stringResource(BitwardenString.cipher_key_encryption)
-    FlagKey.RestrictCipherItemDeletion -> stringResource(BitwardenString.restrict_item_deletion)
     FlagKey.UserManagedPrivilegedApps -> {
         stringResource(BitwardenString.user_trusted_privileged_app_management)
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -7,7 +7,6 @@ import androidx.credentials.provider.ProviderCreateCredentialRequest
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.DateTime
-import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.takeUntilLoaded
 import com.bitwarden.network.model.PolicyTypeJson
@@ -30,7 +29,6 @@ import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.credentials.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.credentials.util.getCreatePasskeyCredentialRequestOrNull
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
@@ -128,7 +126,6 @@ class VaultAddEditViewModel @Inject constructor(
     private val organizationEventManager: OrganizationEventManager,
     private val networkConnectionManager: NetworkConnectionManager,
     private val firstTimeActionManager: FirstTimeActionManager,
-    private val featureFlagManager: FeatureFlagManager,
 ) : BaseViewModel<VaultAddEditState, VaultAddEditEvent, VaultAddEditAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
@@ -1784,10 +1781,6 @@ class VaultAddEditViewModel @Inject constructor(
         vaultData: VaultData?,
         userData: UserState?,
     ): VaultAddEditState {
-        val restrictCipherItemDeletionEnabled = featureFlagManager
-            .getFeatureFlag(
-                FlagKey.RestrictCipherItemDeletion,
-            )
         val internalVaultData = vaultData
             ?: VaultData(
                 decryptCipherListResult = DecryptCipherListResult(
@@ -1826,9 +1819,7 @@ class VaultAddEditViewModel @Inject constructor(
                     currentAccount = userData?.activeAccount,
                     vaultAddEditType = vaultAddEditType,
                 ) { currentAccount, cipherView ->
-                    val canDelete = if (restrictCipherItemDeletionEnabled &&
-                        cipherView?.permissions?.delete != null
-                    ) {
+                    val canDelete = if (cipherView?.permissions?.delete != null) {
                         cipherView.permissions?.delete == true
                     } else {
                         val needsManagePermission = cipherView

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -147,7 +147,6 @@ private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
     FlagKey.EmailVerification to true,
     FlagKey.CredentialExchangeProtocolImport to true,
     FlagKey.CredentialExchangeProtocolExport to true,
-    FlagKey.RestrictCipherItemDeletion to true,
     FlagKey.UserManagedPrivilegedApps to true,
     FlagKey.RemoveCardPolicy to true,
 )
@@ -156,7 +155,6 @@ private val UPDATED_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
     FlagKey.EmailVerification to false,
     FlagKey.CredentialExchangeProtocolImport to false,
     FlagKey.CredentialExchangeProtocolExport to false,
-    FlagKey.RestrictCipherItemDeletion to false,
     FlagKey.UserManagedPrivilegedApps to false,
     FlagKey.RemoveCardPolicy to false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -40,7 +40,6 @@ import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.credentials.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.credentials.model.createMockCreateCredentialRequest
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
@@ -49,7 +48,6 @@ import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardMan
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.CoachMarkTourType
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
-import com.bitwarden.core.data.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
@@ -203,10 +201,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     private val firstTimeActionManager = mockk<FirstTimeActionManager> {
         every { markCoachMarkTourCompleted(CoachMarkTourType.ADD_LOGIN) } just runs
         every { shouldShowAddLoginCoachMarkFlow } returns mutableShouldShowAddLoginCoachMarkFlow
-    }
-
-    private val featureFlagManager: FeatureFlagManager = mockk {
-        every { getFeatureFlag(key = FlagKey.RestrictCipherItemDeletion) } returns false
     }
     private val mutableSnackbarDataFlow: MutableSharedFlow<BitwardenSnackbarData> =
         bufferedMutableSharedFlow()
@@ -1350,89 +1344,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `in edit mode, canDelete should be false when cipher permission is false`() =
-        runTest {
-            val cipherListView = createMockCipherListView(
-                number = 1,
-                permissions = createMockSdkCipherPermissions(
-                    delete = false,
-                    restore = false,
-                ),
-            )
-            val cipherView = createMockCipherView(1)
-                .copy(
-                    permissions = createMockSdkCipherPermissions(
-                        delete = false,
-                        restore = false,
-                    ),
-                )
-            val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
-            val stateWithName = createVaultAddItemState(
-                vaultAddEditType = vaultAddEditType,
-                commonContentViewState = createCommonContentViewState(
-                    name = "mockName-1",
-                    originalCipher = cipherView,
-                    customFieldData = listOf(
-                        VaultAddEditState.Custom.HiddenField(
-                            itemId = "testId",
-                            name = "mockName-1",
-                            value = "mockValue-1",
-                        ),
-                    ),
-                    notes = "mockNotes-1",
-                    canDelete = false,
-                ),
-            )
-            every {
-                featureFlagManager.getFeatureFlag(FlagKey.RestrictCipherItemDeletion)
-            } returns true
-
-            coEvery {
-                vaultRepository.getCipher("mockId-1")
-            } returns GetCipherResult.Success(cipherView)
-            every {
-                cipherView.toViewState(
-                    isClone = false,
-                    isIndividualVaultDisabled = false,
-                    totpData = null,
-                    resourceManager = resourceManager,
-                    clock = fixedClock,
-                    canDelete = false,
-                    canAssignToCollections = true,
-                )
-            } returns stateWithName.viewState
-
-            mutableVaultDataFlow.value = DataState.Loaded(
-                data = createVaultData(
-                    cipherListView = cipherListView,
-                    collectionViewList = listOf(
-                        createEditCollectionView(number = 1),
-                    ),
-                ),
-            )
-
-            createAddVaultItemViewModel(
-                createSavedStateHandleWithState(
-                    state = stateWithName,
-                    vaultAddEditType = vaultAddEditType,
-                    vaultItemCipherType = VaultItemCipherType.LOGIN,
-                ),
-            )
-
-            verify {
-                cipherView.toViewState(
-                    isClone = false,
-                    isIndividualVaultDisabled = false,
-                    totpData = null,
-                    resourceManager = resourceManager,
-                    clock = fixedClock,
-                    canDelete = false,
-                    canAssignToCollections = true,
-                )
-            }
-        }
-
-    @Test
     fun `in edit mode, canDelete should be true when cipher permission is true`() =
         runTest {
             val cipherListView = createMockCipherListView(number = 1)
@@ -1463,9 +1374,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     canDelete = true,
                 ),
             )
-            every {
-                featureFlagManager.getFeatureFlag(FlagKey.RestrictCipherItemDeletion)
-            } returns true
 
             coEvery {
                 vaultRepository.getCipher("mockId-1")
@@ -1507,92 +1415,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     resourceManager = resourceManager,
                     clock = fixedClock,
                     canDelete = true,
-                    canAssignToCollections = true,
-                )
-            }
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `in edit mode, canDelete should be false when cipher is in a collection the user cannot manage and org has limitItemDeletion`() =
-        runTest {
-            val userState = createUserState().copy(
-                accounts = listOf(
-                    createUserState().accounts.first().copy(
-                        organizations = listOf(
-                            Organization(
-                                id = "mockOrganizationId-1",
-                                name = "Mock Organization Name 1",
-                                shouldManageResetPassword = false,
-                                shouldUseKeyConnector = false,
-                                role = OrganizationType.ADMIN,
-                                keyConnectorUrl = null,
-                                userIsClaimedByOrganization = false,
-                                limitItemDeletion = true,
-                            ),
-                        ),
-                    ),
-                ),
-            )
-            mutableUserStateFlow.value = userState
-
-            val cipherListView = createMockCipherListView(number = 1)
-            val cipherView = createMockCipherView(1)
-            val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
-            val stateWithName = createVaultAddItemState(
-                vaultAddEditType = vaultAddEditType,
-                commonContentViewState = createCommonContentViewState(
-                    name = "mockName-1",
-                    originalCipher = cipherView,
-                    customFieldData = listOf(
-                        VaultAddEditState.Custom.HiddenField(
-                            itemId = "testId",
-                            name = "mockName-1",
-                            value = "mockValue-1",
-                        ),
-                    ),
-                    notes = "mockNotes-1",
-                    canDelete = false,
-                ),
-            )
-
-            every {
-                cipherView.toViewState(
-                    isClone = false,
-                    isIndividualVaultDisabled = false,
-                    totpData = null,
-                    resourceManager = resourceManager,
-                    clock = fixedClock,
-                    canDelete = false,
-                    canAssignToCollections = true,
-                )
-            } returns stateWithName.viewState
-
-            mutableVaultDataFlow.value = DataState.Loaded(
-                data = createVaultData(
-                    cipherListView = cipherListView,
-                    collectionViewList = listOf(
-                        createEditCollectionView(number = 1),
-                    ),
-                ),
-            )
-
-            createAddVaultItemViewModel(
-                createSavedStateHandleWithState(
-                    state = stateWithName,
-                    vaultAddEditType = vaultAddEditType,
-                    vaultItemCipherType = VaultItemCipherType.LOGIN,
-                ),
-            )
-
-            verify {
-                cipherView.toViewState(
-                    isClone = false,
-                    isIndividualVaultDisabled = false,
-                    totpData = null,
-                    resourceManager = resourceManager,
-                    clock = fixedClock,
-                    canDelete = false,
                     canAssignToCollections = true,
                 )
             }
@@ -1667,73 +1489,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                     clock = fixedClock,
                     canDelete = true,
                     canAssignToCollections = true,
-                )
-            }
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `in edit mode, canAssociateToCollections should be false when cipher is in a collection with view permission`() =
-        runTest {
-            val cipherListView = createMockCipherListView(number = 1)
-            val cipherView = createMockCipherView(1)
-            val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
-            val stateWithName = createVaultAddItemState(
-                vaultAddEditType = vaultAddEditType,
-                commonContentViewState = createCommonContentViewState(
-                    name = "mockName-1",
-                    originalCipher = cipherView,
-                    customFieldData = listOf(
-                        VaultAddEditState.Custom.HiddenField(
-                            itemId = "testId",
-                            name = "mockName-1",
-                            value = "mockValue-1",
-                        ),
-                    ),
-                    notes = "mockNotes-1",
-                    canDelete = false,
-                    canAssociateToCollections = false,
-                ),
-            )
-
-            every {
-                cipherView.toViewState(
-                    isClone = false,
-                    isIndividualVaultDisabled = false,
-                    totpData = null,
-                    resourceManager = resourceManager,
-                    clock = fixedClock,
-                    canDelete = false,
-                    canAssignToCollections = false,
-                )
-            } returns stateWithName.viewState
-
-            mutableVaultDataFlow.value = DataState.Loaded(
-                data = createVaultData(
-                    cipherListView = cipherListView,
-                    collectionViewList = listOf(
-                        createViewCollectionView(number = 1),
-                    ),
-                ),
-            )
-
-            createAddVaultItemViewModel(
-                createSavedStateHandleWithState(
-                    state = stateWithName,
-                    vaultAddEditType = vaultAddEditType,
-                    vaultItemCipherType = VaultItemCipherType.LOGIN,
-                ),
-            )
-
-            verify {
-                cipherView.toViewState(
-                    isClone = false,
-                    isIndividualVaultDisabled = false,
-                    totpData = null,
-                    resourceManager = resourceManager,
-                    clock = fixedClock,
-                    canDelete = false,
-                    canAssignToCollections = false,
                 )
             }
         }
@@ -3553,7 +3308,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 organizationEventManager = organizationEventManager,
                 networkConnectionManager = networkConnectionManager,
                 firstTimeActionManager = firstTimeActionManager,
-                featureFlagManager = featureFlagManager,
             )
         }
 
@@ -4943,7 +4697,6 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             organizationEventManager = organizationEventManager,
             networkConnectionManager = networkConnectionManager,
             firstTimeActionManager = firstTimeActionManager,
-            featureFlagManager = featureFlagManager,
         )
 
     private fun createVaultData(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -23,11 +23,9 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
-import com.bitwarden.core.data.manager.model.FlagKey
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -118,9 +116,6 @@ class VaultItemViewModelTest : BaseViewModelTest() {
     private val mockSettingsRepository = mockk<SettingsRepository> {
         every { isIconLoadingDisabled } returns false
         every { isIconLoadingDisabledFlow } returns mutableIsIconLoadingDisabledFlow
-    }
-    private val featureFlagManager: FeatureFlagManager = mockk {
-        every { getFeatureFlag(key = FlagKey.RestrictCipherItemDeletion) } returns false
     }
     private val mutableSnackbarDataFlow: MutableSharedFlow<BitwardenSnackbarData> =
         bufferedMutableSharedFlow()
@@ -2154,9 +2149,6 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         @Suppress("MaxLineLength")
         fun `on VaultDataReceive with Loaded and nonnull false permission data should update the ViewState with cipher permissions`() {
             val viewState = mockk<VaultItemState.ViewState>()
-            every {
-                featureFlagManager.getFeatureFlag(FlagKey.RestrictCipherItemDeletion)
-            } returns true
             every { mockCipherView.organizationId } returns "mockOrganizationId"
             every { mockCipherView.collectionIds } returns listOf("mockId-1")
             every { mockCipherView.folderId } returns "mockId-1"
@@ -2219,9 +2211,6 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         @Suppress("MaxLineLength")
         fun `on VaultDataReceive with Loaded and nonnull true permission data should update the ViewState with cipher permissions`() {
             val viewState = mockk<VaultItemState.ViewState>()
-            every {
-                featureFlagManager.getFeatureFlag(FlagKey.RestrictCipherItemDeletion)
-            } returns true
             every { mockCipherView.organizationId } returns "mockOrganizationId"
             every { mockCipherView.deletedDate } returns Instant.MIN
             every { mockCipherView.collectionIds } returns listOf("mockId-1")
@@ -2466,7 +2455,6 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         organizationEventManager = eventManager,
         environmentRepository = environmentRepository,
         settingsRepository = settingsRepository,
-        featureFlagManager = featureFlagManager,
         snackbarRelayManager = snackbarRelayManager,
     )
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -28,7 +28,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CredentialExchangeProtocolImport,
     FlagKey.EmailVerification,
     FlagKey.RemoveCardPolicy,
-    FlagKey.RestrictCipherItemDeletion,
     FlagKey.UserManagedPrivilegedApps,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
@@ -71,7 +70,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.CredentialExchangeProtocolImport -> stringResource(BitwardenString.cxp_import)
     FlagKey.CredentialExchangeProtocolExport -> stringResource(BitwardenString.cxp_export)
     FlagKey.CipherKeyEncryption -> stringResource(BitwardenString.cipher_key_encryption)
-    FlagKey.RestrictCipherItemDeletion -> stringResource(BitwardenString.restrict_item_deletion)
     FlagKey.UserManagedPrivilegedApps -> {
         stringResource(BitwardenString.user_trusted_privileged_app_management)
     }

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -33,7 +33,6 @@ sealed class FlagKey<out T : Any> {
                 EmailVerification,
                 CredentialExchangeProtocolImport,
                 CredentialExchangeProtocolExport,
-                RestrictCipherItemDeletion,
                 UserManagedPrivilegedApps,
                 RemoveCardPolicy,
             )
@@ -71,14 +70,6 @@ sealed class FlagKey<out T : Any> {
      */
     data object CipherKeyEncryption : FlagKey<Boolean>() {
         override val keyName: String = "cipher-key-encryption"
-        override val defaultValue: Boolean = false
-    }
-
-    /**
-     * Data object holding the feature flag key to enable the restriction of cipher item deletion
-     */
-    data object RestrictCipherItemDeletion : FlagKey<Boolean>() {
-        override val keyName: String = "pm-15493-restrict-item-deletion-to-can-manage-permission"
         override val defaultValue: Boolean = false
     }
 

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -25,10 +25,6 @@ class FlagKeyTest {
             "cipher-key-encryption",
         )
         assertEquals(
-            FlagKey.RestrictCipherItemDeletion.keyName,
-            "pm-15493-restrict-item-deletion-to-can-manage-permission",
-        )
-        assertEquals(
             FlagKey.UserManagedPrivilegedApps.keyName,
             "pm-18970-user-managed-privileged-apps",
         )
@@ -50,7 +46,6 @@ class FlagKeyTest {
                 FlagKey.CredentialExchangeProtocolImport,
                 FlagKey.CredentialExchangeProtocolExport,
                 FlagKey.CipherKeyEncryption,
-                FlagKey.RestrictCipherItemDeletion,
                 FlagKey.UserManagedPrivilegedApps,
                 FlagKey.RemoveCardPolicy,
                 FlagKey.BitwardenAuthenticationEnabled,

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -19,7 +19,6 @@
     <string name="restart_onboarding_carousel_details">This will force the change to app state which will cause the first time carousel to show. The carousel will continue to show for any \"new\" account until a login is completed. May need to exit debug menu manually.</string>
     <string name="cipher_key_encryption">Cipher Key Encryption</string>
     <string name="reset_coach_mark_tour_status">Reset all coach mark tours</string>
-    <string name="restrict_item_deletion">Restrict item deletion</string>
     <string name="generate_crash">Generate crash</string>
     <string name="generate_error_report">Generate error report</string>
     <string name="error_reports">Error reports</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24245](https://bitwarden.atlassian.net/browse/PM-24245)

## 📔 Objective

This PR removes the `RestrictCipherItemDeletion` feature flag.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24245]: https://bitwarden.atlassian.net/browse/PM-24245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ