### PR TITLE
Support both camel and pascal case for AccountKeysJson

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/model/AccountKeysJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/AccountKeysJson.kt
@@ -1,7 +1,9 @@
 package com.bitwarden.network.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
 /**
  * Represents private keys in the vault response.
@@ -10,15 +12,19 @@ import kotlinx.serialization.Serializable
  * @property publicKeyEncryptionKeyPair The public key encryption key pair of the profile.
  * @property securityState The security state of the profile (nullable).
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class AccountKeysJson(
-    @SerialName("signatureKeyPair")
+    @SerialName("SignatureKeyPair")
+    @JsonNames("signatureKeyPair")
     val signatureKeyPair: SignatureKeyPair?,
 
-    @SerialName("publicKeyEncryptionKeyPair")
+    @SerialName("PublicKeyEncryptionKeyPair")
+    @JsonNames("publicKeyEncryptionKeyPair")
     val publicKeyEncryptionKeyPair: PublicKeyEncryptionKeyPair,
 
-    @SerialName("securityState")
+    @SerialName("SecurityState")
+    @JsonNames("securityState")
     val securityState: SecurityState?,
 ) {
 
@@ -30,10 +36,12 @@ data class AccountKeysJson(
      */
     @Serializable
     data class SignatureKeyPair(
-        @SerialName("wrappedSigningKey")
+        @SerialName("WrappedSigningKey")
+        @JsonNames("wrappedSigningKey")
         val wrappedSigningKey: String,
 
-        @SerialName("verifyingKey")
+        @SerialName("VerifyingKey")
+        @JsonNames("verifyingKey")
         val verifyingKey: String,
     )
 
@@ -48,13 +56,16 @@ data class AccountKeysJson(
      */
     @Serializable
     data class PublicKeyEncryptionKeyPair(
-        @SerialName("wrappedPrivateKey")
+        @SerialName("WrappedPrivateKey")
+        @JsonNames("wrappedPrivateKey")
         val wrappedPrivateKey: String,
 
-        @SerialName("publicKey")
+        @SerialName("PublicKey")
+        @JsonNames("publicKey")
         val publicKey: String,
 
-        @SerialName("signedPublicKey")
+        @SerialName("SignedPublicKey")
+        @JsonNames("signedPublicKey")
         val signedPublicKey: String?,
     )
 
@@ -66,10 +77,12 @@ data class AccountKeysJson(
      */
     @Serializable
     data class SecurityState(
-        @SerialName("securityState")
+        @SerialName("SecurityState")
+        @JsonNames("securityState")
         val securityState: String,
 
-        @SerialName("securityVersion")
+        @SerialName("SecurityVersion")
+        @JsonNames("securityVersion")
         val securityVersion: Int,
     )
 }


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

The `AccountKeysJson` and its nested classes now support both camelCase and PascalCase for their JSON properties by using `@JsonNames` annotation. This ensures compatibility with different API response formats.

This change is necessary because the `GetToken` response uses `PascalCase` while the `SyncResponseJson` models use `camelCase`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
