### PR TITLE
PM-25069: Update VaultAddEditViewModel toasts to snackbars

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -179,7 +179,9 @@ class SearchViewModel @Inject constructor(
         snackbarRelayManager
             .getSnackbarDataFlow(
                 SnackbarRelay.CIPHER_DELETED,
+                SnackbarRelay.CIPHER_DELETED_SOFT,
                 SnackbarRelay.CIPHER_RESTORED,
+                SnackbarRelay.CIPHER_UPDATED,
                 SnackbarRelay.SEND_DELETED,
                 SnackbarRelay.SEND_UPDATED,
             )
@@ -1348,7 +1350,7 @@ sealed class SearchAction {
          */
         data class SnackbarDataReceived(
             val data: BitwardenSnackbarData,
-        ) : Internal()
+        ) : Internal(), BackgroundEvent
 
         /**
          * Indicates a result for updating a cipher during the autofill-and-save process.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelay.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/snackbar/SnackbarRelay.kt
@@ -9,9 +9,12 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 enum class SnackbarRelay {
+    CIPHER_CREATED,
     CIPHER_DELETED,
+    CIPHER_DELETED_SOFT,
     CIPHER_MOVED_TO_ORGANIZATION,
     CIPHER_RESTORED,
+    CIPHER_UPDATED,
     ENVIRONMENT_SAVED,
     LOGIN_APPROVAL,
     LOGIN_SUCCESS,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.ui.vault.feature.addedit
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -29,7 +28,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -114,8 +112,6 @@ fun VaultAddEditScreen(
     onNavigateToMoveToOrganization: (cipherId: String, showOnlyCollections: Boolean) -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
     val userVerificationHandlers = remember(viewModel) {
         VaultAddEditUserVerificationHandlers.create(viewModel = viewModel)
     }
@@ -139,10 +135,6 @@ fun VaultAddEditScreen(
 
             is VaultAddEditEvent.NavigateToGeneratorModal -> {
                 onNavigateToGeneratorModal(event.generatorMode)
-            }
-
-            is VaultAddEditEvent.ShowToast -> {
-                Toast.makeText(context, event.message(resources), Toast.LENGTH_SHORT).show()
             }
 
             is VaultAddEditEvent.NavigateToAttachments -> onNavigateToAttachments(event.cipherId)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -7,6 +7,7 @@ import androidx.credentials.provider.ProviderCreateCredentialRequest
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.DateTime
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.takeUntilLoaded
 import com.bitwarden.network.model.PolicyTypeJson
@@ -114,7 +115,8 @@ private const val KEY_STATE = "state"
 class VaultAddEditViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     generatorRepository: GeneratorRepository,
-    snackbarRelayManager: SnackbarRelayManager,
+    private val snackbarRelayManager: SnackbarRelayManager,
+    private val toastManager: ToastManager,
     private val authRepository: AuthRepository,
     private val clipboardManager: BitwardenClipboardManager,
     private val policyManager: PolicyManager,
@@ -1192,7 +1194,7 @@ class VaultAddEditViewModel @Inject constructor(
         updateLoginContent { loginType ->
             loginType.copy(fido2CredentialCreationDateTime = null)
         }
-        sendEvent(event = VaultAddEditEvent.ShowToast(BitwardenString.passkey_removed.asText()))
+        sendEvent(event = VaultAddEditEvent.ShowSnackbar(BitwardenString.passkey_removed.asText()))
     }
 
     private fun handlePasswordVisibilityChange(
@@ -1656,10 +1658,9 @@ class VaultAddEditViewModel @Inject constructor(
                 if (state.shouldExitOnSave) {
                     sendEvent(event = VaultAddEditEvent.ExitApp)
                 } else {
-                    sendEvent(
-                        event = VaultAddEditEvent.ShowToast(
-                            BitwardenString.new_item_created.asText(),
-                        ),
+                    snackbarRelayManager.sendSnackbarData(
+                        data = BitwardenSnackbarData(BitwardenString.new_item_created.asText()),
+                        relay = SnackbarRelay.CIPHER_CREATED,
                     )
                     sendEvent(event = VaultAddEditEvent.NavigateBack)
                 }
@@ -1690,10 +1691,9 @@ class VaultAddEditViewModel @Inject constructor(
                 if (state.shouldExitOnSave) {
                     sendEvent(event = VaultAddEditEvent.ExitApp)
                 } else {
-                    sendEvent(
-                        event = VaultAddEditEvent.ShowToast(
-                            BitwardenString.item_updated.asText(),
-                        ),
+                    snackbarRelayManager.sendSnackbarData(
+                        data = BitwardenSnackbarData(BitwardenString.item_updated.asText()),
+                        relay = SnackbarRelay.CIPHER_UPDATED,
                     )
                     sendEvent(event = VaultAddEditEvent.NavigateBack)
                 }
@@ -1714,10 +1714,9 @@ class VaultAddEditViewModel @Inject constructor(
 
             DeleteCipherResult.Success -> {
                 clearDialogState()
-                sendEvent(
-                    VaultAddEditEvent.ShowToast(
-                        message = BitwardenString.item_soft_deleted.asText(),
-                    ),
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.item_soft_deleted.asText()),
+                    relay = SnackbarRelay.CIPHER_DELETED_SOFT,
                 )
                 sendEvent(VaultAddEditEvent.NavigateBack)
             }
@@ -1887,7 +1886,7 @@ class VaultAddEditViewModel @Inject constructor(
         when (val result = action.totpResult) {
             is TotpCodeResult.Success -> {
                 sendEvent(
-                    event = VaultAddEditEvent.ShowToast(
+                    event = VaultAddEditEvent.ShowSnackbar(
                         message = BitwardenString.authenticator_key_added.asText(),
                     ),
                 )
@@ -1962,11 +1961,8 @@ class VaultAddEditViewModel @Inject constructor(
         clearDialogState()
         when (action.result) {
             is Fido2RegisterCredentialResult.Error -> {
-                sendEvent(
-                    VaultAddEditEvent.ShowToast(
-                        BitwardenString.an_error_has_occurred.asText(),
-                    ),
-                )
+                // Use toast here because we are closing the activity.
+                toastManager.show(BitwardenString.an_error_has_occurred)
                 sendEvent(
                     VaultAddEditEvent.CompleteFido2Registration(
                         RegisterFido2CredentialResult.Error(
@@ -1977,7 +1973,8 @@ class VaultAddEditViewModel @Inject constructor(
             }
 
             is Fido2RegisterCredentialResult.Success -> {
-                sendEvent(VaultAddEditEvent.ShowToast(BitwardenString.item_updated.asText()))
+                // Use toast here because we are closing the activity.
+                toastManager.show(BitwardenString.item_updated)
                 sendEvent(
                     VaultAddEditEvent.CompleteFido2Registration(
                         RegisterFido2CredentialResult.Success(action.result.responseJson),
@@ -2804,12 +2801,21 @@ sealed class VaultAddEditEvent {
      */
     data class ShowSnackbar(
         val data: BitwardenSnackbarData,
-    ) : VaultAddEditEvent(), BackgroundEvent
-
-    /**
-     * Shows a toast with the given [message].
-     */
-    data class ShowToast(val message: Text) : VaultAddEditEvent()
+    ) : VaultAddEditEvent(), BackgroundEvent {
+        constructor(
+            message: Text,
+            messageHeader: Text? = null,
+            actionLabel: Text? = null,
+            withDismissAction: Boolean = false,
+        ) : this(
+            data = BitwardenSnackbarData(
+                message = message,
+                messageHeader = messageHeader,
+                actionLabel = actionLabel,
+                withDismissAction = withDismissAction,
+            ),
+        )
+    }
 
     /**
      * Leave the application.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -207,7 +207,11 @@ class VaultItemViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         snackbarRelayManager
-            .getSnackbarDataFlow(SnackbarRelay.CIPHER_MOVED_TO_ORGANIZATION)
+            .getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_DELETED_SOFT,
+                SnackbarRelay.CIPHER_MOVED_TO_ORGANIZATION,
+                SnackbarRelay.CIPHER_UPDATED,
+            )
             .map { VaultItemAction.Internal.SnackbarDataReceived(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -227,8 +227,11 @@ class VaultItemListingViewModel @Inject constructor(
 
         snackbarRelayManager
             .getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_CREATED,
                 SnackbarRelay.CIPHER_DELETED,
+                SnackbarRelay.CIPHER_DELETED_SOFT,
                 SnackbarRelay.CIPHER_RESTORED,
+                SnackbarRelay.CIPHER_UPDATED,
                 SnackbarRelay.SEND_DELETED,
                 SnackbarRelay.SEND_UPDATED,
             )
@@ -3595,7 +3598,7 @@ sealed class VaultItemListingsAction {
          */
         data class SnackbarDataReceived(
             val data: BitwardenSnackbarData,
-        ) : Internal()
+        ) : Internal(), BackgroundEvent
 
         /**
          * Indicates that an error occurred while decrypting a cipher.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -177,8 +177,11 @@ class VaultViewModel @Inject constructor(
                     delay(timeMillis = LOGIN_SUCCESS_SNACKBAR_DELAY)
                 },
             snackbarRelayManager.getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_CREATED,
                 SnackbarRelay.CIPHER_DELETED,
+                SnackbarRelay.CIPHER_DELETED_SOFT,
                 SnackbarRelay.CIPHER_RESTORED,
+                SnackbarRelay.CIPHER_UPDATED,
                 SnackbarRelay.LOGINS_IMPORTED,
             ),
         )
@@ -1725,7 +1728,7 @@ sealed class VaultAction {
          */
         data class SnackbarDataReceive(
             val data: BitwardenSnackbarData,
-        ) : Internal()
+        ) : Internal(), BackgroundEvent
 
         /**
          * Indicates that the flight recorder data was received.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25069](https://bitwarden.atlassian.net/browse/PM-25069)

## 📔 Objective

This PR updates toasts (where possible) in the `VaultAddEditViewModel` o use Snackbars instead.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25069]: https://bitwarden.atlassian.net/browse/PM-25069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ