### PR TITLE
PM-24771: Move the slider to the UI module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -56,6 +56,7 @@ import com.bitwarden.ui.platform.components.field.model.TextToolbarType
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.model.TooltipData
 import com.bitwarden.ui.platform.components.model.TopAppBarDividerStyle
+import com.bitwarden.ui.platform.components.slider.BitwardenSlider
 import com.bitwarden.ui.platform.components.stepper.BitwardenStepper
 import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.bitwarden.ui.platform.components.util.nonLetterColorVisualTransformation
@@ -77,7 +78,6 @@ import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.x8bit.bitwarden.ui.platform.components.segment.BitwardenSegmentedButton
 import com.x8bit.bitwarden.ui.platform.components.segment.SegmentedButtonOptionContent
 import com.x8bit.bitwarden.ui.platform.components.segment.SegmentedButtonState
-import com.x8bit.bitwarden.ui.platform.components.slider.BitwardenSlider
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
 import com.x8bit.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
 import com.x8bit.bitwarden.ui.platform.components.snackbar.rememberBitwardenSnackbarHostState

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/slider/BitwardenSlider.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/slider/BitwardenSlider.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.slider
+package com.bitwarden.ui.platform.components.slider
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
@@ -40,9 +40,9 @@ import com.bitwarden.ui.platform.base.util.nullableTestTag
 import com.bitwarden.ui.platform.base.util.toDp
 import com.bitwarden.ui.platform.components.field.color.bitwardenTextFieldColors
 import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.components.slider.color.bitwardenSliderColors
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.x8bit.bitwarden.ui.platform.components.slider.color.bitwardenSliderColors
 
 /**
  * A custom Bitwarden-themed slider.

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/slider/color/BitwardenSliderColors.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/slider/color/BitwardenSliderColors.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.slider.color
+package com.bitwarden.ui.platform.components.slider.color
 
 import androidx.compose.material3.SliderColors
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24771](https://bitwarden.atlassian.net/browse/PM-24771)

## 📔 Objective

This PR moves the `BitwardenSlider` in the `ui` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24771]: https://bitwarden.atlassian.net/browse/PM-24771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ