### PR TITLE
PM-22465: Identity state is not pre-populated on edit screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
@@ -86,6 +86,7 @@ fun CipherView.toViewState(
                 address2 = identity?.address2.orEmpty(),
                 address3 = identity?.address3.orEmpty(),
                 city = identity?.city.orEmpty(),
+                state = identity?.state.orEmpty(),
                 zip = identity?.postalCode.orEmpty(),
                 country = identity?.country.orEmpty(),
             )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -158,6 +158,7 @@ class CipherViewExtensionsTest {
                     email = "placeholde@email.com",
                     phone = "555-555-5555",
                     city = "Minneapolis",
+                    state = "MN",
                     country = "USA",
                 ),
             ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22465](https://bitwarden.atlassian.net/browse/PM-22465)

## 📔 Objective

This PR updates the edit screen to pre-populate the state field from the cipher model.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22465]: https://bitwarden.atlassian.net/browse/PM-22465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ