### PR TITLE
PM-24440: Log user out for 'invalid_grant'

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LogoutReason.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LogoutReason.kt
@@ -30,6 +30,12 @@ sealed class LogoutReason {
     }
 
     /**
+     * Indicates that the logout is happening because the there was an "invalid_grant" response
+     * from the network.
+     */
+    data object InvalidGrant : LogoutReason()
+
+    /**
      * Indicates that the logout is happening because of an invalid state.
      */
     data class InvalidState(
@@ -57,11 +63,6 @@ sealed class LogoutReason {
      * Indicates that the logout is happening because of a timeout action.
      */
     data object Timeout : LogoutReason()
-
-    /**
-     * Indicates that the logout is happening because the access token could not be refreshed.
-     */
-    data object TokenRefreshFail : LogoutReason()
 
     /**
      * Indicates that the logout is happening because the user tried to unlock the vault

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -911,7 +911,7 @@ class AuthRepositoryTest {
 
         val result = repository.refreshAccessTokenSynchronously(USER_ID_1)
 
-        assertEquals(REFRESH_TOKEN_RESPONSE_JSON.asSuccess(), result)
+        assertEquals(REFRESH_TOKEN_RESPONSE_JSON.accessToken.asSuccess(), result)
         fakeAuthDiskSource.assertAccountTokens(
             userId = USER_ID_1,
             accountTokens = updatedAccountTokens,
@@ -6959,7 +6959,7 @@ class AuthRepositoryTest {
             accessCode = "accessCode",
             fingerprint = "fingerprint",
         )
-        private val REFRESH_TOKEN_RESPONSE_JSON = RefreshTokenResponseJson(
+        private val REFRESH_TOKEN_RESPONSE_JSON = RefreshTokenResponseJson.Success(
             accessToken = ACCESS_TOKEN_2,
             expiresIn = 3600,
             refreshToken = REFRESH_TOKEN_2,

--- a/network/src/main/kotlin/com/bitwarden/network/api/UnauthenticatedIdentityApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/UnauthenticatedIdentityApi.kt
@@ -65,7 +65,7 @@ internal interface UnauthenticatedIdentityApi {
         @Field(value = "client_id") clientId: String,
         @Field(value = "refresh_token") refreshToken: String,
         @Field(value = "grant_type") grantType: String,
-    ): Call<RefreshTokenResponseJson>
+    ): Call<RefreshTokenResponseJson.Success>
 
     @POST("/accounts/prelogin")
     suspend fun preLogin(@Body body: PreLoginRequestJson): NetworkResult<PreLoginResponseJson>

--- a/network/src/main/kotlin/com/bitwarden/network/authenticator/RefreshAuthenticator.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/authenticator/RefreshAuthenticator.kt
@@ -39,11 +39,12 @@ internal class RefreshAuthenticator : Authenticator {
                     ?.fold(
                         onFailure = { null },
                         onSuccess = { newAccessToken ->
-                            response.request
+                            response
+                                .request
                                 .newBuilder()
                                 .header(
                                     name = HEADER_KEY_AUTHORIZATION,
-                                    value = HEADER_VALUE_BEARER_PREFIX + newAccessToken.accessToken,
+                                    value = "$HEADER_VALUE_BEARER_PREFIX$newAccessToken",
                                 )
                                 .build()
                         },

--- a/network/src/main/kotlin/com/bitwarden/network/model/RefreshTokenResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/RefreshTokenResponseJson.kt
@@ -4,24 +4,40 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Models the response body from the refresh token request.
- *
- * @property accessToken The new access token.
- * @property expiresIn When the new [accessToken] expires.
- * @property refreshToken The new refresh token.
- * @property tokenType The type of token the new [accessToken] is.
+ * Represents the JSON response from refreshing the access token.
  */
-@Serializable
-data class RefreshTokenResponseJson(
-    @SerialName("access_token")
-    val accessToken: String,
+sealed class RefreshTokenResponseJson {
+    /**
+     * Models a successful response body from the refresh token request.
+     *
+     * @property accessToken The new access token.
+     * @property expiresIn When the new [accessToken] expires.
+     * @property refreshToken The new refresh token.
+     * @property tokenType The type of token the new [accessToken] is.
+     */
+    @Serializable
+    data class Success(
+        @SerialName("access_token")
+        val accessToken: String,
 
-    @SerialName("expires_in")
-    val expiresIn: Int,
+        @SerialName("expires_in")
+        val expiresIn: Int,
 
-    @SerialName("refresh_token")
-    val refreshToken: String,
+        @SerialName("refresh_token")
+        val refreshToken: String,
 
-    @SerialName("token_type")
-    val tokenType: String,
-)
+        @SerialName("token_type")
+        val tokenType: String,
+    ) : RefreshTokenResponseJson()
+
+    /**
+     * Models a failure response body from the refresh token request.
+     */
+    @Serializable
+    data class Error(
+        @SerialName("error")
+        val error: String,
+    ) : RefreshTokenResponseJson() {
+        val isInvalidGrant: Boolean get() = error == "invalid_grant"
+    }
+}

--- a/network/src/main/kotlin/com/bitwarden/network/provider/RefreshTokenProvider.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/provider/RefreshTokenProvider.kt
@@ -1,7 +1,5 @@
 package com.bitwarden.network.provider
 
-import com.bitwarden.network.model.RefreshTokenResponseJson
-
 /**
  * A provider for all the functionality needed to refresh a user's access token.
  */
@@ -12,5 +10,5 @@ interface RefreshTokenProvider {
      * This call is both synchronous and performs a network request. Make sure that you are calling
      * from an appropriate thread.
      */
-    fun refreshAccessTokenSynchronously(userId: String): Result<RefreshTokenResponseJson>
+    fun refreshAccessTokenSynchronously(userId: String): Result<String>
 }

--- a/network/src/main/kotlin/com/bitwarden/network/service/IdentityServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/IdentityServiceImpl.kt
@@ -130,6 +130,15 @@ internal class IdentityServiceImpl(
         )
         .executeForNetworkResult()
         .toResult()
+        .recoverCatching { throwable ->
+            throwable
+                .toBitwardenError()
+                .parseErrorBodyOrNull<RefreshTokenResponseJson.Error>(
+                    code = NetworkErrorCode.BAD_REQUEST,
+                    json = json,
+                )
+                ?: throw throwable
+        }
 
     override suspend fun registerFinish(
         body: RegisterFinishRequestJson,

--- a/network/src/test/kotlin/com/bitwarden/network/authenticator/RefreshAuthenticatorTests.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/authenticator/RefreshAuthenticatorTests.kt
@@ -3,7 +3,6 @@ package com.bitwarden.network.authenticator
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.network.model.JwtTokenDataJson
-import com.bitwarden.network.model.RefreshTokenResponseJson
 import com.bitwarden.network.provider.RefreshTokenProvider
 import com.bitwarden.network.util.parseJwtTokenDataOrNull
 import io.mockk.every
@@ -72,20 +71,13 @@ class RefreshAuthenticatorTests {
         }
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `RefreshAuthenticator returns updated request when refresh is success`() {
         val newAccessToken = "newAccessToken"
-        val refreshResponse = RefreshTokenResponseJson(
-            accessToken = newAccessToken,
-            expiresIn = 3600,
-            refreshToken = "refreshToken",
-            tokenType = "Bearer",
-        )
         every { parseJwtTokenDataOrNull(JWT_ACCESS_TOKEN) } returns JTW_TOKEN
         every {
             refreshTokenProvider.refreshAccessTokenSynchronously(USER_ID)
-        } returns refreshResponse.asSuccess()
+        } returns newAccessToken.asSuccess()
 
         val authenticatedRequest = authenticator.authenticate(null, RESPONSE_401)
 

--- a/network/src/test/kotlin/com/bitwarden/network/service/IdentityServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/IdentityServiceTest.kt
@@ -312,12 +312,18 @@ class IdentityServiceTest : BaseServiceTest() {
             assertEquals(PREVALIDATE_SSO_ERROR_BODY.asSuccess(), result)
         }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `refreshTokenSynchronously when response is success should return RefreshTokenResponseJson`() {
-        server.enqueue(MockResponse().setResponseCode(200).setBody(REFRESH_TOKEN_JSON))
+    fun `refreshTokenSynchronously when response is success should return Success`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(REFRESH_TOKEN_SUCCESS_JSON))
         val result = identityService.refreshTokenSynchronously(refreshToken = REFRESH_TOKEN)
-        assertEquals(REFRESH_TOKEN_BODY.asSuccess(), result)
+        assertEquals(REFRESH_TOKEN_SUCCESS_BODY.asSuccess(), result)
+    }
+
+    @Test
+    fun `refreshTokenSynchronously when response is error should return Error`() {
+        server.enqueue(MockResponse().setResponseCode(400).setBody(REFRESH_TOKEN_ERROR_JSON))
+        val result = identityService.refreshTokenSynchronously(refreshToken = REFRESH_TOKEN)
+        assertEquals(REFRESH_TOKEN_ERROR_BODY.asSuccess(), result)
     }
 
     @Test
@@ -520,7 +526,17 @@ private val PREVALIDATE_SSO_ERROR_BODY = PrevalidateSsoResponseJson.Error(
     message = "Organization not found from identifier.",
 )
 
-private const val REFRESH_TOKEN_JSON = """
+private const val REFRESH_TOKEN_ERROR_JSON = """
+{
+  "error": "invalid_grant"
+}
+"""
+
+private val REFRESH_TOKEN_ERROR_BODY = RefreshTokenResponseJson.Error(
+    error = "invalid_grant",
+)
+
+private const val REFRESH_TOKEN_SUCCESS_JSON = """
 {
   "access_token": "accessToken",
   "expires_in": 3600,
@@ -529,7 +545,7 @@ private const val REFRESH_TOKEN_JSON = """
 }
 """
 
-private val REFRESH_TOKEN_BODY = RefreshTokenResponseJson(
+private val REFRESH_TOKEN_SUCCESS_BODY = RefreshTokenResponseJson.Success(
     accessToken = "accessToken",
     expiresIn = 3600,
     refreshToken = "refreshToken",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24440](https://bitwarden.atlassian.net/browse/PM-24440)

## 📔 Objective

Add logic to log a user out when an `invalid_grant` is returned from the refresh access token API.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24440]: https://bitwarden.atlassian.net/browse/PM-24440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ