### PR TITLE
PM-25238: Remove debug toast

### DIFF
--- a/app/src/standard/kotlin/com/x8bit/bitwarden/ui/platform/manager/review/AppReviewManagerImpl.kt
+++ b/app/src/standard/kotlin/com/x8bit/bitwarden/ui/platform/manager/review/AppReviewManagerImpl.kt
@@ -1,11 +1,8 @@
 package com.x8bit.bitwarden.ui.platform.manager.review
 
 import android.app.Activity
-import android.widget.Toast
 import com.bitwarden.annotation.OmitFromCoverage
-import com.bitwarden.ui.platform.resource.BitwardenString
 import com.google.android.play.core.review.ReviewManagerFactory
-import com.x8bit.bitwarden.BuildConfig
 import timber.log.Timber
 
 /**
@@ -25,15 +22,6 @@ class AppReviewManagerImpl(
             } else {
                 Timber.e(task.exception, "Failed to launch review flow.")
             }
-        }
-        if (BuildConfig.DEBUG) {
-            Toast
-                .makeText(
-                    activity,
-                    activity.getString(BitwardenString.review_flow_launched),
-                    Toast.LENGTH_SHORT,
-                )
-                .show()
         }
     }
 }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -850,7 +850,6 @@ Do you want to switch to this account?</string>
     <string name="need_some_inspiration">"Need some inspiration?"</string>
     <string name="check_out_the_passphrase_generator">"Check out the passphrase generator"</string>
     <string name="we_couldnt_verify_the_servers_certificate">We couldn’t verify the server’s certificate. The certificate chain or proxy settings on your device or your Bitwarden server may not be set up correctly.</string>
-    <string name="review_flow_launched">Review flow launched!</string>
     <string name="copy_private_key">Copy private key</string>
     <string name="login_credentials">Login Credentials</string>
     <string name="autofill_options">Autofill Options</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25238](https://bitwarden.atlassian.net/browse/PM-25238)

## 📔 Objective

This PR removes a debug only toast that indicates when the app review flow has been invoked.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25238]: https://bitwarden.atlassian.net/browse/PM-25238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ