### PR TITLE
PM-25462: Allow SYNC_FOLDER_DELETE notification to delete Folders for inactive user

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
@@ -227,9 +227,14 @@ class PushManagerImpl @Inject constructor(
                     .decodeFromString<NotificationPayload.SyncFolderNotification>(
                         string = notification.payload,
                     )
-                    .takeIf { isLoggedIn(userId) && it.userMatchesNotification(userId) }
-                    ?.folderId
-                    ?.let { mutableSyncFolderDeleteSharedFlow.tryEmit(SyncFolderDeleteData(it)) }
+                    .takeIf { it.userId != null && it.folderId != null }
+                    ?.let {
+                        SyncFolderDeleteData(
+                            userId = requireNotNull(it.userId),
+                            folderId = requireNotNull(it.folderId),
+                        )
+                    }
+                    ?.let { mutableSyncFolderDeleteSharedFlow.tryEmit(it) }
             }
 
             NotificationType.SYNC_ORG_KEYS -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncFolderDeleteData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncFolderDeleteData.kt
@@ -2,9 +2,8 @@ package com.x8bit.bitwarden.data.platform.manager.model
 
 /**
  * Required data for sync folder delete operations.
- *
- * @property folderId The folder ID.
  */
 data class SyncFolderDeleteData(
+    val userId: String,
     val folderId: String,
 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -929,11 +929,9 @@ class VaultRepositoryImpl(
     }
 
     private suspend fun clearFolderIdFromCiphers(folderId: String, userId: String) {
-        vaultDiskSource.getCiphersFlow(userId).firstOrNull()?.forEach {
+        vaultDiskSource.getCiphers(userId = userId).forEach {
             if (it.folderId == folderId) {
-                vaultDiskSource.saveCipher(
-                    userId, it.copy(folderId = null),
-                )
+                vaultDiskSource.saveCipher(userId = userId, cipher = it.copy(folderId = null))
             }
         }
     }
@@ -1433,16 +1431,13 @@ class VaultRepositoryImpl(
      * Deletes the folder specified by [syncFolderDeleteData] from disk.
      */
     private suspend fun deleteFolder(syncFolderDeleteData: SyncFolderDeleteData) {
-        val userId = activeUserId ?: return
-
-        val folderId = syncFolderDeleteData.folderId
         clearFolderIdFromCiphers(
-            folderId = folderId,
-            userId = userId,
+            folderId = syncFolderDeleteData.folderId,
+            userId = syncFolderDeleteData.userId,
         )
         vaultDiskSource.deleteFolder(
-            folderId = folderId,
-            userId = userId,
+            folderId = syncFolderDeleteData.folderId,
+            userId = syncFolderDeleteData.userId,
         )
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
@@ -285,6 +285,7 @@ class PushManagerTest {
                         pushManager.onMessageReceived(SYNC_FOLDER_DELETE_NOTIFICATION_MAP)
                         assertEquals(
                             SyncFolderDeleteData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                                 folderId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                             ),
                             awaitItem(),
@@ -425,12 +426,19 @@ class PushManagerTest {
             }
 
             @Test
-            fun `onMessageReceived with sync folder delete does nothing`() = runTest {
-                pushManager.syncFolderDeleteFlow.test {
-                    pushManager.onMessageReceived(SYNC_FOLDER_DELETE_NOTIFICATION_MAP)
-                    expectNoEvents()
+            fun `onMessageReceived with sync folder delete emits to syncFolderDeleteFlow`() =
+                runTest {
+                    pushManager.syncFolderDeleteFlow.test {
+                        pushManager.onMessageReceived(SYNC_FOLDER_DELETE_NOTIFICATION_MAP)
+                        assertEquals(
+                            SyncFolderDeleteData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
+                                folderId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
+                            ),
+                            awaitItem(),
+                        )
+                    }
                 }
-            }
 
             @Test
             fun `onMessageReceived with sync folder update does nothing`() = runTest {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25462](https://bitwarden.atlassian.net/browse/PM-25462)

## 📔 Objective

This PR update the `SYNC_FOLDER_DELETE` push notification processing to allow us to delete Folders when the user is not currently the active user.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25462]: https://bitwarden.atlassian.net/browse/PM-25462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ