### PR TITLE
PM-24942: Move Segmented control to UI module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -56,6 +56,9 @@ import com.bitwarden.ui.platform.components.field.model.TextToolbarType
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.model.TooltipData
 import com.bitwarden.ui.platform.components.model.TopAppBarDividerStyle
+import com.bitwarden.ui.platform.components.segment.BitwardenSegmentedButton
+import com.bitwarden.ui.platform.components.segment.SegmentedButtonOptionContent
+import com.bitwarden.ui.platform.components.segment.SegmentedButtonState
 import com.bitwarden.ui.platform.components.slider.BitwardenSlider
 import com.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarData
 import com.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
@@ -78,9 +81,6 @@ import com.x8bit.bitwarden.ui.platform.components.coachmark.model.CoachMarkHighl
 import com.x8bit.bitwarden.ui.platform.components.coachmark.rememberLazyListCoachMarkState
 import com.x8bit.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.x8bit.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
-import com.x8bit.bitwarden.ui.platform.components.segment.BitwardenSegmentedButton
-import com.x8bit.bitwarden.ui.platform.components.segment.SegmentedButtonOptionContent
-import com.x8bit.bitwarden.ui.platform.components.segment.SegmentedButtonState
 import com.x8bit.bitwarden.ui.platform.composition.LocalAppResumeStateManager
 import com.x8bit.bitwarden.ui.platform.composition.LocalIntentManager
 import com.x8bit.bitwarden.ui.platform.manager.intent.IntentManager

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.segment
+package com.bitwarden.ui.platform.components.segment
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -34,8 +34,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.nullableTestTag
 import com.bitwarden.ui.platform.base.util.toDp
+import com.bitwarden.ui.platform.components.segment.color.bitwardenSegmentedButtonColors
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.x8bit.bitwarden.ui.platform.components.segment.color.bitwardenSegmentedButtonColors
 import kotlinx.collections.immutable.ImmutableList
 
 private const val FONT_SCALE_THRESHOLD = 1.5f

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/segment/color/BitwardenSegmentedButtonColors.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/segment/color/BitwardenSegmentedButtonColors.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.segment.color
+package com.bitwarden.ui.platform.components.segment.color
 
 import androidx.compose.material3.SegmentedButtonColors
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24942](https://bitwarden.atlassian.net/browse/PM-24942)

## 📔 Objective

This PR moves the `BitwardenSegmentedControl` to the `ui` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24942]: https://bitwarden.atlassian.net/browse/PM-24942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ