### PR TITLE
PM-25170: Remove the RemoveCardPolicy feature flag

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -30,7 +30,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CredentialExchangeProtocolExport,
     FlagKey.CipherKeyEncryption,
     FlagKey.UserManagedPrivilegedApps,
-    FlagKey.RemoveCardPolicy,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -79,7 +78,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
         stringResource(BitwardenString.user_trusted_privileged_app_management)
     }
 
-    FlagKey.RemoveCardPolicy -> stringResource(BitwardenString.remove_card_policy)
     FlagKey.BitwardenAuthenticationEnabled -> {
         stringResource(BitwardenString.bitwarden_authentication_enabled)
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -110,7 +110,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -212,15 +211,7 @@ class VaultItemListingViewModel @Inject constructor(
 
         policyManager
             .getActivePoliciesFlow(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
-            .combine(
-                featureFlagManager.getFeatureFlagFlow(FlagKey.RemoveCardPolicy),
-            ) { policies, enabledFlag ->
-                if (enabledFlag) {
-                    policies.map { it.organizationId }
-                } else {
-                    emptyList()
-                }
-            }
+            .map { policies -> policies.map { it.organizationId } }
             .map { VaultItemListingsAction.Internal.RestrictItemTypesPolicyUpdateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
@@ -42,13 +42,13 @@ fun VaultData.toViewState(
     isIconLoadingDisabled: Boolean,
     baseIconUrl: String,
     vaultFilterType: VaultFilterType,
-    restrictItemTypesPolicyOrgIds: List<String>?,
+    restrictItemTypesPolicyOrgIds: List<String>,
 ): VaultState.ViewState {
 
     val filteredCipherViewListWithDeletedItems =
         decryptCipherListResult
             .successes
-            .applyRestrictItemTypesPolicy(restrictItemTypesPolicyOrgIds ?: emptyList())
+            .applyRestrictItemTypesPolicy(restrictItemTypesPolicyOrgIds)
             .toFilteredList(vaultFilterType)
 
     val filteredCipherViewList = filteredCipherViewListWithDeletedItems
@@ -154,7 +154,7 @@ fun VaultData.toViewState(
             trashItemsCount = filteredCipherViewListWithDeletedItems.count {
                 it.deletedDate != null
             },
-            showCardGroup = cardCount != 0 || restrictItemTypesPolicyOrgIds == null,
+            showCardGroup = cardCount != 0 || restrictItemTypesPolicyOrgIds.isEmpty(),
         )
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -147,14 +147,12 @@ private val DEFAULT_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf
     FlagKey.CredentialExchangeProtocolImport to true,
     FlagKey.CredentialExchangeProtocolExport to true,
     FlagKey.UserManagedPrivilegedApps to true,
-    FlagKey.RemoveCardPolicy to true,
 )
 
 private val UPDATED_MAP_VALUE: ImmutableMap<FlagKey<Any>, Any> = persistentMapOf(
     FlagKey.CredentialExchangeProtocolImport to false,
     FlagKey.CredentialExchangeProtocolExport to false,
     FlagKey.UserManagedPrivilegedApps to false,
-    FlagKey.RemoveCardPolicy to false,
 )
 
 private val DEFAULT_STATE = DebugMenuState(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
-import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
@@ -31,7 +30,6 @@ import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySele
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManagerImpl
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManagerImpl
@@ -156,13 +154,6 @@ class SearchViewModelTest : BaseViewModelTest() {
         every {
             getSnackbarDataFlow(relay = any(), relays = anyVararg())
         } returns mutableSnackbarDataFlow
-    }
-
-    private val mutableRemoveCardPolicyFeatureFlow = MutableStateFlow(false)
-    private val featureFlagManager: FeatureFlagManager = mockk {
-        every {
-            getFeatureFlagFlow(FlagKey.RemoveCardPolicy)
-        } returns mutableRemoveCardPolicyFeatureFlow
     }
 
     @BeforeEach
@@ -1676,10 +1667,8 @@ class SearchViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly if RemoveCardPolicy flag is enable`() =
+    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly`() =
         runTest {
-            mutableRemoveCardPolicyFeatureFlow.value = true
-
             val viewModel = createViewModel()
             assertEquals(
                 DEFAULT_STATE.copy(restrictItemTypesPolicyOrgIds = persistentListOf()),
@@ -1701,33 +1690,6 @@ class SearchViewModelTest : BaseViewModelTest() {
                 DEFAULT_STATE.copy(
                     restrictItemTypesPolicyOrgIds = persistentListOf("Test Organization"),
                 ),
-                viewModel.stateFlow.value,
-            )
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly if RemoveCardPolicy flag is disabled`() =
-        runTest {
-            val viewModel = createViewModel()
-            assertEquals(
-                DEFAULT_STATE,
-                viewModel.stateFlow.value,
-            )
-            mutableActivePoliciesFlow.emit(
-                listOf(
-                    SyncResponseJson.Policy(
-                        organizationId = "Test Organization",
-                        id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
-                    ),
-                ),
-            )
-
-            assertEquals(
-                DEFAULT_STATE.copy(restrictItemTypesPolicyOrgIds = persistentListOf()),
                 viewModel.stateFlow.value,
             )
         }
@@ -1799,7 +1761,6 @@ class SearchViewModelTest : BaseViewModelTest() {
         autofillSelectionManager = autofillSelectionManager,
         organizationEventManager = organizationEventManager,
         snackbarRelayManager = snackbarRelayManager,
-        featureFlagManager = featureFlagManager,
     )
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultViewModelTest.kt
@@ -3,7 +3,6 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.exportvault
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.exporters.ExportFormat
 import com.bitwarden.network.model.PolicyTypeJson
@@ -20,7 +19,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.RequestOtpResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.VerifyOtpResult
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
@@ -81,13 +79,6 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
         } returns ExportVaultDataResult.Success("data")
     }
     private val fileManager: FileManager = mockk()
-
-    private val featureFlagManager: FeatureFlagManager = mockk {
-        every {
-            getFeatureFlag(FlagKey.RemoveCardPolicy)
-        } returns false
-    }
-
     private val organizationEventManager = mockk<OrganizationEventManager> {
         every { trackEvent(event = any()) } just runs
     }
@@ -143,7 +134,7 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `ConfirmExportVaultClicked correct password should call exportVaultDataToString with restricted item types when policy and feature flags enabled`() {
+    fun `ConfirmExportVaultClicked correct password should call exportVaultDataToString with restricted item types when policy`() {
         val password = "password"
         coEvery {
             authRepository.validatePassword(
@@ -153,9 +144,6 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
         every {
             policyManager.getActivePolicies(type = PolicyTypeJson.RESTRICT_ITEM_TYPES)
         } returns listOf(createMockPolicy())
-        every {
-            featureFlagManager.getFeatureFlag(FlagKey.RemoveCardPolicy)
-        } returns true
 
         val viewModel = createViewModel()
         viewModel.trySendAction(ExportVaultAction.PasswordInputChanged(password))
@@ -172,16 +160,13 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `ConfirmExportVaultClicked correct password should call exportVaultDataToString without restricted item types when policy is disabled and feature flag is enabled`() {
+    fun `ConfirmExportVaultClicked correct password should call exportVaultDataToString without restricted item types when policy is disabled`() {
         val password = "password"
         coEvery {
             authRepository.validatePassword(
                 password = password,
             )
         } returns ValidatePasswordResult.Success(isValid = true)
-        every {
-            featureFlagManager.getFeatureFlag(FlagKey.RemoveCardPolicy)
-        } returns true
 
         val viewModel = createViewModel()
         viewModel.trySendAction(ExportVaultAction.PasswordInputChanged(password))
@@ -845,7 +830,6 @@ class ExportVaultViewModelTest : BaseViewModelTest() {
         fileManager = fileManager,
         vaultRepository = vaultRepository,
         clock = clock,
-        featureFlagManager = featureFlagManager,
         organizationEventManager = organizationEventManager,
     )
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -250,14 +250,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         coEvery { addTrustedPrivilegedApp(any(), any()) } just runs
     }
 
-    private val mutableRemoveCardPolicyFeatureFlow = MutableStateFlow(false)
     private val featureFlagManager: FeatureFlagManager = mockk {
-        every {
-            getFeatureFlagFlow(FlagKey.RemoveCardPolicy)
-        } returns mutableRemoveCardPolicyFeatureFlow
-        every {
-            getFeatureFlag(FlagKey.UserManagedPrivilegedApps)
-        } returns true
+        every { getFeatureFlag(FlagKey.UserManagedPrivilegedApps) } returns true
     }
 
     private val initialState = createVaultItemListingState()
@@ -376,10 +370,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly if RemoveCardPolicy flag is enable`() =
+    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly`() =
         runTest {
-            mutableRemoveCardPolicyFeatureFlow.value = true
-
             val viewModel = createVaultItemListingViewModel()
             assertEquals(
                 initialState.copy(restrictItemTypesPolicyOrgIds = persistentListOf()),
@@ -401,33 +393,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 initialState.copy(
                     restrictItemTypesPolicyOrgIds = persistentListOf("Test Organization"),
                 ),
-                viewModel.stateFlow.value,
-            )
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly if RemoveCardPolicy flag is disabled`() =
-        runTest {
-            val viewModel = createVaultItemListingViewModel()
-            assertEquals(
-                initialState,
-                viewModel.stateFlow.value,
-            )
-            mutableActivePoliciesFlow.emit(
-                listOf(
-                    SyncResponseJson.Policy(
-                        organizationId = "Test Organization",
-                        id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
-                    ),
-                ),
-            )
-
-            assertEquals(
-                initialState.copy(restrictItemTypesPolicyOrgIds = persistentListOf()),
                 viewModel.stateFlow.value,
             )
         }
@@ -1392,7 +1357,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `AddVaultItemClick inside a folder should hide card item selection dialog state when RESTRICT_ITEM_TYPES policy is enabled`() =
         runTest {
-            mutableRemoveCardPolicyFeatureFlow.value = true
             val viewModel = createVaultItemListingViewModel(
                 savedStateHandle = createSavedStateHandleWithVaultItemListingType(
                     vaultItemListingType = VaultItemListingType.Folder(folderId = "id"),
@@ -1431,7 +1395,6 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     @Test
     fun `AddVaultItemClick inside a collection should hide card item selection dialog state when RESTRICT_ITEM_TYPES policy is enabled`() =
         runTest {
-            mutableRemoveCardPolicyFeatureFlow.value = true
             val viewModel = createVaultItemListingViewModel(
                 savedStateHandle = createSavedStateHandleWithVaultItemListingType(
                     vaultItemListingType = VaultItemListingType.Collection(collectionId = "id"),
@@ -5014,8 +4977,8 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                 title = BitwardenString.an_error_has_occurred.asText(),
                 message =
                     BitwardenString
-                    .credential_operation_failed_because_user_verification_was_cancelled
-                    .asText(),
+                        .credential_operation_failed_because_user_verification_was_cancelled
+                        .asText(),
             ),
             viewModel.stateFlow.value.dialogState,
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -2071,7 +2071,7 @@ private val DEFAULT_STATE: VaultState = VaultState(
     isRefreshing = false,
     showImportActionCard = false,
     flightRecorderSnackBar = null,
-    restrictItemTypesPolicyOrgIds = null,
+    restrictItemTypesPolicyOrgIds = emptyList(),
 )
 
 private val DEFAULT_CONTENT_VIEW_STATE: VaultState.ViewState.Content = VaultState.ViewState.Content(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.ui.vault.feature.vault
 
 import app.cash.turbine.test
-import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
@@ -25,7 +24,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
-import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
@@ -171,13 +169,6 @@ class VaultViewModelTest : BaseViewModelTest() {
         every { trackEvent(event = any()) } just runs
     }
 
-    private val mutableRemoveCardPolicyFeatureFlow = MutableStateFlow(false)
-    private val mutableSshKeyVaultItemsEnabledFlow = MutableStateFlow(false)
-    private val featureFlagManager: FeatureFlagManager = mockk {
-        every {
-            getFeatureFlagFlow(FlagKey.RemoveCardPolicy)
-        } returns mutableRemoveCardPolicyFeatureFlow
-    }
     private val reviewPromptManager: ReviewPromptManager = mockk()
 
     private val specialCircumstanceManager: SpecialCircumstanceManager = mockk {
@@ -219,7 +210,6 @@ class VaultViewModelTest : BaseViewModelTest() {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `UserState updates with a non-null value when switching accounts should do nothing`() {
         val viewModel = createViewModel()
@@ -414,10 +404,8 @@ class VaultViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly if RemoveCardPolicy flag is enable`() =
+    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly`() =
         runTest {
-            mutableRemoveCardPolicyFeatureFlow.value = true
-
             val viewModel = createViewModel()
             assertEquals(
                 DEFAULT_STATE,
@@ -437,33 +425,6 @@ class VaultViewModelTest : BaseViewModelTest() {
 
             assertEquals(
                 DEFAULT_STATE.copy(restrictItemTypesPolicyOrgIds = listOf("Test Organization")),
-                viewModel.stateFlow.value,
-            )
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `RESTRICT_ITEM_TYPES policy changes should update restrictItemTypesPolicyOrgIds accordingly if RemoveCardPolicy flag is disabled`() =
-        runTest {
-            val viewModel = createViewModel()
-            assertEquals(
-                DEFAULT_STATE,
-                viewModel.stateFlow.value,
-            )
-            mutableActivePoliciesFlow.emit(
-                listOf(
-                    SyncResponseJson.Policy(
-                        organizationId = "Test Organization",
-                        id = "testId",
-                        type = PolicyTypeJson.RESTRICT_ITEM_TYPES,
-                        isEnabled = true,
-                        data = null,
-                    ),
-                ),
-            )
-
-            assertEquals(
-                DEFAULT_STATE.copy(restrictItemTypesPolicyOrgIds = null),
                 viewModel.stateFlow.value,
             )
         }
@@ -724,7 +685,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                 isIconLoadingDisabled = viewModel.stateFlow.value.isIconLoadingDisabled,
                 baseIconUrl = viewModel.stateFlow.value.baseIconUrl,
                 hasMasterPassword = true,
-                restrictItemTypesPolicyOrgIds = null,
+                restrictItemTypesPolicyOrgIds = emptyList(),
             ),
         )
             .copy(
@@ -749,7 +710,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                     isIconLoadingDisabled = viewModel.stateFlow.value.isIconLoadingDisabled,
                     baseIconUrl = viewModel.stateFlow.value.baseIconUrl,
                     hasMasterPassword = true,
-                    restrictItemTypesPolicyOrgIds = null,
+                    restrictItemTypesPolicyOrgIds = emptyList(),
                 ),
             ),
             viewModel.stateFlow.value,
@@ -759,7 +720,6 @@ class VaultViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `vaultDataStateFlow Loaded with items should update state to Content`() = runTest {
-        mutableSshKeyVaultItemsEnabledFlow.value = true
         mutableVaultDataStateFlow.tryEmit(
             value = DataState.Loaded(
                 data = VaultData(
@@ -1212,7 +1172,6 @@ class VaultViewModelTest : BaseViewModelTest() {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `vaultDataStateFlow NoNetwork with items should update state to Content`() =
         runTest {
@@ -1313,7 +1272,6 @@ class VaultViewModelTest : BaseViewModelTest() {
     @Test
     fun `vaultDataStateFlow Loaded should include SSH key vault items`() =
         runTest {
-            mutableSshKeyVaultItemsEnabledFlow.value = true
             mutableVaultDataStateFlow.tryEmit(
                 value = DataState.Loaded(
                     data = VaultData(
@@ -2593,7 +2551,6 @@ class VaultViewModelTest : BaseViewModelTest() {
     @Test
     fun `SelectAddItemType action should set dialog state to SelectVaultAddItemType accordingly when RESTRICT_ITEM_TYPES is enabled`() =
         runTest {
-            mutableRemoveCardPolicyFeatureFlow.value = true
             val viewModel = createViewModel()
             mutableActivePoliciesFlow.emit(
                 listOf(
@@ -2672,7 +2629,6 @@ class VaultViewModelTest : BaseViewModelTest() {
             settingsRepository = settingsRepository,
             vaultRepository = vaultRepository,
             organizationEventManager = organizationEventManager,
-            featureFlagManager = featureFlagManager,
             firstTimeActionManager = firstTimeActionManager,
             snackbarRelayManager = snackbarRelayManager,
             reviewPromptManager = reviewPromptManager,
@@ -2787,5 +2743,5 @@ private fun createMockVaultState(
         showImportActionCard = true,
         isRefreshing = false,
         flightRecorderSnackBar = null,
-        restrictItemTypesPolicyOrgIds = null,
+        restrictItemTypesPolicyOrgIds = emptyList(),
     )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
@@ -72,7 +72,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -144,7 +144,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.MyVault,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -204,7 +204,7 @@ class VaultDataExtensionsTest {
                 organizationName = "Mock Organization 1",
             ),
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -262,7 +262,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -289,7 +289,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -317,7 +317,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -359,7 +359,7 @@ class VaultDataExtensionsTest {
             isIconLoadingDisabled = false,
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -403,7 +403,7 @@ class VaultDataExtensionsTest {
             isIconLoadingDisabled = false,
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -447,7 +447,7 @@ class VaultDataExtensionsTest {
             isIconLoadingDisabled = false,
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -675,7 +675,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -719,7 +719,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -766,7 +766,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -820,7 +820,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -891,7 +891,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -1087,7 +1087,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(
@@ -1146,7 +1146,7 @@ class VaultDataExtensionsTest {
             baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
-            restrictItemTypesPolicyOrgIds = null,
+            restrictItemTypesPolicyOrgIds = emptyList(),
         )
 
         assertEquals(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/components/FeatureFlagListItems.kt
@@ -26,7 +26,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CipherKeyEncryption,
     FlagKey.CredentialExchangeProtocolExport,
     FlagKey.CredentialExchangeProtocolImport,
-    FlagKey.RemoveCardPolicy,
     FlagKey.UserManagedPrivilegedApps,
         -> BooleanFlagItem(
         label = flagKey.getDisplayLabel(),
@@ -72,7 +71,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
         stringResource(BitwardenString.user_trusted_privileged_app_management)
     }
 
-    FlagKey.RemoveCardPolicy -> stringResource(BitwardenString.remove_card_policy)
     FlagKey.BitwardenAuthenticationEnabled -> {
         stringResource(BitwardenString.bitwarden_authentication_enabled)
     }

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -33,7 +33,6 @@ sealed class FlagKey<out T : Any> {
                 CredentialExchangeProtocolImport,
                 CredentialExchangeProtocolExport,
                 UserManagedPrivilegedApps,
-                RemoveCardPolicy,
             )
         }
     }
@@ -69,15 +68,6 @@ sealed class FlagKey<out T : Any> {
      */
     data object UserManagedPrivilegedApps : FlagKey<Boolean>() {
         override val keyName: String = "pm-18970-user-managed-privileged-apps"
-        override val defaultValue: Boolean = false
-    }
-
-    /**
-     * Data object holding the feature flag key to enable the removal of card item types.
-     * This flag will hide card types from organizations with policy enable and individual vaults
-     */
-    data object RemoveCardPolicy : FlagKey<Boolean>() {
-        override val keyName: String = "pm-16442-remove-card-item-type-policy"
         override val defaultValue: Boolean = false
     }
 

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -25,10 +25,6 @@ class FlagKeyTest {
             "pm-18970-user-managed-privileged-apps",
         )
         assertEquals(
-            FlagKey.RemoveCardPolicy.keyName,
-            "pm-16442-remove-card-item-type-policy",
-        )
-        assertEquals(
             FlagKey.BitwardenAuthenticationEnabled.keyName,
             "bitwarden-authentication-enabled",
         )
@@ -42,7 +38,6 @@ class FlagKeyTest {
                 FlagKey.CredentialExchangeProtocolExport,
                 FlagKey.CipherKeyEncryption,
                 FlagKey.UserManagedPrivilegedApps,
-                FlagKey.RemoveCardPolicy,
                 FlagKey.BitwardenAuthenticationEnabled,
             ).all {
                 !it.defaultValue

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -22,7 +22,6 @@
     <string name="generate_error_report">Generate error report</string>
     <string name="error_reports">Error reports</string>
     <string name="user_trusted_privileged_app_management">User-trusted privileged app management</string>
-    <string name="remove_card_policy">Remove Card Policy</string>
     <string name="bitwarden_authentication_enabled">Bitwarden authentication enabled</string>
     <string name="import_format_label_bitwarden_json">Bitwarden (.json)</string>
     <string name="import_format_label_2fas_json">2FAS (no password)</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25170](https://bitwarden.atlassian.net/browse/PM-25170)

## 📔 Objective

This PR removes the `RemoveCardPolicy` feature flag from the app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25170]: https://bitwarden.atlassian.net/browse/PM-25170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ