### PR TITLE
Refactor AccountKeysJson property names

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/model/AccountKeysJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/AccountKeysJson.kt
@@ -1,9 +1,7 @@
 package com.bitwarden.network.model
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonNames
 
 /**
  * Represents private keys in the vault response.
@@ -12,19 +10,15 @@ import kotlinx.serialization.json.JsonNames
  * @property publicKeyEncryptionKeyPair The public key encryption key pair of the profile.
  * @property securityState The security state of the profile (nullable).
  */
-@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class AccountKeysJson(
-    @SerialName("SignatureKeyPair")
-    @JsonNames("signatureKeyPair")
+    @SerialName("signatureKeyPair")
     val signatureKeyPair: SignatureKeyPair?,
 
-    @SerialName("PublicKeyEncryptionKeyPair")
-    @JsonNames("publicKeyEncryptionKeyPair")
+    @SerialName("publicKeyEncryptionKeyPair")
     val publicKeyEncryptionKeyPair: PublicKeyEncryptionKeyPair,
 
-    @SerialName("SecurityState")
-    @JsonNames("securityState")
+    @SerialName("securityState")
     val securityState: SecurityState?,
 ) {
 
@@ -36,12 +30,10 @@ data class AccountKeysJson(
      */
     @Serializable
     data class SignatureKeyPair(
-        @SerialName("WrappedSigningKey")
-        @JsonNames("wrappedSigningKey")
+        @SerialName("wrappedSigningKey")
         val wrappedSigningKey: String,
 
-        @SerialName("VerifyingKey")
-        @JsonNames("verifyingKey")
+        @SerialName("verifyingKey")
         val verifyingKey: String,
     )
 
@@ -56,16 +48,13 @@ data class AccountKeysJson(
      */
     @Serializable
     data class PublicKeyEncryptionKeyPair(
-        @SerialName("WrappedPrivateKey")
-        @JsonNames("wrappedPrivateKey")
+        @SerialName("wrappedPrivateKey")
         val wrappedPrivateKey: String,
 
-        @SerialName("PublicKey")
-        @JsonNames("publicKey")
+        @SerialName("publicKey")
         val publicKey: String,
 
-        @SerialName("SignedPublicKey")
-        @JsonNames("signedPublicKey")
+        @SerialName("signedPublicKey")
         val signedPublicKey: String?,
     )
 
@@ -77,12 +66,10 @@ data class AccountKeysJson(
      */
     @Serializable
     data class SecurityState(
-        @SerialName("SecurityState")
-        @JsonNames("securityState")
+        @SerialName("securityState")
         val securityState: String,
 
-        @SerialName("SecurityVersion")
-        @JsonNames("securityVersion")
+        @SerialName("securityVersion")
         val securityVersion: Int,
     )
 }


### PR DESCRIPTION
## 🎟️ Tracking

Relates to https://github.com/bitwarden/server/commit/8a39481fec87848e19cdd92d620d3e23b97901cb

## 📔 Objective

The commit refactors the `AccountKeysJson` data class and its nested classes.
It removes the `@OptIn(ExperimentalSerializationApi::class)` annotation and updates the `@SerialName` annotations to use camelCase for consistency.
The `@JsonNames` annotations, which provided alternative names for deserialization, have been removed. This implies that the API now strictly expects camelCase keys.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
