### PR TITLE
[PM-25327] Display default user collections first

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -82,6 +82,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.UpdateSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
 import com.x8bit.bitwarden.data.vault.repository.util.sortAlphabetically
+import com.x8bit.bitwarden.data.vault.repository.util.sortAlphabeticallyByType
 import com.x8bit.bitwarden.data.vault.repository.util.toDomainsData
 import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedNetworkFolder
 import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedNetworkSend
@@ -1167,7 +1168,7 @@ class VaultRepositoryImpl(
                     .fold(
                         onSuccess = { collections ->
                             DataState.Loaded(
-                                collections.sortAlphabetically(),
+                                collections.sortAlphabeticallyByType(),
                             )
                         },
                         onFailure = { throwable -> DataState.Error(throwable) },

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCollectionExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCollectionExtensionsTest.kt
@@ -103,7 +103,7 @@ class VaultSdkCollectionExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `toSortAlphabetically should sort collections by name`() {
+    fun `toSortAlphabetically should sort collections by type and name`() {
         val list = listOf(
             createMockCollectionView(1).copy(name = "c"),
             createMockCollectionView(1).copy(name = "B"),
@@ -111,29 +111,35 @@ class VaultSdkCollectionExtensionsTest {
             createMockCollectionView(1).copy(name = "4"),
             createMockCollectionView(1).copy(name = "A"),
             createMockCollectionView(1).copy(name = "#"),
-            createMockCollectionView(1).copy(name = "D"),
+            createMockCollectionView(1).copy(
+                name = "D",
+                type = CollectionType.DEFAULT_USER_COLLECTION,
+            ),
         )
 
         val expected = listOf(
+            createMockCollectionView(1).copy(
+                name = "D",
+                type = CollectionType.DEFAULT_USER_COLLECTION,
+            ),
             createMockCollectionView(1).copy(name = "#"),
             createMockCollectionView(1).copy(name = "4"),
             createMockCollectionView(1).copy(name = "A"),
             createMockCollectionView(1).copy(name = "B"),
             createMockCollectionView(1).copy(name = "c"),
-            createMockCollectionView(1).copy(name = "D"),
             createMockCollectionView(1).copy(name = "z"),
         )
 
         assertEquals(
             expected,
-            list.sortAlphabetically(),
+            list.sortAlphabeticallyByType(),
         )
     }
 
     @Test
     fun `toCollectionType should convert CollectionTypeJson to CollectionType`() {
         val collectionType = CollectionTypeJson.SHARED_COLLECTION
-        val sdkCollectionType = collectionType.toCollectionType()
+        val sdkCollectionType = collectionType.toSdkCollectionType()
         assertEquals(
             CollectionType.SHARED_COLLECTION,
             sdkCollectionType,


### PR DESCRIPTION
## 🎟️ Tracking

PM-25327

## 📔 Objective

Collections are now sorted primarily by `CollectionType`, with `DEFAULT_USER_COLLECTION` appearing first, and then alphabetically by name within each type group.

Additionally, the `toCollectionType()` function has been renamed to `toSdkCollectionType()` for clarity.

Corresponding test cases have been updated to reflect these changes.

## 📸 Screenshots

<img width="365" alt="image" src="https://github.com/user-attachments/assets/fac36ab0-b001-4ed7-b603-aa9851075e79" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
