### PR TITLE
[PM-25239] Remove unnecessary vault sync from `Fido2CredentialStoreImpl`

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/Fido2CredentialStoreImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/Fido2CredentialStoreImpl.kt
@@ -12,7 +12,6 @@ import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
-import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
 import timber.log.Timber
 
 /**
@@ -28,21 +27,13 @@ class Fido2CredentialStoreImpl(
     /**
      * Return all active ciphers that contain FIDO 2 credentials.
      */
-    override suspend fun allCredentials(): List<CipherListView> {
-        val syncResult = vaultRepository.syncForResult()
-        if (syncResult is SyncVaultDataResult.Error) {
-            syncResult.throwable
-                ?.let { throw it }
-                ?: throw IllegalStateException("Sync failed.")
-        }
-        return vaultRepository
-            .decryptCipherListResultStateFlow
-            .value
-            .data
-            ?.successes
-            .orEmpty()
-            .filter { it.isActiveWithFido2Credentials }
-    }
+    override suspend fun allCredentials(): List<CipherListView> = vaultRepository
+        .decryptCipherListResultStateFlow
+        .value
+        .data
+        ?.successes
+        .orEmpty()
+        .filter { it.isActiveWithFido2Credentials }
 
     /**
      * Returns ciphers that contain FIDO 2 credentials for the given [ripId] with the provided
@@ -51,15 +42,8 @@ class Fido2CredentialStoreImpl(
      * @param ids Optional list of FIDO 2 credential ID's to find.
      * @param ripId Relying Party ID to find.
      */
-    override suspend fun findCredentials(ids: List<ByteArray>?, ripId: String): List<CipherView> {
-        val syncResult = vaultRepository.syncForResult()
-        if (syncResult is SyncVaultDataResult.Error) {
-            syncResult.throwable
-                ?.let { throw it }
-                ?: throw IllegalStateException("Sync failed.")
-        }
-
-        return vaultRepository
+    override suspend fun findCredentials(ids: List<ByteArray>?, ripId: String): List<CipherView> =
+        vaultRepository
             .decryptCipherListResultStateFlow
             .value
             .data
@@ -78,7 +62,6 @@ class Fido2CredentialStoreImpl(
                             .toCipherViewOrNull()
                     }
             }
-    }
 
     /**
      * Save the provided [cred] to the users vault.
@@ -95,7 +78,7 @@ class Fido2CredentialStoreImpl(
                     ?: vaultRepository.createCipher(decryptedCipherView)
             }
             .onFailure { throw it }
-        }
+    }
 
     /**
      * Return a filtered list containing elements that match the given [relyingPartyId] and a


### PR DESCRIPTION
## 🎟️ Tracking

PM-25239
Resolves #5218 

## 📔 Objective

Do not attempt sync when performing passkey operations so that vault connectivity is not required.

Legacy passkeys that require counters may fail if they have not been synced recently. Users must manually trigger sync in order to use the legacy passkey.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
