### PR TITLE
[PM-24411] Introduce BuildInfoManager for build-related information

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/BitwardenBuildInfoManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/BitwardenBuildInfoManagerImpl.kt
@@ -1,0 +1,42 @@
+package com.x8bit.bitwarden.ui.platform.manager
+
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.core.data.manager.BuildInfoManager
+import com.x8bit.bitwarden.BuildConfig
+
+/**
+ * Implementation of [BuildInfoManager] for Bitwarden Password Manager.
+ */
+@OmitFromCoverage
+class BitwardenBuildInfoManagerImpl : BuildInfoManager {
+    override val applicationId: String
+        get() = BuildConfig.APPLICATION_ID
+
+    override val isFdroid: Boolean
+        get() = BuildConfig.FLAVOR == "fdroid"
+
+    override val isDevBuild: Boolean
+        get() = BuildConfig.BUILD_TYPE == "debug"
+
+    override val versionData: String
+        get() = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+
+    override val sdkData: String
+        get() = BuildConfig.SDK_VERSION
+
+    override val ciBuildInfo: String?
+        get() = BuildConfig.CI_INFO.takeUnless { it.isBlank() }
+
+    override val buildFlavorName: String
+        get() = when (BuildConfig.FLAVOR) {
+            "standard" -> ""
+            else -> "-${BuildConfig.FLAVOR}"
+        }
+
+    override val buildTypeName: String
+        get() = when (BuildConfig.BUILD_TYPE) {
+            "debug" -> "dev"
+            "release" -> "prod"
+            else -> BuildConfig.BUILD_TYPE
+        }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/di/PlatformUiManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/di/PlatformUiManagerModule.kt
@@ -1,7 +1,9 @@
 package com.x8bit.bitwarden.ui.platform.manager.di
 
 import android.content.Context
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.data.manager.DispatcherManager
+import com.x8bit.bitwarden.ui.platform.manager.BitwardenBuildInfoManagerImpl
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManagerImpl
 import com.x8bit.bitwarden.ui.platform.manager.resource.ResourceManager
@@ -21,7 +23,11 @@ import javax.inject.Singleton
  */
 @Module
 @InstallIn(SingletonComponent::class)
-class PlatformUiManagerModule {
+object PlatformUiManagerModule {
+
+    @Provides
+    @Singleton
+    fun provideBuildInfoManager(): BuildInfoManager = BitwardenBuildInfoManagerImpl()
 
     @Provides
     @Singleton

--- a/authenticator/build.gradle.kts
+++ b/authenticator/build.gradle.kts
@@ -2,6 +2,8 @@ import com.android.build.gradle.internal.api.BaseVariantOutputImpl
 import com.google.protobuf.gradle.proto
 import dagger.hilt.android.plugin.util.capitalize
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.io.FileInputStream
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
@@ -16,6 +18,16 @@ plugins {
     alias(libs.plugins.google.protobuf)
     alias(libs.plugins.google.services)
     alias(libs.plugins.sonarqube)
+}
+
+/**
+ * Loads CI-specific build properties that are not checked into source control.
+ */
+val ciProperties = Properties().apply {
+    val ciPropsFile = File(rootDir, "ci.properties")
+    if (ciPropsFile.exists()) {
+        FileInputStream(ciPropsFile).use { load(it) }
+    }
 }
 
 android {
@@ -34,6 +46,17 @@ android {
         versionName = libs.versions.appVersionName.get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField(
+            type = "String",
+            name = "CI_INFO",
+            value = "${ciProperties.getOrDefault("ci.info", "\"\uD83D\uDCBB local\"")}",
+        )
+        buildConfigField(
+            type = "String",
+            name = "SDK_VERSION",
+            value = "\"${libs.versions.bitwardenSdk.get()}\"",
+        )
     }
 
     androidResources {

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/AuthenticatorBuildInfoManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/AuthenticatorBuildInfoManagerImpl.kt
@@ -1,0 +1,47 @@
+package com.bitwarden.authenticator.ui.platform.manager
+
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.authenticator.BuildConfig
+import com.bitwarden.core.data.manager.BuildInfoManager
+
+/**
+ * Implementation of [BuildInfoManager] for Bitwarden Authenticator.
+ */
+@OmitFromCoverage
+class AuthenticatorBuildInfoManagerImpl : BuildInfoManager {
+    override val applicationId: String
+        get() = BuildConfig.APPLICATION_ID
+
+    /**
+     * Indicates whether the build is from the F-Droid flavor.
+     * This is always false for Authenticator as it does not have an F-Droid compatible flavor.
+     */
+    override val isFdroid: Boolean
+        get() = false
+
+    override val isDevBuild: Boolean
+        get() = BuildConfig.BUILD_TYPE == "debug"
+
+    override val versionData: String
+        get() = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+
+    override val sdkData: String
+        get() = BuildConfig.SDK_VERSION
+
+    override val ciBuildInfo: String?
+        get() = BuildConfig.CI_INFO.takeUnless { it.isBlank() }
+
+    /**
+     * Returns the build flavor name.
+     * For Authenticator, this is always an empty string as it does not have different flavors.
+     */
+    override val buildFlavorName: String
+        get() = ""
+
+    override val buildTypeName: String
+        get() = when (BuildConfig.BUILD_TYPE) {
+            "debug" -> "dev"
+            "release" -> "prod"
+            else -> BuildConfig.BUILD_TYPE
+        }
+}

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/BuildInfoManager.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/BuildInfoManager.kt
@@ -1,0 +1,51 @@
+package com.bitwarden.core.data.manager
+
+/**
+ * An manager interface for accessing build information for a Bitwarden client application.
+ *
+ * This interface provides properties to access various build-related information such as
+ * whether the build is an F-Droid flavor, if it's a dev build, and details about the app version,
+ * SDK version, device information, and CI build info.
+ */
+interface BuildInfoManager {
+
+    /**
+     * The ID of the running application.
+     */
+    val applicationId: String
+
+    /**
+     * A boolean property that indicates whether the current build flavor is "fdroid".
+     */
+    val isFdroid: Boolean
+
+    /**
+     * A boolean property that indicates whether the current build is a dev build.
+     */
+    val isDevBuild: Boolean
+
+    /**
+     * A string that represents a displayable app version.
+     */
+    val versionData: String
+
+    /**
+     * A string that represents a displayable SDK version.
+     */
+    val sdkData: String
+
+    /**
+     * A string representing the CI information if available.
+     */
+    val ciBuildInfo: String?
+
+    /**
+     * A string representing the build flavor or blank if it is the standard configuration.
+     */
+    val buildFlavorName: String
+
+    /**
+     * A string representing the build type.
+     */
+    val buildTypeName: String
+}

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/util/BuildInfoManagerExtensions.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/util/BuildInfoManagerExtensions.kt
@@ -1,0 +1,38 @@
+@file:OmitFromCoverage
+
+package com.bitwarden.ui.platform.manager.util
+
+import android.os.Build
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.core.data.manager.BuildInfoManager
+
+/**
+ * A string representing the device brand and model.
+ */
+val BuildInfoManager.deviceBrandModel: String
+    get() = "\uD83D\uDCF1 ${Build.BRAND} ${Build.MODEL}"
+
+/**
+ * A string representing the operating system information.
+ */
+val BuildInfoManager.osInfo: String
+    get() = "\uD83E\uDD16 ${Build.VERSION.RELEASE}@${Build.VERSION.SDK_INT}"
+
+/**
+ * A string representing the build information.
+ */
+val BuildInfoManager.buildInfo: String
+    get() = "\uD83D\uDCE6 $buildTypeName" +
+        buildFlavorName.takeUnless { it.isBlank() }?.let { " $it" }.orEmpty()
+
+/**
+ * A string that represents device data.
+ */
+val BuildInfoManager.deviceData: String
+    get() = "$deviceBrandModel $osInfo $buildInfo"
+
+/**
+ * The authority for the FileProvider used in the application.
+ */
+val BuildInfoManager.fileProviderAuthority: String
+    get() = "$applicationId.fileprovider"


### PR DESCRIPTION
## 🎟️ Tracking

PM-24411

## 📔 Objective

This commit introduces a `BuildInfoManager` interface and its implementations to centralize access to build-specific information across different Bitwarden client applications.

Key changes:
- Added `BuildInfoManager` interface in the `ui` module to define a contract for accessing build details like application ID, flavor, build type, version, and CI information.
- Created `BitwardenBuildInfoManagerImpl` in the `app` module, providing the implementation for the Bitwarden Password Manager, sourcing data from its `BuildConfig`.
- Created `AuthenticatorBuildInfoManagerImpl` in the `authenticator` module, providing the implementation for Bitwarden Authenticator, sourcing data from its `BuildConfig`.
- Added `BuildInfoManagerExtensions.kt` in the `ui` module, offering convenient extension properties for formatted device, OS, and build information, and FileProvider authority.
- Updated `PlatformUiManagerModule` in the `app` module to provide `BuildInfoManager` as a singleton dependency.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
