### PR TITLE
PM-20198: Update generator modal 'Save' button to 'Apply'

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -345,7 +345,7 @@ private fun ModalAppBar(
         },
         actions = {
             BitwardenTextButton(
-                label = stringResource(id = BitwardenString.save),
+                label = stringResource(id = BitwardenString.apply),
                 onClick = onSaveClick,
                 modifier = Modifier.testTag("SaveButton"),
             )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -87,7 +87,7 @@ class GeneratorScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText(text = "Save")
+            .onNodeWithText(text = "Apply")
             .assertIsDisplayed()
     }
 
@@ -104,7 +104,7 @@ class GeneratorScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
 
         composeTestRule
-            .onNodeWithText(text = "Save")
+            .onNodeWithText(text = "Apply")
             .assertIsDisplayed()
     }
 
@@ -126,7 +126,7 @@ class GeneratorScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `on save click should send SaveClick`() {
+    fun `on Apply click should send SaveClick`() {
         updateState(
             DEFAULT_STATE.copy(
                 generatorMode = GeneratorMode.Modal.Username(website = null),
@@ -134,7 +134,7 @@ class GeneratorScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithText(text = "Save")
+            .onNodeWithText(text = "Apply")
             .performClick()
 
         verify {

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="add_folder">Add folder</string>
     <string name="add_item">Add Item</string>
     <string name="an_error_has_occurred">An error has occurred</string>
+    <string name="apply">Apply</string>
     <string name="back">Back</string>
     <string name="bitwarden">Bitwarden</string>
     <string name="cancel">Cancel</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20198](https://bitwarden.atlassian.net/browse/PM-20198)

## 📔 Objective

This PR updates the Generator modal `Save` button to be `Apply`.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d5bd26dd-f1d2-4cae-9764-77f6942b8ab2" width="300" /> | <img src="https://github.com/user-attachments/assets/2e722186-49a3-4269-988b-749ffa9cb32c" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20198]: https://bitwarden.atlassian.net/browse/PM-20198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ