### PR TITLE
[PM-24598] Map AutofillSaveItem to VaultItemCipherType

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -61,9 +61,9 @@ import com.x8bit.bitwarden.ui.tools.feature.send.addedit.ModeType
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.navigateToAddEditSend
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
 import com.x8bit.bitwarden.ui.vault.feature.addedit.navigateToVaultAddEdit
+import com.x8bit.bitwarden.ui.vault.feature.addedit.util.toVaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.navigateToVaultItemListingAsRoot
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
-import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
 import java.util.concurrent.atomic.AtomicReference
 
@@ -225,7 +225,7 @@ fun RootNavScreen(
                 navController.navigateToVaultAddEdit(
                     args = VaultAddEditArgs(
                         vaultAddEditType = VaultAddEditType.AddItem,
-                        vaultItemCipherType = VaultItemCipherType.LOGIN,
+                        vaultItemCipherType = currentState.autofillSaveItem.toVaultItemCipherType(),
                     ),
                     navOptions = rootNavOptions,
                 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensions.kt
@@ -5,6 +5,7 @@ import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
 import com.x8bit.bitwarden.ui.vault.model.VaultCardExpirationMonth
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import java.util.UUID
 
 /**
@@ -54,3 +55,11 @@ fun AutofillSaveItem.toDefaultAddTypeContent(
             )
         }
     }
+
+/**
+ * Converts an [AutofillSaveItem] to a [VaultItemCipherType].
+ */
+fun AutofillSaveItem.toVaultItemCipherType(): VaultItemCipherType = when (this) {
+    is AutofillSaveItem.Card -> VaultItemCipherType.CARD
+    is AutofillSaveItem.Login -> VaultItemCipherType.LOGIN
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.rootnav
 
 import androidx.navigation.navOptions
 import com.bitwarden.ui.platform.base.createMockNavHostController
+import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupAutofillRoute
 import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupCompleteRoute
@@ -242,9 +243,9 @@ class RootNavScreenTest : BitwardenComposeTest() {
             }
         }
 
-        // Make sure navigating to vault unlocked for autofill save works as expected:
+        // Make sure navigating to vault unlocked for autofill save for login works as expected:
         rootNavStateFlow.value = RootNavState.VaultUnlockedForAutofillSave(
-            autofillSaveItem = mockk(),
+            autofillSaveItem = mockk<AutofillSaveItem.Login>(),
         )
         composeTestRule.runOnIdle {
             verify {
@@ -257,6 +258,29 @@ class RootNavScreenTest : BitwardenComposeTest() {
                         vaultAddEditMode = VaultAddEditMode.ADD,
                         vaultItemId = null,
                         vaultItemCipherType = VaultItemCipherType.LOGIN,
+                        selectedFolderId = null,
+                        selectedCollectionId = null,
+                    ),
+                    navOptions = expectedNavOptions,
+                )
+            }
+        }
+
+        // Make sure navigating to vault unlocked for autofill save for card works as expected:
+        rootNavStateFlow.value = RootNavState.VaultUnlockedForAutofillSave(
+            autofillSaveItem = mockk<AutofillSaveItem.Card>(),
+        )
+        composeTestRule.runOnIdle {
+            verify {
+                mockNavHostController.navigate(
+                    route = VaultUnlockedGraphRoute,
+                    navOptions = expectedNavOptions,
+                )
+                mockNavHostController.navigate(
+                    route = VaultAddEditRoute(
+                        vaultAddEditMode = VaultAddEditMode.ADD,
+                        vaultItemId = null,
+                        vaultItemCipherType = VaultItemCipherType.CARD,
                         selectedFolderId = null,
                         selectedCollectionId = null,
                     ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensionsTest.kt
@@ -4,7 +4,9 @@ import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
 import com.x8bit.bitwarden.ui.vault.model.VaultCardExpirationMonth
+import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -74,6 +76,19 @@ class AutofillSaveItemExtensionsTest {
                 uri = "https://www.test.com",
             )
                 .toDefaultAddTypeContent(isIndividualVaultDisabled = true),
+        )
+    }
+
+    @Test
+    fun `toVaultItemCipherType should return the correct VaultItemCipherType`() {
+        assertEquals(
+            VaultItemCipherType.CARD,
+            mockk<AutofillSaveItem.Card>().toVaultItemCipherType(),
+        )
+
+        assertEquals(
+            VaultItemCipherType.LOGIN,
+            mockk<AutofillSaveItem.Login>().toVaultItemCipherType(),
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-24598

## 📔 Objective

When navigating to VaultAddEdit from an Autofill save notification, map the AutofillSaveItem type (Card or Login) to the corresponding VaultItemCipherType. This ensures the correct item type is pre-selected in the add/edit screen.

## 📸 Screenshots

<img width="661" height="234" alt="image" src="https://github.com/user-attachments/assets/842ce673-9d20-4cb2-9464-245723b42971" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
