### PR TITLE
[PM-24590] Add support to hotfix specific apps in Cut Release Branch workflow

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -9,7 +9,8 @@ on:
         type: choice
         options:
           - RC
-          - Hotfix
+          - Hotfix Password Manager
+          - Hotfix Authenticator
           - Test
 
 jobs:
@@ -48,9 +49,17 @@ jobs:
 
       - name: Create Hotfix Branch
         id: hotfix_branch
-        if: inputs.release_type == 'Hotfix'
+        if: startsWith(inputs.release_type, 'Hotfix')
+        env:
+          _RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
-          latest_tag=$(git tag -l --sort=-creatordate | head -n 1)
+          app_codename="bwpm"
+          if [ "$_RELEASE_TYPE" == "Hotfix Authenticator" ]; then
+            app_codename="bwa"
+          fi
+          echo "🌿 app codename: $app_codename"
+
+          latest_tag=$(git tag -l --sort=-creatordate | grep "$app_codename" | head -n 1)
           if [ -z "$latest_tag" ]; then
             echo "::error::No tags found in the repository"
             exit 1


### PR DESCRIPTION
## 🎟️ Tracking

PM-24590

## 📔 Objective

Support creating hotfix branches for Password Manager or Authenticator.

Test runs:
* BWPM -  https://github.com/bitwarden/android/actions/runs/16828964830
* BWA - https://github.com/bitwarden/android/actions/runs/16829006054

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
