### PR TITLE
[PM-24568] Add `accountKeys` to `SyncResponseJson.Profile`

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
@@ -142,6 +142,8 @@ data class SyncResponseJson(
      * @property isEmailVerified If the profile has a verified email.
      * @property isTwoFactorEnabled If the profile has two factor authentication enabled.
      * @property privateKey The private key of the profile (nullable).
+     * @property accountKeys The account keys associated with the profile. This is temporarily
+     * nullable to maintain backwards compatibility.
      * @property isPremium If the profile is premium.
      * @property culture The culture of the profile (nullable).
      * @property name The name of the profile (nullable).
@@ -175,8 +177,12 @@ data class SyncResponseJson(
         @SerialName("twoFactorEnabled")
         val isTwoFactorEnabled: Boolean,
 
+        @Deprecated("Use accountKeys instead", ReplaceWith("accountKeys"))
         @SerialName("privateKey")
         val privateKey: String?,
+
+        @SerialName("accountKeys")
+        val accountKeys: AccountKeys?,
 
         @SerialName("premium")
         val isPremium: Boolean,
@@ -410,6 +416,77 @@ data class SyncResponseJson(
             @SerialName("managePolicies")
             val shouldManagePolicies: Boolean,
         )
+
+        /**
+         * Represents private keys in the vault response.
+         *
+         * @property signatureKeyPair The signature key pair of the profile.
+         * @property publicKeyEncryptionKeyPair The public key encryption key pair of the profile.
+         * @property securityState The security state of the profile (nullable).
+         */
+        @Serializable
+        data class AccountKeys(
+            @SerialName("signatureKeyPair")
+            val signatureKeyPair: SignatureKeyPair?,
+
+            @SerialName("publicKeyEncryptionKeyPair")
+            val publicKeyEncryptionKeyPair: PublicKeyEncryptionKeyPair,
+
+            @SerialName("securityState")
+            val securityState: SecurityState?,
+        ) {
+
+            /**
+             * Represents a signature key pair in the vault response.
+             *
+             * @property wrappedSigningKey The wrapped signing key of the signature key pair.
+             * @property verifyingKey The verifying key of the signature key pair.
+             */
+            @Serializable
+            data class SignatureKeyPair(
+                @SerialName("wrappedSigningKey")
+                val wrappedSigningKey: String,
+
+                @SerialName("verifyingKey")
+                val verifyingKey: String,
+            )
+
+            /**
+             * Represents a public key encryption key pair in the vault response.
+             *
+             * @property wrappedPrivateKey The wrapped private key of the public key encryption key
+             * pair.
+             * @property publicKey The public key of the public key encryption key pair.
+             * @property signedPublicKey The signed public key of the public key encryption key pair
+             * (nullable).
+             */
+            @Serializable
+            data class PublicKeyEncryptionKeyPair(
+                @SerialName("wrappedPrivateKey")
+                val wrappedPrivateKey: String,
+
+                @SerialName("publicKey")
+                val publicKey: String,
+
+                @SerialName("signedPublicKey")
+                val signedPublicKey: String?,
+            )
+
+            /**
+             * Represents security state in the vault response.
+             *
+             * @property securityState The security state of the profile.
+             * @property securityVersion The security version of the profile.
+             */
+            @Serializable
+            data class SecurityState(
+                @SerialName("securityState")
+                val securityState: String,
+
+                @SerialName("securityVersion")
+                val securityVersion: Int,
+            )
+        }
     }
 
     /**

--- a/network/src/test/kotlin/com/bitwarden/network/service/SyncServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/SyncServiceTest.kt
@@ -51,6 +51,23 @@ private const val SYNC_SUCCESS_JSON = """
     "twoFactorEnabled": false,
     "key": "mockKey-1",
     "privateKey": "mockPrivateKey-1",
+    "accountKeys": {
+      "signatureKeyPair": {
+        "wrappedSigningKey": "mockWrappedSigningKey-1",
+        "verifyingKey": "mockVerifyingKey-1"
+      },
+      "publicKeyEncryptionKeyPair": {
+        "wrappedPrivateKey": "mockWrappedPrivateKey-1",
+        "publicKey": "mockPublicKey-1",
+        "signedPublicKey": "mockSignedPublicKey-1",
+        "object": "publicKeyEncryptionKeyPair"
+      },
+      "securityState": {
+        "securityState": "mockSecurityState-1",
+        "securityVersion": 1
+      },
+      "object": "privateKeys"
+    },
     "securityStamp": "mockSecurityStamp-1",
     "forcePasswordReset": false,
     "usesKeyConnector": false,

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseProfileUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseProfileUtil.kt
@@ -18,6 +18,7 @@ fun createMockProfile(
     isEmailVerified: Boolean = false,
     isTwoFactorEnabled: Boolean = false,
     privateKey: String? = "mockPrivateKey-$number",
+    accountKeys: SyncResponseJson.Profile.AccountKeys? = createMockPrivateKeys(number = number),
     isPremium: Boolean = false,
     culture: String? = "mockCulture-$number",
     name: String? = "mockName-$number",
@@ -43,6 +44,7 @@ fun createMockProfile(
         isEmailVerified = isEmailVerified,
         isTwoFactorEnabled = isTwoFactorEnabled,
         privateKey = privateKey,
+        accountKeys = accountKeys,
         isPremium = isPremium,
         culture = culture,
         name = name,
@@ -55,6 +57,60 @@ fun createMockProfile(
         securityStamp = securityStamp,
         providers = providers,
         creationDate = creationDate,
+    )
+
+/**
+ * Create a mock set of private keys with a given [number].
+ */
+fun createMockPrivateKeys(
+    number: Int,
+): SyncResponseJson.Profile.AccountKeys =
+    SyncResponseJson.Profile.AccountKeys(
+        signatureKeyPair = createMockSignatureKeyPair(number = number),
+        publicKeyEncryptionKeyPair = createMockPublicKeyEncryptionKeyPair(number = number),
+        securityState = createMockSecurityState(number = number),
+    )
+
+/**
+ * Create a mock [SyncResponseJson.Profile.AccountKeys.SecurityState] with a given [number].
+ */
+fun createMockSecurityState(
+    number: Int,
+    securityState: String = "mockSecurityState-$number",
+    securityVersion: Int = number,
+): SyncResponseJson.Profile.AccountKeys.SecurityState =
+    SyncResponseJson.Profile.AccountKeys.SecurityState(
+        securityState = securityState,
+        securityVersion = securityVersion,
+    )
+
+/**
+ * Create a mock [SyncResponseJson.Profile.AccountKeys.PublicKeyEncryptionKeyPair] with a given
+ * number.
+ */
+fun createMockPublicKeyEncryptionKeyPair(
+    number: Int,
+    publicKey: String = "mockPublicKey-$number",
+    wrappedPrivateKey: String = "mockWrappedPrivateKey-$number",
+    signedPublicKey: String? = "mockSignedPublicKey-$number",
+): SyncResponseJson.Profile.AccountKeys.PublicKeyEncryptionKeyPair =
+    SyncResponseJson.Profile.AccountKeys.PublicKeyEncryptionKeyPair(
+        publicKey = publicKey,
+        wrappedPrivateKey = wrappedPrivateKey,
+        signedPublicKey = signedPublicKey,
+    )
+
+/**
+ * Create a mock [SyncResponseJson.Profile.AccountKeys.SignatureKeyPair] with a given number.
+ */
+fun createMockSignatureKeyPair(
+    number: Int,
+    wrappedSigningKey: String = "mockWrappedSigningKey-$number",
+    verifyingKey: String = "mockVerifyingKey-$number",
+): SyncResponseJson.Profile.AccountKeys.SignatureKeyPair =
+    SyncResponseJson.Profile.AccountKeys.SignatureKeyPair(
+        wrappedSigningKey = wrappedSigningKey,
+        verifyingKey = verifyingKey,
     )
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

PM-24568

## 📔 Objective

Introduce the `accountKeys` field to the `SyncResponseJson.Profile` data class. This new field will hold the user's signature key pair, public key encryption key pair, and security state.

The `privateKey` field has been deprecated in favor of `accountKeys`.

Additionally, new test fixture utilities (`createMockPrivateKeys`, `createMockSecurityState`, `createMockPublicKeyEncryptionKeyPair`, `createMockSignatureKeyPair`) have been added to facilitate testing of this new structure. The existing `SyncServiceTest` has been updated to include `accountKeys` in its mock response.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
