### PR TITLE
[PM-24569] Save accountKeys to AuthDiskSource

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
@@ -126,12 +126,33 @@ interface AuthDiskSource : AppIdProvider {
     /**
      * Retrieves a private key using a [userId].
      */
+    @Deprecated(
+        message = "Use getAccountKeys instead.",
+        replaceWith = ReplaceWith("getAccountKeys"),
+    )
     fun getPrivateKey(userId: String): String?
 
     /**
      * Stores a private key using a [userId].
      */
+    @Deprecated(
+        message = "Use storeAccountKeys instead.",
+        replaceWith = ReplaceWith("storeAccountKeys"),
+    )
     fun storePrivateKey(userId: String, privateKey: String?)
+
+    /**
+     * Returns the profile account keys for the given [userId].
+     */
+    fun getAccountKeys(userId: String): SyncResponseJson.Profile.AccountKeys?
+
+    /**
+     * Stores the profile account keys for the given [userId].
+     */
+    fun storeAccountKeys(
+        userId: String,
+        accountKeys: SyncResponseJson.Profile.AccountKeys?,
+    )
 
     /**
      * Retrieves a user auto-unlock key for the given [userId].

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
@@ -48,6 +48,7 @@ private const val USES_KEY_CONNECTOR = "usesKeyConnector"
 private const val ONBOARDING_STATUS_KEY = "onboardingStatus"
 private const val SHOW_IMPORT_LOGINS_KEY = "showImportLogins"
 private const val LAST_LOCK_TIMESTAMP = "lastLockTimestamp"
+private const val PROFILE_ACCOUNT_KEYS_KEY = "profileAccountKeys"
 
 /**
  * Primary implementation of [AuthDiskSource].
@@ -142,6 +143,7 @@ class AuthDiskSourceImpl(
         storePinProtectedUserKey(userId = userId, pinProtectedUserKey = null)
         storeEncryptedPin(userId = userId, encryptedPin = null)
         storePrivateKey(userId = userId, privateKey = null)
+        storeAccountKeys(userId = userId, accountKeys = null)
         storeOrganizationKeys(userId = userId, organizationKeys = null)
         storeOrganizations(userId = userId, organizations = null)
         storeUserBiometricInitVector(userId = userId, iv = null)
@@ -228,13 +230,29 @@ class AuthDiskSourceImpl(
         )
     }
 
+    @Deprecated("Use getAccountKeys instead.", replaceWith = ReplaceWith("getAccountKeys"))
     override fun getPrivateKey(userId: String): String? =
         getString(key = MASTER_KEY_ENCRYPTION_PRIVATE_KEY.appendIdentifier(userId))
 
+    @Deprecated("Use storeAccountKeys instead.", replaceWith = ReplaceWith("storeAccountKeys"))
     override fun storePrivateKey(userId: String, privateKey: String?) {
         putString(
             key = MASTER_KEY_ENCRYPTION_PRIVATE_KEY.appendIdentifier(userId),
             value = privateKey,
+        )
+    }
+
+    override fun getAccountKeys(userId: String): SyncResponseJson.Profile.AccountKeys? =
+        getEncryptedString(key = PROFILE_ACCOUNT_KEYS_KEY.appendIdentifier(userId))
+            ?.let { json.decodeFromStringOrNull(it) }
+
+    override fun storeAccountKeys(
+        userId: String,
+        accountKeys: SyncResponseJson.Profile.AccountKeys?,
+    ) {
+        putEncryptedString(
+            key = PROFILE_ACCOUNT_KEYS_KEY.appendIdentifier(userId),
+            value = accountKeys?.let { json.encodeToString(it) },
         )
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -12,6 +12,7 @@ import com.bitwarden.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.bitwarden.network.model.UserDecryptionOptionsJson
 import com.bitwarden.network.model.createMockOrganization
 import com.bitwarden.network.model.createMockPolicy
+import com.bitwarden.network.model.createMockPrivateKeys
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
@@ -280,6 +281,10 @@ class AuthDiskSourceTest {
             userAutoUnlockKey = "userAutoUnlockKey",
         )
         authDiskSource.storePrivateKey(userId = userId, privateKey = "privateKey")
+        authDiskSource.storeAccountKeys(
+            userId = userId,
+            accountKeys = createMockPrivateKeys(number = 1),
+        )
         authDiskSource.storeOrganizationKeys(
             userId = userId,
             organizationKeys = mapOf("organizationId" to "key"),
@@ -330,6 +335,7 @@ class AuthDiskSourceTest {
         assertNull(authDiskSource.getUserKey(userId = userId))
         assertNull(authDiskSource.getUserAutoUnlockKey(userId = userId))
         assertNull(authDiskSource.getPrivateKey(userId = userId))
+        assertNull(authDiskSource.getAccountKeys(userId = userId))
         assertNull(authDiskSource.getOrganizationKeys(userId = userId))
         assertNull(authDiskSource.getOrganizations(userId = userId))
         assertNull(authDiskSource.getPolicies(userId = userId))
@@ -473,6 +479,43 @@ class AuthDiskSourceTest {
         assertEquals(
             mockPrivateKey,
             actual,
+        )
+    }
+
+    @Test
+    fun `getAccountKeys should pull from SharedPreferences`() {
+        val accountKeysBaseKey = "bwSecureStorage:profileAccountKeys"
+        val mockUserId = "mockUserId"
+        val mockAccountKeys = createMockPrivateKeys(number = 1)
+        fakeEncryptedSharedPreferences.edit {
+            putString(
+                "${accountKeysBaseKey}_$mockUserId",
+                json.encodeToString(mockAccountKeys),
+            )
+        }
+        val actual = authDiskSource.getAccountKeys(userId = mockUserId)
+        assertEquals(
+            mockAccountKeys,
+            actual,
+        )
+    }
+
+    @Test
+    fun `storeAccountKeys should update sharedPreferences`() {
+        val accountKeysBaseKey = "bwSecureStorage:profileAccountKeys"
+        val mockUserId = "mockUserId"
+        val mockAccountKeys = createMockPrivateKeys(number = 1)
+        authDiskSource.storeAccountKeys(
+            userId = mockUserId,
+            accountKeys = mockAccountKeys,
+        )
+        val actual = fakeEncryptedSharedPreferences.getString(
+            "${accountKeysBaseKey}_$mockUserId",
+            null,
+        )
+        assertEquals(
+            json.encodeToJsonElement(mockAccountKeys),
+            json.parseToJsonElement(requireNotNull(actual)),
         )
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
@@ -63,6 +63,7 @@ class FakeAuthDiskSource : AuthDiskSource {
     private val storedOnboardingStatus = mutableMapOf<String, OnboardingStatus?>()
     private val storedShowImportLogins = mutableMapOf<String, Boolean?>()
     private val storedLastLockTimestampState = mutableMapOf<String, Instant?>()
+    private val storedAccountKeys = mutableMapOf<String, SyncResponseJson.Profile.AccountKeys?>()
 
     override var userState: UserStateJson? = null
         set(value) {
@@ -137,10 +138,22 @@ class FakeAuthDiskSource : AuthDiskSource {
         storedUserKeys[userId] = userKey
     }
 
+    @Deprecated("Use getAccountKeys instead.", replaceWith = ReplaceWith("getAccountKeys"))
     override fun getPrivateKey(userId: String): String? = storedPrivateKeys[userId]
 
+    @Deprecated("Use storeAccountKeys instead.", replaceWith = ReplaceWith("storeAccountKeys"))
     override fun storePrivateKey(userId: String, privateKey: String?) {
         storedPrivateKeys[userId] = privateKey
+    }
+
+    override fun getAccountKeys(userId: String): SyncResponseJson.Profile.AccountKeys? =
+        storedAccountKeys[userId]
+
+    override fun storeAccountKeys(
+        userId: String,
+        accountKeys: SyncResponseJson.Profile.AccountKeys?,
+    ) {
+        storedAccountKeys[userId] = accountKeys
     }
 
     override fun getTwoFactorToken(email: String): String? = storedTwoFactorTokens[email]


### PR DESCRIPTION
## 🎟️ Tracking

PM-24569

## 📔 Objective

This adds functions to `AuthDiskSource` to store and retrieve `accountKeys`. Additionally, functions to store and retrieve the private key have been marked deprecated in favor of the account keys.

This includes:
- Adding `getAccountKeys` and `storeAccountKeys` methods to `AuthDiskSource` and its implementations.
- Deprecating the old `getPrivateKey` and `storePrivateKey` methods.
- Updating tests to use the new methods and verify their functionality.
- Ensuring that `clearAccountData` also clears the new `accountKeys`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
