### PR TITLE
[PM-24697] Allow cleartext traffic on OCSP and CRL servers

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -12,6 +12,18 @@
         </trust-anchors>
     </base-config>
 
+    <!-- A lot of TLS certificates point to http:// URLs for CRL and OCSP checking,
+    so we need to allow cleartext traffic on them -->
+    <domain-config cleartextTrafficPermitted="true">
+        <!-- CRL Distribution Servers -->
+        <domain includeSubdomains="true">c.lencr.org</domain>
+        <domain includeSubdomains="true">c.pki.goog</domain>
+
+        <!-- OCSP Responder Servers -->
+        <domain includeSubdomains="true">o.pki.goog</domain>
+        <domain includeSubdomains="true">ocsp.sectigo.com</domain>
+    </domain-config>
+
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="true">bitwarden.com</domain>
         <domain includeSubdomains="true">bitwarden.eu</domain>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24697

## 📔 Objective

SDK is using HTTP uris for CRL and OCSP checking and was causing the generator to fail when verifying forwarders.
This adds the servers for the `cleartextTrafficPermitted` exception list on the `network_security_config` file

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
