### PR TITLE
Refactor Autofill Hint Logic and Add Card Autofill Support

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
@@ -116,15 +116,13 @@ class FilledDataBuilderImpl(
     ): FilledPartition {
         val filledItems = autofillViews
             .mapNotNull { autofillView ->
-                val value = when (autofillView) {
-                    is AutofillView.Card.ExpirationMonth -> autofillCipher.expirationMonth
-                    is AutofillView.Card.ExpirationYear -> autofillCipher.expirationYear
-                    is AutofillView.Card.Number -> autofillCipher.number
-                    is AutofillView.Card.SecurityCode -> autofillCipher.code
-                }
-                autofillView.buildFilledItemOrNull(
-                    value = value,
-                )
+                autofillCipher
+                    .getAutofillValueOrNull(autofillView)
+                    ?.let { value ->
+                        autofillView.buildFilledItemOrNull(
+                            value = value,
+                        )
+                    }
             }
 
         return FilledPartition(
@@ -161,6 +159,44 @@ class FilledDataBuilderImpl(
         )
     }
 }
+
+/**
+ * Get the autofill value for the given [autofillView], or null if no value is available.
+ */
+private fun AutofillCipher.Card.getAutofillValueOrNull(autofillView: AutofillView.Card): String? =
+    when (autofillView) {
+        is AutofillView.Card.CardholderName -> {
+            cardholderName.takeIf { it.isNotEmpty() }
+        }
+
+        is AutofillView.Card.ExpirationMonth -> {
+            expirationMonth.takeIf { it.isNotEmpty() }
+        }
+
+        is AutofillView.Card.ExpirationYear -> {
+            expirationYear.takeIf { it.isNotEmpty() }
+        }
+
+        is AutofillView.Card.Number -> {
+            number
+                .filter { it.isDigit() }
+                .takeIf { it.isNotEmpty() }
+        }
+
+        is AutofillView.Card.SecurityCode -> {
+            code
+                .filter { it.isDigit() }
+                .takeIf { it.isNotEmpty() }
+        }
+
+        is AutofillView.Card.ExpirationDate -> {
+            if (expirationMonth.isNotBlank() && expirationYear.isNotBlank()) {
+                expirationMonth.padStart(2, '0') + expirationYear.takeLast(2)
+            } else {
+                null
+            }
+        }
+    }
 
 /**
  * Get the item at the [index]. If that fails, return the last item in the list. If that also fails,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillHint.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillHint.kt
@@ -1,0 +1,15 @@
+package com.x8bit.bitwarden.data.autofill.model
+
+/**
+ * Autofill hints used to determine what data an input field is associated with.
+ */
+enum class AutofillHint {
+    CARD_CARDHOLDER,
+    CARD_EXPIRATION_DATE,
+    CARD_EXPIRATION_MONTH,
+    CARD_EXPIRATION_YEAR,
+    CARD_NUMBER,
+    CARD_SECURITY_CODE,
+    PASSWORD,
+    USERNAME,
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillView.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillView.kt
@@ -55,6 +55,20 @@ sealed class AutofillView {
         ) : Card()
 
         /**
+         * The expiration date [AutofillView] for the [Card] data partition.
+         */
+        data class ExpirationDate(
+            override val data: Data,
+        ) : Card()
+
+        /**
+         * The cardholder name [AutofillView] for the [Card] data partition.
+         */
+        data class CardholderName(
+            override val data: Data,
+        ) : Card()
+
+        /**
          * The number [AutofillView] for the [Card] data partition.
          */
         data class Number(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/HtmlInfoExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/HtmlInfoExtensions.kt
@@ -1,53 +1,111 @@
+@file:Suppress("TooManyFunctions")
+
 package com.x8bit.bitwarden.data.autofill.util
 
 import android.view.ViewStructure.HtmlInfo
-import com.bitwarden.annotation.OmitFromCoverage
 
 /**
  * Whether this [HtmlInfo] represents a password field.
- *
- * This function is untestable as [HtmlInfo] contains [android.util.Pair] which requires
- * instrumentation testing.
  */
-@OmitFromCoverage
-fun HtmlInfo?.isPasswordField(): Boolean =
-    this
-        ?.let { htmlInfo ->
-            if (htmlInfo.isInputField) {
-                htmlInfo
-                    .attributes
-                    ?.any {
-                        it.first == "type" && it.second == "password"
-                    }
-            } else {
-                false
-            }
-        }
-        ?: false
+fun HtmlInfo?.isPasswordField(): Boolean = isInputField &&
+    hints().containsAnyTerms(SUPPORTED_RAW_PASSWORD_HINTS)
 
 /**
  * Whether this [HtmlInfo] represents a username field.
+ */
+fun HtmlInfo?.isUsernameField(): Boolean = isInputField &&
+    hints().containsAnyTerms(SUPPORTED_RAW_USERNAME_HINTS)
+
+/**
+ * Whether this [HtmlInfo] represents a cardholder name field.
+ */
+fun HtmlInfo?.isCardholderNameField(): Boolean = isInputField &&
+    hints().containsAnyPatterns(SUPPORTED_RAW_CARDHOLDER_NAME_HINT_PATTERNS)
+
+/**
+ * Whether this [HtmlInfo] represents a card number field.
+ */
+fun HtmlInfo?.isCardNumberField(): Boolean = isInputField &&
+    hints().containsAnyPatterns(SUPPORTED_RAW_CARD_NUMBER_HINT_PATTERNS)
+
+/**
+ * Whether this [HtmlInfo] represents a card expiration month field.
+ */
+fun HtmlInfo?.isCardExpirationMonthField(): Boolean = isInputField &&
+    hints().containsAnyPatterns(SUPPORTED_RAW_CARD_EXP_MONTH_HINT_PATTERNS)
+
+/**
+ * Whether this [HtmlInfo] represents a card expiration year field.
+ */
+fun HtmlInfo?.isCardExpirationYearField(): Boolean = isInputField &&
+    hints().containsAnyPatterns(SUPPORTED_RAW_CARD_EXP_YEAR_HINT_PATTERNS)
+
+/**
+ * Whether this [HtmlInfo] represents a card expiration date field.
+ */
+fun HtmlInfo?.isCardExpirationDateField(): Boolean = isInputField &&
+    hints().containsAnyPatterns(SUPPORTED_RAW_CARD_EXP_DATE_HINT_PATTERNS)
+
+/**
+ * Whether this [HtmlInfo] represents a card security code field.
+ */
+fun HtmlInfo?.isCardSecurityCodeField(): Boolean = isInputField &&
+    hints().containsAnyPatterns(SUPPORTED_RAW_CARD_SECURITY_CODE_HINT_PATTERNS)
+
+/**
+ * Attributes that can be used as hints to determine the type of data the associated node expects.
  *
  * This function is untestable as [HtmlInfo] contains [android.util.Pair] which requires
  * instrumentation testing.
+ *
+ * @see IGNORED_RAW_HINTS
+ * @see SUPPORTED_HTML_ATTRIBUTE_HINTS
  */
-@OmitFromCoverage
-fun HtmlInfo?.isUsernameField(): Boolean =
-    this
-        ?.let { htmlInfo ->
-            if (htmlInfo.isInputField) {
-                htmlInfo
-                    .attributes
-                    ?.any {
-                        it.first == "type" && it.second == "email"
-                    }
-            } else {
-                false
+fun HtmlInfo?.hints(): List<String> = this
+    ?.let { htmlInfo ->
+        htmlInfo
+            .attributes
+            // Filter out attributes with null values or values that match ignored raw hints
+            ?.filter { attribute ->
+                attribute.second != null &&
+                    !attribute.second.containsAnyTerms(IGNORED_RAW_HINTS)
             }
-        }
-        ?: false
+            // Filter attributes that match supported HTML attribute hints
+            ?.filter { attribute ->
+                attribute.first.containsAnyTerms(
+                    terms = SUPPORTED_HTML_ATTRIBUTE_HINTS,
+                    ignoreCase = true,
+                )
+            }
+            .orEmpty()
+            .mapNotNull { it.second }
+    }
+    .orEmpty()
 
 /**
  * Whether this [HtmlInfo] represents an input field.
  */
 val HtmlInfo?.isInputField: Boolean get() = this?.tag == "input"
+
+/**
+ * Checks if the list of strings contains any of the specified patterns.
+ */
+private fun List<String>.containsAnyPatterns(patterns: List<Regex>): Boolean = this
+    .any { string -> patterns.any { pattern -> string.matches(pattern) } }
+
+/**
+ * Checks if the list of strings contains any of the specified terms.
+ */
+private fun List<String>.containsAnyTerms(terms: List<String>): Boolean =
+    this.any { string -> string.containsAnyTerms(terms) }
+
+/**
+ * The supported attribute keys whose value can represent an autofill hint.
+ */
+private val SUPPORTED_HTML_ATTRIBUTE_HINTS: List<String> = listOf(
+    "name",
+    "label",
+    "type",
+    "hint",
+    "autofill",
+)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/StringExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/StringExtensions.kt
@@ -16,3 +16,13 @@ fun String.containsAnyTerms(
             ignoreCase = ignoreCase,
         )
     }
+
+/**
+ * Check whether this string matches any of these [expressions].
+ */
+fun String.matchesAnyExpressions(
+    expressions: List<Regex>,
+): Boolean =
+    expressions.any {
+        this.matches(regex = it)
+    }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewStructureUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewStructureUtils.kt
@@ -1,0 +1,137 @@
+package com.x8bit.bitwarden.data.autofill.util
+
+/**
+ * The set of raw autofill hints that should be ignored.
+ */
+val IGNORED_RAW_HINTS: List<String> = listOf(
+    "search",
+    "find",
+    "recipient",
+    "edit",
+)
+
+/**
+ * The supported password autofill hints.
+ */
+val SUPPORTED_RAW_PASSWORD_HINTS: List<String> = listOf(
+    "password",
+    "pswd",
+)
+
+/**
+ * The supported raw autofill hints.
+ */
+val SUPPORTED_RAW_USERNAME_HINTS: List<String> = listOf(
+    "email",
+    "phone",
+    "username",
+)
+
+/**
+ * Matches common patterns for cardholder name hints.
+ * - `\b(?i)`: Case-insensitive word boundary to ensure we match whole words.
+ * - `(?:credit[\\s_-])?`: Optionally matches "credit" followed by a space, underscore, or hyphen.
+ * - `(?:cc|card)[\\s_-](?:name|cardholder).*`: Matches "cc" or "card" followed by a space,
+ * underscore, or hyphen, then "name" or "cardholder", and finally any characters. This covers
+ * variations like "cc name", "card_cardholder", "credit-card-name something else".
+ * - `|`: OR operator, allowing for an alternative pattern.
+ * - `name[\\s_-]on[\\s_-]card`: Matches "name" followed by a space, underscore, or hyphen, then
+ * "on", another space, underscore, or hyphen, and finally "card". This covers phrases like "name on
+ * card" or "name_on_card".
+ * - `\b`: Word boundary to ensure we match whole words.
+ */
+val SUPPORTED_RAW_CARDHOLDER_NAME_HINT_PATTERNS: List<Regex> = listOf(
+    "\\b(?i)(?:credit[\\s_-])?(?:cc|card)[\\s_-](?:name|cardholder).*\\b".toRegex(),
+    "\\b(?i)name[\\s_-]on[\\s_-]card\\b".toRegex(),
+)
+
+/**
+ * Matches common patterns for card number hints.
+ * - `\b(?i)`: Case-insensitive word boundary to ensure we match whole words.
+ * - `(?:credit[\\s_-])?`: Optionally matches "credit" followed by a space, underscore, or hyphen.
+ * - `(?:cc|card)`: Matches "cc" or "card".
+ * - `[\\s_-]number`: Matches "number" preceded by a space, underscore, or hyphen.
+ * - `\b`: Word boundary to ensure we match whole words.
+ */
+val SUPPORTED_RAW_CARD_NUMBER_HINT_PATTERNS: List<Regex> = listOf(
+    "\\b(?i)(?:credit[\\s_-])?(?:cc|card)[\\s_-]number\\b".toRegex(),
+)
+
+/**
+ * Matches common patterns for card expiration month hints.
+ * - `\b(?i)`: Case-insensitive word boundary to ensure we match whole words.
+ * - `(?:credit[\\s_-])?`: Optionally matches "credit" followed by a space, underscore, or hyphen.
+ * - `(?:cc|card)`: Matches "cc" or "card".
+ * - `[\\s_-]exp[\\s_-]month`: Matches "exp" followed by a space, underscore, or hyphen, then
+ * "month".
+ * - `\b`: Word boundary to ensure we match whole words.
+ *
+ * Examples:
+ * - "credit card exp month"
+ * - "cc_exp_month"
+ * - "card-exp-month"
+ */
+val SUPPORTED_RAW_CARD_EXP_MONTH_HINT_PATTERNS: List<Regex> = listOf(
+    "\\b(?i)(?:credit[\\s_-])?(?:(cc|card)[\\s_-])?(?:exp|expiration|expiry)[\\s_-]month\\b"
+        .toRegex(),
+)
+
+/**
+ * Matches common patterns for card expiration year hints.
+ * - `\b(?i)`: Case-insensitive word boundary to ensure we match whole words.
+ * - `(?:credit[\\s_-])?`: Optionally matches "credit" followed by a space, underscore, or hyphen.
+ * - `(?:cc|card)`: Matches "cc" or "card".
+ * - `[\\s_-]exp[\\s_-]year`: Matches "exp" followed by a space, underscore, or hyphen, then "year".
+ * - `\b`: Word boundary to ensure we match whole words.
+ *
+ * Similar to [SUPPORTED_RAW_CARD_EXP_MONTH_HINT_PATTERNS], but for "year" instead of "month".
+ * @see SUPPORTED_RAW_CARD_EXP_MONTH_HINT_PATTERNS
+ */
+val SUPPORTED_RAW_CARD_EXP_YEAR_HINT_PATTERNS: List<Regex> = listOf(
+    "\\b(?i)(?:credit[\\s_-])?(?:(cc|card)[\\s_-])?(?:exp|expiration|expiry)[\\s_-]year\\b"
+        .toRegex(),
+)
+
+/**
+ * Matches common patterns for card expiration date hints.
+ * - `\b(?i)`: Case-insensitive word boundary to ensure we match whole words.
+ * - `(?:credit[\\s_-])?`: Optionally matches "credit" followed by a space, underscore, or hyphen.
+ * - `(?:cc|card)`: Matches "cc" or "card".
+ * - `[\\s_-]exp[\\s_-]date`: Matches "exp" followed by a space, underscore, or hyphen, then "date".
+ * - `.*`: Matches any characters following "date" (e.g., "MM/YY", "month/year").
+ * - `\b`: Word boundary to ensure we match whole words.
+ *
+ * Examples:
+ * - "credit card exp date"
+ * - "cc_exp_date_mm_yy"
+ * - "card-exp-date month/year"
+ */
+val SUPPORTED_RAW_CARD_EXP_DATE_HINT_PATTERNS: List<Regex> = listOf(
+    "\\b(?i)(?:credit[\\s_-])?(?:(cc|card)[\\s_-])?(?:exp|expiration|expiry)[\\s_-]date\\b"
+        .toRegex(),
+)
+
+/**
+ * Matches common patterns for card security code hints.
+ * - `\b(?i)`: Case-insensitive word boundary to ensure we match whole words.
+ * - `(?:credit[\\s_-])?`: Optionally matches "credit" followed by a space, underscore, or hyphen.
+ * - The first pattern `(?:cc|card[\\s_-])(cvc|cvv)\b`:
+ *    - `(?:cc|card[\\s_-])`: Matches "cc" or "card" followed by a space, underscore, or hyphen.
+ *    - `(cvc|cvv)\b`: Matches "cvc" or "cvv" followed by a word boundary.
+ * - The second pattern `(?:cc|card)(?:[\\s_-]verification)?([\\s_-]code)\b`:
+ *    - `(?:cc|card)`: Matches "cc" or "card".
+ *    - `(?:[\\s_-]verification)?`: Optionally matches "verification" preceded by a space,
+ *    underscore, or hyphen.
+ * - `([\\s_-]code)\b`: Matches "code" preceded by a space, underscore, or hyphen, and
+ * followed by a word boundary.
+ *
+ * Examples:
+ * - "credit card cvc"
+ * - "cc_verification_code"
+ * - "card-code"
+ */
+val SUPPORTED_RAW_CARD_SECURITY_CODE_HINT_PATTERNS: List<Regex> = listOf(
+    "\\b(?i)(?:credit[\\s_-])?(?:cc|card[\\s_-])?(cvc|cvv)2?\\b".toRegex(),
+    "\\b(?i)(?:credit[\\s_-])?(?:cc|card)(?:[\\s_-](?:verification|security))?([\\s_-]code)\\b"
+        .toRegex(),
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderTest.kt
@@ -177,11 +177,13 @@ class FilledDataBuilderTest {
         runTest {
             // Setup
             val code = "123"
-            val expirationMonth = "January"
+            val expirationMonth = "01"
             val expirationYear = "1999"
             val number = "1234567890"
+            val expirationDate = "0199"
+            val cardholderName = "John"
             val autofillCipher = AutofillCipher.Card(
-                cardholderName = "John",
+                cardholderName = cardholderName,
                 cipherId = null,
                 code = code,
                 expirationMonth = expirationMonth,
@@ -194,6 +196,8 @@ class FilledDataBuilderTest {
             val filledItemExpirationMonth: FilledItem = mockk()
             val filledItemExpirationYear: FilledItem = mockk()
             val filledItemNumber: FilledItem = mockk()
+            val filledItemCardholderName: FilledItem = mockk()
+            val filledItemExpirationDate: FilledItem = mockk()
             val autofillViewCode: AutofillView.Card.SecurityCode = mockk {
                 every { buildFilledItemOrNull(code) } returns filledItemCode
             }
@@ -209,6 +213,12 @@ class FilledDataBuilderTest {
             val autofillViewNumberTwo: AutofillView.Card.Number = mockk {
                 every { buildFilledItemOrNull(number) } returns null
             }
+            val autofillViewCardholderName: AutofillView.Card.CardholderName = mockk {
+                every { buildFilledItemOrNull(cardholderName) } returns filledItemCardholderName
+            }
+            val autofillViewExpirationDate: AutofillView.Card.ExpirationDate = mockk {
+                every { buildFilledItemOrNull(expirationDate) } returns filledItemExpirationDate
+            }
             val autofillPartition = AutofillPartition.Card(
                 views = listOf(
                     autofillViewCode,
@@ -216,6 +226,8 @@ class FilledDataBuilderTest {
                     autofillViewExpirationYear,
                     autofillViewNumberOne,
                     autofillViewNumberTwo,
+                    autofillViewCardholderName,
+                    autofillViewExpirationDate,
                 ),
             )
             val ignoreAutofillIds: List<AutofillId> = mockk()
@@ -234,6 +246,8 @@ class FilledDataBuilderTest {
                     filledItemExpirationMonth,
                     filledItemExpirationYear,
                     filledItemNumber,
+                    filledItemCardholderName,
+                    filledItemExpirationDate,
                 ),
                 inlinePresentationSpec = null,
             )
@@ -260,6 +274,96 @@ class FilledDataBuilderTest {
             assertEquals(expected, actual)
             coVerify(exactly = 1) {
                 autofillCipherProvider.getCardAutofillCiphers()
+                autofillViewCode.buildFilledItemOrNull(code)
+                autofillViewExpirationMonth.buildFilledItemOrNull(expirationMonth)
+                autofillViewExpirationYear.buildFilledItemOrNull(expirationYear)
+                autofillViewNumberOne.buildFilledItemOrNull(number)
+                autofillViewNumberTwo.buildFilledItemOrNull(number)
+                autofillViewCardholderName.buildFilledItemOrNull(cardholderName)
+                autofillViewExpirationDate.buildFilledItemOrNull(expirationDate)
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `build should skip empty AutofillValues and return empty data when Card data is blank`() =
+        runTest {
+            // Setup
+            val code = ""
+            val expirationMonth = ""
+            val expirationYear = ""
+            val number = ""
+            val autofillCipher = AutofillCipher.Card(
+                cardholderName = "",
+                cipherId = null,
+                code = code,
+                expirationMonth = expirationMonth,
+                expirationYear = expirationYear,
+                name = "",
+                number = number,
+                subtitle = "",
+            )
+            val filledItemCode: FilledItem = mockk()
+            val filledItemExpirationMonth: FilledItem = mockk()
+            val filledItemExpirationYear: FilledItem = mockk()
+            val filledItemNumber: FilledItem = mockk()
+            val autofillViewCode: AutofillView.Card.SecurityCode = mockk()
+            val autofillViewExpirationMonth: AutofillView.Card.ExpirationMonth = mockk()
+            val autofillViewExpirationYear: AutofillView.Card.ExpirationYear = mockk()
+            val autofillViewNumberOne: AutofillView.Card.Number = mockk()
+            val autofillViewNumberTwo: AutofillView.Card.Number = mockk()
+            val autofillViewCardholderName: AutofillView.Card.CardholderName = mockk()
+            val autofillViewExpirationDate: AutofillView.Card.ExpirationDate = mockk()
+            val autofillPartition = AutofillPartition.Card(
+                views = listOf(
+                    autofillViewCode,
+                    autofillViewExpirationMonth,
+                    autofillViewExpirationYear,
+                    autofillViewNumberOne,
+                    autofillViewNumberTwo,
+                    autofillViewCardholderName,
+                    autofillViewExpirationDate,
+                ),
+            )
+            val ignoreAutofillIds: List<AutofillId> = mockk()
+            val autofillRequest = AutofillRequest.Fillable(
+                ignoreAutofillIds = ignoreAutofillIds,
+                inlinePresentationSpecs = emptyList(),
+                maxInlineSuggestionsCount = 0,
+                packageName = null,
+                partition = autofillPartition,
+                uri = URI,
+            )
+            val filledPartition = FilledPartition(
+                autofillCipher = autofillCipher,
+                filledItems = emptyList(),
+                inlinePresentationSpec = null,
+            )
+            val expected = FilledData(
+                filledPartitions = listOf(
+                    filledPartition,
+                ),
+                ignoreAutofillIds = ignoreAutofillIds,
+                originalPartition = autofillPartition,
+                uri = URI,
+                vaultItemInlinePresentationSpec = null,
+                isVaultLocked = false,
+            )
+            coEvery {
+                autofillCipherProvider.getCardAutofillCiphers()
+            } returns listOf(autofillCipher)
+
+            // Test
+            val actual = filledDataBuilder.build(
+                autofillRequest = autofillRequest,
+            )
+
+            // Verify
+            assertEquals(expected, actual)
+            coVerify(exactly = 1) {
+                autofillCipherProvider.getCardAutofillCiphers()
+            }
+            coVerify(exactly = 0) {
                 autofillViewCode.buildFilledItemOrNull(code)
                 autofillViewExpirationMonth.buildFilledItemOrNull(expirationMonth)
                 autofillViewExpirationYear.buildFilledItemOrNull(expirationYear)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/HtmlInfoExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/HtmlInfoExtensionsTest.kt
@@ -10,29 +10,23 @@ import org.junit.jupiter.api.Test
 class HtmlInfoExtensionsTest {
     @Test
     fun `isInputField should return true when tag is 'input'`() {
-        // Setup
         val htmlInfo: HtmlInfo = mockk {
             every { tag } returns "input"
         }
 
-        // Test
         val actual = htmlInfo.isInputField
 
-        // Verify
         assertTrue(actual)
     }
 
     @Test
     fun `isInputField should return false when tag is not 'input'`() {
-        // Setup
         val htmlInfo: HtmlInfo = mockk {
             every { tag } returns "not input"
         }
 
-        // Test
         val actual = htmlInfo.isInputField
 
-        // Verify
         assertFalse(actual)
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
@@ -30,17 +30,21 @@ class ViewNodeExtensionsTest {
         hasPasswordTerms = false,
     )
     private val testAutofillValue: AutofillValue = mockk()
+    private val mockHtmlInfo: HtmlInfo = mockk {
+        every { attributes } returns emptyList()
+    }
 
     private val viewNode: AssistStructure.ViewNode = mockk {
-        every { this@mockk.autofillId } returns expectedAutofillId
-        every { this@mockk.idEntry } returns null
-        every { this@mockk.hint } returns null
-        every { this@mockk.autofillOptions } returns AUTOFILL_OPTIONS_ARRAY
-        every { this@mockk.autofillType } returns AUTOFILL_TYPE
-        every { this@mockk.autofillValue } returns testAutofillValue
-        every { this@mockk.childCount } returns 0
-        every { this@mockk.inputType } returns 1
-        every { this@mockk.isFocused } returns expectedIsFocused
+        every { autofillId } returns expectedAutofillId
+        every { idEntry } returns null
+        every { hint } returns null
+        every { autofillOptions } returns AUTOFILL_OPTIONS_ARRAY
+        every { autofillType } returns AUTOFILL_TYPE
+        every { autofillValue } returns testAutofillValue
+        every { childCount } returns 0
+        every { inputType } returns 1
+        every { isFocused } returns expectedIsFocused
+        every { htmlInfo } returns mockHtmlInfo
     }
 
     @BeforeEach
@@ -69,8 +73,9 @@ class ViewNodeExtensionsTest {
         unmockkStatic(AutofillValue::extractTextValue)
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `toAutofillView should return AutofillView Card ExpirationMonth when hint matches`() {
+    fun `toAutofillView should return AutofillView Card ExpirationMonth when autofillHints match`() {
         // Setup
         val autofillHint = View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH
         val expected = AutofillView.Card.ExpirationMonth(
@@ -88,7 +93,7 @@ class ViewNodeExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `toAutofillView should return AutofillView Card ExpirationMonth with empty options when hint matches and options are null`() {
+    fun `toAutofillView should return AutofillView Card ExpirationMonth with empty options when autofillHints match and options are null`() {
         // Setup
         val autofillViewData = autofillViewData.copy(
             autofillOptions = emptyList(),
@@ -114,24 +119,139 @@ class ViewNodeExtensionsTest {
         assertEquals(expected, actual)
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `toAutofillView should return AutofillView Card ExpirationYear when hint matches`() {
-        // Setup
+    fun `toAutofillView should return AutofillView Card ExpirationMonth when html info isCardExpirationMonthField`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.ExpirationMonth(
+            data = autofillViewData,
+            monthValue = MONTH_VALUE,
+        )
+        every { viewNode.htmlInfo.hints() } returns SUPPORTED_RAW_CARD_EXP_MONTH_HINTS
+
+        val actual = viewNode.toAutofillView()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card ExpirationMonth when idEntry matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.ExpirationMonth(
+            data = autofillViewData,
+            monthValue = MONTH_VALUE,
+        )
+        SUPPORTED_RAW_CARD_EXP_MONTH_HINTS.forEach { idEntry ->
+            every { viewNode.idEntry } returns idEntry
+
+            val actual = viewNode.toAutofillView()
+
+            assertEquals(expected, actual, "Failed for idEntry: $idEntry")
+        }
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card ExpirationMonth when hint matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.ExpirationMonth(
+            data = autofillViewData,
+            monthValue = MONTH_VALUE,
+        )
+        SUPPORTED_RAW_CARD_EXP_MONTH_HINTS.forEach { hint ->
+            every { viewNode.hint } returns hint
+            val actual = viewNode.toAutofillView()
+            assertEquals(expected, actual, "Failed for hint: $hint")
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toAutofillView should return AutofillView Card ExpirationYear when autofillHints match`() {
         val autofillHint = View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR
         val expected = AutofillView.Card.ExpirationYear(
             data = autofillViewData,
         )
         every { viewNode.autofillHints } returns arrayOf(autofillHint)
 
-        // Test
         val actual = viewNode.toAutofillView()
 
-        // Verify
         assertEquals(expected, actual)
     }
 
     @Test
-    fun `toAutofillView should return AutofillView Card Number when hint matches`() {
+    fun `toAutofillView should return AutofillView Card ExpirationYear when hint matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.ExpirationYear(
+            data = autofillViewData,
+        )
+        SUPPORTED_RAW_CARD_EXP_YEAR_HINTS.forEach { hint ->
+            every { viewNode.hint } returns hint
+
+            val actual = viewNode.toAutofillView()
+
+            assertEquals(expected, actual, "Failed for hint: $hint")
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toAutofillView should return AutofillView Card ExpirationYear when html info isCardExpirationYearField`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.ExpirationYear(
+            data = autofillViewData,
+        )
+        every { viewNode.htmlInfo.hints() } returns SUPPORTED_RAW_CARD_EXP_YEAR_HINTS
+
+        val actual = viewNode.toAutofillView()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card ExpirationDate when autofillHints match`() {
+        val autofillHint = View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE
+        val expected = AutofillView.Card.ExpirationDate(
+            data = autofillViewData,
+        )
+        every { viewNode.autofillHints } returns arrayOf(autofillHint)
+        every { mockHtmlInfo.isInputField } returns true
+
+        val actual = viewNode.toAutofillView()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card ExpirationDate when hint matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.ExpirationDate(
+            data = autofillViewData,
+        )
+        SUPPORTED_RAW_CARD_EXP_DATE_HINTS.forEach { hint ->
+            every { viewNode.hint } returns hint
+
+            val actual = viewNode.toAutofillView()
+
+            assertEquals(expected, actual, "Failed for hint: $hint")
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toAutofillView should return AutofillView Card ExpirationDate when html info isCardExpirationDateField`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.ExpirationDate(
+            data = autofillViewData,
+        )
+        every { viewNode.htmlInfo.hints() } returns SUPPORTED_RAW_CARD_EXP_DATE_HINTS
+
+        val actual = viewNode.toAutofillView()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card Number when autofillHints match`() {
         // Setup
         val autofillHint = View.AUTOFILL_HINT_CREDIT_CARD_NUMBER
         val expected = AutofillView.Card.Number(
@@ -147,7 +267,35 @@ class ViewNodeExtensionsTest {
     }
 
     @Test
-    fun `toAutofillView should return AutofillView Card SecurityCode when hint matches`() {
+    fun `toAutofillView should return AutofillView Card Number when hint matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.Number(
+            data = autofillViewData,
+        )
+        SUPPORTED_RAW_CARD_NUMBER_HINTS.forEach { hint ->
+            every { viewNode.hint } returns hint
+
+            val actual = viewNode.toAutofillView()
+
+            assertEquals(expected, actual, "Failed for hint: $hint")
+        }
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card Number when html info isCardNumberField`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.Number(
+            data = autofillViewData,
+        )
+        every { viewNode.htmlInfo.hints() } returns SUPPORTED_RAW_CARD_NUMBER_HINTS
+
+        val actual = viewNode.toAutofillView()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card SecurityCode when autofillHints match`() {
         // Setup
         val autofillHint = View.AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE
         val expected = AutofillView.Card.SecurityCode(
@@ -163,18 +311,114 @@ class ViewNodeExtensionsTest {
     }
 
     @Test
-    fun `toAutofillView should return AutofillView Login Password when isPasswordField`() {
-        // Setup
+    fun `toAutofillView should return AutofillView Card SecurityCode when hint matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.SecurityCode(
+            data = autofillViewData,
+        )
+        SUPPORTED_RAW_CARD_SECURITY_CODE_HINTS.forEach { hint ->
+            every { viewNode.hint } returns hint
+
+            val actual = viewNode.toAutofillView()
+
+            assertEquals(expected, actual, "Failed for hint: $hint")
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toAutofillView should return AutofillView Card SecurityCode when html info isCardSecurityCodeField`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.SecurityCode(
+            data = autofillViewData,
+        )
+        every { viewNode.htmlInfo.hints() } returns SUPPORTED_RAW_CARD_SECURITY_CODE_HINTS
+        val actual = viewNode.toAutofillView()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card CardholderName when idEntry matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.CardholderName(
+            data = autofillViewData,
+        )
+        SUPPORTED_RAW_CARDHOLDER_NAME_HINTS.forEach { idEntry ->
+            every { viewNode.idEntry } returns idEntry
+
+            val actual = viewNode.toAutofillView()
+
+            assertEquals(expected, actual, "Failed for idEntry: $idEntry")
+        }
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Card CardholderName when hint matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.CardholderName(
+            data = autofillViewData,
+        )
+        SUPPORTED_RAW_CARDHOLDER_NAME_HINTS.forEach { hint ->
+            every { viewNode.hint } returns hint
+
+            val actual = viewNode.toAutofillView()
+
+            assertEquals(expected, actual, "Failed for hint: $hint")
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toAutofillView should return AutofillView Card CardholderName when html info isCardholderNameField`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Card.CardholderName(
+            data = autofillViewData,
+        )
+        every { viewNode.htmlInfo.hints() } returns SUPPORTED_RAW_CARDHOLDER_NAME_HINTS
+        val actual = viewNode.toAutofillView()
+        assertEquals(expected, actual)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toAutofillView should return AutofillView Login Password when autofillHints match`() {
         val autofillHint = View.AUTOFILL_HINT_PASSWORD
         val expected = AutofillView.Login.Password(
             data = autofillViewData,
         )
         every { viewNode.autofillHints } returns arrayOf(autofillHint)
 
-        // Test
         val actual = viewNode.toAutofillView()
 
-        // Verify
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `toAutofillView should return AutofillView Login Password when hint matches`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Login.Password(
+            data = autofillViewData.copy(hasPasswordTerms = true),
+        )
+        SUPPORTED_RAW_PASSWORD_HINTS.forEach { hint ->
+            every { viewNode.hint } returns hint
+
+            val actual = viewNode.toAutofillView()
+
+            assertEquals(expected, actual, "Failed for hint: $hint")
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toAutofillView should return AutofillView Login Password when html info isPasswordField`() {
+        setupUnsupportedInputFieldViewNode()
+        val expected = AutofillView.Login.Password(
+            data = autofillViewData,
+        )
+        every { viewNode.htmlInfo.isPasswordField() } returns true
+
+        val actual = viewNode.toAutofillView()
+
         assertEquals(expected, actual)
     }
 
@@ -234,16 +478,13 @@ class ViewNodeExtensionsTest {
     @Suppress("MaxLineLength")
     @Test
     fun `toAutofillView should return only unused field when hint is not supported, is an inputField, and isn't a username or password`() {
-        // Setup
         setupUnsupportedInputFieldViewNode()
         val expected = AutofillView.Unused(
             data = autofillViewData,
         )
 
-        // Test
         val actual = viewNode.toAutofillView()
 
-        // Verify
         assertEquals(expected, actual)
     }
 
@@ -265,14 +506,13 @@ class ViewNodeExtensionsTest {
     }
 
     @Test
-    fun `isPasswordField returns true when supportedHint is AUTOFILL_HINT_PASSWORD`() {
+    fun `isPasswordField returns true when html hints contains a supported password hint`() {
         // Setup
-        val supportedHint = View.AUTOFILL_HINT_PASSWORD
+        every { mockHtmlInfo.isInputField } returns true
+        every { mockHtmlInfo.hints() } returns listOf("password")
 
         // Test
-        val actual = viewNode.isPasswordField(
-            supportedHint = supportedHint,
-        )
+        val actual = viewNode.isPasswordField
 
         // Verify
         assertTrue(actual)
@@ -286,9 +526,7 @@ class ViewNodeExtensionsTest {
         every { any<Int>().isPasswordInputType } returns true
 
         // Test
-        val actual = viewNode.isPasswordField(
-            supportedHint = null,
-        )
+        val actual = viewNode.isPasswordField
 
         // Verify
         assertTrue(actual)
@@ -302,9 +540,7 @@ class ViewNodeExtensionsTest {
         every { viewNode.htmlInfo.isPasswordField() } returns true
 
         // Test
-        val actual = viewNode.isPasswordField(
-            supportedHint = null,
-        )
+        val actual = viewNode.isPasswordField
 
         // Verify
         assertTrue(actual)
@@ -322,9 +558,7 @@ class ViewNodeExtensionsTest {
             every { viewNode.hint } returns hint
 
             // Test
-            val actual = viewNode.isPasswordField(
-                supportedHint = null,
-            )
+            val actual = viewNode.isPasswordField
 
             // Verify
             assertFalse(actual)
@@ -337,9 +571,7 @@ class ViewNodeExtensionsTest {
             every { viewNode.idEntry } returns hint
 
             // Test
-            val actual = viewNode.isPasswordField(
-                supportedHint = null,
-            )
+            val actual = viewNode.isPasswordField
 
             // Verify
             assertFalse(actual)
@@ -355,37 +587,20 @@ class ViewNodeExtensionsTest {
         every { viewNode.hint } returns SUPPORTED_RAW_USERNAME_HINTS.first()
 
         // Test
-        val actual = viewNode.isPasswordField(
-            supportedHint = null,
-        )
+        val actual = viewNode.isPasswordField
 
         // Verify
         assertFalse(actual)
     }
 
     @Test
-    fun `isUsernameField returns true when supportedHint is AUTOFILL_HINT_USERNAME`() {
+    fun `isUsernameField returns true when html hints contains a supported username hint`() {
         // Setup
-        val supportedHint = View.AUTOFILL_HINT_USERNAME
+        every { mockHtmlInfo.isInputField } returns true
+        every { mockHtmlInfo.hints() } returns SUPPORTED_RAW_USERNAME_HINTS
 
         // Test
-        val actual = viewNode.isUsernameField(
-            supportedHint = supportedHint,
-        )
-
-        // Verify
-        assertTrue(actual)
-    }
-
-    @Test
-    fun `isUsernameField returns true when supportedHint is AUTOFILL_HINT_EMAIL_ADDRESS`() {
-        // Setup
-        val supportedHint = View.AUTOFILL_HINT_EMAIL_ADDRESS
-
-        // Test
-        val actual = viewNode.isUsernameField(
-            supportedHint = supportedHint,
-        )
+        val actual = viewNode.isUsernameField
 
         // Verify
         assertTrue(actual)
@@ -400,9 +615,7 @@ class ViewNodeExtensionsTest {
             every { viewNode.hint } returns hint
 
             // Test
-            val actual = viewNode.isUsernameField(
-                supportedHint = null,
-            )
+            val actual = viewNode.isUsernameField
 
             // Verify
             assertTrue(actual)
@@ -415,9 +628,7 @@ class ViewNodeExtensionsTest {
             every { viewNode.idEntry } returns hint
 
             // Test
-            val actual = viewNode.isUsernameField(
-                supportedHint = null,
-            )
+            val actual = viewNode.isUsernameField
 
             // Verify
             assertTrue(actual)
@@ -431,9 +642,7 @@ class ViewNodeExtensionsTest {
         every { viewNode.htmlInfo.isUsernameField() } returns true
 
         // Test
-        val actual = viewNode.isUsernameField(
-            supportedHint = null,
-        )
+        val actual = viewNode.isUsernameField
 
         // Verify
         assertTrue(actual)
@@ -570,6 +779,7 @@ class ViewNodeExtensionsTest {
         every { viewNode.className } returns null
         every { any<Int>().isPasswordInputType } returns false
         every { any<Int>().isUsernameInputType } returns false
+        every { viewNode.htmlInfo.hints() } returns emptyList()
     }
 }
 
@@ -598,6 +808,51 @@ private val SUPPORTED_RAW_USERNAME_HINTS: List<String> = listOf(
     "email",
     "phone",
     "username",
+)
+private val SUPPORTED_RAW_CARD_EXP_MONTH_HINTS: List<String> = listOf(
+    "exp_month",
+    "expiration_month",
+    "cc_exp_month",
+    "card_exp_month",
+)
+private val SUPPORTED_RAW_CARD_EXP_YEAR_HINTS: List<String> = listOf(
+    "exp_year",
+    "expiration_year",
+    "cc_exp_year",
+    "card_exp_year",
+)
+private val SUPPORTED_RAW_CARD_NUMBER_HINTS: List<String> = listOf(
+    "cc_number",
+    "card_number",
+    "credit_card_number",
+)
+private val SUPPORTED_RAW_CARD_SECURITY_CODE_HINTS: List<String> = listOf(
+    "cc_security_code",
+    "card_security_code",
+    "credit_card_security_code",
+    "cc_verification_code",
+    "card_verification_code",
+    "credit_card_verification_code",
+    "cvv",
+    "cvc",
+    "cvv2",
+    "cvc2",
+)
+private val SUPPORTED_RAW_CARD_EXP_DATE_HINTS: List<String> = listOf(
+    "exp_date",
+    "expiration_date",
+    "expiry_date",
+    "cc_exp_date",
+    "card_exp_date",
+)
+private val SUPPORTED_RAW_CARDHOLDER_NAME_HINTS: List<String> = listOf(
+    "cc_name",
+    "cc_cardholder",
+    "card_name",
+    "card_cardholder",
+    "credit_card_name",
+    "credit_card_cardholder",
+    "name_on_card",
 )
 private const val MONTH_VALUE: String = "MONTH_VALUE"
 private const val TEXT_VALUE: String = "TEXT_VALUE"

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1069,4 +1069,5 @@ Do you want to switch to this account?</string>
     <string name="local_items_are_collapsed_click_to_expand">Local items are collapsed, click to expand.</string>
     <string name="items_expanded_click_to_collapse">Items are expanded, click to collapse.</string>
     <string name="items_are_collapsed_click_to_expand">Items are collapsed, click to expand.</string>
+    <string name="select_a_card_for_x">Select a card for %s</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

TBD

## 📔 Objective

This commit refactors the autofill hint detection logic in `ViewNodeExtensions.kt` and introduces support for new autofill hints related to credit card information.

Key changes include:
- Introduced a new `AutofillHint` enum to represent various autofill field types.
- Added regular expressions to detect hints for cardholder name, card number, expiration month, expiration year, expiration date, and security code from HTML attributes.
- Updated `ViewNode.supportedAutofillHint` to use the new `AutofillHint` enum and prioritize explicit hints over inferred ones.
- Modified `ViewNode.isPasswordField` and `ViewNode.isUsernameField` to be properties and utilize the new hint logic.
- Added new `AutofillView.Card` subtypes: `ExpirationDate` and `CardholderName`.
- Updated `FilledDataBuilderImpl.kt` to handle the new card-related `AutofillView` types.
- Added `String.matchesAnyExpressions` extension function.
- Included corresponding unit tests for the changes in `ViewNodeExtensionsTest.kt`.

## 📸 Screenshots

https://github.com/user-attachments/assets/709fed43-8f3d-4054-af62-f31d2e6e85df

https://github.com/user-attachments/assets/441861e1-e839-4dd1-a543-1919334c80e2

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
