### PR TITLE
[PM-25027] Rename "Ask to add login" to "Ask to add item"

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -302,8 +302,8 @@ private fun AutoFillScreenContent(
         )
         Spacer(modifier = Modifier.height(8.dp))
         BitwardenSwitch(
-            label = stringResource(id = BitwardenString.ask_to_add_login),
-            supportingText = stringResource(id = BitwardenString.ask_to_add_login_description),
+            label = stringResource(id = BitwardenString.ask_to_add_item),
+            supportingText = stringResource(id = BitwardenString.ask_to_add_item_description),
             isChecked = state.isAskToAddLoginEnabled,
             onCheckedChange = autoFillHandlers.onAskToAddLoginClick,
             cardStyle = CardStyle.Full,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -405,23 +405,23 @@ class AutoFillScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `on ask to add login toggle should send AskToAddLoginClick`() {
+    fun `on Ask to add item toggle should send AskToAddLoginClick`() {
         composeTestRule
-            .onNodeWithText("Ask to add login")
+            .onNodeWithText("Ask to add item")
             .performScrollTo()
             .performClick()
         verify { viewModel.trySendAction(AutoFillAction.AskToAddLoginClick(true)) }
     }
 
     @Test
-    fun `ask to add login should be toggled on or off according to state`() {
+    fun `Ask to add item should be toggled on or off according to state`() {
         composeTestRule
-            .onNodeWithText("Ask to add login")
+            .onNodeWithText("Ask to add item")
             .performScrollTo()
             .assertIsOff()
         mutableStateFlow.update { it.copy(isAskToAddLoginEnabled = true) }
         composeTestRule
-            .onNodeWithText("Ask to add login")
+            .onNodeWithText("Ask to add item")
             .performScrollTo()
             .assertIsOn()
     }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -365,8 +365,8 @@ Scanning will happen automatically.</string>
     <string name="exit_confirmation">Are you sure you want to exit Bitwarden?</string>
     <string name="require_master_password_on_app_restart">Require master password on app restart?</string>
     <string name="pin_require_master_password_restart">Do you want to require unlocking with your master password when the application is restarted?</string>
-    <string name="ask_to_add_login">Ask to add login</string>
-    <string name="ask_to_add_login_description">Ask to add an item if one isn\'t found in your vault.</string>
+    <string name="ask_to_add_item">Ask to add item</string>
+    <string name="ask_to_add_item_description">Ask to add an item if one isn\'t found in your vault.</string>
     <string name="on_restart">On app restart</string>
     <string name="capitalize">Capitalize</string>
     <string name="include_number">Include number</string>


### PR DESCRIPTION
## 🎟️ Tracking

PM-25027

## 📔 Objective

The string resources and their usage in the Autofill settings screen were updated to reflect that items other than logins can be added.

## 📸 Screenshots

| Header | Header |
|--------|--------|
| <img width="365" alt="before" src="https://github.com/user-attachments/assets/abed539b-2cfe-4dd5-8a10-797997787d62" /> | <img width="365" alt="after" src="https://github.com/user-attachments/assets/876a2cdb-3b27-4af1-932f-d086baf089f9" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
