### PR TITLE
PM-24544: Update Segmented Control to handle large font better

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/DensityExtensions.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/DensityExtensions.kt
@@ -3,12 +3,14 @@ package com.bitwarden.ui.platform.base.util
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.sp
 
 /**
  * A function for converting pixels to [Dp] within a composable function.
@@ -49,3 +51,26 @@ fun Dp.toUnscaledTextUnit(): TextUnit {
     val scalingFactor = LocalConfiguration.current.fontScale
     return TextUnit(value / scalingFactor, TextUnitType.Sp)
 }
+
+/**
+ * Modifies the [TextUnit] value to have a maximum scale factor for accessibility.
+ */
+@Composable
+fun TextUnit.maxScaledSp(maxScaleFactor: Float): TextUnit {
+    val scaleFactor = LocalConfiguration.current.fontScale
+    val adjustedScaleFactor = scaleFactor.coerceAtMost(maximumValue = maxScaleFactor)
+    val adjustedValue = (this.value / scaleFactor) * adjustedScaleFactor
+    return adjustedValue.sp
+}
+
+/**
+ * Creates a copy of the [TextStyle] that has a maximum scale factor.
+ */
+@Composable
+fun TextStyle.toMaxScale(
+    maxScaleFactor: Float,
+): TextStyle = this.copy(
+    fontSize = this.fontSize.maxScaledSp(maxScaleFactor = maxScaleFactor),
+    lineHeight = this.lineHeight.maxScaledSp(maxScaleFactor = maxScaleFactor),
+    letterSpacing = this.letterSpacing.maxScaledSp(maxScaleFactor = maxScaleFactor),
+)

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/segment/BitwardenSegmentedButton.kt
@@ -26,19 +26,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.style.Hyphens
+import androidx.compose.ui.text.style.LineBreak
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.nullableTestTag
 import com.bitwarden.ui.platform.base.util.toDp
+import com.bitwarden.ui.platform.base.util.toMaxScale
 import com.bitwarden.ui.platform.components.segment.color.bitwardenSegmentedButtonColors
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import kotlinx.collections.immutable.ImmutableList
-
-private const val FONT_SCALE_THRESHOLD = 1.5f
 
 /**
  * Displays a Bitwarden styled row of segmented buttons.
@@ -107,12 +107,6 @@ fun SingleChoiceSegmentedButtonRowScope.SegmentedButtonOptionContent(
     option: SegmentedButtonState,
     modifier: Modifier = Modifier,
 ) {
-    val fontScale = LocalConfiguration.current.fontScale
-    val labelVerticalPadding = if (fontScale > FONT_SCALE_THRESHOLD) {
-        8.dp
-    } else {
-        0.dp
-    }
     SegmentedButton(
         enabled = option.isEnabled,
         selected = option.isChecked,
@@ -123,13 +117,12 @@ fun SingleChoiceSegmentedButtonRowScope.SegmentedButtonOptionContent(
         label = {
             Text(
                 text = option.text,
-                style = BitwardenTheme.typography.labelLarge.copy(
-                    hyphens = Hyphens.Auto,
-                ),
-                modifier = Modifier.padding(
-                    vertical = labelVerticalPadding,
-                    horizontal = 4.dp,
-                ),
+                style = BitwardenTheme.typography.labelLarge
+                    .copy(lineBreak = LineBreak.Heading)
+                    .toMaxScale(maxScaleFactor = 2f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
             )
         },
         icon = {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24544](https://bitwarden.atlassian.net/browse/PM-24544)

## 📔 Objective

This PR updates the `BitwardenSegmentedControl` to handle large font without wrapping to multiple lines.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="300" src="https://github.com/user-attachments/assets/642d6906-db01-4499-8baa-a938d88912fb" /> | <img width="300" src="https://github.com/user-attachments/assets/838ce7f2-d5d6-4338-a079-945e1de5cee0" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24544]: https://bitwarden.atlassian.net/browse/PM-24544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ