### PR TITLE
[PM-24575] Add feature flag for AEAD enrollment on key rotation

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -31,6 +31,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CipherKeyEncryption,
     FlagKey.UserManagedPrivilegedApps,
     FlagKey.RemoveCardPolicy,
+    FlagKey.EnrollAeadOnKeyRotation,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -82,5 +83,9 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.RemoveCardPolicy -> stringResource(BitwardenString.remove_card_policy)
     FlagKey.BitwardenAuthenticationEnabled -> {
         stringResource(BitwardenString.bitwarden_authentication_enabled)
+    }
+
+    FlagKey.EnrollAeadOnKeyRotation -> {
+        stringResource(BitwardenString.enroll_aead_on_key_rotation)
     }
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -28,6 +28,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CredentialExchangeProtocolImport,
     FlagKey.RemoveCardPolicy,
     FlagKey.UserManagedPrivilegedApps,
+    FlagKey.EnrollAeadOnKeyRotation,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
         key = flagKey as FlagKey<Boolean>,
@@ -75,5 +76,9 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.RemoveCardPolicy -> stringResource(BitwardenString.remove_card_policy)
     FlagKey.BitwardenAuthenticationEnabled -> {
         stringResource(BitwardenString.bitwarden_authentication_enabled)
+    }
+
+    FlagKey.EnrollAeadOnKeyRotation -> {
+        stringResource(BitwardenString.enroll_aead_on_key_rotation)
     }
 }

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -89,6 +89,14 @@ sealed class FlagKey<out T : Any> {
         override val defaultValue: Boolean = false
     }
 
+    /**
+     * Represents the feature flag to enable the enrollment of AEAD on key rotation.
+     */
+    data object EnrollAeadOnKeyRotation : FlagKey<Boolean>() {
+        override val keyName: String = "enroll-aead-on-key-rotation"
+        override val defaultValue: Boolean = false
+    }
+
     //region Dummy keys for testing
     /**
      * Data object holding the key for a [Boolean] flag to be used in tests.

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -32,6 +32,10 @@ class FlagKeyTest {
             FlagKey.BitwardenAuthenticationEnabled.keyName,
             "bitwarden-authentication-enabled",
         )
+        assertEquals(
+            FlagKey.EnrollAeadOnKeyRotation.keyName,
+            "enroll-aead-on-key-rotation",
+        )
     }
 
     @Test
@@ -44,6 +48,7 @@ class FlagKeyTest {
                 FlagKey.UserManagedPrivilegedApps,
                 FlagKey.RemoveCardPolicy,
                 FlagKey.BitwardenAuthenticationEnabled,
+                FlagKey.EnrollAeadOnKeyRotation,
             ).all {
                 !it.defaultValue
             },

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -28,6 +28,7 @@
     <string name="import_format_label_2fas_json">2FAS (no password)</string>
     <string name="import_format_label_lastpass_json">LastPass (.json)</string>
     <string name="import_format_label_aegis_json">Aegis (.json)</string>
+    <string name="enroll_aead_on_key_rotation">Enroll AEAD on key rotation</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

PM-24575

## 📔 Objective

This commit introduces a new feature flag, `EnrollAeadOnKeyRotation`.

Note, the feature flag is not "active" so it will not display in the debug menu at this time.

The changes include:
- Defining the `EnrollAeadOnKeyRotation` `FlagKey` in `core`.
- Adding the new flag to the debug menu feature flag list in both `app` and `authenticator` modules.
- Including a display string for the new flag.
- Updating tests in `core` to include the new flag.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
