### PR TITLE
[PM-24589] Trigger CI builds for release branches

### DIFF
--- a/.github/workflows/build-authenticator.yml
+++ b/.github/workflows/build-authenticator.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**/*
   workflow_dispatch:
     inputs:
       version-name:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**/*
   workflow_dispatch:
     inputs:
       version-name:

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
         options:
           - RC
           - Hotfix
+          - Test
 
 jobs:
   create-release-branch:
@@ -17,29 +18,36 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - name: Create RC Branch
-        if: inputs.release_type == 'RC'
+      - name: Create RC or Test Branch
+        id: rc_branch
+        if: inputs.release_type == 'RC' || inputs.release_type == 'Test'
         env:
-          RC_PREFIX_DATE: "true" # replace with input if needed
+          _TEST_MODE: ${{ inputs.release_type == 'Test' }}
+          _RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
-          if [ "$RC_PREFIX_DATE" = "true" ]; then
-            current_date=$(date +'%Y.%m')
-            branch_name="release/${current_date}-rc${{ github.run_number }}"
-          else
-            branch_name="release/rc${{ github.run_number }}"
+          current_date=$(date +'%Y.%-m')
+          branch_name="${current_date}-rc${{ github.run_number }}"
+
+          if [ "$_TEST_MODE" = "true" ]; then
+            branch_name="WORKFLOW-TEST-${branch_name}"
           fi
+          branch_name="release/${branch_name}"
+
           git switch main
           git switch -c $branch_name
           git push origin $branch_name
-          echo "# :cherry_blossom: RC branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY
+          echo "# :cherry_blossom: ${_RELEASE_TYPE} branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 
       - name: Create Hotfix Branch
+        id: hotfix_branch
         if: inputs.release_type == 'Hotfix'
         run: |
           latest_tag=$(git tag -l --sort=-creatordate | head -n 1)
@@ -49,6 +57,7 @@ jobs:
           fi
           branch_name="release/hotfix-${latest_tag}"
           echo "🌿 branch name: $branch_name"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           if git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
             echo "# :fire: :warning: Hotfix branch already exists: ${branch_name}" >> $GITHUB_STEP_SUMMARY
             exit 0
@@ -56,3 +65,12 @@ jobs:
           git switch -c $branch_name $latest_tag
           git push origin $branch_name
           echo "# :fire: Hotfix branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger CI Workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          _BRANCH_NAME: ${{ steps.rc_branch.outputs.branch_name || steps.hotfix_branch.outputs.branch_name }}
+        run: |
+          echo "🌿 branch name: $_BRANCH_NAME"
+          gh workflow run build.yml --ref $_BRANCH_NAME -f distribute-to-firebase=true -f publish-to-play-store=true
+          gh workflow run build-authenticator.yml --ref $_BRANCH_NAME -f distribute-to-firebase=true -f publish-to-play-store=true


### PR DESCRIPTION
## 🎟️ Tracking

PM-24589

## 📔 Objective

Trigger CI builds when release branches are created or updated. 

Test execution runs:
* Cut Release Branch - https://github.com/bitwarden/android/actions/runs/16828616993
* Build - https://github.com/bitwarden/android/actions/runs/16828621611
* Build Authenticator - https://github.com/bitwarden/android/actions/runs/16828621731


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
