### PR TITLE
[PM-25396] Publish store builds when release branches are updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ on:
       distribute-to-firebase:
         description: "Optional. Distribute artifacts to Firebase."
         required: false
-        default: false
+        default: true
         type: boolean
       publish-to-play-store:
         description: "Optional. Deploy bundle artifact to Google Play Store"
         required: false
-        default: false
+        default: true
         type: boolean
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,7 +417,7 @@ jobs:
           bundle exec fastlane run validate_play_store_json_key
 
       - name: Publish Play Store bundle
-        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && (inputs.publish-to-play-store || github.ref_name == 'main') }}
+        if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' && (inputs.publish-to-play-store || github.event_name == 'push') }}
         run: |
           bundle exec fastlane publishProdToPlayStore
           bundle exec fastlane publishBetaToPlayStore


### PR DESCRIPTION
## 🎟️ Tracking

PM-25396

## 📔 Objective

While handling the release process our team noticed builds in Firebase that weren't published to PlayStore, this PR addresses that. 

Our QA team noted something similar previously happened when distribution inputs were missed while triggering manual builds, changing the input defaults too while at it. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
