### PR TITLE
PM-24481: Logout when token refresh API returns 401 or 403

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -779,10 +779,19 @@ class AuthRepositoryImpl(
                 when (refreshTokenResponse) {
                     is RefreshTokenResponseJson.Error -> {
                         if (refreshTokenResponse.isInvalidGrant) {
-                            // We only logout for an invalid grant
                             logout(userId = userId, reason = LogoutReason.InvalidGrant)
                         }
                         IllegalStateException(refreshTokenResponse.error).asFailure()
+                    }
+
+                    is RefreshTokenResponseJson.Forbidden -> {
+                        logout(userId = userId, reason = LogoutReason.RefreshForbidden)
+                        refreshTokenResponse.error.asFailure()
+                    }
+
+                    is RefreshTokenResponseJson.Unauthorized -> {
+                        logout(userId = userId, reason = LogoutReason.RefreshUnauthorized)
+                        refreshTokenResponse.error.asFailure()
                     }
 
                     is RefreshTokenResponseJson.Success -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LogoutReason.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LogoutReason.kt
@@ -36,6 +36,18 @@ sealed class LogoutReason {
     data object InvalidGrant : LogoutReason()
 
     /**
+     * Indicates that the logout is happening because the there was a "Forbidden" response from
+     * token refresh API.
+     */
+    data object RefreshForbidden : LogoutReason()
+
+    /**
+     * Indicates that the logout is happening because the there was a "Unauthorized" response from
+     * token refresh API.
+     */
+    data object RefreshUnauthorized : LogoutReason()
+
+    /**
      * Indicates that the logout is happening because of an invalid state.
      */
     data class InvalidState(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -878,21 +878,88 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `refreshAccessTokenSynchronously returns failure and logs out on failure`() = runTest {
-        fakeAuthDiskSource.storeAccountTokens(
-            userId = USER_ID_1,
-            accountTokens = ACCOUNT_TOKENS_1,
-        )
-        coEvery {
-            identityService.refreshTokenSynchronously(REFRESH_TOKEN)
-        } returns Throwable("Fail").asFailure()
+    fun `refreshAccessTokenSynchronously returns failure if refreshTokenSynchronously fails`() =
+        runTest {
+            fakeAuthDiskSource.storeAccountTokens(
+                userId = USER_ID_1,
+                accountTokens = ACCOUNT_TOKENS_1,
+            )
+            coEvery {
+                identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+            } returns Throwable("Fail").asFailure()
 
-        assertTrue(repository.refreshAccessTokenSynchronously(USER_ID_1).isFailure)
+            assertTrue(repository.refreshAccessTokenSynchronously(USER_ID_1).isFailure)
 
-        coVerify(exactly = 1) {
-            identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+            coVerify(exactly = 1) {
+                identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+            }
         }
-    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `refreshAccessTokenSynchronously returns logs out and returns failure if refreshTokenSynchronously returns invalid_grant`() =
+        runTest {
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+            fakeAuthDiskSource.storeAccountTokens(
+                userId = USER_ID_1,
+                accountTokens = ACCOUNT_TOKENS_1,
+            )
+            coEvery {
+                identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+            } returns RefreshTokenResponseJson.Error(error = "invalid_grant").asSuccess()
+
+            assertTrue(repository.refreshAccessTokenSynchronously(USER_ID_1).isFailure)
+
+            coVerify(exactly = 1) {
+                identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+                userLogoutManager.logout(userId = USER_ID_1, reason = LogoutReason.InvalidGrant)
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `refreshAccessTokenSynchronously returns logs out and returns failure if refreshTokenSynchronously returns Forbidden`() =
+        runTest {
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+            fakeAuthDiskSource.storeAccountTokens(
+                userId = USER_ID_1,
+                accountTokens = ACCOUNT_TOKENS_1,
+            )
+            coEvery {
+                identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+            } returns RefreshTokenResponseJson.Forbidden(error = Throwable("Fail!")).asSuccess()
+
+            assertTrue(repository.refreshAccessTokenSynchronously(USER_ID_1).isFailure)
+
+            coVerify(exactly = 1) {
+                identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+                userLogoutManager.logout(userId = USER_ID_1, reason = LogoutReason.RefreshForbidden)
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `refreshAccessTokenSynchronously returns logs out and returns failure if refreshTokenSynchronously returns Unauthorized`() =
+        runTest {
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+            fakeAuthDiskSource.storeAccountTokens(
+                userId = USER_ID_1,
+                accountTokens = ACCOUNT_TOKENS_1,
+            )
+            coEvery {
+                identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+            } returns RefreshTokenResponseJson.Unauthorized(error = Throwable("Fail!")).asSuccess()
+
+            assertTrue(repository.refreshAccessTokenSynchronously(USER_ID_1).isFailure)
+
+            coVerify(exactly = 1) {
+                identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+                userLogoutManager.logout(
+                    userId = USER_ID_1,
+                    reason = LogoutReason.RefreshUnauthorized,
+                )
+            }
+        }
 
     @Test
     fun `refreshAccessTokenSynchronously returns success and sets account tokens`() = runTest {

--- a/network/src/main/kotlin/com/bitwarden/network/model/RefreshTokenResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/RefreshTokenResponseJson.kt
@@ -40,4 +40,18 @@ sealed class RefreshTokenResponseJson {
     ) : RefreshTokenResponseJson() {
         val isInvalidGrant: Boolean get() = error == "invalid_grant"
     }
+
+    /**
+     * Models a failure response with a 403 "Forbidden" response code.
+     */
+    data class Forbidden(
+        val error: Throwable,
+    ) : RefreshTokenResponseJson()
+
+    /**
+     * Models a failure response with a 401 "Unauthorized" response code.
+     */
+    data class Unauthorized(
+        val error: Throwable,
+    ) : RefreshTokenResponseJson()
 }

--- a/network/src/main/kotlin/com/bitwarden/network/util/ExceptionExtensions.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/util/ExceptionExtensions.kt
@@ -6,6 +6,14 @@ import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 
 /**
+ * Returns the [NetworkErrorCode] for the given error if it is available.
+ */
+internal fun BitwardenError.getNetworkErrorCodeOrNull(): NetworkErrorCode? =
+    (this as? BitwardenError.Http)?.let { httpError ->
+        NetworkErrorCode.entries.firstOrNull { httpError.code == it.code }
+    }
+
+/**
  * Attempt to parse the error body to serializable type [T].
  *
  * Useful in service layer for parsing non-200 response bodies.

--- a/network/src/main/kotlin/com/bitwarden/network/util/NetworkErrorCode.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/util/NetworkErrorCode.kt
@@ -7,5 +7,7 @@ internal enum class NetworkErrorCode(
     val code: Int,
 ) {
     BAD_REQUEST(code = 400),
+    UNAUTHORIZED(code = 401),
+    FORBIDDEN(code = 403),
     TOO_MANY_REQUESTS(code = 429),
 }

--- a/network/src/test/kotlin/com/bitwarden/network/service/IdentityServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/IdentityServiceTest.kt
@@ -334,6 +334,20 @@ class IdentityServiceTest : BaseServiceTest() {
     }
 
     @Test
+    fun `refreshTokenSynchronously when response is a 403 error should return an Forbidden`() {
+        server.enqueue(MockResponse().setResponseCode(403))
+        val result = identityService.refreshTokenSynchronously(refreshToken = REFRESH_TOKEN)
+        assertTrue(result.getOrThrow() is RefreshTokenResponseJson.Forbidden)
+    }
+
+    @Test
+    fun `refreshTokenSynchronously when response is a 401 error should return an Unauthorized`() {
+        server.enqueue(MockResponse().setResponseCode(401))
+        val result = identityService.refreshTokenSynchronously(refreshToken = REFRESH_TOKEN)
+        assertTrue(result.getOrThrow() is RefreshTokenResponseJson.Unauthorized)
+    }
+
+    @Test
     fun `registerFinish success json should be Success`() = runTest {
         val expectedResponse = RegisterResponseJson.Success(
             captchaBypassToken = "mock_token",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24481](https://bitwarden.atlassian.net/browse/PM-24481)

## 📔 Objective

This PR updates the refresh API to log the user out if a 401 (unauthorized) or 403 (forbidden) is returned from the server.
This is in addition to the logging out if a 400 (bad request) is returned with the `invalid_grant` response.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
