### PR TITLE
[PM-24411] Add MIME type parameter to file chooser intent

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -95,8 +95,12 @@ interface IntentManager {
 
     /**
      * Creates an intent for choosing a file saved to disk.
+     *
+     * @param withCameraIntents Whether to include camera intents in the chooser.
+     * @param mimeType The MIME type of the files to be selected. Defaults to wildcard to allow all
+     * types.
      */
-    fun createFileChooserIntent(withCameraIntents: Boolean): Intent
+    fun createFileChooserIntent(withCameraIntents: Boolean, mimeType: String = "*/*"): Intent
 
     /**
      * Creates an intent to use when selecting to save an item with [fileName] to disk.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -228,11 +228,11 @@ class IntentManagerImpl(
         }
     }
 
-    override fun createFileChooserIntent(withCameraIntents: Boolean): Intent {
+    override fun createFileChooserIntent(withCameraIntents: Boolean, mimeType: String): Intent {
         val chooserIntent = Intent.createChooser(
             Intent(Intent.ACTION_OPEN_DOCUMENT)
                 .addCategory(Intent.CATEGORY_OPENABLE)
-                .setType("*/*"),
+                .setType(mimeType),
             ContextCompat.getString(context, BitwardenString.file_source),
         )
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-24411

## 📔 Objective

This commit modifies the `createFileChooserIntent` method in `IntentManager` and its implementation `IntentManagerImpl` to accept an optional `mimeType` parameter.

Key changes:
- `IntentManager.createFileChooserIntent` now has a `mimeType` parameter, which defaults to `"*/*"` to allow all file types.
- `IntentManagerImpl.createFileChooserIntent` now uses the provided `mimeType` when creating the `ACTION_OPEN_DOCUMENT` intent.
- KDoc for `createFileChooserIntent` has been updated to reflect the new `mimeType` parameter.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
