### PR TITLE
[PM-24564] Address GitHub Release creation workflow feedback

### DIFF
--- a/.github/actions/log-inputs/action.yml
+++ b/.github/actions/log-inputs/action.yml
@@ -1,0 +1,20 @@
+name: 'Log Inputs to Job Summary'
+description: 'Log workflow inputs to the GitHub Actions job summary'
+
+inputs:
+  inputs:
+    description: 'Workflow inputs as JSON'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Log inputs to job summary
+      shell: bash
+      run: |
+        echo "<details><summary>Job Inputs</summary>" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo '```json' >> $GITHUB_STEP_SUMMARY
+        echo '${{ inputs.inputs }}' >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "</details>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -148,7 +148,8 @@ jobs:
           for file in "${files_to_remove[@]}"; do
             find $ARTIFACTS_PATH -name "$file" -type f -delete
           done
-
+          echo "🔖 Removed internal artifacts."
+          echo ""
           echo "🔖 Files to be included in the release:"
           find $ARTIFACTS_PATH -type f
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -125,6 +125,33 @@ jobs:
             find $ARTIFACTS_PATH -type f
           fi
 
+          # Files that won't be included in any release
+          files_to_remove=(
+            "com.x8bit.bitwarden.aab"
+            "com.x8bit.bitwarden.aab-sha256.txt"
+
+            "com.x8bit.bitwarden.beta.apk"
+            "com.x8bit.bitwarden.beta.apk-sha256.txt"
+            "com.x8bit.bitwarden.beta.aab"
+            "com.x8bit.bitwarden.beta.aab-sha256.txt"
+
+            "com.x8bit.bitwarden.beta-fdroid.apk"
+            "com.x8bit.bitwarden.beta-fdroid.apk-sha256.txt"
+
+            "com.x8bit.bitwarden.dev.apk"
+            "com.x8bit.bitwarden.dev.apk-sha256.txt"
+
+            "com.bitwarden.authenticator.aab"
+            "authenticator-android-aab-sha256.txt"
+          )
+
+          for file in "${files_to_remove[@]}"; do
+            find $ARTIFACTS_PATH -name "$file" -type f -delete
+          done
+
+          echo "🔖 Files to be included in the release:"
+          find $ARTIFACTS_PATH -type f
+
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
         with:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -50,6 +50,8 @@ jobs:
             exit 1
           fi
 
+          echo "🔖 Release branch: $release_branch"
+          echo "🔖 Workflow name: $workflow_name"
           echo "release_branch=$release_branch" >> $GITHUB_OUTPUT
           echo "workflow_name=$workflow_name" >> $GITHUB_OUTPUT
 
@@ -67,6 +69,8 @@ jobs:
               exit 1
               ;;
           esac
+          echo "🔖 App name: $app_name"
+          echo "🔖 App name suffix: $app_name_suffix"
 
       - name: Get version info from run logs and set release tag name
         id: get_release_info

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -108,7 +108,7 @@ jobs:
           echo "🔖 New tag name: $tag_name"
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 
-          last_release_tag=$(git tag -l --sort=-authordate | grep "$APP_NAME_SUFFIX" | head -n 1)
+          last_release_tag=$(git tag -l --sort=-authordate | grep "$_APP_NAME_SUFFIX" | head -n 1)
           echo "🔖 Last release tag: $last_release_tag"
           echo "last_release_tag=$last_release_tag" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -176,12 +176,18 @@ jobs:
           _TAG_NAME: ${{ steps.get_release_info.outputs.tag_name }}
           _LAST_RELEASE_TAG: ${{ steps.get_release_info.outputs.last_release_tag }}
         run: |
+          is_latest_release=false
+          if [[ "$_APP_NAME" == "Password Manager" ]]; then
+            is_latest_release=true
+          fi
+
           echo "⌛️ Creating release for $_APP_NAME $_VERSION_NAME ($_VERSION_NUMBER) on $_TARGET_COMMIT"
           release_url=$(gh release create "$_TAG_NAME" \
             --title "$_APP_NAME $_VERSION_NAME ($_VERSION_NUMBER)" \
             --target "$_TARGET_COMMIT" \
             --generate-notes \
             --notes-start-tag "$_LAST_RELEASE_TAG" \
+            --latest=$is_latest_release \
             --draft \
             $ARTIFACTS_PATH/*/*)
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -24,15 +24,15 @@ jobs:
       id-token: write
 
     steps:
-      - name: Log inputs to job summary
-        uses: ./.github/actions/log-inputs
-        with:
-          inputs: ${{ toJson(inputs) }}
-
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+
+      - name: Log inputs to job summary
+        uses: ./.github/actions/log-inputs
+        with:
+          inputs: ${{ toJson(inputs) }}
 
       - name: Get branch from workflow run
         id: get_release_branch

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -191,14 +191,13 @@ jobs:
             --draft \
             $ARTIFACTS_PATH/*/*)
 
-          echo "✅ Release created: $release_url"
-
-          # Get release info for outputs
-          release_data=$(gh release view "$_TAG_NAME" --json id)
-          release_id=$(echo "$release_data" | jq -r .id)
-
-          echo "id=$release_id" >> $GITHUB_OUTPUT
+          # Extract release tag from URL
+          release_id_from_url=$(echo "$release_url" | sed 's/.*\/tag\///')
+          echo "release_id_from_url=$release_id_from_url" >> $GITHUB_OUTPUT
           echo "url=$release_url" >> $GITHUB_OUTPUT
+
+          echo "✅ Release created: $release_url"
+          echo "🔖 Release ID from URL: $release_id_from_url"
 
       - name: Update Release Description
         id: update_release_description
@@ -206,10 +205,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
           _VERSION_NAME: ${{ steps.get_release_info.outputs.version_name }}
-          _TAG_NAME: ${{ steps.get_release_info.outputs.tag_name }}
+          _RELEASE_ID: ${{ steps.create_release.outputs.release_id_from_url }}
         run: |
-          echo "Getting current release body. Tag: $_TAG_NAME"
-          current_body=$(gh release view "$_TAG_NAME" --json body --jq .body)
+          echo "Getting current release body. Release ID: $_RELEASE_ID"
+          current_body=$(gh release view "$_RELEASE_ID" --json body --jq .body)
 
           product_release_notes=$(cat product_release_notes.txt)
 
@@ -220,7 +219,7 @@ jobs:
           ${current_body}
           **Builds Source:** https://github.com/${{ github.repository }}/actions/runs/$ARTIFACT_RUN_ID"
 
-          new_release_url=$(gh release edit "$_TAG_NAME" --notes "$updated_body")
+          new_release_url=$(gh release edit "$_RELEASE_ID" --notes "$updated_body")
 
           # draft release links change after editing
           echo "release_url=$new_release_url" >> $GITHUB_OUTPUT

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -57,12 +57,12 @@ jobs:
 
           case "$workflow_name" in
             *"Password Manager"* | "Build")
-              echo "app_name=Password Manager" >> $GITHUB_OUTPUT
-              echo "app_name_suffix=bwpm" >> $GITHUB_OUTPUT
+              app_name="Password Manager"
+              app_name_suffix="bwpm"
               ;;
             *"Authenticator"*)
-              echo "app_name=Authenticator" >> $GITHUB_OUTPUT
-              echo "app_name_suffix=bwa" >> $GITHUB_OUTPUT
+              app_name="Authenticator"
+              app_name_suffix="bwa"
               ;;
             *)
               echo "::error::Unknown workflow name: $workflow_name"
@@ -71,6 +71,8 @@ jobs:
           esac
           echo "🔖 App name: $app_name"
           echo "🔖 App name suffix: $app_name_suffix"
+          echo "app_name=$app_name" >> $GITHUB_OUTPUT
+          echo "app_name_suffix=$app_name_suffix" >> $GITHUB_OUTPUT
 
       - name: Get version info from run logs and set release tag name
         id: get_release_info

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -24,6 +24,11 @@ jobs:
       id-token: write
 
     steps:
+      - name: Log inputs to job summary
+        uses: ./.github/actions/log-inputs
+        with:
+          inputs: ${{ toJson(inputs) }}
+
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## 🎟️ Tracking

PM-24564

## 📔 Objective

QoL improvements and fixes to the GitHub Release Creation workflow:

* Remove internal artifacts from the GitHub Release 
* Set "Publish as Latest" as false for Authenticator 
* fix: gh release diff link using the wrong app tag (bwa diffing with bwpm)
* fix: consecutive workflow runs would update older drafts, by using the release ID instead of the release tag for updates 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
