### PR TITLE
[PM-25057] Refactor card restriction logic in AutofillCipherProvider

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillCipherProviderTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillCipherProviderTest.kt
@@ -279,7 +279,13 @@ class AutofillCipherProviderTest {
                 every { deletedDate } returns null
                 every { type } returns CipherListViewType.Card(cardListView)
                 every { reprompt } returns CipherRepromptType.NONE
-                every { organizationId } returns ORGANIZATION_ID
+                every { organizationId } returns ORGANIZATION_ID_WITH_CARD_TYPE_RESTRICTIONS
+            }
+            val personalVaultCardCipherView: CipherListView = mockk {
+                every { deletedDate } returns null
+                every { type } returns CipherListViewType.Card(cardListView)
+                every { reprompt } returns CipherRepromptType.NONE
+                every { organizationId } returns null
             }
             val decryptCipherListViewsResult = DecryptCipherListResult(
                 successes = listOf(
@@ -287,6 +293,7 @@ class AutofillCipherProviderTest {
                     deletedCardCipherView,
                     repromptCardCipherView,
                     restrictedCardCipherView,
+                    personalVaultCardCipherView,
                     loginCipherListViewWithTotp,
                     loginCipherListViewWithoutTotp,
                 ),
@@ -295,7 +302,12 @@ class AutofillCipherProviderTest {
 
             every {
                 policyManager.getActivePolicies(PolicyTypeJson.RESTRICT_ITEM_TYPES)
-            } returns listOf(createMockPolicy(number = 1, organizationId = ORGANIZATION_ID))
+            } returns listOf(
+                createMockPolicy(
+                    number = 1,
+                    organizationId = ORGANIZATION_ID_WITH_CARD_TYPE_RESTRICTIONS,
+                ),
+            )
             coEvery {
                 vaultRepository.getCipher(CARD_CIPHER_ID)
             } returns GetCipherResult.Success(
@@ -314,6 +326,7 @@ class AutofillCipherProviderTest {
             val expected = listOf(
                 CARD_AUTOFILL_CIPHER,
             )
+            every { cardCipherListView.organizationId } returns ORGANIZATION_ID
             every { cardCipherListView.subtitle } returns CARD_SUBTITLE
 
             // Test & Verify
@@ -563,6 +576,8 @@ class AutofillCipherProviderTest {
 
 private const val ACTIVE_USER_ID = "activeUserId"
 private const val ORGANIZATION_ID = "organizationId"
+private const val ORGANIZATION_ID_WITH_CARD_TYPE_RESTRICTIONS =
+    "organizationIdWithCardTypeRestrictions"
 private const val CARD_CARDHOLDER_NAME = "John Doe"
 private const val CARD_CODE = "123"
 private const val CARD_EXP_MONTH = "January"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25057](https://bitwarden.atlassian.net/browse/PM-25057)

## 📔 Objective

Correct the logic for handling organization-based card type restrictions within the autofill feature.

The `isExcludedByOrgCardRestrictions` function was introduced in `AutofillCipherProviderImpl.kt` to consolidate the logic for determining if a `CipherListView` item should be excluded due to these restrictions. This function now correctly handles cases where:
- The item is a personal vault item and any organization has card type restrictions.
- The item belongs to an organization that has card type restrictions.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25057]: https://bitwarden.atlassian.net/browse/PM-25057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ