### PR TITLE
PM-25125: Refactor user state managment into UserStateManager

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManager.kt
@@ -1,0 +1,43 @@
+package com.x8bit.bitwarden.data.auth.manager
+
+import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Manages the global state of all users.
+ */
+interface UserStateManager {
+    /**
+     * Emits updates for changes to the [UserState].
+     */
+    val userStateFlow: StateFlow<UserState?>
+
+    /**
+     * Tracks whether there is an additional account that is pending login/registration in order to
+     * have multiple accounts available.
+     *
+     * This allows a direct view into and modification of [UserState.hasPendingAccountAddition].
+     * Note that this call has no effect when there is no [UserState] information available.
+     */
+    var hasPendingAccountAddition: Boolean
+
+    /**
+     * Emits updates for changes to the [UserState.hasPendingAccountAddition] flag.
+     */
+    val hasPendingAccountAdditionStateFlow: StateFlow<Boolean>
+
+    /**
+     * Tracks whether there is an account that is pending deletion in order to allow the account to
+     * remain active until the deletion is finalized.
+     */
+    var hasPendingAccountDeletion: Boolean
+
+    /**
+     * Run the given [block] while preventing any updates to [UserState]. This is useful in cases
+     * where many individual changes might occur that would normally affect the [UserState] but we
+     * only want a single final emission. In the rare case that multiple threads are running
+     * transactions simultaneously, there will be no [UserState] updates until the last
+     * transaction completes.
+     */
+    suspend fun <T> userStateTransaction(block: suspend () -> T): T
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManagerImpl.kt
@@ -1,0 +1,162 @@
+package com.x8bit.bitwarden.data.auth.manager
+
+import com.bitwarden.data.manager.DispatcherManager
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.auth.repository.model.UserAccountTokens
+import com.x8bit.bitwarden.data.auth.repository.model.UserKeyConnectorState
+import com.x8bit.bitwarden.data.auth.repository.model.UserOrganizations
+import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
+import com.x8bit.bitwarden.data.auth.repository.util.currentOnboardingStatus
+import com.x8bit.bitwarden.data.auth.repository.util.onboardingStatusChangesFlow
+import com.x8bit.bitwarden.data.auth.repository.util.toUserState
+import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokens
+import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokensFlow
+import com.x8bit.bitwarden.data.auth.repository.util.userKeyConnectorStateFlow
+import com.x8bit.bitwarden.data.auth.repository.util.userKeyConnectorStateList
+import com.x8bit.bitwarden.data.auth.repository.util.userOrganizationsList
+import com.x8bit.bitwarden.data.auth.repository.util.userOrganizationsListFlow
+import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
+import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
+import com.x8bit.bitwarden.data.vault.manager.VaultLockManager
+import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+
+/**
+ * The default implementation of the [UserStateManager].
+ */
+class UserStateManagerImpl(
+    private val authDiskSource: AuthDiskSource,
+    firstTimeActionManager: FirstTimeActionManager,
+    vaultLockManager: VaultLockManager,
+    dispatcherManager: DispatcherManager,
+) : UserStateManager {
+    private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
+
+    //region Pending Account Addition
+    private val mutableHasPendingAccountAdditionStateFlow = MutableStateFlow(value = false)
+
+    override val hasPendingAccountAdditionStateFlow: StateFlow<Boolean>
+        get() = mutableHasPendingAccountAdditionStateFlow
+
+    override var hasPendingAccountAddition: Boolean
+        by mutableHasPendingAccountAdditionStateFlow::value
+    //endregion Pending Account Addition
+
+    //region Pending Account Deletion
+    /**
+     * If there is a pending account deletion, continue showing the original UserState until it
+     * is confirmed. This is accomplished by blocking the emissions of the [userStateFlow]
+     * whenever set to `true`.
+     */
+    private val mutableHasPendingAccountDeletionStateFlow = MutableStateFlow(value = false)
+
+    override var hasPendingAccountDeletion: Boolean
+        by mutableHasPendingAccountDeletionStateFlow::value
+    //endregion Pending Account Deletion
+
+    /**
+     * Whenever a function needs to update multiple underlying data-points that contribute to the
+     * [UserState], we update this [MutableStateFlow] and continue to show the original `UserState`
+     * until the transaction is complete. This is accomplished by blocking the emissions of the
+     * [userStateFlow] whenever this is set to a value above 0 (a count is used if more than one
+     * process is updating data simultaneously).
+     */
+    private val mutableUserStateTransactionCountStateFlow = MutableStateFlow(0)
+
+    @Suppress("UNCHECKED_CAST", "MagicNumber")
+    override val userStateFlow: StateFlow<UserState?> = combine(
+        authDiskSource.userStateFlow,
+        authDiskSource.userAccountTokensFlow,
+        authDiskSource.userOrganizationsListFlow,
+        authDiskSource.userKeyConnectorStateFlow,
+        authDiskSource.onboardingStatusChangesFlow,
+        firstTimeActionManager.firstTimeStateFlow,
+        vaultLockManager.vaultUnlockDataStateFlow,
+        hasPendingAccountAdditionStateFlow,
+        // Ignore the data in the merge, but trigger an update when they emit.
+        merge(
+            mutableHasPendingAccountDeletionStateFlow,
+            mutableUserStateTransactionCountStateFlow,
+            vaultLockManager.isActiveUserUnlockingFlow,
+        ),
+    ) { array ->
+        val userStateJson = array[0] as UserStateJson?
+        val userAccountTokens = array[1] as List<UserAccountTokens>
+        val userOrganizationsList = array[2] as List<UserOrganizations>
+        val userIsUsingKeyConnectorList = array[3] as List<UserKeyConnectorState>
+        val onboardingStatus = array[4] as OnboardingStatus?
+        val firstTimeState = array[5] as FirstTimeState
+        val vaultState = array[6] as List<VaultUnlockData>
+        val hasPendingAccountAddition = array[7] as Boolean
+        userStateJson?.toUserState(
+            vaultState = vaultState,
+            userAccountTokens = userAccountTokens,
+            userOrganizationsList = userOrganizationsList,
+            userIsUsingKeyConnectorList = userIsUsingKeyConnectorList,
+            hasPendingAccountAddition = hasPendingAccountAddition,
+            onboardingStatus = onboardingStatus,
+            isBiometricsEnabledProvider = ::isBiometricsEnabled,
+            vaultUnlockTypeProvider = ::getVaultUnlockType,
+            isDeviceTrustedProvider = ::isDeviceTrusted,
+            firstTimeState = firstTimeState,
+        )
+    }
+        .filterNot {
+            mutableHasPendingAccountDeletionStateFlow.value ||
+                mutableUserStateTransactionCountStateFlow.value > 0 ||
+                vaultLockManager.isActiveUserUnlockingFlow.value
+        }
+        .stateIn(
+            scope = unconfinedScope,
+            started = SharingStarted.Eagerly,
+            initialValue = authDiskSource
+                .userState
+                ?.toUserState(
+                    vaultState = vaultLockManager.vaultUnlockDataStateFlow.value,
+                    userAccountTokens = authDiskSource.userAccountTokens,
+                    userOrganizationsList = authDiskSource.userOrganizationsList,
+                    userIsUsingKeyConnectorList = authDiskSource.userKeyConnectorStateList,
+                    hasPendingAccountAddition = mutableHasPendingAccountAdditionStateFlow.value,
+                    onboardingStatus = authDiskSource.currentOnboardingStatus,
+                    isBiometricsEnabledProvider = ::isBiometricsEnabled,
+                    vaultUnlockTypeProvider = ::getVaultUnlockType,
+                    isDeviceTrustedProvider = ::isDeviceTrusted,
+                    firstTimeState = firstTimeActionManager.currentOrDefaultUserFirstTimeState,
+                ),
+        )
+
+    override suspend fun <T> userStateTransaction(block: suspend () -> T): T {
+        mutableUserStateTransactionCountStateFlow.update { it.inc() }
+        return try {
+            block()
+        } finally {
+            mutableUserStateTransactionCountStateFlow.update { it.dec() }
+        }
+    }
+
+    private fun isBiometricsEnabled(
+        userId: String,
+    ): Boolean = authDiskSource.getUserBiometricUnlockKey(userId = userId) != null
+
+    private fun isDeviceTrusted(
+        userId: String,
+    ): Boolean = authDiskSource.getDeviceKey(userId = userId) != null
+
+    private fun getVaultUnlockType(
+        userId: String,
+    ): VaultUnlockType = authDiskSource
+        .getPinProtectedUserKey(userId = userId)
+        ?.let { VaultUnlockType.PIN }
+        ?: VaultUnlockType.MASTER_PASSWORD
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -46,7 +46,6 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
-import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.network.model.DeviceDataModel
 import com.x8bit.bitwarden.data.auth.datasource.sdk.AuthSdkSource
 import com.x8bit.bitwarden.data.auth.datasource.sdk.util.toInt
@@ -55,6 +54,7 @@ import com.x8bit.bitwarden.data.auth.manager.AuthRequestManager
 import com.x8bit.bitwarden.data.auth.manager.KeyConnectorManager
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
+import com.x8bit.bitwarden.data.auth.manager.UserStateManager
 import com.x8bit.bitwarden.data.auth.manager.model.MigrateExistingUserToKeyConnectorResult
 import com.x8bit.bitwarden.data.auth.repository.model.AuthState
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
@@ -77,13 +77,8 @@ import com.x8bit.bitwarden.data.auth.repository.model.ResetPasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.SendVerificationEmailResult
 import com.x8bit.bitwarden.data.auth.repository.model.SetPasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
-import com.x8bit.bitwarden.data.auth.repository.model.UserAccountTokens
-import com.x8bit.bitwarden.data.auth.repository.model.UserKeyConnectorState
-import com.x8bit.bitwarden.data.auth.repository.model.UserOrganizations
-import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
-import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.auth.repository.model.VerifiedOrganizationDomainSsoDetailsResult
 import com.x8bit.bitwarden.data.auth.repository.model.VerifyOtpResult
 import com.x8bit.bitwarden.data.auth.repository.model.toLoginErrorResult
@@ -91,36 +86,25 @@ import com.x8bit.bitwarden.data.auth.repository.util.DuoCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.SsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
-import com.x8bit.bitwarden.data.auth.repository.util.currentOnboardingStatus
-import com.x8bit.bitwarden.data.auth.repository.util.onboardingStatusChangesFlow
 import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
 import com.x8bit.bitwarden.data.auth.repository.util.toRemovedPasswordUserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.toUserState
 import com.x8bit.bitwarden.data.auth.repository.util.toUserStateJsonWithPassword
-import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokens
-import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokensFlow
-import com.x8bit.bitwarden.data.auth.repository.util.userKeyConnectorStateFlow
-import com.x8bit.bitwarden.data.auth.repository.util.userKeyConnectorStateList
-import com.x8bit.bitwarden.data.auth.repository.util.userOrganizationsList
-import com.x8bit.bitwarden.data.auth.repository.util.userOrganizationsListFlow
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
 import com.x8bit.bitwarden.data.auth.util.KdfParamsConstants.DEFAULT_PBKDF2_ITERATIONS
 import com.x8bit.bitwarden.data.auth.util.YubiKeyResult
 import com.x8bit.bitwarden.data.auth.util.toSdkParams
 import com.x8bit.bitwarden.data.platform.error.MissingPropertyException
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
-import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
-import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.util.getActivePolicies
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
-import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockError
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
 import kotlinx.coroutines.CoroutineScope
@@ -128,13 +112,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
@@ -144,7 +126,6 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import java.time.Clock
 import javax.inject.Singleton
 
@@ -172,12 +153,13 @@ class AuthRepositoryImpl(
     private val trustedDeviceManager: TrustedDeviceManager,
     private val userLogoutManager: UserLogoutManager,
     private val policyManager: PolicyManager,
-    firstTimeActionManager: FirstTimeActionManager,
+    private val userStateManager: UserStateManager,
     logsManager: LogsManager,
     pushManager: PushManager,
     dispatcherManager: DispatcherManager,
 ) : AuthRepository,
-    AuthRequestManager by authRequestManager {
+    AuthRequestManager by authRequestManager,
+    UserStateManager by userStateManager {
     /**
      * A scope intended for use when simply collecting multiple flows in order to combine them. The
      * use of [Dispatchers.Unconfined] allows for this to happen synchronously whenever any of
@@ -189,24 +171,6 @@ class AuthRepositoryImpl(
      * A scope intended for use when operating asynchronously.
      */
     private val ioScope = CoroutineScope(dispatcherManager.io)
-
-    private val mutableHasPendingAccountAdditionStateFlow = MutableStateFlow(false)
-
-    /**
-     * If there is a pending account deletion, continue showing the original UserState until it
-     * is confirmed. This is accomplished by blocking the emissions of the [userStateFlow]
-     * whenever set to `true`.
-     */
-    private val mutableHasPendingAccountDeletionStateFlow = MutableStateFlow(false)
-
-    /**
-     * Whenever a function needs to update multiple underlying data-points that contribute to the
-     * [UserState], we update this [MutableStateFlow] and continue to show the original `UserState`
-     * until the transaction is complete. This is accomplished by blocking the emissions of the
-     * [userStateFlow] whenever this is set to a value above 0 (a count is used if more than one
-     * process is updating data simultaneously).
-     */
-    private val mutableUserStateTransactionCountStateFlow = MutableStateFlow(0)
 
     /**
      * The auth information to make the identity token request will need to be
@@ -268,68 +232,6 @@ class AuthRepositoryImpl(
             initialValue = AuthState.Uninitialized,
         )
 
-    @Suppress("UNCHECKED_CAST", "MagicNumber")
-    override val userStateFlow: StateFlow<UserState?> = combine(
-        authDiskSource.userStateFlow,
-        authDiskSource.userAccountTokensFlow,
-        authDiskSource.userOrganizationsListFlow,
-        authDiskSource.userKeyConnectorStateFlow,
-        authDiskSource.onboardingStatusChangesFlow,
-        firstTimeActionManager.firstTimeStateFlow,
-        vaultRepository.vaultUnlockDataStateFlow,
-        mutableHasPendingAccountAdditionStateFlow,
-        // Ignore the data in the merge, but trigger an update when they emit.
-        merge(
-            mutableHasPendingAccountDeletionStateFlow,
-            mutableUserStateTransactionCountStateFlow,
-            vaultRepository.isActiveUserUnlockingFlow,
-        ),
-    ) { array ->
-        val userStateJson = array[0] as UserStateJson?
-        val userAccountTokens = array[1] as List<UserAccountTokens>
-        val userOrganizationsList = array[2] as List<UserOrganizations>
-        val userIsUsingKeyConnectorList = array[3] as List<UserKeyConnectorState>
-        val onboardingStatus = array[4] as OnboardingStatus?
-        val firstTimeState = array[5] as FirstTimeState
-        val vaultState = array[6] as List<VaultUnlockData>
-        val hasPendingAccountAddition = array[7] as Boolean
-        userStateJson?.toUserState(
-            vaultState = vaultState,
-            userAccountTokens = userAccountTokens,
-            userOrganizationsList = userOrganizationsList,
-            userIsUsingKeyConnectorList = userIsUsingKeyConnectorList,
-            hasPendingAccountAddition = hasPendingAccountAddition,
-            onboardingStatus = onboardingStatus,
-            isBiometricsEnabledProvider = ::isBiometricsEnabled,
-            vaultUnlockTypeProvider = ::getVaultUnlockType,
-            isDeviceTrustedProvider = ::isDeviceTrusted,
-            firstTimeState = firstTimeState,
-        )
-    }
-        .filterNot {
-            mutableHasPendingAccountDeletionStateFlow.value ||
-                mutableUserStateTransactionCountStateFlow.value > 0 ||
-                vaultRepository.isActiveUserUnlockingFlow.value
-        }
-        .stateIn(
-            scope = unconfinedScope,
-            started = SharingStarted.Eagerly,
-            initialValue = authDiskSource
-                .userState
-                ?.toUserState(
-                    vaultState = vaultRepository.vaultUnlockDataStateFlow.value,
-                    userAccountTokens = authDiskSource.userAccountTokens,
-                    userOrganizationsList = authDiskSource.userOrganizationsList,
-                    userIsUsingKeyConnectorList = authDiskSource.userKeyConnectorStateList,
-                    hasPendingAccountAddition = mutableHasPendingAccountAdditionStateFlow.value,
-                    onboardingStatus = authDiskSource.currentOnboardingStatus,
-                    isBiometricsEnabledProvider = ::isBiometricsEnabled,
-                    vaultUnlockTypeProvider = ::getVaultUnlockType,
-                    isDeviceTrustedProvider = ::isDeviceTrusted,
-                    firstTimeState = firstTimeActionManager.currentOrDefaultUserFirstTimeState,
-                ),
-        )
-
     private val duoTokenChannel = Channel<DuoCallbackTokenResult>(capacity = Int.MAX_VALUE)
     override val duoTokenResultFlow: Flow<DuoCallbackTokenResult> = duoTokenChannel.receiveAsFlow()
 
@@ -358,9 +260,6 @@ class AuthRepositoryImpl(
             }
         }
 
-    override var hasPendingAccountAddition: Boolean
-        by mutableHasPendingAccountAdditionStateFlow::value
-
     override val passwordPolicies: List<PolicyInformation.MasterPassword>
         get() = policyManager.getActivePolicies()
 
@@ -379,7 +278,7 @@ class AuthRepositoryImpl(
 
     init {
         combine(
-            mutableHasPendingAccountAdditionStateFlow,
+            userStateManager.hasPendingAccountAdditionStateFlow,
             authDiskSource.userStateFlow,
             environmentRepository.environmentStateFlow,
         ) { hasPendingAddition, userState, environment ->
@@ -460,16 +359,12 @@ class AuthRepositoryImpl(
             .launchIn(unconfinedScope)
     }
 
-    override fun clearPendingAccountDeletion() {
-        mutableHasPendingAccountDeletionStateFlow.value = false
-    }
-
     override suspend fun deleteAccountWithMasterPassword(
         masterPassword: String,
     ): DeleteAccountResult {
         val profile = authDiskSource.userState?.activeAccount?.profile
             ?: return DeleteAccountResult.Error(message = null, error = NoActiveUserException())
-        mutableHasPendingAccountDeletionStateFlow.value = true
+        userStateManager.hasPendingAccountDeletion = true
         return authSdkSource
             .hashPassword(
                 email = profile.email,
@@ -489,7 +384,7 @@ class AuthRepositoryImpl(
     override suspend fun deleteAccountWithOneTimePassword(
         oneTimePassword: String,
     ): DeleteAccountResult {
-        mutableHasPendingAccountDeletionStateFlow.value = true
+        userStateManager.hasPendingAccountDeletion = true
         return accountsService
             .deleteAccount(
                 masterPasswordHash = null,
@@ -501,13 +396,13 @@ class AuthRepositoryImpl(
     private fun Result<DeleteAccountResponseJson>.finalizeDeleteAccount(): DeleteAccountResult =
         fold(
             onFailure = {
-                clearPendingAccountDeletion()
+                userStateManager.hasPendingAccountDeletion = false
                 DeleteAccountResult.Error(error = it, message = null)
             },
             onSuccess = { response ->
                 when (response) {
                     is DeleteAccountResponseJson.Invalid -> {
-                        clearPendingAccountDeletion()
+                        userStateManager.hasPendingAccountDeletion = false
                         DeleteAccountResult.Error(message = response.message, error = null)
                     }
 
@@ -874,7 +769,7 @@ class AuthRepositoryImpl(
             // We need to make sure that the environment is set back to the correct spot.
             updateEnvironment()
             // No switching to do but clear any pending account additions
-            hasPendingAccountAddition = false
+            userStateManager.hasPendingAccountAddition = false
             return SwitchAccountResult.NoChange
         }
 
@@ -889,7 +784,7 @@ class AuthRepositoryImpl(
         authDiskSource.userState = currentUserState.copy(activeUserId = userId)
 
         // Clear any pending account additions
-        hasPendingAccountAddition = false
+        userStateManager.hasPendingAccountAddition = false
 
         return SwitchAccountResult.AccountSwitched
     }
@@ -1552,27 +1447,6 @@ class AuthRepositoryImpl(
             )
         }
 
-    private fun isBiometricsEnabled(
-        userId: String,
-    ): Boolean = authDiskSource.getUserBiometricUnlockKey(userId = userId) != null
-
-    private fun isDeviceTrusted(
-        userId: String,
-    ): Boolean = authDiskSource.getDeviceKey(userId = userId) != null
-
-    private fun getVaultUnlockType(
-        userId: String,
-    ): VaultUnlockType =
-        when {
-            authDiskSource.getPinProtectedUserKey(userId = userId) != null -> {
-                VaultUnlockType.PIN
-            }
-
-            else -> {
-                VaultUnlockType.MASTER_PASSWORD
-            }
-        }
-
     /**
      * Update the saved state with the force password reset reason.
      */
@@ -1683,7 +1557,7 @@ class AuthRepositoryImpl(
         deviceData: DeviceDataModel?,
         orgIdentifier: String?,
         userConfirmedKeyConnector: Boolean,
-    ): LoginResult = userStateTransaction {
+    ): LoginResult = userStateManager.userStateTransaction {
         val userStateJson = loginResponse.toUserState(
             previousUserState = authDiskSource.userState,
             environmentUrlData = environmentRepository.environment.environmentUrlData,
@@ -1722,7 +1596,7 @@ class AuthRepositoryImpl(
                 // we should ask him to confirm the domain
                 if (isNewKeyConnectorUser && isNotConfirmed) {
                     keyConnectorResponse = loginResponse
-                    return LoginResult.ConfirmKeyConnectorDomain(
+                    return@userStateTransaction LoginResult.ConfirmKeyConnectorDomain(
                         domain = keyConnectorUrl,
                     )
                 }
@@ -2156,22 +2030,6 @@ class AuthRepositoryImpl(
     }
 
     //endregion LoginCommon
-
-    /**
-     * Run the given [block] while preventing any updates to [UserState]. This is useful in cases
-     * where many individual changes might occur that would normally affect the [UserState] but we
-     * only want a single final emission. In the rare case that multiple threads are running
-     * transactions simultaneously, there will be no [UserState] updates until the last
-     * transaction completes.
-     */
-    private inline fun <T> userStateTransaction(block: () -> T): T {
-        mutableUserStateTransactionCountStateFlow.update { it.inc() }
-        return try {
-            block()
-        } finally {
-            mutableUserStateTransactionCountStateFlow.update { it.dec() }
-        }
-    }
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
@@ -13,6 +13,8 @@ import com.x8bit.bitwarden.data.auth.manager.AuthRequestManager
 import com.x8bit.bitwarden.data.auth.manager.KeyConnectorManager
 import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
+import com.x8bit.bitwarden.data.auth.manager.UserStateManager
+import com.x8bit.bitwarden.data.auth.manager.UserStateManagerImpl
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.AuthRepositoryImpl
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
@@ -22,6 +24,7 @@ import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
+import com.x8bit.bitwarden.data.vault.manager.VaultLockManager
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import dagger.Module
 import dagger.Provides
@@ -60,8 +63,8 @@ object AuthRepositoryModule {
         userLogoutManager: UserLogoutManager,
         pushManager: PushManager,
         policyManager: PolicyManager,
-        firstTimeActionManager: FirstTimeActionManager,
         logsManager: LogsManager,
+        userStateManager: UserStateManager,
     ): AuthRepository = AuthRepositoryImpl(
         clock = clock,
         accountsService = accountsService,
@@ -83,7 +86,21 @@ object AuthRepositoryModule {
         userLogoutManager = userLogoutManager,
         pushManager = pushManager,
         policyManager = policyManager,
-        firstTimeActionManager = firstTimeActionManager,
         logsManager = logsManager,
+        userStateManager = userStateManager,
+    )
+
+    @Provides
+    @Singleton
+    fun providesUserStateManager(
+        authDiskSource: AuthDiskSource,
+        firstTimeActionManager: FirstTimeActionManager,
+        vaultLockManager: VaultLockManager,
+        dispatcherManager: DispatcherManager,
+    ): UserStateManager = UserStateManagerImpl(
+        authDiskSource = authDiskSource,
+        firstTimeActionManager = firstTimeActionManager,
+        vaultLockManager = vaultLockManager,
+        dispatcherManager = dispatcherManager,
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModel.kt
@@ -109,7 +109,7 @@ class DeleteAccountViewModel @Inject constructor(
     }
 
     private fun handleAccountDeletionConfirm() {
-        authRepository.clearPendingAccountDeletion()
+        authRepository.hasPendingAccountDeletion = false
         dismissDialog()
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModel.kt
@@ -69,7 +69,7 @@ class DeleteAccountConfirmationViewModel @Inject constructor(
     }
 
     private fun handleDeleteAccountAcknowledge() {
-        authRepository.clearPendingAccountDeletion()
+        authRepository.hasPendingAccountDeletion = false
         mutableStateFlow.update { it.copy(dialog = null) }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserStateManagerTest.kt
@@ -1,0 +1,342 @@
+package com.x8bit.bitwarden.data.auth.manager
+
+import app.cash.turbine.test
+import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
+import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
+import com.bitwarden.data.manager.DispatcherManager
+import com.bitwarden.network.model.GetTokenResponseJson
+import com.bitwarden.network.model.KdfTypeJson
+import com.bitwarden.network.model.createMockOrganization
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.auth.repository.model.UserKeyConnectorState
+import com.x8bit.bitwarden.data.auth.repository.model.UserOrganizations
+import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
+import com.x8bit.bitwarden.data.auth.repository.util.toOrganizations
+import com.x8bit.bitwarden.data.auth.repository.util.toUserState
+import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
+import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
+import com.x8bit.bitwarden.data.vault.manager.VaultLockManager
+import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+import java.time.ZonedDateTime
+
+class UserStateManagerTest {
+
+    private val fakeAuthDiskSource = FakeAuthDiskSource()
+    private val firstTimeActionManager = mockk<FirstTimeActionManager> {
+        every { currentOrDefaultUserFirstTimeState } returns FIRST_TIME_STATE
+        every { firstTimeStateFlow } returns MutableStateFlow(FIRST_TIME_STATE)
+    }
+    private val mutableVaultUnlockDataStateFlow = MutableStateFlow(VAULT_UNLOCK_DATA)
+    private val mutableIsActiveUserUnlockingFlow = MutableStateFlow(false)
+    private val vaultLockManager: VaultLockManager = mockk {
+        every { vaultUnlockDataStateFlow } returns mutableVaultUnlockDataStateFlow
+        every { isActiveUserUnlockingFlow } returns mutableIsActiveUserUnlockingFlow
+    }
+    private val dispatcherManager: DispatcherManager = FakeDispatcherManager()
+
+    private val userStateManager: UserStateManager = UserStateManagerImpl(
+        authDiskSource = fakeAuthDiskSource,
+        firstTimeActionManager = firstTimeActionManager,
+        vaultLockManager = vaultLockManager,
+        dispatcherManager = dispatcherManager,
+    )
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(GetTokenResponseJson.Success::toUserState)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(GetTokenResponseJson.Success::toUserState)
+    }
+
+    @Test
+    fun `userStateFlow should update according to changes in its underlying data sources`() =
+        runTest {
+            fakeAuthDiskSource.userState = null
+            userStateManager.userStateFlow.test {
+                assertNull(awaitItem())
+
+                mutableVaultUnlockDataStateFlow.value = VAULT_UNLOCK_DATA
+                fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+                assertEquals(
+                    SINGLE_USER_STATE_1.toUserState(
+                        vaultState = VAULT_UNLOCK_DATA,
+                        userAccountTokens = emptyList(),
+                        userOrganizationsList = emptyList(),
+                        userIsUsingKeyConnectorList = emptyList(),
+                        hasPendingAccountAddition = false,
+                        onboardingStatus = null,
+                        isBiometricsEnabledProvider = { false },
+                        vaultUnlockTypeProvider = { VaultUnlockType.MASTER_PASSWORD },
+                        isDeviceTrustedProvider = { false },
+                        firstTimeState = FIRST_TIME_STATE,
+                    ),
+                    awaitItem(),
+                )
+
+                fakeAuthDiskSource.apply {
+                    storePinProtectedUserKey(
+                        userId = USER_ID_1,
+                        pinProtectedUserKey = "pinProtectedUseKey",
+                    )
+                    storePinProtectedUserKey(
+                        userId = USER_ID_2,
+                        pinProtectedUserKey = "pinProtectedUseKey",
+                    )
+                    userState = MULTI_USER_STATE
+                }
+                assertEquals(
+                    MULTI_USER_STATE.toUserState(
+                        vaultState = VAULT_UNLOCK_DATA,
+                        userAccountTokens = emptyList(),
+                        userOrganizationsList = emptyList(),
+                        userIsUsingKeyConnectorList = emptyList(),
+                        hasPendingAccountAddition = false,
+                        isBiometricsEnabledProvider = { false },
+                        vaultUnlockTypeProvider = { VaultUnlockType.PIN },
+                        isDeviceTrustedProvider = { false },
+                        onboardingStatus = null,
+                        firstTimeState = FIRST_TIME_STATE,
+                    ),
+                    awaitItem(),
+                )
+
+                val emptyVaultState = emptyList<VaultUnlockData>()
+                mutableVaultUnlockDataStateFlow.value = emptyVaultState
+                assertEquals(
+                    MULTI_USER_STATE.toUserState(
+                        vaultState = emptyVaultState,
+                        userAccountTokens = emptyList(),
+                        userOrganizationsList = emptyList(),
+                        userIsUsingKeyConnectorList = emptyList(),
+                        hasPendingAccountAddition = false,
+                        isBiometricsEnabledProvider = { false },
+                        vaultUnlockTypeProvider = { VaultUnlockType.PIN },
+                        isDeviceTrustedProvider = { false },
+                        onboardingStatus = null,
+                        firstTimeState = FIRST_TIME_STATE,
+                    ),
+                    awaitItem(),
+                )
+
+                fakeAuthDiskSource.apply {
+                    storePinProtectedUserKey(
+                        userId = USER_ID_1,
+                        pinProtectedUserKey = null,
+                    )
+                    storePinProtectedUserKey(
+                        userId = USER_ID_2,
+                        pinProtectedUserKey = null,
+                    )
+                    storeOrganizations(
+                        userId = USER_ID_1,
+                        organizations = ORGANIZATIONS,
+                    )
+                }
+                assertEquals(
+                    MULTI_USER_STATE.toUserState(
+                        vaultState = emptyVaultState,
+                        userAccountTokens = emptyList(),
+                        userOrganizationsList = USER_ORGANIZATIONS,
+                        userIsUsingKeyConnectorList = USER_SHOULD_USER_KEY_CONNECTOR,
+                        hasPendingAccountAddition = false,
+                        isBiometricsEnabledProvider = { false },
+                        vaultUnlockTypeProvider = { VaultUnlockType.MASTER_PASSWORD },
+                        isDeviceTrustedProvider = { false },
+                        onboardingStatus = null,
+                        firstTimeState = FIRST_TIME_STATE,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `clear Pending Account Deletion should unblock userState updates`() = runTest {
+        val originalUserState = SINGLE_USER_STATE_1.toUserState(
+            vaultState = VAULT_UNLOCK_DATA,
+            userAccountTokens = emptyList(),
+            userOrganizationsList = emptyList(),
+            userIsUsingKeyConnectorList = emptyList(),
+            hasPendingAccountAddition = false,
+            isBiometricsEnabledProvider = { false },
+            vaultUnlockTypeProvider = { VaultUnlockType.MASTER_PASSWORD },
+            isDeviceTrustedProvider = { false },
+            onboardingStatus = null,
+            firstTimeState = FIRST_TIME_STATE,
+        )
+        val finalUserState = SINGLE_USER_STATE_2.toUserState(
+            vaultState = VAULT_UNLOCK_DATA,
+            userAccountTokens = emptyList(),
+            userOrganizationsList = emptyList(),
+            userIsUsingKeyConnectorList = emptyList(),
+            hasPendingAccountAddition = false,
+            isBiometricsEnabledProvider = { false },
+            vaultUnlockTypeProvider = { VaultUnlockType.MASTER_PASSWORD },
+            isDeviceTrustedProvider = { false },
+            onboardingStatus = null,
+            firstTimeState = FIRST_TIME_STATE,
+        )
+        fakeAuthDiskSource.userState = SINGLE_USER_STATE_1
+
+        userStateManager.userStateFlow.test {
+            assertEquals(originalUserState, awaitItem())
+
+            // Set the pending deletion flag
+            userStateManager.hasPendingAccountDeletion = true
+
+            // Update the account. No changes are emitted because
+            // the pending deletion blocks the update.
+            fakeAuthDiskSource.userState = SINGLE_USER_STATE_2
+            expectNoEvents()
+
+            // Clearing the pending deletion allows the change to go through
+            userStateManager.hasPendingAccountDeletion = false
+            assertEquals(finalUserState, awaitItem())
+        }
+    }
+
+    @Test
+    fun `hasPendingAccountAdditionStateFlow updates when hasPendingAccountAddition changes`() =
+        runTest {
+            userStateManager.hasPendingAccountAdditionStateFlow.test {
+                assertFalse(awaitItem())
+                userStateManager.hasPendingAccountAddition = true
+                assertTrue(awaitItem())
+                userStateManager.hasPendingAccountAddition = false
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `hasPendingAccountAddition updates when hasPendingAccountAddition changes`() {
+        assertFalse(userStateManager.hasPendingAccountAddition)
+        userStateManager.hasPendingAccountAddition = true
+        assertTrue(userStateManager.hasPendingAccountAddition)
+        userStateManager.hasPendingAccountAddition = false
+        assertFalse(userStateManager.hasPendingAccountAddition)
+    }
+
+    @Test
+    fun `hasPendingAccountDeletion updates when hasPendingAccountDeletion changes`() {
+        assertFalse(userStateManager.hasPendingAccountDeletion)
+        userStateManager.hasPendingAccountDeletion = true
+        assertTrue(userStateManager.hasPendingAccountDeletion)
+        userStateManager.hasPendingAccountDeletion = false
+        assertFalse(userStateManager.hasPendingAccountDeletion)
+    }
+}
+
+private const val EMAIL_1 = "test@bitwarden.com"
+private const val EMAIL_2 = "test2@bitwarden.com"
+private const val USER_ID_1 = "2a135b23-e1fb-42c9-bec3-573857bc8181"
+private const val USER_ID_2 = "b9d32ec0-6497-4582-9798-b350f53bfa02"
+
+private val FIRST_TIME_STATE = FirstTimeState(
+    showImportLoginsCard = true,
+)
+
+private val ORGANIZATIONS = listOf(createMockOrganization(number = 0))
+private val USER_ORGANIZATIONS = listOf(
+    UserOrganizations(
+        userId = USER_ID_1,
+        organizations = ORGANIZATIONS.toOrganizations(),
+    ),
+)
+private val USER_SHOULD_USER_KEY_CONNECTOR = listOf(
+    UserKeyConnectorState(
+        userId = USER_ID_1,
+        isUsingKeyConnector = null,
+    ),
+)
+
+private val VAULT_UNLOCK_DATA = listOf(
+    VaultUnlockData(
+        userId = USER_ID_1,
+        status = VaultUnlockData.Status.UNLOCKED,
+    ),
+)
+
+private val PROFILE_1 = AccountJson.Profile(
+    userId = USER_ID_1,
+    email = EMAIL_1,
+    isEmailVerified = true,
+    name = "Bitwarden Tester",
+    hasPremium = false,
+    stamp = null,
+    organizationId = null,
+    avatarColorHex = null,
+    forcePasswordResetReason = null,
+    kdfType = KdfTypeJson.ARGON2_ID,
+    kdfIterations = 600000,
+    kdfMemory = 16,
+    kdfParallelism = 4,
+    userDecryptionOptions = null,
+    isTwoFactorEnabled = false,
+    creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+)
+private val ACCOUNT_1 = AccountJson(
+    profile = PROFILE_1,
+    settings = AccountJson.Settings(
+        environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+    ),
+)
+private val ACCOUNT_2 = AccountJson(
+    profile = AccountJson.Profile(
+        userId = USER_ID_2,
+        email = EMAIL_2,
+        isEmailVerified = true,
+        name = "Bitwarden Tester 2",
+        hasPremium = false,
+        stamp = null,
+        organizationId = null,
+        avatarColorHex = null,
+        forcePasswordResetReason = null,
+        kdfType = KdfTypeJson.PBKDF2_SHA256,
+        kdfIterations = 400000,
+        kdfMemory = null,
+        kdfParallelism = null,
+        userDecryptionOptions = null,
+        isTwoFactorEnabled = true,
+        creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+    ),
+    settings = AccountJson.Settings(
+        environmentUrlData = EnvironmentUrlDataJson.DEFAULT_EU,
+    ),
+)
+private val SINGLE_USER_STATE_1 = UserStateJson(
+    activeUserId = USER_ID_1,
+    accounts = mapOf(
+        USER_ID_1 to ACCOUNT_1,
+    ),
+)
+private val SINGLE_USER_STATE_2 = UserStateJson(
+    activeUserId = USER_ID_2,
+    accounts = mapOf(
+        USER_ID_2 to ACCOUNT_2,
+    ),
+)
+private val MULTI_USER_STATE = UserStateJson(
+    activeUserId = USER_ID_1,
+    accounts = mapOf(
+        USER_ID_1 to ACCOUNT_1,
+        USER_ID_2 to ACCOUNT_2,
+    ),
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountViewModelTest.kt
@@ -186,7 +186,7 @@ class DeleteAccountViewModelTest : BaseViewModelTest() {
     @Test
     fun `AccountDeletionConfirm should clear dialog state and call clearPendingAccountDeletion`() =
         runTest {
-            every { authRepo.clearPendingAccountDeletion() } just runs
+            every { authRepo.hasPendingAccountDeletion = false } just runs
             val state = DEFAULT_STATE.copy(
                 dialog = DeleteAccountState.DeleteAccountDialog.DeleteSuccess,
             )
@@ -198,7 +198,7 @@ class DeleteAccountViewModelTest : BaseViewModelTest() {
                 viewModel.stateFlow.value,
             )
             verify {
-                authRepo.clearPendingAccountDeletion()
+                authRepo.hasPendingAccountDeletion = false
             }
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationViewModelTest.kt
@@ -55,7 +55,7 @@ class DeleteAccountConfirmationViewModelTest : BaseViewModelTest() {
     @Test
     fun `DeleteAccountAcknowledge should clear dialog and call clearPendingAccountDeletion`() =
         runTest {
-            every { authRepo.clearPendingAccountDeletion() } just runs
+            every { authRepo.hasPendingAccountDeletion = false } just runs
             val state = DEFAULT_STATE.copy(
                 dialog =
                     DeleteAccountConfirmationState.DeleteAccountConfirmationDialog.DeleteSuccess(),
@@ -68,7 +68,7 @@ class DeleteAccountConfirmationViewModelTest : BaseViewModelTest() {
                 viewModel.stateFlow.value,
             )
             verify {
-                authRepo.clearPendingAccountDeletion()
+                authRepo.hasPendingAccountDeletion = false
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25125](https://bitwarden.atlassian.net/browse/PM-25125)

## 📔 Objective

This PR refactors the location in which we manage all the `UserState` in the app so it can be used in other places in the future 😉.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25125]: https://bitwarden.atlassian.net/browse/PM-25125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ