### PR TITLE
Handle tile intents without IntentManager

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/tiles/BitwardenGeneratorTileService.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/tiles/BitwardenGeneratorTileService.kt
@@ -1,24 +1,22 @@
 package com.x8bit.bitwarden.data.tiles
 
 import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Intent
 import android.os.Build
 import android.service.quicksettings.TileService
 import androidx.annotation.Keep
+import androidx.core.net.toUri
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.core.util.isBuildVersionAtLeast
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
-import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
+import com.x8bit.bitwarden.MainActivity
 
 /**
  * A service for handling the Password Generator quick settings tile.
  */
-@AndroidEntryPoint
 @Keep
 @OmitFromCoverage
 class BitwardenGeneratorTileService : TileService() {
-    @Inject
-    lateinit var intentManager: IntentManager
 
     override fun onClick() {
         if (isLocked) {
@@ -29,13 +27,22 @@ class BitwardenGeneratorTileService : TileService() {
     }
 
     private fun launchGenerator() {
-        val intent = intentManager.createTileIntent("bitwarden://password_generator")
+        val intent = Intent(applicationContext, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .setData("bitwarden://password_generator".toUri())
         if (!isBuildVersionAtLeast(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
             @Suppress("DEPRECATION")
             @SuppressLint("StartActivityAndCollapseDeprecated")
             startActivityAndCollapse(intent)
         } else {
-            startActivityAndCollapse(intentManager.createTilePendingIntent(0, intent))
+            startActivityAndCollapse(
+                PendingIntent.getActivity(
+                    this,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE,
+                ),
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/tiles/BitwardenVaultTileService.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/tiles/BitwardenVaultTileService.kt
@@ -1,24 +1,22 @@
 package com.x8bit.bitwarden.data.tiles
 
 import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Intent
 import android.os.Build
 import android.service.quicksettings.TileService
 import androidx.annotation.Keep
+import androidx.core.net.toUri
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.core.util.isBuildVersionAtLeast
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
-import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
+import com.x8bit.bitwarden.MainActivity
 
 /**
  * A service for handling the My Vault quick settings tile.
  */
-@AndroidEntryPoint
 @Keep
 @OmitFromCoverage
 class BitwardenVaultTileService : TileService() {
-    @Inject
-    lateinit var intentManager: IntentManager
 
     override fun onClick() {
         if (isLocked) {
@@ -29,13 +27,22 @@ class BitwardenVaultTileService : TileService() {
     }
 
     private fun launchVault() {
-        val intent = intentManager.createTileIntent("bitwarden://my_vault")
+        val intent = Intent(applicationContext, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .setData("bitwarden://my_vault".toUri())
         if (!isBuildVersionAtLeast(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
             @Suppress("DEPRECATION")
             @SuppressLint("StartActivityAndCollapseDeprecated")
             startActivityAndCollapse(intent)
         } else {
-            startActivityAndCollapse(intentManager.createTilePendingIntent(0, intent))
+            startActivityAndCollapse(
+                PendingIntent.getActivity(
+                    this,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE,
+                ),
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -107,17 +107,6 @@ interface IntentManager {
     fun createDocumentIntent(fileName: String): Intent
 
     /**
-     * Creates an intent using [data] when selecting a quick settings tile.
-     */
-    fun createTileIntent(data: String): Intent
-
-    /**
-     * Creates a pending intent using [requestCode] and [tileIntent] when selecting a quick
-     * settings tile on API 34+.
-     */
-    fun createTilePendingIntent(requestCode: Int, tileIntent: Intent): PendingIntent
-
-    /**
      * Creates a pending intent to use when providing [CreateEntry]
      * instances for FIDO 2 credential creation.
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -28,7 +28,6 @@ import com.bitwarden.core.data.util.toFormattedPattern
 import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.BuildConfig
-import com.x8bit.bitwarden.MainActivity
 import com.x8bit.bitwarden.data.autofill.model.browser.BrowserPackage
 import com.x8bit.bitwarden.data.autofill.util.toPendingIntentMutabilityFlag
 import java.io.File
@@ -288,24 +287,6 @@ class IntentManagerImpl(
             addCategory(Intent.CATEGORY_OPENABLE)
             putExtra(Intent.EXTRA_TITLE, fileName)
         }
-
-    override fun createTileIntent(data: String): Intent {
-        return Intent(
-            context,
-            MainActivity::class.java,
-        )
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            .setData(data.toUri())
-    }
-
-    override fun createTilePendingIntent(requestCode: Int, tileIntent: Intent): PendingIntent {
-        return PendingIntent.getActivity(
-            context,
-            requestCode,
-            tileIntent,
-            PendingIntent.FLAG_IMMUTABLE,
-        )
-    }
 
     override fun createFido2CreationPendingIntent(
         action: String,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the logic for tile intents from the `IntentMnager` to make things just a little simpler.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
