### PR TITLE
Fix Autofill settings deeplink

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/utils/IntentManagerUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/utils/IntentManagerUtils.kt
@@ -19,7 +19,7 @@ import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
  */
 fun IntentManager.startSystemAutofillSettingsActivity(
     context: Context,
-): Boolean = !startActivity(
+): Boolean = startActivity(
     intent = Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE)
         .setData("package:${context.packageName}".toUri()),
 )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

The `startSystemAutofillSettingsActivity` function was incorrectly negating the result of `startActivity`. This commit removes the negation to correctly reflect the activity launch status.

## 📸 Screenshots

https://github.com/user-attachments/assets/ead381da-c003-4028-ae69-8a10e657827f

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
