### PR TITLE
PM-17755: Fix comparator inconsistency based on Locale

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/data/repository/util/SpecialCharWithPrecedenceComparator.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/repository/util/SpecialCharWithPrecedenceComparator.kt
@@ -38,8 +38,9 @@ private fun compareCharsSpecialCharsWithPrecedence(c1: Char, c2: Char): Int {
         }
 
         else -> {
-            val upperCaseStr1 = c1.toString().uppercase(Locale.getDefault())
-            val upperCaseStr2 = c2.toString().uppercase(Locale.getDefault())
+            // Use Locale.ROOT for consistent, locale-insensitive comparison
+            val upperCaseStr1 = c1.toString().uppercase(Locale.ROOT)
+            val upperCaseStr2 = c2.toString().uppercase(Locale.ROOT)
             upperCaseStr1.compareTo(upperCaseStr2)
         }
     }

--- a/core/src/test/kotlin/com/bitwarden/core/data/repository/util/SpecialCharWithPrecedenceComparatorTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/repository/util/SpecialCharWithPrecedenceComparatorTest.kt
@@ -1,9 +1,24 @@
 package com.bitwarden.core.data.repository.util
 
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.Locale
 
 class SpecialCharWithPrecedenceComparatorTest {
+
+    private lateinit var defaultLocale: Locale
+
+    @BeforeEach
+    fun setup() {
+        defaultLocale = Locale.getDefault()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
 
     @Test
     fun `Sorting with comparator should return expected result of sorted string`() {
@@ -40,5 +55,23 @@ class SpecialCharWithPrecedenceComparatorTest {
             expectedSortedList,
             unsortedList.sortedWith(SpecialCharWithPrecedenceComparator),
         )
+    }
+
+    @Test
+    fun `comparator should return consistent values across locales`() {
+        val unsortedList = listOf("i", "z", "j")
+        val sortedList = listOf("i", "j", "z")
+        val locales = listOf(
+            Locale.forLanguageTag("tr-TR"),
+            Locale.US,
+        )
+
+        locales.forEach { locale ->
+            Locale.setDefault(locale)
+            assertEquals(
+                sortedList,
+                unsortedList.sortedWith(SpecialCharWithPrecedenceComparator),
+            )
+        }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17755](https://bitwarden.atlassian.net/browse/PM-17755)

## 📔 Objective

This PR fixes a `Comparator` bug cause by inconsistent comparison logic based on the users locale.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17755]: https://bitwarden.atlassian.net/browse/PM-17755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ