### PR TITLE
[PM-25057] Filter Card Autofill Ciphers by Policy

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
@@ -108,11 +108,13 @@ object AutofillModule {
         authRepository: AuthRepository,
         cipherMatchingManager: CipherMatchingManager,
         vaultRepository: VaultRepository,
+        policyManager: PolicyManager,
     ): AutofillCipherProvider =
         AutofillCipherProviderImpl(
             authRepository = authRepository,
             cipherMatchingManager = cipherMatchingManager,
             vaultRepository = vaultRepository,
+            policyManager = policyManager,
         )
 
     @Singleton

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/provider/AutofillCipherProviderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/provider/AutofillCipherProviderImpl.kt
@@ -1,11 +1,13 @@
 package com.x8bit.bitwarden.data.autofill.provider
 
+import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.vault.CipherListView
 import com.bitwarden.vault.CipherListViewType
 import com.bitwarden.vault.CipherRepromptType
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.autofill.model.AutofillCipher
+import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
 import com.x8bit.bitwarden.data.platform.util.firstWithTimeoutOrNull
 import com.x8bit.bitwarden.data.platform.util.subtitle
@@ -34,6 +36,7 @@ class AutofillCipherProviderImpl(
     private val authRepository: AuthRepository,
     private val cipherMatchingManager: CipherMatchingManager,
     private val vaultRepository: VaultRepository,
+    private val policyManager: PolicyManager,
 ) : AutofillCipherProvider {
     private val activeUserId: String? get() = authRepository.activeUserId
 
@@ -53,7 +56,9 @@ class AutofillCipherProviderImpl(
 
     override suspend fun getCardAutofillCiphers(): List<AutofillCipher.Card> {
         val cipherListViews = getUnlockedCipherListViewsOrNull() ?: return emptyList()
-
+        val organizationIdsWithCardTypeRestrictions = policyManager
+            .getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+            .map { it.organizationId }
         return cipherListViews
             .mapNotNull { cipherListView ->
                 cipherListView
@@ -64,7 +69,9 @@ class AutofillCipherProviderImpl(
                             // Must not be deleted.
                             it.deletedDate == null &&
                             // Must not require a reprompt.
-                            it.reprompt == CipherRepromptType.NONE
+                            it.reprompt == CipherRepromptType.NONE &&
+                            // Must not be restricted by organization.
+                            it.organizationId !in organizationIdsWithCardTypeRestrictions
                     }
                     ?.let { nonNullCipherListView ->
                         nonNullCipherListView.id?.let { cipherId ->


### PR DESCRIPTION
## 🎟️ Tracking

PM-25057

## 📔 Objective

This commit filters the list of card autofill ciphers based on active policies that restrict item types for organizations.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
