### PR TITLE
[PM-24940] Add Card Brand to Autofill

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderImpl.kt
@@ -196,6 +196,10 @@ private fun AutofillCipher.Card.getAutofillValueOrNull(autofillView: AutofillVie
                 null
             }
         }
+
+        is AutofillView.Card.Brand -> {
+            brand.takeIf { it.isNotEmpty() }
+        }
     }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillCipher.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillCipher.kt
@@ -46,6 +46,7 @@ sealed class AutofillCipher {
         val expirationMonth: String,
         val expirationYear: String,
         val number: String,
+        val brand: String,
     ) : AutofillCipher() {
         override val iconRes: Int
             @DrawableRes get() = BitwardenDrawable.ic_payment_card

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillHint.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillHint.kt
@@ -10,6 +10,7 @@ enum class AutofillHint {
     CARD_EXPIRATION_YEAR,
     CARD_NUMBER,
     CARD_SECURITY_CODE,
+    CARD_BRAND,
     PASSWORD,
     USERNAME,
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillSaveItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillSaveItem.kt
@@ -25,6 +25,7 @@ sealed class AutofillSaveItem : Parcelable {
         val expirationMonth: String?,
         val expirationYear: String?,
         val securityCode: String?,
+        val brand: String?,
     ) : AutofillSaveItem()
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillView.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/AutofillView.kt
@@ -85,6 +85,17 @@ sealed class AutofillView {
         data class SecurityCode(
             override val data: Data,
         ) : Card()
+
+        /**
+         * The brand [AutofillView] for the [Card] data partition. This implementation also has its
+         * own [brandValue] because it can be present in lists, in which case there is specialized
+         * logic for determining its [brandValue]. The [Data.textValue] is very likely going to be
+         * a very different value.
+         */
+        data class Brand(
+            override val data: Data,
+            val brandValue: String?,
+        ) : Card()
     }
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/provider/AutofillCipherProviderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/provider/AutofillCipherProviderImpl.kt
@@ -78,6 +78,7 @@ class AutofillCipherProviderImpl(
                                     expirationMonth = cipherView.card?.expMonth.orEmpty(),
                                     expirationYear = cipherView.card?.expYear.orEmpty(),
                                     number = cipherView.card?.number.orEmpty(),
+                                    brand = cipherView.card?.brand.orEmpty(),
                                 )
                             }
                         }
@@ -138,10 +139,12 @@ class AutofillCipherProviderImpl(
                 Timber.e("Cipher not found for autofill.")
                 null
             }
+
             is GetCipherResult.Failure -> {
                 Timber.e(result.error, "Failed to decrypt cipher for autofill.")
                 null
             }
+
             is GetCipherResult.Success -> result.cipherView
         }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillPartitionExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillPartitionExtensions.kt
@@ -45,6 +45,17 @@ val AutofillPartition.Card.cardholderNameSaveValue: String?
         .extractNonNullTextValueOrNull { it is AutofillView.Card.CardholderName }
 
 /**
+ * The text value representation of the brand from the [AutofillPartition.Card].
+ */
+val AutofillPartition.Card.brandSaveValue: String?
+    get() = this
+        .views
+        .filterIsInstance<AutofillView.Card.Brand>()
+        .firstOrNull { it.brandValue != null }
+        ?.brandValue
+        ?: this.extractNonNullTextValueOrNull { it is AutofillView.Card.Brand }
+
+/**
  * The text value representation of the password from the [AutofillPartition.Login].
  */
 val AutofillPartition.Login.passwordSaveValue: String?

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensions.kt
@@ -16,6 +16,7 @@ fun AutofillRequest.Fillable.toAutofillSaveItem(): AutofillSaveItem =
                 expirationMonth = partition.expirationMonthSaveValue,
                 expirationYear = partition.expirationYearSaveValue,
                 securityCode = partition.securityCodeSaveValue,
+                brand = partition.brandSaveValue,
             )
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensions.kt
@@ -53,3 +53,21 @@ fun AutofillValue.extractYearValue(
 
         else -> null
     }
+
+/**
+ * Extract a card brand value from this [AutofillValue].
+ */
+fun AutofillValue.extractCardBrandValue(
+    autofillOptions: List<String>,
+): String? =
+    when {
+        this.isList && autofillOptions.isNotEmpty() -> {
+            autofillOptions.getOrNull(listValue)
+        }
+
+        this.isText -> {
+            this.textValue.toString()
+        }
+
+        else -> null
+    }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillViewExtensions.kt
@@ -4,6 +4,8 @@ import android.view.View
 import android.view.autofill.AutofillValue
 import com.x8bit.bitwarden.data.autofill.model.AutofillView
 import com.x8bit.bitwarden.data.autofill.model.FilledItem
+import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
+import com.x8bit.bitwarden.ui.vault.model.findVaultCardBrandWithNameOrNull
 
 /**
  * Convert this [AutofillView] into a [FilledItem]. Return null if not possible.
@@ -66,6 +68,16 @@ private fun AutofillView.buildListAutofillValueOrNull(
             autofillOptions
                 .firstOrNull { it == value || it.takeLast(2) == value.takeLast(2) }
                 ?.let { AutofillValue.forList(autofillOptions.indexOf(it)) }
+        }
+
+        is AutofillView.Card.Brand -> {
+            value.findVaultCardBrandWithNameOrNull()
+                ?.takeUnless { it == VaultCardBrand.SELECT }
+                ?.let { vaultCardBrand ->
+                    this.data.autofillOptions
+                        .firstOrNull { it.findVaultCardBrandWithNameOrNull() == vaultCardBrand }
+                        ?.let { AutofillValue.forList(this.data.autofillOptions.indexOf(it)) }
+                }
         }
 
         is AutofillView.Card.CardholderName,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensions.kt
@@ -24,6 +24,7 @@ fun CipherView.toAutofillCipherProvider(): AutofillCipherProvider =
                     expirationMonth = card.expMonth.orEmpty(),
                     expirationYear = card.expYear.orEmpty(),
                     number = card.number.orEmpty(),
+                    brand = card.brand.orEmpty(),
                 ),
             )
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/HtmlInfoExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/HtmlInfoExtensions.kt
@@ -53,6 +53,12 @@ fun HtmlInfo?.isCardSecurityCodeField(): Boolean = isInputField &&
     hints().containsAnyPatterns(SUPPORTED_RAW_CARD_SECURITY_CODE_HINT_PATTERNS)
 
 /**
+ * Whether this [HtmlInfo] represents a card brand field.
+ */
+fun HtmlInfo?.isCardBrandField(): Boolean = isInputField &&
+    hints().containsAnyTerms(SUPPORTED_RAW_CARD_BRAND_HINTS)
+
+/**
  * Attributes that can be used as hints to determine the type of data the associated node expects.
  *
  * This function is untestable as [HtmlInfo] contains [android.util.Pair] which requires
@@ -97,7 +103,11 @@ private fun List<String>.containsAnyPatterns(patterns: List<Regex>): Boolean = t
  * Checks if the list of strings contains any of the specified terms.
  */
 private fun List<String>.containsAnyTerms(terms: List<String>): Boolean =
-    this.any { string -> string.containsAnyTerms(terms) }
+    this.any { string ->
+        string
+            .toLowerCaseAndStripNonAlpha()
+            .containsAnyTerms(terms)
+    }
 
 /**
  * The supported attribute keys whose value can represent an autofill hint.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/StringExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/StringExtensions.kt
@@ -26,3 +26,10 @@ fun String.matchesAnyExpressions(
     expressions.any {
         this.matches(regex = it)
     }
+
+/**
+ * Convert this [String] to lowercase and remove all non-alpha characters.
+ */
+fun String.toLowerCaseAndStripNonAlpha(): String = this
+    .lowercase()
+    .replace(Regex("[^a-z]"), "")

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewStructureUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewStructureUtils.kt
@@ -135,3 +135,15 @@ val SUPPORTED_RAW_CARD_SECURITY_CODE_HINT_PATTERNS: List<Regex> = listOf(
     "\\b(?i)(?:credit[\\s_-])?(?:cc|card)(?:[\\s_-](?:verification|security))?([\\s_-]code)\\b"
         .toRegex(),
 )
+
+/**
+ * The supported card brand autofill hints.
+ */
+val SUPPORTED_RAW_CARD_BRAND_HINTS: List<String> = listOf(
+    "cctype",
+    "creditcardtype",
+    "cardtype",
+    "cardbrand",
+    "creditcardbrand",
+    "ccbrand",
+)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensions.kt
@@ -4,8 +4,10 @@ import com.bitwarden.ui.platform.base.util.toHostOrPathOrNull
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
+import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 import com.x8bit.bitwarden.ui.vault.model.VaultCardExpirationMonth
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.model.findVaultCardBrandWithNameOrNull
 import java.util.UUID
 
 /**
@@ -29,6 +31,9 @@ fun AutofillSaveItem.toDefaultAddTypeContent(
                         ?: VaultCardExpirationMonth.SELECT,
                     expirationYear = this.expirationYear.orEmpty(),
                     securityCode = this.securityCode.orEmpty(),
+                    brand = this.brand
+                        ?.findVaultCardBrandWithNameOrNull()
+                        ?: VaultCardBrand.SELECT,
                 ),
             )
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/builder/FilledDataBuilderTest.kt
@@ -191,6 +191,7 @@ class FilledDataBuilderTest {
                 name = "Cipher One",
                 number = number,
                 subtitle = "Subtitle",
+                brand = "Visa",
             )
             val filledItemCode: FilledItem = mockk()
             val filledItemExpirationMonth: FilledItem = mockk()
@@ -198,6 +199,7 @@ class FilledDataBuilderTest {
             val filledItemNumber: FilledItem = mockk()
             val filledItemCardholderName: FilledItem = mockk()
             val filledItemExpirationDate: FilledItem = mockk()
+            val filledItemCardBrand: FilledItem = mockk()
             val autofillViewCode: AutofillView.Card.SecurityCode = mockk {
                 every { buildFilledItemOrNull(code) } returns filledItemCode
             }
@@ -219,6 +221,9 @@ class FilledDataBuilderTest {
             val autofillViewExpirationDate: AutofillView.Card.ExpirationDate = mockk {
                 every { buildFilledItemOrNull(expirationDate) } returns filledItemExpirationDate
             }
+            val autofillViewCardBrand: AutofillView.Card.Brand = mockk {
+                every { buildFilledItemOrNull(autofillCipher.brand) } returns filledItemCardBrand
+            }
             val autofillPartition = AutofillPartition.Card(
                 views = listOf(
                     autofillViewCode,
@@ -228,6 +233,7 @@ class FilledDataBuilderTest {
                     autofillViewNumberTwo,
                     autofillViewCardholderName,
                     autofillViewExpirationDate,
+                    autofillViewCardBrand,
                 ),
             )
             val ignoreAutofillIds: List<AutofillId> = mockk()
@@ -248,6 +254,7 @@ class FilledDataBuilderTest {
                     filledItemNumber,
                     filledItemCardholderName,
                     filledItemExpirationDate,
+                    filledItemCardBrand,
                 ),
                 inlinePresentationSpec = null,
             )
@@ -281,6 +288,7 @@ class FilledDataBuilderTest {
                 autofillViewNumberTwo.buildFilledItemOrNull(number)
                 autofillViewCardholderName.buildFilledItemOrNull(cardholderName)
                 autofillViewExpirationDate.buildFilledItemOrNull(expirationDate)
+                autofillViewCardBrand.buildFilledItemOrNull(autofillCipher.brand)
             }
         }
 
@@ -302,11 +310,8 @@ class FilledDataBuilderTest {
                 name = "",
                 number = number,
                 subtitle = "",
+                brand = "",
             )
-            val filledItemCode: FilledItem = mockk()
-            val filledItemExpirationMonth: FilledItem = mockk()
-            val filledItemExpirationYear: FilledItem = mockk()
-            val filledItemNumber: FilledItem = mockk()
             val autofillViewCode: AutofillView.Card.SecurityCode = mockk()
             val autofillViewExpirationMonth: AutofillView.Card.ExpirationMonth = mockk()
             val autofillViewExpirationYear: AutofillView.Card.ExpirationYear = mockk()
@@ -314,6 +319,7 @@ class FilledDataBuilderTest {
             val autofillViewNumberTwo: AutofillView.Card.Number = mockk()
             val autofillViewCardholderName: AutofillView.Card.CardholderName = mockk()
             val autofillViewExpirationDate: AutofillView.Card.ExpirationDate = mockk()
+            val autofillViewBrand: AutofillView.Card.Brand = mockk()
             val autofillPartition = AutofillPartition.Card(
                 views = listOf(
                     autofillViewCode,
@@ -323,6 +329,7 @@ class FilledDataBuilderTest {
                     autofillViewNumberTwo,
                     autofillViewCardholderName,
                     autofillViewExpirationDate,
+                    autofillViewBrand,
                 ),
             )
             val ignoreAutofillIds: List<AutofillId> = mockk()
@@ -369,6 +376,10 @@ class FilledDataBuilderTest {
                 autofillViewExpirationYear.buildFilledItemOrNull(expirationYear)
                 autofillViewNumberOne.buildFilledItemOrNull(number)
                 autofillViewNumberTwo.buildFilledItemOrNull(number)
+                autofillViewCardholderName.buildFilledItemOrNull(autofillCipher.cardholderName)
+                autofillViewExpirationMonth.buildFilledItemOrNull(autofillCipher.expirationMonth)
+                autofillViewExpirationYear.buildFilledItemOrNull(autofillCipher.expirationYear)
+                autofillViewBrand.buildFilledItemOrNull(autofillCipher.brand)
             }
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillCipherProviderTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillCipherProviderTest.kt
@@ -62,7 +62,7 @@ class AutofillCipherProviderTest {
         every { expMonth } returns CARD_EXP_MONTH
         every { expYear } returns CARD_EXP_YEAR
         every { number } returns CARD_NUMBER
-        every { brand } returns null
+        every { brand } returns CARD_BRAND
     }
     private val cardCipherView: CipherView = mockk {
         every { card } returns cardView
@@ -548,7 +548,8 @@ private const val CARD_EXP_MONTH = "January"
 private const val CARD_EXP_YEAR = "2029"
 private const val CARD_NAME = "John's Card"
 private const val CARD_NUMBER = "1234567890"
-private const val CARD_SUBTITLE = "7890"
+private const val CARD_BRAND = "Visa"
+private const val CARD_SUBTITLE = "$CARD_BRAND, *7890"
 private const val LOGIN_WITH_TOTP_CIPHER_ID = "1234567890"
 private const val LOGIN_WITHOUT_TOTP_CIPHER_ID = "ABCDEFGHIJ"
 private const val CARD_CIPHER_ID = "0987654321"
@@ -561,6 +562,7 @@ private val CARD_AUTOFILL_CIPHER = AutofillCipher.Card(
     name = CARD_NAME,
     number = CARD_NUMBER,
     subtitle = CARD_SUBTITLE,
+    brand = CARD_BRAND,
 )
 private const val LOGIN_NAME = "John's Login"
 private const val LOGIN_PASSWORD = "Password123"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillPartitionExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillPartitionExtensionsTest.kt
@@ -300,6 +300,76 @@ class AutofillPartitionExtensionsTest {
         assertEquals(TEXT_VALUE, actual)
     }
 
+    @Test
+    fun `brandSaveValue should return null when no brand views present`() {
+        val autofillPartition = AutofillPartition.Card(
+            views = listOf(
+                AutofillView.Card.ExpirationYear(
+                    data = autofillDataValidText,
+                    yearValue = TEXT_VALUE,
+                ),
+            ),
+        )
+        val actual = autofillPartition.brandSaveValue
+        assertNull(actual)
+    }
+
+    @Test
+    fun `brandSaveValue should return null when has brand view but no textValue`() {
+        val autofillPartition = AutofillPartition.Card(
+            views = listOf(
+                AutofillView.Card.Brand(
+                    data = autofillDataEmptyText,
+                    brandValue = null,
+                ),
+            ),
+        )
+        val actual = autofillPartition.brandSaveValue
+        assertNull(actual)
+    }
+
+    @Test
+    fun `brandSaveValue should return text value when has brand view has textValue`() {
+        val autofillPartition = AutofillPartition.Card(
+            views = listOf(
+                AutofillView.Card.Brand(
+                    data = autofillDataValidText,
+                    brandValue = TEXT_VALUE,
+                ),
+            ),
+        )
+        val actual = autofillPartition.brandSaveValue
+        assertEquals(TEXT_VALUE, actual)
+    }
+
+    @Test
+    fun `brandSaveValue should return null when has brand view but no brandValue`() {
+        val autofillPartition = AutofillPartition.Card(
+            views = listOf(
+                AutofillView.Card.Brand(
+                    data = autofillDataValidText.copy(textValue = null),
+                    brandValue = null,
+                ),
+            ),
+        )
+        val actual = autofillPartition.brandSaveValue
+        assertNull(actual)
+    }
+
+    @Test
+    fun `brandSaveValue should return text value when has brand view has brandValue`() {
+        val autofillPartition = AutofillPartition.Card(
+            views = listOf(
+                AutofillView.Card.Brand(
+                    data = autofillDataValidText,
+                    brandValue = TEXT_VALUE,
+                ),
+            ),
+        )
+        val actual = autofillPartition.brandSaveValue
+        assertEquals(TEXT_VALUE, actual)
+    }
+
     //endregion Card tests
 
     // region Login tests

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillRequestExtensionsTest.kt
@@ -32,6 +32,7 @@ class AutofillRequestExtensionsTest {
             every { numberSaveValue } returns SAVE_VALUE_NUMBER
             every { securityCodeSaveValue } returns SAVE_VALUE_CODE
             every { cardholderNameSaveValue } returns SAVE_VALUE_CARDHOLDER_NAME
+            every { brandSaveValue } returns SAVE_VALUE_BRAND
         }
         val autofillRequest: AutofillRequest.Fillable = mockk {
             every { partition } returns autofillPartition
@@ -42,6 +43,7 @@ class AutofillRequestExtensionsTest {
             expirationMonth = SAVE_VALUE_MONTH,
             expirationYear = SAVE_VALUE_YEAR,
             securityCode = SAVE_VALUE_CODE,
+            brand = SAVE_VALUE_BRAND,
         )
 
         // Test
@@ -52,7 +54,7 @@ class AutofillRequestExtensionsTest {
     }
 
     @Test
-    fun `toAutofillSaveItem should return AutofillSaveItem Login when card partition`() {
+    fun `toAutofillSaveItem should return AutofillSaveItem Login when login partition`() {
         RAW_URI_LIST
             .forEach { rawUri ->
                 // Setup
@@ -108,6 +110,7 @@ private const val AUTOFILL_REQUEST_EXTENSIONS_PATH =
 
 // CARD DATA
 private const val SAVE_VALUE_CODE: String = "SAVE_VALUE_CODE"
+private const val SAVE_VALUE_BRAND: String = "SAVE_VALUE_BRAND"
 private const val SAVE_VALUE_MONTH: String = "SAVE_VALUE_MONTH"
 private const val SAVE_VALUE_NUMBER: String = "SAVE_VALUE_NUMBER"
 private const val SAVE_VALUE_YEAR: String = "SAVE_VALUE_YEAR"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/AutofillValueExtensionsTest.kt
@@ -60,7 +60,7 @@ class AutofillValueExtensionsTest {
     }
 
     @Test
-    fun `extractMonthValue should return null not list or text`() {
+    fun `extractMonthValue should return null when not list or text`() {
         // Setup
         val autofillOptions = List(1) { "option-$it" }
         val autofillValue: AutofillValue = mockk {
@@ -126,7 +126,7 @@ class AutofillValueExtensionsTest {
     }
 
     @Test
-    fun `extractYearValue should return null not list or text`() {
+    fun `extractYearValue should return null when not list or text`() {
         // Setup
         val autofillOptions = List(1) { "option-$it" }
         val autofillValue: AutofillValue = mockk {
@@ -137,6 +137,64 @@ class AutofillValueExtensionsTest {
         // Test
         val actual = autofillValue.extractYearValue(autofillOptions)
 
+        // Verify
+        assertNull(actual)
+    }
+
+    @Test
+    fun `extractCardBrandValue should return listValue when isList and options are not empty`() {
+        // Setup
+        val autofillOptions = List(8) { "$it" }
+        val autofillValue: AutofillValue = mockk {
+            every { isList } returns true
+            every { listValue } returns LIST_VALUE
+        }
+        val expected = LIST_VALUE.toString()
+        // Test
+        val actual = autofillValue.extractCardBrandValue(autofillOptions)
+        // Verify
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `extractCardBrandValue should return null when isList and options are empty`() {
+        // Setup
+        val autofillOptions = emptyList<String>()
+        val autofillValue: AutofillValue = mockk {
+            every { isList } returns true
+            every { isText } returns false
+        }
+        // Test
+        val actual = autofillValue.extractCardBrandValue(autofillOptions)
+        // Verify
+        assertNull(actual)
+    }
+
+    @Test
+    fun `extractCardBrandValue should return textValue when isText`() {
+        // Setup
+        val autofillOptions = emptyList<String>()
+        val autofillValue: AutofillValue = mockk {
+            every { isList } returns false
+            every { isText } returns true
+            every { textValue } returns TEXT_VALUE
+        }
+
+        val actual = autofillValue.extractCardBrandValue(autofillOptions)
+
+        assertEquals(TEXT_VALUE, actual)
+    }
+
+    @Test
+    fun `extractCardBrandValue should return null when not list or text`() {
+        // Setup
+        val autofillOptions = List(1) { "option-$it" }
+        val autofillValue: AutofillValue = mockk {
+            every { isList } returns false
+            every { isText } returns false
+        }
+        // Test
+        val actual = autofillValue.extractCardBrandValue(autofillOptions)
         // Verify
         assertNull(actual)
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensionsTest.kt
@@ -104,6 +104,7 @@ class CipherViewExtensionsTest {
                         expirationMonth = "mockExpMonth-1",
                         expirationYear = "mockExpirationYear-1",
                         number = "mockNumber-1",
+                        brand = "mockBrand-1",
                     ),
                 ),
                 autofillCipherProvider.getCardAutofillCiphers(),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/StringExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/StringExtensionsTest.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.autofill.util
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -60,5 +61,49 @@ class StringExtensionsTest {
 
         // Verify
         assertTrue(actual)
+    }
+
+    @Test
+    fun `matchesAnyExpressions returns true when string matches an expression`() {
+        val patterns = listOf(
+            Regex(".*bike.*"),
+            Regex(".*bicycle.*"),
+        )
+        val string = "I want to ride my bicycle"
+        val actual = string.matchesAnyExpressions(patterns)
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `matchesAnyExpressions returns false when string doesn't match an expression`() {
+        val patterns = listOf(
+            Regex(".*bike.*"),
+            Regex(".*bicycle.*"),
+        )
+        val string = "I want to ride my tricycle"
+        val actual = string.matchesAnyExpressions(patterns)
+        assertFalse(actual)
+    }
+
+    @Test
+    fun `toLowerCaseAndStripNonAlpha returns lowercase string with non-alpha characters removed`() {
+        val string = "Hello, World!"
+        val actual = string.toLowerCaseAndStripNonAlpha()
+        assertEquals("helloworld", actual)
+    }
+
+    @Test
+    fun `toLowerCaseAndStripNonAlpha returns empty string when input is empty`() {
+        val string = ""
+        val actual = string.toLowerCaseAndStripNonAlpha()
+        assertEquals("", actual)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `toLowerCaseAndStripNonAlpha returns empty string when input contains only non-alpha characters`() {
+        val string = "1234567890"
+        val actual = string.toLowerCaseAndStripNonAlpha()
+        assertEquals("", actual)
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/ViewNodeExtensionsTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@Suppress("LargeClass")
 class ViewNodeExtensionsTest {
     private val expectedAutofillId: AutofillId = mockk()
     private val expectedIsFocused = true
@@ -701,6 +702,421 @@ class ViewNodeExtensionsTest {
             // Verify
             assertTrue(actual)
         }
+    }
+
+    @Test
+    fun `isCardholderNameField returns true when htmlInfo isCardholderNameField is true`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardholderNameField() } returns true
+
+        val actual = viewNode.isCardholderNameField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardholderNameField returns true when hint is supported`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.htmlInfo.isCardholderNameField() } returns false
+
+        SUPPORTED_RAW_CARDHOLDER_NAME_HINTS.forEach {
+            every { viewNode.hint } returns it
+
+            val actual = viewNode.isCardholderNameField
+
+            assertTrue(actual) { "Failed for hint: $it" }
+        }
+    }
+
+    @Test
+    fun `isCardholderNameField returns true when idEntry is supported`() {
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardholderNameField() } returns false
+
+        SUPPORTED_RAW_CARDHOLDER_NAME_HINTS.forEach {
+            every { viewNode.idEntry } returns it
+
+            val actual = viewNode.isCardholderNameField
+
+            assertTrue(actual) { "Failed for idEntry: $it" }
+        }
+    }
+
+    @Test
+    fun `isCardholderNameField returns false when idEntry, hint, and htmlInfo are all null`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardholderNameField() } returns false
+
+        val actual = viewNode.isCardholderNameField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    fun `isCardholderNameField returns false when idEntry, hint, and htmlInfo are not supported`() {
+        every { viewNode.idEntry } returns "unsupportedIdEntry"
+        every { viewNode.hint } returns "unsupportedHint"
+        every { viewNode.htmlInfo.isCardholderNameField() } returns false
+
+        val actual = viewNode.isCardholderNameField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    fun `isCardBrandField returns true when htmlInfo isCardBrandField is true`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardBrandField() } returns true
+
+        val actual = viewNode.isCardBrandField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardBrandField returns true when hint is supported`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.htmlInfo.isCardBrandField() } returns false
+
+        SUPPORTED_RAW_CARD_BRAND_HINTS.forEach {
+            every { viewNode.hint } returns it
+
+            val actual = viewNode.isCardBrandField
+
+            assertTrue(actual) { "Failed for hint: $it" }
+        }
+    }
+
+    @Test
+    fun `isCardBrandField returns true when idEntry is supported`() {
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardBrandField() } returns false
+
+        SUPPORTED_RAW_CARD_BRAND_HINTS.forEach {
+            every { viewNode.idEntry } returns it
+
+            val actual = viewNode.isCardBrandField
+
+            assertTrue(actual) { "Failed for idEntry: $it" }
+        }
+    }
+
+    @Test
+    fun `isCardBrandField returns false when idEntry, hint, and htmlInfo are all null`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardBrandField() } returns false
+
+        val actual = viewNode.isCardBrandField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `isCardBrandField returns false when idEntry and hint are not supported, and htmlInfo isCardBrandField is false`() {
+        every { viewNode.idEntry } returns "unsupportedIdEntry"
+        every { viewNode.hint } returns "unsupportedHint"
+        every { viewNode.htmlInfo.isCardBrandField() } returns false
+
+        val actual = viewNode.isCardBrandField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    fun `isCardNumberField returns true when htmlInfo isCardNumberField is true`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardNumberField() } returns true
+
+        val actual = viewNode.isCardNumberField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardNumberField returns true when hint is supported`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.htmlInfo.isCardNumberField() } returns false
+        every { viewNode.hint } returns "credit-card-number"
+
+        val actual = viewNode.isCardNumberField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardNumberField returns true when idEntry is supported`() {
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardNumberField() } returns false
+        every { viewNode.idEntry } returns "credit-card-number"
+
+        val actual = viewNode.isCardNumberField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardNumberField returns false when idEntry, hint, and htmlInfo are all null`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardNumberField() } returns false
+
+        val actual = viewNode.isCardNumberField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `isCardNumberField returns false when idEntry and hint are not supported, and htmlInfo isCardNumberField is false`() {
+        every { viewNode.idEntry } returns "unsupportedIdEntry"
+        every { viewNode.hint } returns "unsupportedHint"
+        every { viewNode.htmlInfo.isCardNumberField() } returns false
+
+        val actual = viewNode.isCardNumberField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    fun `isCardSecurityCodeField returns true when htmlInfo isCardSecurityCodeField is true`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardSecurityCodeField() } returns true
+
+        val actual = viewNode.isCardSecurityCodeField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardSecurityCodeField returns true when hint is supported`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.htmlInfo.isCardSecurityCodeField() } returns false
+
+        SUPPORTED_RAW_CARD_SECURITY_CODE_HINTS.forEach {
+            every { viewNode.hint } returns it
+
+            val actual = viewNode.isCardSecurityCodeField
+
+            assertTrue(actual) { "Failed for hint: $it" }
+        }
+    }
+
+    @Test
+    fun `isCardSecurityCodeField returns true when idEntry is supported`() {
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardSecurityCodeField() } returns false
+
+        SUPPORTED_RAW_CARD_SECURITY_CODE_HINTS.forEach {
+            every { viewNode.idEntry } returns it
+
+            val actual = viewNode.isCardSecurityCodeField
+
+            assertTrue(actual) { "Failed for idEntry: $it" }
+        }
+    }
+
+    @Test
+    fun `isCardSecurityCodeField returns false when idEntry, hint, and htmlInfo are all null`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardSecurityCodeField() } returns false
+
+        val actual = viewNode.isCardSecurityCodeField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `isCardSecurityCodeField returns false when idEntry and hint are not supported, and htmlInfo isCardSecurityCodeField is false`() {
+        every { viewNode.idEntry } returns "unsupportedIdEntry"
+        every { viewNode.hint } returns "unsupportedHint"
+        every { viewNode.htmlInfo.isCardSecurityCodeField() } returns false
+
+        val actual = viewNode.isCardSecurityCodeField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    fun `isCardExpirationDateField returns true when htmlInfo isCardExpirationDateField is true`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationDateField() } returns true
+
+        // Test
+        val actual = viewNode.isCardExpirationDateField
+
+        // Verify
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationDateField returns true when hint is supported`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.htmlInfo.isCardExpirationDateField() } returns false
+        every { viewNode.hint } returns "expiration_date"
+
+        val actual = viewNode.isCardExpirationDateField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationDateField returns true when idEntry is supported`() {
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationDateField() } returns false
+        every { viewNode.idEntry } returns "expiration_date"
+
+        val actual = viewNode.isCardExpirationDateField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationDateField returns false when idEntry, hint, and htmlInfo are all null`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationDateField() } returns false
+
+        val actual = viewNode.isCardExpirationDateField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `isCardExpirationDateField returns false when idEntry and hint are not supported, and htmlInfo isCardExpirationDateField is false`() {
+        every { viewNode.idEntry } returns "unsupportedIdEntry"
+        every { viewNode.hint } returns "unsupportedHint"
+        every { viewNode.htmlInfo.isCardExpirationDateField() } returns false
+
+        val actual = viewNode.isCardExpirationDateField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    fun `isCardExpirationYearField returns true when htmlInfo isCardExpirationYearField is true`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationYearField() } returns true
+
+        // Test
+        val actual = viewNode.isCardExpirationYearField
+
+        // Verify
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationYearField returns true when hint is supported`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.htmlInfo.isCardExpirationYearField() } returns false
+        every { viewNode.hint } returns "expiration_year"
+
+        val actual = viewNode.isCardExpirationYearField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationYearField returns true when idEntry is supported`() {
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationYearField() } returns false
+        every { viewNode.idEntry } returns "expiration_year"
+
+        val actual = viewNode.isCardExpirationYearField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationYearField returns false when idEntry, hint, and htmlInfo are all null`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationYearField() } returns false
+
+        val actual = viewNode.isCardExpirationYearField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `isCardExpirationYearField returns false when idEntry and hint are not supported and htmlInfo isCardExpirationYearField is false`() {
+        every { viewNode.idEntry } returns "unsupportedIdEntry"
+        every { viewNode.hint } returns "unsupportedHint"
+        every { viewNode.htmlInfo.isCardExpirationYearField() } returns false
+
+        val actual = viewNode.isCardExpirationYearField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `isCardExpirationMonthField returns true when htmlInfo isCardExpirationMonthField is true`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationMonthField() } returns true
+
+        // Test
+        val actual = viewNode.isCardExpirationMonthField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationMonthField returns true when hint is supported`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.htmlInfo.isCardExpirationMonthField() } returns false
+        every { viewNode.hint } returns "expiration_month"
+
+        val actual = viewNode.isCardExpirationMonthField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationMonthField returns true when idEntry is supported`() {
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationMonthField() } returns false
+        every { viewNode.idEntry } returns "expiration_month"
+
+        val actual = viewNode.isCardExpirationMonthField
+
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `isCardExpirationMonthField returns false when idEntry, hint, and htmlInfo are all null`() {
+        every { viewNode.idEntry } returns null
+        every { viewNode.hint } returns null
+        every { viewNode.htmlInfo.isCardExpirationMonthField() } returns false
+
+        val actual = viewNode.isCardExpirationMonthField
+
+        assertFalse(actual)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `isCardExpirationMonthField returns false when idEntry and hint are not supported, and htmlInfo isCardExpirationMonthField is false`() {
+        every { viewNode.idEntry } returns "unsupportedIdEntry"
+        every { viewNode.hint } returns "unsupportedHint"
+        every { viewNode.htmlInfo.isCardExpirationMonthField() } returns false
+
+        val actual = viewNode.isCardExpirationMonthField
+
+        assertFalse(actual)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/autofill/util/AutofillUtilsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/autofill/util/AutofillUtilsTest.kt
@@ -51,6 +51,7 @@ class AutofillUtilsTest {
                     name = "Cipher One",
                     number = "number",
                     subtitle = "Subtitle",
+                    brand = "Visa",
                 ),
                 second = AutofillAppInfo(
                     context = context,
@@ -69,6 +70,7 @@ class AutofillUtilsTest {
                     name = "Capital One",
                     number = "number",
                     subtitle = "JohnCardName",
+                    brand = "Visa",
                 ),
                 second = AutofillAppInfo(
                     context = context,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/AutofillSaveItemExtensionsTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
+import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 import com.x8bit.bitwarden.ui.vault.model.VaultCardExpirationMonth
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
 import io.mockk.every
@@ -37,6 +38,7 @@ class AutofillSaveItemExtensionsTest {
                     expirationMonth = VaultCardExpirationMonth.JANUARY,
                     expirationYear = "2024",
                     securityCode = "securityCode",
+                    brand = VaultCardBrand.VISA,
                 ),
             ),
             AutofillSaveItem.Card(
@@ -45,6 +47,7 @@ class AutofillSaveItemExtensionsTest {
                 expirationMonth = "1",
                 expirationYear = "2024",
                 securityCode = "securityCode",
+                brand = "visa",
             )
                 .toDefaultAddTypeContent(isIndividualVaultDisabled = false),
         )


### PR DESCRIPTION
## 🎟️ Tracking

PM-24940

## 📔 Objective

Add the ability to autofill and save card brand information.

The following changes were made:
- Added `brand` property to `AutofillCipher.Card` and `AutofillSaveItem.Card`.
- Updated `AutofillRequestExtensions` and `AutofillCipherProviderImpl` to include card brand.
- Added `brandSaveValue` to `AutofillPartition.Card`.
- Implemented card brand detection in `ViewNodeExtensions` and `HtmlInfoExtensions`.
- Updated `CipherViewExtensions` and `AutofillSaveItemExtensions` to handle card brand.
- Added `SUPPORTED_RAW_CARD_BRAND_HINTS` in `ViewStructureUtils`.
- Added `extractCardBrandValue` in `AutofillValueExtensions`.
- Added `CARD_BRAND` to `AutofillHint` enum.
- Added `AutofillView.Card.Brand` sealed class.
- Added `toLowerCaseAndStripNonAlpha` string extension.

## 📸 Screenshots

https://github.com/user-attachments/assets/18880ee3-05cc-47fa-aa17-1192db31a91e

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
