### PR TITLE
PM-24727: Update VaultUnlockScreen to use user specific environment

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModel.kt
@@ -25,7 +25,6 @@ import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.manager.util.toCreateCredentialRequestOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toFido2AssertionRequestOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toGetCredentialsRequestOrNull
-import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.manager.VaultLockManager
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
@@ -61,7 +60,6 @@ class VaultUnlockViewModel @Inject constructor(
     private val bitwardenCredentialManager: BitwardenCredentialManager,
     private val appResumeManager: AppResumeManager,
     private val vaultLockManager: VaultLockManager,
-    environmentRepo: EnvironmentRepository,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<VaultUnlockState, VaultUnlockEvent, VaultUnlockAction>(
     // We load the state from the savedStateHandle for testing purposes.
@@ -96,7 +94,7 @@ class VaultUnlockViewModel @Inject constructor(
             initials = activeAccountSummary.initials,
             email = activeAccountSummary.email,
             dialog = null,
-            environmentUrl = environmentRepo.environment.label,
+            environmentUrl = activeAccount.environment.label,
             input = "",
             isBiometricEnabled = activeAccount.isBiometricsEnabled,
             isBiometricsValid = isBiometricsValid,
@@ -113,14 +111,6 @@ class VaultUnlockViewModel @Inject constructor(
     },
 ) {
     init {
-        environmentRepo
-            .environmentStateFlow
-            .onEach { environment ->
-                mutableStateFlow.update {
-                    it.copy(environmentUrl = environment.label)
-                }
-            }
-            .launchIn(viewModelScope)
         authRepository
             .userStateFlow
             .onEach {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockViewModelTest.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.auth.feature.vaultunlock
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
-import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -22,8 +21,6 @@ import com.x8bit.bitwarden.data.platform.manager.BiometricsEncryptionManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
-import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.vault.manager.VaultLockManager
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
@@ -55,7 +52,6 @@ import javax.crypto.Cipher
 class VaultUnlockViewModelTest : BaseViewModelTest() {
 
     private val mutableUserStateFlow = MutableStateFlow<UserState?>(DEFAULT_USER_STATE)
-    private val environmentRepository = FakeEnvironmentRepository()
     private val authRepository = mockk<AuthRepository> {
         every { activeUserId } answers { mutableUserStateFlow.value?.activeUserId }
         every { userStateFlow } returns mutableUserStateFlow
@@ -196,19 +192,6 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         verify(exactly = 0) {
             authRepository.logout(reason = any())
         }
-    }
-
-    @Test
-    fun `environment url should update when environment repo emits an update`() {
-        val viewModel = createViewModel()
-        assertEquals(DEFAULT_STATE, viewModel.stateFlow.value)
-        environmentRepository.environment = Environment.SelfHosted(
-            environmentUrlData = EnvironmentUrlDataJson(base = "https://vault.qa.bitwarden.pw"),
-        )
-        assertEquals(
-            DEFAULT_STATE.copy(environmentUrl = "vault.qa.bitwarden.pw"),
-            viewModel.stateFlow.value,
-        )
     }
 
     @Test
@@ -1352,11 +1335,9 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         }
     }
 
-    @Suppress("LongParameterList")
     private fun createViewModel(
         state: VaultUnlockState? = null,
         unlockType: UnlockType = UnlockType.STANDARD,
-        environmentRepo: EnvironmentRepository = environmentRepository,
         vaultRepo: VaultRepository = vaultRepository,
         biometricsEncryptionManager: BiometricsEncryptionManager = encryptionManager,
         lockManager: VaultLockManager = vaultLockManager,
@@ -1367,7 +1348,6 @@ class VaultUnlockViewModelTest : BaseViewModelTest() {
         },
         authRepository = authRepository,
         vaultRepo = vaultRepo,
-        environmentRepo = environmentRepo,
         biometricsEncryptionManager = biometricsEncryptionManager,
         bitwardenCredentialManager = bitwardenCredentialManager,
         specialCircumstanceManager = specialCircumstanceManager,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24727](https://bitwarden.atlassian.net/browse/PM-24727)

## 📔 Objective

This PR updates the `VaultUnlockScreen` to display the user environment instead of the pre-auth environment.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
