### PR TITLE
🍒[PM-24206] Fix filtered verification code search 

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
@@ -125,7 +125,7 @@ private fun CipherListView.filterBySearchType(
         }
 
         is SearchTypeData.Vault.SshKeys -> type is CipherListViewType.SshKey && deletedDate == null
-        is SearchTypeData.Vault.VerificationCodes -> organizationUseTotp && deletedDate == null
+        is SearchTypeData.Vault.VerificationCodes -> login?.totp != null && deletedDate == null
         is SearchTypeData.Vault.Trash -> deletedDate != null
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-24206
Cherry-picked from #5619

## 📔 Objective

This commit updates the filtering logic for `SearchTypeData.Vault.VerificationCodes`. Instead of checking `organizationUseTotp`, it now verifies if `login?.totp` is not null to determine if a cipher has a verification code. This makes the check more direct and accurate.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
