### PR TITLE
Move 'FileData' and 'ShareData' to ui module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
@@ -2,13 +2,13 @@ package com.x8bit.bitwarden.data.platform.manager.model
 
 import android.os.Parcelable
 import androidx.credentials.CredentialManager
+import com.bitwarden.ui.platform.model.ShareData
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
 import com.x8bit.bitwarden.data.credentials.model.Fido2CredentialAssertionRequest
 import com.x8bit.bitwarden.data.credentials.model.GetCredentialsRequest
 import com.x8bit.bitwarden.data.credentials.model.ProviderGetPasswordCredentialRequest
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.vault.model.TotpData
 import kotlinx.parcelize.Parcelize
 
@@ -30,7 +30,7 @@ sealed class SpecialCircumstance : Parcelable {
      */
     @Parcelize
     data class ShareNewSend(
-        val data: IntentManager.ShareData,
+        val data: ShareData,
         val shouldFinishWhenComplete: Boolean,
     ) : SpecialCircumstance()
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModel.kt
@@ -11,6 +11,7 @@ import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.isValidUri
 import com.bitwarden.ui.platform.base.util.orNullIfBlank
 import com.bitwarden.ui.platform.base.util.prefixHttpsIfNecessaryOrNull
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -20,7 +21,6 @@ import com.x8bit.bitwarden.data.platform.manager.model.ImportPrivateKeyResult
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.manager.FileManager
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.keychain.model.PrivateKeyAliasSelectionResult
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
@@ -481,7 +481,7 @@ data class EnvironmentState(
          * Show a dialog to capture the certificate alias and password.
          */
         data class SetCertificateData(
-            val certificateBytes: IntentManager.FileData,
+            val certificateBytes: FileData,
         ) : DialogState()
 
         /**
@@ -626,7 +626,7 @@ sealed class EnvironmentAction {
      * Indicates that the certificate file selection result was received.
      */
     data class ImportCertificateFilePickerResultReceive(
-        val certificateFileData: IntentManager.FileData,
+        val certificateFileData: FileData,
     ) : EnvironmentAction()
 
     /**
@@ -634,7 +634,7 @@ sealed class EnvironmentAction {
      */
     @Parcelize
     data class SetCertificateInfoResultReceive(
-        val certificateFileData: IntentManager.FileData,
+        val certificateFileData: FileData,
         val password: String,
         val alias: String,
     ) : EnvironmentAction(), Parcelable

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.network.model.OrganizationType
 import com.bitwarden.network.util.parseJwtTokenDataOrNull
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.model.ShareData
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
@@ -17,7 +18,6 @@ import com.x8bit.bitwarden.data.credentials.model.GetCredentialsRequest
 import com.x8bit.bitwarden.data.credentials.model.ProviderGetPasswordCredentialRequest
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
@@ -130,8 +130,8 @@ class RootNavViewModel @Inject constructor(
                     is SpecialCircumstance.ShareNewSend -> {
                         RootNavState.VaultUnlockedForNewSend(
                             sendType = when (specialCircumstance.data) {
-                                is IntentManager.ShareData.FileSend -> SendItemType.FILE
-                                is IntentManager.ShareData.TextSend -> SendItemType.TEXT
+                                is ShareData.FileSend -> SendItemType.FILE
+                                is ShareData.TextSend -> SendItemType.TEXT
                             },
                         )
                     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -4,7 +4,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Parcelable
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
 import androidx.compose.runtime.Composable
@@ -12,8 +11,9 @@ import androidx.compose.runtime.Immutable
 import androidx.credentials.provider.AuthenticationAction
 import androidx.credentials.provider.CreateEntry
 import androidx.credentials.provider.CredentialEntry
+import com.bitwarden.ui.platform.model.FileData
+import com.bitwarden.ui.platform.model.ShareData
 import com.x8bit.bitwarden.data.autofill.model.browser.BrowserPackage
-import kotlinx.parcelize.Parcelize
 
 /**
  * A manager class for simplifying the handling of Android Intents within a given context.
@@ -156,36 +156,4 @@ interface IntentManager {
      * Open the default email app on device.
      */
     fun startDefaultEmailApplication()
-
-    /**
-     * Represents file information.
-     */
-    @Parcelize
-    data class FileData(
-        val fileName: String,
-        val uri: Uri,
-        val sizeBytes: Long,
-    ) : Parcelable
-
-    /**
-     * Represents data for a share request coming from outside the app.
-     */
-    sealed class ShareData : Parcelable {
-        /**
-         * The data required to create a new Text Send.
-         */
-        @Parcelize
-        data class TextSend(
-            val subject: String?,
-            val text: String,
-        ) : ShareData()
-
-        /**
-         * The data required to create a new File Send.
-         */
-        @Parcelize
-        data class FileSend(
-            val fileData: FileData,
-        ) : ShareData()
-    }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -11,6 +11,7 @@ import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.send.SendView
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -29,7 +30,6 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateSendResult
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.model.AddEditSendType
@@ -889,7 +889,7 @@ sealed class AddEditSendAction {
     /**
      * User has chosen a file to be part of the send.
      */
-    data class FileChoose(val fileData: IntentManager.FileData) : AddEditSendAction()
+    data class FileChoose(val fileData: FileData) : AddEditSendAction()
 
     /**
      * User clicked the remove password button.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/handlers/AddEditSendHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/handlers/AddEditSendHandlers.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.ui.tools.feature.send.addedit.handlers
 
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.bitwarden.ui.platform.model.FileData
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendAction
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendViewModel
 import java.time.ZonedDateTime
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime
 data class AddEditSendHandlers(
     val onNameChange: (String) -> Unit,
     val onChooseFileClick: (hasPermission: Boolean) -> Unit,
-    val onFileChoose: (IntentManager.FileData) -> Unit,
+    val onFileChoose: (FileData) -> Unit,
     val onTextChange: (String) -> Unit,
     val onIsHideByDefaultToggle: (Boolean) -> Unit,
     val onMaxAccessCountChange: (Int) -> Unit,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/util/SpecialCircumstanceExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/util/SpecialCircumstanceExtensions.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.ui.tools.feature.send.addedit.util
 
+import com.bitwarden.ui.platform.model.ShareData
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendState
 
 /**
@@ -12,7 +12,7 @@ fun SpecialCircumstance?.toSendType(): AddEditSendState.ViewState.Content.SendTy
     when (this) {
         is SpecialCircumstance.ShareNewSend -> {
             when (data) {
-                is IntentManager.ShareData.FileSend -> {
+                is ShareData.FileSend -> {
                     AddEditSendState.ViewState.Content.SendType.File(
                         uri = data.fileData.uri,
                         name = data.fileData.fileName,
@@ -21,7 +21,7 @@ fun SpecialCircumstance?.toSendType(): AddEditSendState.ViewState.Content.SendTy
                     )
                 }
 
-                is IntentManager.ShareData.TextSend -> {
+                is ShareData.TextSend -> {
                     AddEditSendState.ViewState.Content.SendType.Text(
                         input = data.text,
                         isHideByDefaultChecked = false,
@@ -40,8 +40,8 @@ fun SpecialCircumstance?.toSendName(): String? =
     when (this) {
         is SpecialCircumstance.ShareNewSend -> {
             when (data) {
-                is IntentManager.ShareData.FileSend -> data.fileData.fileName
-                is IntentManager.ShareData.TextSend -> data.subject
+                is ShareData.FileSend -> data.fileData.fileName
+                is ShareData.TextSend -> data.subject
             }
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -17,7 +18,6 @@ import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.CreateAttachmentResult
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteAttachmentResult
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.vault.feature.attachments.util.toViewState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
@@ -488,7 +488,7 @@ sealed class AttachmentsAction {
      * User has chosen the file attachment.
      */
     data class FileChoose(
-        val fileData: IntentManager.FileData,
+        val fileData: FileData,
     ) : AttachmentsAction()
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/handlers/AttachmentsHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/handlers/AttachmentsHandlers.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.ui.vault.feature.attachments.handlers
 
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
+import com.bitwarden.ui.platform.model.FileData
 import com.x8bit.bitwarden.ui.vault.feature.attachments.AttachmentsAction
 import com.x8bit.bitwarden.ui.vault.feature.attachments.AttachmentsViewModel
 
@@ -11,7 +11,7 @@ data class AttachmentsHandlers(
     val onBackClick: () -> Unit,
     val onSaveClick: () -> Unit,
     val onChooseFileClick: () -> Unit,
-    val onFileChoose: (IntentManager.FileData) -> Unit,
+    val onFileChoose: (FileData) -> Unit,
     val onDeleteClick: (attachmentId: String) -> Unit,
     val onDismissRequest: () -> Unit,
 ) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -13,6 +13,7 @@ import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
+import com.bitwarden.ui.platform.model.ShareData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.bitwarden.vault.CipherView
@@ -449,7 +450,7 @@ class MainViewModelTest : BaseViewModelTest() {
     fun `on ReceiveFirstIntent with share data should set the special circumstance to ShareNewSend`() {
         val viewModel = createViewModel()
         val mockIntent = createMockIntent()
-        val shareData = mockk<IntentManager.ShareData>()
+        val shareData = mockk<ShareData>()
         every { intentManager.getShareDataFromIntent(mockIntent) } returns shareData
 
         viewModel.trySendAction(
@@ -850,7 +851,7 @@ class MainViewModelTest : BaseViewModelTest() {
     fun `on ReceiveNewIntent with share data should set the special circumstance to ShareNewSend`() {
         val viewModel = createViewModel()
         val mockIntent = createMockIntent()
-        val shareData = mockk<IntentManager.ShareData>()
+        val shareData = mockk<ShareData>()
         every { intentManager.getShareDataFromIntent(mockIntent) } returns shareData
 
         viewModel.trySendAction(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreenTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.auth.feature.environment.EnvironmentState.DialogState
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
@@ -366,7 +367,7 @@ class EnvironmentScreenTest : BitwardenComposeTest() {
     @Suppress("MaxLineLength")
     @Test
     fun `ConfirmOverwriteCertificate dialog Replace certificate click should send ConfirmOverwriteCertificate action`() {
-        val mockFileData = mockk<IntentManager.FileData>()
+        val mockFileData = mockk<FileData>()
         mutableStateFlow.update {
             it.copy(
                 dialog = DialogState.ConfirmOverwriteAlias(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentViewModelTest.kt
@@ -7,6 +7,7 @@ import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.platform.datasource.disk.model.MutualTlsKeyHost
@@ -15,7 +16,6 @@ import com.x8bit.bitwarden.data.platform.manager.model.ImportPrivateKeyResult
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.vault.manager.FileManager
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.keychain.model.PrivateKeyAliasSelectionResult
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
@@ -423,7 +423,7 @@ class EnvironmentViewModelTest : BaseViewModelTest() {
     fun `ImportCertificateFilePickerResultReceive should show SetCertificateData dialog`() =
         runTest {
             val viewModel = createViewModel()
-            val mockFileData = mockk<IntentManager.FileData>()
+            val mockFileData = mockk<FileData>()
             viewModel.trySendAction(
                 EnvironmentAction.ImportCertificateFilePickerResultReceive(
                     certificateFileData = mockFileData,
@@ -587,7 +587,7 @@ class EnvironmentViewModelTest : BaseViewModelTest() {
         runTest {
             val viewModel = createViewModel()
             val mockUri = mockk<Uri>()
-            val mockFileData = IntentManager.FileData(
+            val mockFileData = FileData(
                 fileName = "mockFileName",
                 uri = mockUri,
                 sizeBytes = 0,
@@ -708,7 +708,7 @@ class EnvironmentViewModelTest : BaseViewModelTest() {
         runTest {
             val viewModel = createViewModel()
             val mockUri = mockk<Uri>()
-            val mockFileData = IntentManager.FileData(
+            val mockFileData = FileData(
                 fileName = "mockFileName",
                 uri = mockUri,
                 sizeBytes = 0,
@@ -740,7 +740,7 @@ class EnvironmentViewModelTest : BaseViewModelTest() {
     fun `ConfirmOverwriteCertificateClick should clear dialog and import certificate`() = runTest {
         val viewModel = createViewModel()
         val mockUri = mockk<Uri>()
-        val mockFileData = IntentManager.FileData(
+        val mockFileData = FileData(
             fileName = "mockFileName",
             uri = mockUri,
             sizeBytes = 0,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -7,6 +7,7 @@ import com.bitwarden.network.model.JwtTokenDataJson
 import com.bitwarden.network.model.OrganizationType
 import com.bitwarden.network.util.parseJwtTokenDataOrNull
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.bitwarden.ui.platform.model.ShareData
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
@@ -23,7 +24,6 @@ import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.model.CompleteRegistrationData
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
 import io.mockk.every
 import io.mockk.mockk
@@ -530,7 +530,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
     fun `when the active user has an unlocked vault but the is a ShareNewSend special circumstance the nav state should be VaultUnlockedForNewSend`() {
         specialCircumstanceManager.specialCircumstance =
             SpecialCircumstance.ShareNewSend(
-                data = mockk<IntentManager.ShareData.TextSend>(),
+                data = mockk<ShareData.TextSend>(),
                 shouldFinishWhenComplete = true,
             )
         mutableUserStateFlow.tryEmit(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -9,6 +9,7 @@ import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.send.SendView
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -29,7 +30,6 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateSendResult
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelay
 import com.x8bit.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.model.AddEditSendType
@@ -799,7 +799,7 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
         val fileName = "test.png"
         val uri = mockk<Uri>()
         val size = 50L
-        val fileData = IntentManager.FileData(
+        val fileData = FileData(
             fileName = fileName,
             uri = uri,
             sizeBytes = size,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/util/SpecialCircumstanceExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/util/SpecialCircumstanceExtensionsTest.kt
@@ -1,8 +1,9 @@
 package com.x8bit.bitwarden.ui.tools.feature.send.addedit.util
 
 import android.net.Uri
+import com.bitwarden.ui.platform.model.FileData
+import com.bitwarden.ui.platform.model.ShareData
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendState
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -21,7 +22,7 @@ class SpecialCircumstanceExtensionsTest {
             isHideByDefaultChecked = false,
         )
         val specialCircumstance = SpecialCircumstance.ShareNewSend(
-            data = IntentManager.ShareData.TextSend(
+            data = ShareData.TextSend(
                 subject = "",
                 text = text,
             ),
@@ -45,8 +46,8 @@ class SpecialCircumstanceExtensionsTest {
             displaySize = null,
         )
         val specialCircumstance = SpecialCircumstance.ShareNewSend(
-            data = IntentManager.ShareData.FileSend(
-                fileData = IntentManager.FileData(
+            data = ShareData.FileSend(
+                fileData = FileData(
                     fileName = fileName,
                     uri = uri,
                     sizeBytes = sizeBytes,
@@ -70,7 +71,7 @@ class SpecialCircumstanceExtensionsTest {
     fun `toSendName with TextSend should return subject`() {
         val subject = "Subject"
         val specialCircumstance = SpecialCircumstance.ShareNewSend(
-            data = IntentManager.ShareData.TextSend(
+            data = ShareData.TextSend(
                 subject = subject,
                 text = "",
             ),
@@ -86,8 +87,8 @@ class SpecialCircumstanceExtensionsTest {
     fun `toSendName with FileSend should return file name`() {
         val fileName = "File Name"
         val specialCircumstance = SpecialCircumstance.ShareNewSend(
-            data = IntentManager.ShareData.FileSend(
-                fileData = IntentManager.FileData(
+            data = ShareData.FileSend(
+                fileData = FileData(
                     fileName = fileName,
                     uri = mockk(),
                     sizeBytes = 0L,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
@@ -19,7 +20,6 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.CreateAttachmentResult
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteAttachmentResult
-import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.vault.feature.attachments.util.toViewState
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -159,7 +159,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
             ),
             isPremiumUser = true,
         )
-        val fileData = IntentManager.FileData(
+        val fileData = FileData(
             fileName = fileName,
             uri = uri,
             sizeBytes = sizeToBig,
@@ -204,7 +204,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                 ),
                 isPremiumUser = true,
             )
-            val fileData = IntentManager.FileData(
+            val fileData = FileData(
                 fileName = fileName,
                 uri = uri,
                 sizeBytes = sizeJustRight,
@@ -279,7 +279,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
                 ),
                 isPremiumUser = true,
             )
-            val fileData = IntentManager.FileData(
+            val fileData = FileData(
                 fileName = fileName,
                 uri = uri,
                 sizeBytes = sizeJustRight,
@@ -350,7 +350,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
             ),
             isPremiumUser = true,
         )
-        val fileData = IntentManager.FileData(
+        val fileData = FileData(
             fileName = fileName,
             uri = uri,
             sizeBytes = sizeJustRight,
@@ -414,7 +414,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
     @Test
     fun `ChooseFile should update state with new file data`() = runTest {
         val uri = createMockUri()
-        val fileData = IntentManager.FileData(
+        val fileData = FileData(
             fileName = "filename-1",
             uri = uri,
             sizeBytes = 100L,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepository.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepository.kt
@@ -11,8 +11,8 @@ import com.bitwarden.authenticator.data.authenticator.repository.model.TotpCodeR
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportDataResult
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportFileFormat
 import com.bitwarden.authenticator.ui.platform.feature.settings.export.model.ExportVaultFormat
-import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.ui.platform.model.FileData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -82,7 +82,7 @@ interface AuthenticatorRepository {
      */
     suspend fun importVaultData(
         format: ImportFileFormat,
-        fileData: IntentManager.FileData,
+        fileData: FileData,
     ): ImportDataResult
 
     /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/AuthenticatorRepositoryImpl.kt
@@ -21,13 +21,13 @@ import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportDat
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportFileFormat
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticator.ui.platform.feature.settings.export.model.ExportVaultFormat
-import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.authenticatorbridge.manager.model.AccountSyncState
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.repository.util.map
 import com.bitwarden.data.manager.DispatcherManager
+import com.bitwarden.ui.platform.model.FileData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
@@ -248,7 +248,7 @@ class AuthenticatorRepositoryImpl @Inject constructor(
 
     override suspend fun importVaultData(
         format: ImportFileFormat,
-        fileData: IntentManager.FileData,
+        fileData: FileData,
     ): ImportDataResult = fileManager.uriToByteArray(fileData.uri)
         .map {
             importManager

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
@@ -38,6 +38,7 @@ import com.bitwarden.authenticator.ui.platform.composition.LocalIntentManager
 import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.authenticator.ui.platform.util.displayLabel
 import com.bitwarden.ui.platform.base.util.EventsEffect
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import kotlinx.collections.immutable.toImmutableList
@@ -54,7 +55,7 @@ fun ImportingScreen(
     onNavigateBack: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val importLocationReceive: (IntentManager.FileData) -> Unit = remember {
+    val importLocationReceive: (FileData) -> Unit = remember {
         {
             viewModel.trySendAction(ImportAction.ImportLocationReceive(it))
         }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportDataResult
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportFileFormat
-import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -202,7 +202,7 @@ sealed class ImportAction {
     /**
      * Indicates the user selected a file to import.
      */
-    data class ImportLocationReceive(val fileUri: IntentManager.FileData) : ImportAction()
+    data class ImportLocationReceive(val fileUri: FileData) : ImportAction()
 
     /**
      * Models actions the [ImportingScreen] itself may send.

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManager.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManager.kt
@@ -2,12 +2,11 @@ package com.bitwarden.authenticator.ui.platform.manager.intent
 
 import android.content.Intent
 import android.net.Uri
-import android.os.Parcelable
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import kotlinx.parcelize.Parcelize
+import com.bitwarden.ui.platform.model.FileData
 
 /**
  * A manager class for simplifying the handling of Android Intents within a given context.
@@ -58,14 +57,4 @@ interface IntentManager {
      * Creates an intent to use when selecting to save an item with [fileName] to disk.
      */
     fun createDocumentIntent(fileName: String): Intent
-
-    /**
-     * Represents file information.
-     */
-    @Parcelize
-    data class FileData(
-        val fileName: String,
-        val uri: Uri,
-        val sizeBytes: Long,
-    ) : Parcelable
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/model/FileData.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/model/FileData.kt
@@ -1,0 +1,15 @@
+package com.bitwarden.ui.platform.model
+
+import android.net.Uri
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Represents file information.
+ */
+@Parcelize
+data class FileData(
+    val fileName: String,
+    val uri: Uri,
+    val sizeBytes: Long,
+) : Parcelable

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/model/ShareData.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/model/ShareData.kt
@@ -1,0 +1,26 @@
+package com.bitwarden.ui.platform.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Represents data for a share request coming from outside the app.
+ */
+sealed class ShareData : Parcelable {
+    /**
+     * The data required to create a new Text Send.
+     */
+    @Parcelize
+    data class TextSend(
+        val subject: String?,
+        val text: String,
+    ) : ShareData()
+
+    /**
+     * The data required to create a new File Send.
+     */
+    @Parcelize
+    data class FileSend(
+        val fileData: FileData,
+    ) : ShareData()
+}


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR moves the 'FileData' and 'ShareData' classes to ui module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
