### PR TITLE
[PM-25143] Retain intent on Activity recreation in old OS revisions

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
@@ -237,8 +237,7 @@ class MainActivity : AppCompatActivity() {
             // been fixed but certain phones that are no longer supported will never get the fix.
             // The OS bug is tracked here: https://issuetracker.google.com/issues/370180732
             startActivity(
-                Intent
-                    .makeMainActivity(componentName)
+                Intent(intent)
                     .addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION),
             )
             finish()


### PR DESCRIPTION
## 🎟️ Tracking

PM-25143

## 📔 Objective

The `MainActivity` intent was using `makeMainActivity` which was
causing intent data loss on recreation. This change uses the existing
intent to prevent intent data loss.

This is related to the fix for an OS bug tracked at
https://issuetracker.google.com/issues/370180732 for devices
that will no longer receive OS updates.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
