### PR TITLE
Fix autofill overwriting user data with empty field values

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
@@ -122,9 +122,15 @@ class FilledDataBuilderImpl(
                     is AutofillView.Card.Number -> autofillCipher.number
                     is AutofillView.Card.SecurityCode -> autofillCipher.code
                 }
-                autofillView.buildFilledItemOrNull(
-                    value = value,
-                )
+                // Only create FilledItem if the value is not empty to avoid overwriting
+                // user-entered data with empty values
+                if (value.isNotEmpty()) {
+                    autofillView.buildFilledItemOrNull(
+                        value = value,
+                    )
+                } else {
+                    null
+                }
             }
 
         return FilledPartition(
@@ -149,9 +155,15 @@ class FilledDataBuilderImpl(
                     is AutofillView.Login.Username -> autofillCipher.username
                     is AutofillView.Login.Password -> autofillCipher.password
                 }
-                autofillView.buildFilledItemOrNull(
-                    value = value,
-                )
+                // Only create FilledItem if the value is not empty to avoid overwriting
+                // user-entered data with empty values
+                if (value.isNotEmpty()) {
+                    autofillView.buildFilledItemOrNull(
+                        value = value,
+                    )
+                } else {
+                    null
+                }
             }
 
         return FilledPartition(


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #5648

## 📔 Objective

Fix Android autofill service overwriting user-entered form data with empty values when vault items contain empty fields.  
This affects both login credentials (username/password) and payment card information, preventing data loss and improving user experience.   

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
