### PR TITLE
Require RefreshAuthenticator to be nonnull

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/retrofit/RetrofitsImpl.kt
@@ -30,7 +30,7 @@ internal class RetrofitsImpl(
     authTokenInterceptor: AuthTokenInterceptor,
     baseUrlInterceptors: BaseUrlInterceptors,
     headersInterceptor: HeadersInterceptor,
-    refreshAuthenticator: RefreshAuthenticator?,
+    refreshAuthenticator: RefreshAuthenticator,
     json: Json,
     private val certificateProvider: CertificateProvider,
     private val logHttpBody: Boolean = false,
@@ -106,9 +106,7 @@ internal class RetrofitsImpl(
         baseOkHttpClient
             .newBuilder()
             .addInterceptor(authTokenInterceptor)
-            .also { builder ->
-                refreshAuthenticator?.let { builder.authenticator(it) }
-            }
+            .authenticator(refreshAuthenticator)
             .build()
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR cleans up the usage of the `RefreshAuthenticator` by requiring it to be nonnull. The parameter was already nonnull all circumstances.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
