### PR TITLE
[PM-??] Improve Autofill Card Expiration Month and Year Parsing

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillView.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillView.kt
@@ -48,10 +48,14 @@ sealed class AutofillView {
         ) : Card()
 
         /**
-         * The expiration year [AutofillView] for the [Card] data partition.
+         * The expiration year [AutofillView] for the [Card] data partition. This implementation
+         * also has its own [yearValue] because it can be present in lists, in which case there
+         * is specialized logic for determining its [yearValue]. The [Data.textValue] is very
+         * likely going to be a very different value.
          */
         data class ExpirationYear(
             override val data: Data,
+            val yearValue: String?,
         ) : Card()
 
         /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillPartitionExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillPartitionExtensions.kt
@@ -9,16 +9,19 @@ import com.x8bit.bitwarden.data.autofill.model.AutofillView
 val AutofillPartition.Card.expirationMonthSaveValue: String?
     get() = this
         .views
-        .firstOrNull { it is AutofillView.Card.ExpirationMonth && it.monthValue != null }
-        ?.data
-        ?.textValue
+        .filterIsInstance<AutofillView.Card.ExpirationMonth>()
+        .firstOrNull { it.monthValue != null }
+        ?.monthValue
 
 /**
  * The text value representation of the year from the [AutofillPartition.Card].
  */
 val AutofillPartition.Card.expirationYearSaveValue: String?
     get() = this
-        .extractNonNullTextValueOrNull { it is AutofillView.Card.ExpirationYear }
+        .views
+        .filterIsInstance<AutofillView.Card.ExpirationYear>()
+        .firstOrNull { it.yearValue != null }
+        ?.yearValue
 
 /**
  * The text value representation of the card number from the [AutofillPartition.Card].

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensions.kt
@@ -35,3 +35,21 @@ fun AutofillValue.extractTextValue(): String? =
     } else {
         null
     }
+
+/**
+ * Extract a year value from this [AutofillValue].
+ */
+fun AutofillValue.extractYearValue(
+    autofillOptions: List<String>,
+): String? =
+    when {
+        this.isList && autofillOptions.isNotEmpty() -> {
+            autofillOptions.getOrNull(listValue)
+        }
+
+        this.isText -> {
+            this.textValue.toString()
+        }
+
+        else -> null
+    }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensions.kt
@@ -141,8 +141,15 @@ private fun AssistStructure.ViewNode.buildAutofillView(
     }
 
     AutofillHint.CARD_EXPIRATION_YEAR -> {
+        val yearValue = this
+            .autofillValue
+            ?.extractYearValue(
+                autofillOptions = autofillOptions,
+            )
+
         AutofillView.Card.ExpirationYear(
             data = autofillViewData,
+            yearValue = yearValue,
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

TBD

## 📔 Objective

This commit introduces a new `extractYearValue` extension function for `AutofillValue` to better handle year extraction, especially when presented as a list.

The `AutofillView.Card.ExpirationYear` now directly stores the parsed `yearValue`, and `AutofillPartition.Card.expirationYearSaveValue` utilizes this for more reliable year retrieval.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
