### PR TITLE
PM-25474: Allow SYNC_CIPHER_DELETE notification to delete Cipher for inactive user

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
@@ -190,9 +190,14 @@ class PushManagerImpl @Inject constructor(
                     .decodeFromString<NotificationPayload.SyncCipherNotification>(
                         string = notification.payload,
                     )
-                    .takeIf { isLoggedIn(userId) && it.userMatchesNotification(userId) }
-                    ?.cipherId
-                    ?.let { mutableSyncCipherDeleteSharedFlow.tryEmit(SyncCipherDeleteData(it)) }
+                    .takeIf { it.userId != null && it.cipherId != null }
+                    ?.let {
+                        SyncCipherDeleteData(
+                            userId = requireNotNull(it.userId),
+                            cipherId = requireNotNull(it.cipherId),
+                        )
+                    }
+                    ?.let { mutableSyncCipherDeleteSharedFlow.tryEmit(it) }
             }
 
             NotificationType.SYNC_CIPHERS,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncCipherDeleteData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncCipherDeleteData.kt
@@ -2,9 +2,8 @@ package com.x8bit.bitwarden.data.platform.manager.model
 
 /**
  * Required data for sync cipher delete operations.
- *
- * @property cipherId The cipher ID.
  */
 data class SyncCipherDeleteData(
+    val userId: String,
     val cipherId: String,
 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -1248,12 +1248,9 @@ class VaultRepositoryImpl(
      * Deletes the cipher specified by [syncCipherDeleteData] from disk.
      */
     private suspend fun deleteCipher(syncCipherDeleteData: SyncCipherDeleteData) {
-        val userId = activeUserId ?: return
-
-        val cipherId = syncCipherDeleteData.cipherId
         vaultDiskSource.deleteCipher(
-            userId = userId,
-            cipherId = cipherId,
+            userId = syncCipherDeleteData.userId,
+            cipherId = syncCipherDeleteData.cipherId,
         )
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
@@ -237,6 +237,7 @@ class PushManagerTest {
                         pushManager.onMessageReceived(SYNC_CIPHER_DELETE_NOTIFICATION_MAP)
                         assertEquals(
                             SyncCipherDeleteData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                                 cipherId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                             ),
                             awaitItem(),
@@ -316,6 +317,7 @@ class PushManagerTest {
                         pushManager.onMessageReceived(SYNC_LOGIN_DELETE_NOTIFICATION_MAP)
                         assertEquals(
                             SyncCipherDeleteData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                                 cipherId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                             ),
                             awaitItem(),
@@ -405,7 +407,13 @@ class PushManagerTest {
             fun `onMessageReceived with sync cipher delete does nothing`() = runTest {
                 pushManager.syncCipherDeleteFlow.test {
                     pushManager.onMessageReceived(SYNC_CIPHER_DELETE_NOTIFICATION_MAP)
-                    expectNoEvents()
+                    assertEquals(
+                        SyncCipherDeleteData(
+                            userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
+                            cipherId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
+                        ),
+                        awaitItem(),
+                    )
                 }
             }
 
@@ -449,12 +457,19 @@ class PushManagerTest {
             }
 
             @Test
-            fun `onMessageReceived with sync login delete does nothing`() = runTest {
-                pushManager.syncCipherDeleteFlow.test {
-                    pushManager.onMessageReceived(SYNC_LOGIN_DELETE_NOTIFICATION_MAP)
-                    expectNoEvents()
+            fun `onMessageReceived with sync login delete emits to syncCipherDeleteFlow`() =
+                runTest {
+                    pushManager.syncCipherDeleteFlow.test {
+                        pushManager.onMessageReceived(SYNC_LOGIN_DELETE_NOTIFICATION_MAP)
+                        assertEquals(
+                            SyncCipherDeleteData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
+                                cipherId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
+                            ),
+                            awaitItem(),
+                        )
+                    }
                 }
-            }
 
             @Test
             fun `onMessageReceived with sync send create does nothing`() = runTest {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -3317,11 +3317,10 @@ class VaultRepositoryTest {
         val userId = "mockId-1"
         val cipherId = "mockId-1"
 
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
         coEvery { vaultDiskSource.deleteCipher(userId = userId, cipherId = cipherId) } just runs
 
         mutableSyncCipherDeleteFlow.tryEmit(
-            SyncCipherDeleteData(cipherId = cipherId),
+            SyncCipherDeleteData(userId = userId, cipherId = cipherId),
         )
 
         coVerify { vaultDiskSource.deleteCipher(userId = userId, cipherId = cipherId) }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25474](https://bitwarden.atlassian.net/browse/PM-25474)

## 📔 Objective

This PR update the `SYNC_CIPHER_DELETE` push notification processing to allow us to delete Ciphers when the user is not currently the active user.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25474]: https://bitwarden.atlassian.net/browse/PM-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ