### PR TITLE
[PM-24599] Add cardholderName to AutofillSaveItem.Card

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillSaveItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillSaveItem.kt
@@ -16,9 +16,11 @@ sealed class AutofillSaveItem : Parcelable {
      * @property expirationMonth The expiration month in string form (if applicable).
      * @property expirationYear The expiration year in string form (if applicable).
      * @property securityCode The security code for the card (if applicable).
+     * @property cardholderName The name on the card (if applicable).
      */
     @Parcelize
     data class Card(
+        val cardholderName: String?,
         val number: String?,
         val expirationMonth: String?,
         val expirationYear: String?,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillPartitionExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillPartitionExtensions.kt
@@ -35,6 +35,13 @@ val AutofillPartition.Card.securityCodeSaveValue: String?
         .extractNonNullTextValueOrNull { it is AutofillView.Card.SecurityCode }
 
 /**
+ * The text value representation of the cardholder name from the [AutofillPartition.Card].
+ */
+val AutofillPartition.Card.cardholderName: String?
+    get() = this
+        .extractNonNullTextValueOrNull { it is AutofillView.Card.CardholderName }
+
+/**
  * The text value representation of the password from the [AutofillPartition.Login].
  */
 val AutofillPartition.Login.passwordSaveValue: String?

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensions.kt
@@ -11,6 +11,7 @@ fun AutofillRequest.Fillable.toAutofillSaveItem(): AutofillSaveItem =
     when (this.partition) {
         is AutofillPartition.Card -> {
             AutofillSaveItem.Card(
+                cardholderName = partition.cardholderName,
                 number = partition.numberSaveValue,
                 expirationMonth = partition.expirationMonthSaveValue,
                 expirationYear = partition.expirationYearSaveValue,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensions.kt
@@ -21,6 +21,7 @@ fun AutofillSaveItem.toDefaultAddTypeContent(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 isIndividualVaultDisabled = isIndividualVaultDisabled,
                 type = VaultAddEditState.ViewState.Content.ItemType.Card(
+                    cardHolderName = this.cardholderName.orEmpty(),
                     number = this.number.orEmpty(),
                     expirationMonth = VaultCardExpirationMonth
                         .entries

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensionsTest.kt
@@ -36,6 +36,7 @@ class AutofillRequestExtensionsTest {
             every { partition } returns autofillPartition
         }
         val expected = AutofillSaveItem.Card(
+            cardholderName = SAVE_VALUE_CARDHOLDER_NAME,
             number = SAVE_VALUE_NUMBER,
             expirationMonth = SAVE_VALUE_MONTH,
             expirationYear = SAVE_VALUE_YEAR,
@@ -109,6 +110,7 @@ private const val SAVE_VALUE_CODE: String = "SAVE_VALUE_CODE"
 private const val SAVE_VALUE_MONTH: String = "SAVE_VALUE_MONTH"
 private const val SAVE_VALUE_NUMBER: String = "SAVE_VALUE_NUMBER"
 private const val SAVE_VALUE_YEAR: String = "SAVE_VALUE_YEAR"
+private const val SAVE_VALUE_CARDHOLDER_NAME: String = "SAVE_VALUE_CARDHOLDER_NAME"
 
 // LOGIN DATA
 private const val SAVE_VALUE_PASSWORD: String = "SAVE_VALUE_PASSWORD"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensionsTest.kt
@@ -39,6 +39,7 @@ class AutofillSaveItemExtensionsTest {
                 ),
             ),
             AutofillSaveItem.Card(
+                cardholderName = "cardholderName",
                 number = "number",
                 expirationMonth = "1",
                 expirationYear = "2024",


### PR DESCRIPTION
## 🎟️ Tracking

PM-24599

## 📔 Objective

This commit adds the `cardholderName` field to the `AutofillSaveItem.Card` data class and updates relevant extensions and tests to include this new field. Now, the cardholder's name can be saved and retrieved during autofill operations.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
