### PR TITLE
PM-24690: Use ToastManager in MainViewModel

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.WindowManager
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -186,12 +185,6 @@ class MainActivity : AppCompatActivity() {
                 is MainEvent.CompleteAutofill -> handleCompleteAutofill(event)
                 MainEvent.Recreate -> handleRecreate()
                 MainEvent.NavigateToDebugMenu -> navController.navigateToDebugMenuScreen()
-                is MainEvent.ShowToast -> {
-                    Toast
-                        .makeText(baseContext, event.message.invoke(resources), Toast.LENGTH_SHORT)
-                        .show()
-                }
-
                 is MainEvent.UpdateAppLocale -> {
                     AppCompatDelegate.setApplicationLocales(
                         LocaleListCompat.forLanguageTags(event.localeName),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -4,11 +4,10 @@ import android.content.Intent
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.resource.BitwardenString
-import com.bitwarden.ui.util.Text
-import com.bitwarden.ui.util.asText
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.manager.AddTotpItemFromAuthenticatorManager
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -84,6 +83,7 @@ class MainViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val appResumeManager: AppResumeManager,
     private val clock: Clock,
+    private val toastManager: ToastManager,
 ) : BaseViewModel<MainState, MainEvent, MainAction>(
     initialState = MainState(
         theme = settingsRepository.appTheme,
@@ -433,16 +433,15 @@ class MainViewModel @Inject constructor(
             )
             when (emailTokenResult) {
                 is EmailTokenResult.Error -> {
-                    sendEvent(
-                        MainEvent.ShowToast(
-                            message = emailTokenResult
-                                .message
-                                ?.asText()
-                                ?: BitwardenString
-                                    .there_was_an_issue_validating_the_registration_token
-                                    .asText(),
-                        ),
-                    )
+                    emailTokenResult
+                        .message
+                        ?.let { toastManager.show(message = it) }
+                        ?: run {
+                            toastManager.show(
+                                messageId = BitwardenString
+                                    .there_was_an_issue_validating_the_registration_token,
+                            )
+                        }
                 }
 
                 EmailTokenResult.Expired -> {
@@ -584,11 +583,6 @@ sealed class MainEvent {
      * Navigate to the debug menu.
      */
     data object NavigateToDebugMenu : MainEvent()
-
-    /**
-     * Show a toast with the given [message].
-     */
-    data class ShowToast(val message: Text) : MainEvent()
 
     /**
      * Indicates that the app language has been updated.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24690](https://bitwarden.atlassian.net/browse/PM-24690)

## 📔 Objective

This PR updates the way we display toasts in the MainActivity so we use the `ToastManager` directly in the ViewModel.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24690]: https://bitwarden.atlassian.net/browse/PM-24690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ