### PR TITLE
Remove context param from IntentManager extensions

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -64,15 +63,12 @@ fun SetupAutoFillScreen(
     intentManager: IntentManager = LocalIntentManager.current,
     viewModel: SetupAutoFillViewModel = hiltViewModel(),
 ) {
-    val context = LocalContext.current
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val handler = rememberSetupAutoFillHandler(viewModel = viewModel)
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             SetupAutoFillEvent.NavigateToAutofillSettings -> {
-                val showFallback = !intentManager.startSystemAutofillSettingsActivity(
-                    context = context,
-                )
+                val showFallback = !intentManager.startSystemAutofillSettingsActivity()
                 if (showFallback) {
                     handler.sendAutoFillServiceFallback.invoke()
                 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity
 
-import android.content.Context
 import android.content.res.Resources
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
@@ -93,7 +92,6 @@ fun AccountSecurityScreen(
     biometricsManager: BiometricsManager = LocalBiometricsManager.current,
     intentManager: IntentManager = LocalIntentManager.current,
 ) {
-    val context: Context = LocalContext.current
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     var showBiometricsPrompt by rememberSaveable { mutableStateOf(false) }
     val unlockWithBiometricToggle: (cipher: Cipher) -> Unit = remember(viewModel) {
@@ -108,7 +106,7 @@ fun AccountSecurityScreen(
             AccountSecurityEvent.NavigateBack -> onNavigateBack()
 
             AccountSecurityEvent.NavigateToApplicationDataSettings -> {
-                intentManager.startApplicationDetailsSettingsActivity(context = context)
+                intentManager.startApplicationDetailsSettingsActivity()
             }
 
             AccountSecurityEvent.NavigateToDeleteAccount -> onNavigateToDeleteAccount()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -82,7 +82,6 @@ fun AutoFillScreen(
     onNavigateToPrivilegedAppsList: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     var shouldShowAutofillFallbackDialog by rememberSaveable { mutableStateOf(false) }
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -93,10 +92,7 @@ fun AutoFillScreen(
             }
 
             AutoFillEvent.NavigateToAutofillSettings -> {
-                val isSuccess = intentManager.startSystemAutofillSettingsActivity(
-                    context = context,
-                )
-
+                val isSuccess = intentManager.startSystemAutofillSettingsActivity()
                 shouldShowAutofillFallbackDialog = !isSuccess
             }
 
@@ -105,7 +101,7 @@ fun AutoFillScreen(
             }
 
             AutoFillEvent.NavigateToSettings -> {
-                intentManager.startCredentialManagerSettings(context)
+                intentManager.startCredentialManagerSettings()
             }
 
             AutoFillEvent.NavigateToSetupAutofill -> onNavigateToSetupAutofill()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManager.kt
@@ -21,6 +21,11 @@ import java.time.Clock
 @Immutable
 interface IntentManager {
     /**
+     * The package name for the current app, this can be used to generate an [Intent].
+     */
+    val packageName: String
+
+    /**
      * Start an activity using the provided [Intent].
      *
      * @return `true` if the activity was started successfully, `false` otherwise.
@@ -35,7 +40,7 @@ interface IntentManager {
     /**
      * Starts the credential manager settings.
      */
-    fun startCredentialManagerSettings(context: Context)
+    fun startCredentialManagerSettings()
 
     /**
      * Start an activity to view the given [uri] in an external browser.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -53,6 +53,8 @@ class IntentManagerImpl(
     private val clock: Clock,
     private val buildInfoManager: BuildInfoManager,
 ) : IntentManager {
+    override val packageName: String get() = context.packageName
+
     override fun startActivity(intent: Intent): Boolean = try {
         context.startActivity(intent)
         true
@@ -76,7 +78,7 @@ class IntentManagerImpl(
             .launchUrl(context, uri)
     }
 
-    override fun startCredentialManagerSettings(context: Context) {
+    override fun startCredentialManagerSettings() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             CredentialManager.create(context).createSettingsPendingIntent().send()
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/utils/IntentManagerUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/utils/IntentManagerUtils.kt
@@ -2,8 +2,6 @@
 
 package com.x8bit.bitwarden.ui.platform.manager.utils
 
-import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.Intent
 import android.provider.Settings
 import androidx.core.net.toUri
@@ -17,11 +15,9 @@ import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager
  * @param context The context from which to start the activity.
  * @return `true` if the activity was started successfully, `false` otherwise.
  */
-fun IntentManager.startSystemAutofillSettingsActivity(
-    context: Context,
-): Boolean = startActivity(
+fun IntentManager.startSystemAutofillSettingsActivity(): Boolean = startActivity(
     intent = Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE)
-        .setData("package:${context.packageName}".toUri()),
+        .setData("package:$packageName".toUri()),
 )
 
 /**
@@ -36,7 +32,7 @@ fun IntentManager.startSystemAccessibilitySettingsActivity() {
  */
 fun IntentManager.startBrowserAutofillSettingsActivity(
     browserPackage: BrowserPackage,
-): Boolean = try {
+): Boolean {
     val intent = Intent(Intent.ACTION_APPLICATION_PREFERENCES)
         .apply {
             addCategory(Intent.CATEGORY_DEFAULT)
@@ -44,17 +40,15 @@ fun IntentManager.startBrowserAutofillSettingsActivity(
             addCategory(Intent.CATEGORY_PREFERENCE)
             setPackage(browserPackage.packageName)
         }
-    startActivity(intent)
-} catch (_: ActivityNotFoundException) {
-    false
+    return startActivity(intent)
 }
 
 /**
  * Starts the application's settings activity.
  */
-fun IntentManager.startApplicationDetailsSettingsActivity(context: Context) {
+fun IntentManager.startApplicationDetailsSettingsActivity() {
     val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-    intent.data = "package:${context.packageName}".toUri()
+    intent.data = "package:$packageName".toUri()
     startActivity(intent = intent)
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
@@ -109,10 +109,10 @@ class SetupAutofillScreenTest : BitwardenComposeTest() {
     @Test
     fun `NavigateToAutoFillSettings should start system autofill settings activity`() {
         mockkStatic(IntentManager::startSystemAutofillSettingsActivity) {
-            every { intentManager.startSystemAutofillSettingsActivity(any()) } returns true
+            every { intentManager.startSystemAutofillSettingsActivity() } returns true
             mutableEventFlow.tryEmit(SetupAutoFillEvent.NavigateToAutofillSettings)
             verify {
-                intentManager.startSystemAutofillSettingsActivity(any())
+                intentManager.startSystemAutofillSettingsActivity()
             }
         }
     }
@@ -121,7 +121,7 @@ class SetupAutofillScreenTest : BitwardenComposeTest() {
     @Test
     fun `NavigateToAutoFillSettings should send AutoFillServiceFallback action when intent fails`() {
         mockkStatic(IntentManager::startSystemAutofillSettingsActivity) {
-            every { intentManager.startSystemAutofillSettingsActivity(any()) } returns false
+            every { intentManager.startSystemAutofillSettingsActivity() } returns false
             mutableEventFlow.tryEmit(SetupAutoFillEvent.NavigateToAutofillSettings)
             verify { viewModel.trySendAction(SetupAutoFillAction.AutoFillServiceFallback) }
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -106,9 +106,9 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
     @Test
     fun `on NavigateToApplicationDataSettings should launch the correct intent`() {
         mockkStatic(IntentManager::startApplicationDetailsSettingsActivity) {
-            every { intentManager.startApplicationDetailsSettingsActivity(any()) } just runs
+            every { intentManager.startApplicationDetailsSettingsActivity() } just runs
             mutableEventFlow.tryEmit(AccountSecurityEvent.NavigateToApplicationDataSettings)
-            verify { intentManager.startApplicationDetailsSettingsActivity(any()) }
+            verify { intentManager.startApplicationDetailsSettingsActivity() }
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -55,7 +55,7 @@ class AutoFillScreenTest : BitwardenComposeTest() {
         every { stateFlow } returns mutableStateFlow
     }
     private val intentManager: IntentManager = mockk {
-        every { startCredentialManagerSettings(any()) } just runs
+        every { startCredentialManagerSettings() } just runs
         every { launchUri(any()) } just runs
     }
 
@@ -68,7 +68,7 @@ class AutoFillScreenTest : BitwardenComposeTest() {
         )
         every { intentManager.startBrowserAutofillSettingsActivity(any()) } returns true
         every {
-            intentManager.startSystemAutofillSettingsActivity(any())
+            intentManager.startSystemAutofillSettingsActivity()
         } answers { isSystemSettingsRequestSuccess }
         every { intentManager.startSystemAccessibilitySettingsActivity() } just runs
 
@@ -116,7 +116,7 @@ class AutoFillScreenTest : BitwardenComposeTest() {
         mutableEventFlow.tryEmit(AutoFillEvent.NavigateToAutofillSettings)
 
         verify {
-            intentManager.startSystemAutofillSettingsActivity(any())
+            intentManager.startSystemAutofillSettingsActivity()
         }
         composeTestRule.assertNoDialogExists()
     }
@@ -129,7 +129,7 @@ class AutoFillScreenTest : BitwardenComposeTest() {
         mutableEventFlow.tryEmit(AutoFillEvent.NavigateToAutofillSettings)
 
         verify {
-            intentManager.startSystemAutofillSettingsActivity(any())
+            intentManager.startSystemAutofillSettingsActivity()
         }
 
         composeTestRule
@@ -150,7 +150,7 @@ class AutoFillScreenTest : BitwardenComposeTest() {
     fun `on NavigateToSettings should attempt to navigate to credential manager settings`() {
         mutableEventFlow.tryEmit(AutoFillEvent.NavigateToSettings)
 
-        verify { intentManager.startCredentialManagerSettings(any()) }
+        verify { intentManager.startCredentialManagerSettings() }
 
         composeTestRule.assertNoDialogExists()
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -138,7 +138,7 @@ fun ItemListingScreen(
 
             is ItemListingEvent.NavigateToEditItem -> onNavigateToEditItemScreen(event.id)
             is ItemListingEvent.NavigateToAppSettings -> {
-                intentManager.startAuthenticatorAppSettings(context)
+                intentManager.startAuthenticatorAppSettings()
             }
 
             ItemListingEvent.NavigateToBitwardenListing -> {

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManager.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManager.kt
@@ -11,9 +11,13 @@ import com.bitwarden.ui.platform.model.FileData
 /**
  * A manager class for simplifying the handling of Android Intents within a given context.
  */
-@Suppress("TooManyFunctions")
 @Immutable
 interface IntentManager {
+    /**
+     * The package name for the current app, this can be used to generate an [Intent].
+     */
+    val packageName: String
+
     /**
      * Start an activity using the provided [Intent].
      */

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/intent/IntentManagerImpl.kt
@@ -25,6 +25,8 @@ import com.bitwarden.ui.platform.resource.BitwardenString
 class IntentManagerImpl(
     private val context: Context,
 ) : IntentManager {
+    override val packageName: String get() = context.packageName
+
     override fun startActivity(intent: Intent) {
         try {
             context.startActivity(intent)

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/IntentManagerUtils.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/util/IntentManagerUtils.kt
@@ -2,7 +2,6 @@
 
 package com.bitwarden.authenticator.ui.platform.util
 
-import android.content.Context
 import android.content.Intent
 import android.provider.Settings
 import androidx.core.net.toUri
@@ -12,10 +11,10 @@ import com.bitwarden.authenticator.ui.platform.manager.intent.IntentManager
 /**
  * Launches the authenticator app settings.
  */
-fun IntentManager.startAuthenticatorAppSettings(context: Context) {
+fun IntentManager.startAuthenticatorAppSettings() {
     startActivity(
         Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-            .setData("package:${context.packageName}".toUri()),
+            .setData("package:$packageName".toUri()),
     )
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the `IntentManager` and its extensions to simplify things where possible.

* Expose `packageName` from the IntentManager.
* Removes the context param from `ntentManager extensions.
* Minor bug fixes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
