### PR TITLE
PM-25193: Clear last sync time on push notification for inactive user

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserStateManager
 import com.x8bit.bitwarden.data.auth.manager.UserStateManagerImpl
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.AuthRepositoryImpl
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
@@ -52,6 +53,7 @@ object AuthRepositoryModule {
         authSdkSource: AuthSdkSource,
         vaultSdkSource: VaultSdkSource,
         authDiskSource: AuthDiskSource,
+        settingsDiskSource: SettingsDiskSource,
         configDiskSource: ConfigDiskSource,
         dispatcherManager: DispatcherManager,
         environmentRepository: EnvironmentRepository,
@@ -74,6 +76,7 @@ object AuthRepositoryModule {
         authSdkSource = authSdkSource,
         vaultSdkSource = vaultSdkSource,
         authDiskSource = authDiskSource,
+        settingsDiskSource = settingsDiskSource,
         configDiskSource = configDiskSource,
         haveIBeenPwnedService = haveIBeenPwnedService,
         dispatcherManager = dispatcherManager,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManager.kt
@@ -52,7 +52,7 @@ interface PushManager {
     /**
      * Flow that represents requests intended to trigger syncing organization keys.
      */
-    val syncOrgKeysFlow: Flow<Unit>
+    val syncOrgKeysFlow: Flow<String>
 
     /**
      * Flow that represents requests intended to trigger a sync send delete.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
@@ -74,4 +74,13 @@ sealed class NotificationPayload {
         @JsonNames("UserId", "userId") override val userId: String?,
         @JsonNames("Id", "id") val loginRequestId: String?,
     ) : NotificationPayload()
+
+    /**
+     * A notification payload for resynchronizing organization keys.
+     */
+    @Serializable
+    data class SynchronizeOrganizationKeysNotifications(
+        @JsonNames("UserId", "userId") override val userId: String?,
+        @JsonNames("Id", "id") val loginRequestId: String?,
+    ) : NotificationPayload()
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -470,6 +470,13 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         assertEquals(expected, storedFlightRecorderData)
     }
 
+    /**
+     * Asserts that the stored last sync time matches the [expected] one.
+     */
+    fun assertLastSyncTime(userId: String, expected: Instant?) {
+        assertEquals(expected, storedLastSyncTime[userId])
+    }
+
     //region Private helper functions
     private fun getMutableLastSyncTimeFlow(
         userId: String,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
@@ -364,6 +364,17 @@ class PushManagerTest {
                     )
                 }
             }
+
+            @Test
+            fun `onMessageReceived with sync org keys emits to syncOrgKeysFlow`() = runTest {
+                pushManager.syncOrgKeysFlow.test {
+                    pushManager.onMessageReceived(SYNC_ORG_KEYS_NOTIFICATION_MAP)
+                    assertEquals(
+                        "078966a2-93c2-4618-ae2a-0a2394c88d37",
+                        awaitItem(),
+                    )
+                }
+            }
         }
 
         @Nested
@@ -546,13 +557,10 @@ class PushManagerTest {
             }
 
             @Test
-            fun `onMessageReceived with sync org keys emits to syncOrgKeysFlow`() = runTest {
+            fun `onMessageReceived with sync org keys does not emit`() = runTest {
                 pushManager.syncOrgKeysFlow.test {
                     pushManager.onMessageReceived(SYNC_ORG_KEYS_NOTIFICATION_MAP)
-                    assertEquals(
-                        Unit,
-                        awaitItem(),
-                    )
+                    expectNoEvents()
                 }
             }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25193](https://bitwarden.atlassian.net/browse/PM-25193)

## 📔 Objective

This PR clears the `lastSyncTime` value after receiving a `SYNC_ORG_KEYS` push notification for the inactive user. This ensures that they will always sync on the next request.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
