### PR TITLE
🍒 PM-25143: Retain intent data on recreate

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
@@ -43,8 +43,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-private const val ANDROID_15_BUG_MAX_REVISION: Int = 241007
-
 /**
  * Primary entry point for the application.
  */
@@ -217,35 +215,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun handleRecreate() {
-        val isOldAndroidBuildRevision = {
-            // This fetches the date portion of the ID in order to determine the revision of
-            // Android 15 being used and whether we want to use the `recreate` API or not.
-            // If we fail to parse a date, we assume it is not an old revision.
-            "\\.([^.]+)\\."
-                .toRegex()
-                .find(Build.ID)
-                ?.groups
-                ?.get(1)
-                ?.value
-                ?.toIntOrNull()
-                ?.let { it <= ANDROID_15_BUG_MAX_REVISION } == true
-        }
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.VANILLA_ICE_CREAM &&
-            isOldAndroidBuildRevision()
-        ) {
-            // This is done to avoid a bug in specific older revisions of Android 15. The bug has
-            // been fixed but certain phones that are no longer supported will never get the fix.
-            // The OS bug is tracked here: https://issuetracker.google.com/issues/370180732
-            startActivity(
-                Intent
-                    .makeMainActivity(componentName)
-                    .addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION),
-            )
-            finish()
-            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
-        } else {
-            ActivityCompat.recreate(this)
-        }
+        ActivityCompat.recreate(this)
     }
 
     private fun updateScreenCapture(isScreenCaptureAllowed: Boolean) {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25143](https://bitwarden.atlassian.net/browse/PM-25143)

## 📔 Objective

🍒 This PR updates the mechanism used to restart the main activity on old revisions of Android 15.

The issue was that the intent was generated using the `makeMainActivity` function, this was causing intent data loss on recreation. This change uses the existing intent to prevent intent data loss and manually applies all the same properties as `makeMainActivity` to maintain the correct other functionality.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25143]: https://bitwarden.atlassian.net/browse/PM-25143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ