### PR TITLE
PM-24943: Move the scrim package to the UI module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/account/BitwardenAccountSwitcher.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/account/BitwardenAccountSwitcher.kt
@@ -53,6 +53,7 @@ import com.bitwarden.ui.platform.base.util.scrolledContainerBackground
 import com.bitwarden.ui.platform.base.util.toSafeOverlayColor
 import com.bitwarden.ui.platform.base.util.toUnscaledTextUnit
 import com.bitwarden.ui.platform.components.divider.BitwardenHorizontalDivider
+import com.bitwarden.ui.platform.components.scrim.BitwardenAnimatedScrim
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -62,7 +63,6 @@ import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenRemovalConfirm
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenSelectionDialog
 import com.x8bit.bitwarden.ui.platform.components.dialog.row.BitwardenBasicDialogRow
 import com.x8bit.bitwarden.ui.platform.components.model.AccountSummary
-import com.x8bit.bitwarden.ui.platform.components.scrim.BitwardenAnimatedScrim
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.iconRes
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.iconTestTag
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.initials

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/scaffold/BitwardenScaffold.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/scaffold/BitwardenScaffold.kt
@@ -42,13 +42,13 @@ import androidx.compose.ui.zIndex
 import com.bitwarden.ui.platform.base.util.toDp
 import com.bitwarden.ui.platform.components.navigation.BitwardenBottomAppBar
 import com.bitwarden.ui.platform.components.navigation.BitwardenNavigationRail
+import com.bitwarden.ui.platform.components.scrim.BitwardenAnimatedScrim
 import com.bitwarden.ui.platform.model.WindowSize
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.platform.util.rememberWindowSize
 import com.x8bit.bitwarden.ui.platform.components.model.BitwardenPullToRefreshState
 import com.x8bit.bitwarden.ui.platform.components.model.ScaffoldNavigationData
 import com.x8bit.bitwarden.ui.platform.components.model.rememberBitwardenPullToRefreshState
-import com.x8bit.bitwarden.ui.platform.components.scrim.BitwardenAnimatedScrim
 
 /**
  * Direct passthrough to [Scaffold] but contains a few specific override values. Everything is

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/scrim/BitwardenAnimatedScrim.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/scrim/BitwardenAnimatedScrim.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.components.scrim
+package com.bitwarden.ui.platform.components.scrim
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24943](https://bitwarden.atlassian.net/browse/PM-24943)

## 📔 Objective

This PR moves the `BitwardenAnimatedScrim` to the `ui` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24943]: https://bitwarden.atlassian.net/browse/PM-24943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ