### PR TITLE
PM-25393: Allow push notifications to update a cipher while vault is locked

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -1268,14 +1268,11 @@ class VaultRepositoryImpl(
         val revisionDate = syncCipherUpsertData.revisionDate
         val isUpdate = syncCipherUpsertData.isUpdate
 
-        val localCipher = decryptCipherListResultStateFlow
-            .mapNotNull { it.data?.successes }
-            .first()
-            .find { it.id == cipherId }
+        val localCipher = vaultDiskSource.getCipher(userId = userId, cipherId = cipherId)
 
         // Return if local cipher is more recent
         if (localCipher != null &&
-            localCipher.revisionDate.epochSecond > revisionDate.toEpochSecond()
+            localCipher.revisionDate.toEpochSecond() > revisionDate.toEpochSecond()
         ) {
             return
         }
@@ -1302,11 +1299,10 @@ class VaultRepositoryImpl(
 
         if (!shouldUpdate && shouldCheckCollections && organizationId != null) {
             // Check if there are any collections in common
-            shouldUpdate = collectionsStateFlow
-                .mapNotNull { it.data }
+            shouldUpdate = vaultDiskSource
+                .getCollections(userId = userId)
                 .first()
-                .mapNotNull { it.id }
-                .any { collectionIds?.contains(it) == true } == true
+                .any { collectionIds?.contains(it.id) == true }
         }
 
         if (!shouldUpdate) return


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25393](https://bitwarden.atlassian.net/browse/PM-25393)

## 📔 Objective

This PR allows the upsert events from push notifications to update a vault cipher without requiring the vault to be unlocked.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
