### PR TITLE
PM-25431: Allow SYNC_SEND_DELETE notification to delete sends for inactive user

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 import java.time.Clock
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
@@ -129,8 +130,8 @@ class PushManagerImpl @Inject constructor(
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     private fun onMessageReceived(notification: BitwardenNotification) {
         if (authDiskSource.uniqueAppId == notification.contextId) return
-
         val userId = activeUserId ?: return
+        Timber.d("Push Notification Received: ${notification.notificationType}")
 
         when (val type = notification.notificationType) {
             NotificationType.AUTH_REQUEST,
@@ -266,9 +267,14 @@ class PushManagerImpl @Inject constructor(
                     .decodeFromString<NotificationPayload.SyncSendNotification>(
                         string = notification.payload,
                     )
-                    .takeIf { isLoggedIn(userId) && it.userMatchesNotification(userId) }
-                    ?.sendId
-                    ?.let { mutableSyncSendDeleteSharedFlow.tryEmit(SyncSendDeleteData(it)) }
+                    .takeIf { it.userId != null && it.sendId != null }
+                    ?.let {
+                        SyncSendDeleteData(
+                            userId = requireNotNull(it.userId),
+                            sendId = requireNotNull(it.sendId),
+                        )
+                    }
+                    ?.let { mutableSyncSendDeleteSharedFlow.tryEmit(it) }
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncSendDeleteData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncSendDeleteData.kt
@@ -2,9 +2,8 @@ package com.x8bit.bitwarden.data.platform.manager.model
 
 /**
  * Required data for sync send delete operations.
- *
- * @property sendId The send ID.
  */
 data class SyncSendDeleteData(
+    val userId: String,
     val sendId: String,
 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -1385,12 +1385,9 @@ class VaultRepositoryImpl(
      * Deletes the send specified by [syncSendDeleteData] from disk.
      */
     private suspend fun deleteSend(syncSendDeleteData: SyncSendDeleteData) {
-        val userId = activeUserId ?: return
-
-        val sendId = syncSendDeleteData.sendId
         vaultDiskSource.deleteSend(
-            userId = userId,
-            sendId = sendId,
+            userId = syncSendDeleteData.userId,
+            sendId = syncSendDeleteData.sendId,
         )
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
@@ -343,6 +343,7 @@ class PushManagerTest {
                     pushManager.onMessageReceived(SYNC_SEND_DELETE_NOTIFICATION_MAP)
                     assertEquals(
                         SyncSendDeleteData(
+                            userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                             sendId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                         ),
                         awaitItem(),
@@ -456,10 +457,16 @@ class PushManagerTest {
             }
 
             @Test
-            fun `onMessageReceived with sync send delete does nothing`() = runTest {
+            fun `onMessageReceived with sync send delete emits to syncSendDeleteFlow`() = runTest {
                 pushManager.syncSendDeleteFlow.test {
                     pushManager.onMessageReceived(SYNC_SEND_DELETE_NOTIFICATION_MAP)
-                    expectNoEvents()
+                    assertEquals(
+                        SyncSendDeleteData(
+                            userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
+                            sendId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
+                        ),
+                        awaitItem(),
+                    )
                 }
             }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -3679,13 +3679,9 @@ class VaultRepositoryTest {
     fun `syncSendDeleteFlow should delete send from disk`() {
         val userId = "mockId-1"
         val sendId = "mockId-1"
-
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
         coEvery { vaultDiskSource.deleteSend(userId = userId, sendId = sendId) } just runs
 
-        mutableSyncSendDeleteFlow.tryEmit(
-            SyncSendDeleteData(sendId = sendId),
-        )
+        mutableSyncSendDeleteFlow.tryEmit(SyncSendDeleteData(userId = userId, sendId = sendId))
 
         coVerify { vaultDiskSource.deleteSend(userId = userId, sendId = sendId) }
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25431](https://bitwarden.atlassian.net/browse/PM-25431)

## 📔 Objective

This PR update the `SYNC_SEND_DELETE` push notification processing to allow us to delete Sends when the user is not currently the active user.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25431]: https://bitwarden.atlassian.net/browse/PM-25431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ