### PR TITLE
PM-25478: Update sends and folders while vault is locked

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -114,7 +114,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -1400,15 +1399,14 @@ class VaultRepositoryImpl(
         val isUpdate = syncSendUpsertData.isUpdate
         val revisionDate = syncSendUpsertData.revisionDate
 
-        val localSend = sendDataStateFlow
-            .mapNotNull { it.data }
+        val localSend = vaultDiskSource
+            .getSends(userId = userId)
             .first()
-            .sendViewList
             .find { it.id == sendId }
         val isValidCreate = !isUpdate && localSend == null
         val isValidUpdate = isUpdate &&
             localSend != null &&
-            localSend.revisionDate.epochSecond < revisionDate.toEpochSecond()
+            localSend.revisionDate.toEpochSecond() < revisionDate.toEpochSecond()
 
         if (!isValidCreate && !isValidUpdate) return
 
@@ -1450,21 +1448,20 @@ class VaultRepositoryImpl(
         val folderId = syncFolderUpsertData.folderId
         val isUpdate = syncFolderUpsertData.isUpdate
         val revisionDate = syncFolderUpsertData.revisionDate
-
-        val localFolder = foldersStateFlow
-            .mapNotNull { it.data }
+        val localFolder = vaultDiskSource
+            .getFolders(userId = userId)
             .first()
             .find { it.id == folderId }
         val isValidCreate = !isUpdate && localFolder == null
         val isValidUpdate = isUpdate &&
             localFolder != null &&
-            localFolder.revisionDate.epochSecond < revisionDate.toEpochSecond()
+            localFolder.revisionDate.toEpochSecond() < revisionDate.toEpochSecond()
 
         if (!isValidCreate && !isValidUpdate) return
 
         folderService
-            .getFolder(folderId)
-            .onSuccess { vaultDiskSource.saveFolder(userId, it) }
+            .getFolder(folderId = folderId)
+            .onSuccess { vaultDiskSource.saveFolder(userId = userId, folder = it) }
     }
     //endregion Push Notification helpers
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -3789,53 +3789,37 @@ class VaultRepositoryTest {
     fun `syncSendUpsertFlow update failure with 404 code should make a request for a send and then delete it`() =
         runTest {
             val number = 1
+            val userId = MOCK_USER_STATE.activeUserId
             val sendId = "mockId-$number"
 
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
             val response: HttpException = mockk {
                 every { code() } returns 404
             }
+            coEvery { sendsService.getSend(sendId = sendId) } returns response.asFailure()
             coEvery {
-                sendsService.getSend(sendId)
-            } returns response.asFailure()
-
-            coEvery {
-                vaultDiskSource.deleteSend(any(), any())
+                vaultDiskSource.deleteSend(userId = userId, sendId = sendId)
             } just runs
 
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            setVaultToUnlocked(userId = MOCK_USER_STATE.activeUserId)
-            val sendView = createMockSendView(number = number)
+            val sendView = createMockSend(
+                number = number,
+                revisionDate = ZonedDateTime.now(clock).minus(5, ChronoUnit.MINUTES),
+            )
             coEvery {
-                vaultSdkSource.decryptSendList(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    sendList = listOf(createMockSdkSend(number = number)),
-                )
-            } returns listOf(sendView).asSuccess()
+                vaultDiskSource.getSends(userId = userId)
+            } returns MutableStateFlow(listOf(sendView))
 
-            val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-            setupVaultDiskSourceFlows(sendsFlow = sendsFlow)
-
-            vaultRepository.sendDataStateFlow.test {
-                // Populate and consume items related to the sends flow
-                awaitItem()
-                sendsFlow.tryEmit(listOf(createMockSend(number = number)))
-                awaitItem()
-
-                mutableSyncSendUpsertFlow.tryEmit(
-                    SyncSendUpsertData(
-                        sendId = sendId,
-                        revisionDate = ZonedDateTime.now(),
-                        isUpdate = true,
-                    ),
-                )
-            }
+            mutableSyncSendUpsertFlow.tryEmit(
+                SyncSendUpsertData(
+                    sendId = sendId,
+                    revisionDate = ZonedDateTime.now(clock),
+                    isUpdate = true,
+                ),
+            )
 
             coVerify(exactly = 1) {
-                sendsService.getSend(sendId)
-                vaultDiskSource.deleteSend(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    sendId = sendId,
-                )
+                sendsService.getSend(sendId = sendId)
+                vaultDiskSource.deleteSend(userId = userId, sendId = sendId)
             }
         }
 
@@ -3843,51 +3827,31 @@ class VaultRepositoryTest {
     @Test
     fun `syncSendUpsertFlow create failure with 404 code should make a request for a send and do nothing`() =
         runTest {
+            val userId = MOCK_USER_STATE.activeUserId
             val sendId = "mockId-1"
 
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            setVaultToUnlocked(userId = MOCK_USER_STATE.activeUserId)
-
             val response: HttpException = mockk {
                 every { code() } returns 404
             }
+            coEvery { sendsService.getSend(sendId = sendId) } returns response.asFailure()
             coEvery {
-                sendsService.getSend(sendId)
-            } returns response.asFailure()
+                vaultDiskSource.getSends(userId = userId)
+            } returns MutableStateFlow(emptyList())
 
-            coEvery {
-                vaultSdkSource.decryptSendList(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    sendList = listOf(),
-                )
-            } returns emptyList<SendView>().asSuccess()
-
-            val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-            setupVaultDiskSourceFlows(sendsFlow = sendsFlow)
-
-            vaultRepository.sendDataStateFlow.test {
-                // Populate and consume items related to the sends flow
-                awaitItem()
-                sendsFlow.tryEmit(emptyList())
-                awaitItem()
-
-                mutableSyncSendUpsertFlow.tryEmit(
-                    SyncSendUpsertData(
-                        sendId = sendId,
-                        revisionDate = ZonedDateTime.now(),
-                        isUpdate = false,
-                    ),
-                )
-            }
+            mutableSyncSendUpsertFlow.tryEmit(
+                SyncSendUpsertData(
+                    sendId = sendId,
+                    revisionDate = ZonedDateTime.now(clock),
+                    isUpdate = false,
+                ),
+            )
 
             coVerify(exactly = 1) {
-                sendsService.getSend(sendId)
+                sendsService.getSend(sendId = sendId)
             }
             coVerify(exactly = 0) {
-                vaultDiskSource.deleteSend(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    sendId = sendId,
-                )
+                vaultDiskSource.deleteSend(userId = userId, sendId = sendId)
             }
         }
 
@@ -3896,50 +3860,28 @@ class VaultRepositoryTest {
     fun `syncSendUpsertFlow valid create success should make a request for a send and then store it`() =
         runTest {
             val number = 1
+            val userId = MOCK_USER_STATE.activeUserId
             val sendId = "mockId-$number"
 
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            setVaultToUnlocked(userId = MOCK_USER_STATE.activeUserId)
             coEvery {
-                vaultSdkSource.decryptSendList(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    sendList = listOf(),
-                )
-            } returns listOf<SendView>().asSuccess()
+                vaultDiskSource.getSends(userId = userId)
+            } returns MutableStateFlow(emptyList())
+            val send = mockk<SyncResponseJson.Send>()
+            coEvery { sendsService.getSend(sendId = sendId) } returns send.asSuccess()
+            coEvery { vaultDiskSource.saveSend(userId = userId, send = send) } just runs
 
-            val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-            setupVaultDiskSourceFlows(sendsFlow = sendsFlow)
-
-            val send: SyncResponseJson.Send = mockk()
-            coEvery {
-                sendsService.getSend(sendId)
-            } returns send.asSuccess()
-
-            coEvery {
-                vaultDiskSource.saveSend(any(), any())
-            } just runs
-
-            vaultRepository.sendDataStateFlow.test {
-                // Populate and consume items related to the sends flow
-                awaitItem()
-                sendsFlow.tryEmit(listOf())
-                awaitItem()
-
-                mutableSyncSendUpsertFlow.tryEmit(
-                    SyncSendUpsertData(
-                        sendId = sendId,
-                        revisionDate = ZonedDateTime.now(),
-                        isUpdate = false,
-                    ),
-                )
-            }
+            mutableSyncSendUpsertFlow.tryEmit(
+                SyncSendUpsertData(
+                    sendId = sendId,
+                    revisionDate = ZonedDateTime.now(clock),
+                    isUpdate = false,
+                ),
+            )
 
             coVerify(exactly = 1) {
-                sendsService.getSend(sendId)
-                vaultDiskSource.saveSend(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    send = send,
-                )
+                sendsService.getSend(sendId = sendId)
+                vaultDiskSource.saveSend(userId = userId, send = send)
             }
         }
 
@@ -3948,51 +3890,33 @@ class VaultRepositoryTest {
     fun `syncSendUpsertFlow valid update success should make a request for a send and then store it`() =
         runTest {
             val number = 1
+            val userId = MOCK_USER_STATE.activeUserId
             val sendId = "mockId-$number"
 
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            setVaultToUnlocked(userId = MOCK_USER_STATE.activeUserId)
-            val sendView = createMockSendView(number = number)
+            val sendView = createMockSend(
+                number = number,
+                revisionDate = ZonedDateTime.now(clock).minus(5, ChronoUnit.MINUTES),
+            )
             coEvery {
-                vaultSdkSource.decryptSendList(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    sendList = listOf(createMockSdkSend(number = number)),
-                )
-            } returns listOf(sendView).asSuccess()
+                vaultDiskSource.getSends(userId = userId)
+            } returns MutableStateFlow(listOf(sendView))
 
-            val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-            setupVaultDiskSourceFlows(sendsFlow = sendsFlow)
+            val send = mockk<SyncResponseJson.Send>()
+            coEvery { sendsService.getSend(sendId = sendId) } returns send.asSuccess()
+            coEvery { vaultDiskSource.saveSend(userId = userId, send = send) } just runs
 
-            val send: SyncResponseJson.Send = mockk()
-            coEvery {
-                sendsService.getSend(sendId)
-            } returns send.asSuccess()
-
-            coEvery {
-                vaultDiskSource.saveSend(any(), any())
-            } just runs
-
-            vaultRepository.sendDataStateFlow.test {
-                // Populate and consume items related to the sends flow
-                awaitItem()
-                sendsFlow.tryEmit(listOf(createMockSend(number = number)))
-                awaitItem()
-
-                mutableSyncSendUpsertFlow.tryEmit(
-                    SyncSendUpsertData(
-                        sendId = sendId,
-                        revisionDate = ZonedDateTime.now(),
-                        isUpdate = true,
-                    ),
-                )
-            }
+            mutableSyncSendUpsertFlow.tryEmit(
+                SyncSendUpsertData(
+                    sendId = sendId,
+                    revisionDate = ZonedDateTime.now(clock),
+                    isUpdate = true,
+                ),
+            )
 
             coVerify(exactly = 1) {
-                sendsService.getSend(sendId)
-                vaultDiskSource.saveSend(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    send = send,
-                )
+                sendsService.getSend(sendId = sendId)
+                vaultDiskSource.saveSend(userId = userId, send = send)
             }
         }
 
@@ -4141,50 +4065,28 @@ class VaultRepositoryTest {
     fun `syncFolderUpsertFlow valid create success should make a request for a folder and then store it`() =
         runTest {
             val number = 1
+            val userId = MOCK_USER_STATE.activeUserId
             val folderId = "mockId-$number"
 
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            setVaultToUnlocked(userId = MOCK_USER_STATE.activeUserId)
             coEvery {
-                vaultSdkSource.decryptFolderList(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    folderList = listOf(),
-                )
-            } returns listOf<FolderView>().asSuccess()
+                vaultDiskSource.getFolders(userId = userId)
+            } returns MutableStateFlow(emptyList())
+            val folder = mockk<SyncResponseJson.Folder>()
+            coEvery { folderService.getFolder(folderId = folderId) } returns folder.asSuccess()
+            coEvery { vaultDiskSource.saveFolder(userId = userId, folder = folder) } just runs
 
-            val foldersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>()
-            setupVaultDiskSourceFlows(foldersFlow = foldersFlow)
-
-            val folder: SyncResponseJson.Folder = mockk()
-            coEvery {
-                folderService.getFolder(folderId)
-            } returns folder.asSuccess()
-
-            coEvery {
-                vaultDiskSource.saveFolder(any(), any())
-            } just runs
-
-            vaultRepository.foldersStateFlow.test {
-                // Populate and consume items related to the folders flow
-                awaitItem()
-                foldersFlow.tryEmit(listOf())
-                awaitItem()
-
-                mutableSyncFolderUpsertFlow.tryEmit(
-                    SyncFolderUpsertData(
-                        folderId = folderId,
-                        revisionDate = ZonedDateTime.now(),
-                        isUpdate = false,
-                    ),
-                )
-            }
+            mutableSyncFolderUpsertFlow.tryEmit(
+                SyncFolderUpsertData(
+                    folderId = folderId,
+                    revisionDate = ZonedDateTime.now(clock),
+                    isUpdate = false,
+                ),
+            )
 
             coVerify(exactly = 1) {
-                folderService.getFolder(folderId)
-                vaultDiskSource.saveFolder(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    folder = folder,
-                )
+                folderService.getFolder(folderId = folderId)
+                vaultDiskSource.saveFolder(userId = userId, folder = folder)
             }
         }
 
@@ -4193,51 +4095,32 @@ class VaultRepositoryTest {
     fun `syncFolderUpsertFlow valid update success should make a request for a folder and then store it`() =
         runTest {
             val number = 1
+            val userId = MOCK_USER_STATE.activeUserId
             val folderId = "mockId-$number"
 
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            setVaultToUnlocked(userId = MOCK_USER_STATE.activeUserId)
-            val folderView = createMockFolderView(number = number)
+            val folderView = createMockFolder(
+                number = number,
+                revisionDate = ZonedDateTime.now(clock).minus(5, ChronoUnit.MINUTES),
+            )
             coEvery {
-                vaultSdkSource.decryptFolderList(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    folderList = listOf(createMockSdkFolder(number = number)),
-                )
-            } returns listOf(folderView).asSuccess()
+                vaultDiskSource.getFolders(userId = userId)
+            } returns MutableStateFlow(listOf(folderView))
+            val folder = mockk<SyncResponseJson.Folder>()
+            coEvery { folderService.getFolder(folderId = folderId) } returns folder.asSuccess()
+            coEvery { vaultDiskSource.saveFolder(userId = userId, folder = folder) } just runs
 
-            val foldersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>()
-            setupVaultDiskSourceFlows(foldersFlow = foldersFlow)
-
-            val folder: SyncResponseJson.Folder = mockk()
-            coEvery {
-                folderService.getFolder(folderId)
-            } returns folder.asSuccess()
-
-            coEvery {
-                vaultDiskSource.saveFolder(any(), any())
-            } just runs
-
-            vaultRepository.foldersStateFlow.test {
-                // Populate and consume items related to the folders flow
-                awaitItem()
-                foldersFlow.tryEmit(listOf(createMockFolder(number = number)))
-                awaitItem()
-
-                mutableSyncFolderUpsertFlow.tryEmit(
-                    SyncFolderUpsertData(
-                        folderId = folderId,
-                        revisionDate = ZonedDateTime.now(),
-                        isUpdate = true,
-                    ),
-                )
-            }
+            mutableSyncFolderUpsertFlow.tryEmit(
+                SyncFolderUpsertData(
+                    folderId = folderId,
+                    revisionDate = ZonedDateTime.now(clock),
+                    isUpdate = true,
+                ),
+            )
 
             coVerify(exactly = 1) {
                 folderService.getFolder(folderId)
-                vaultDiskSource.saveFolder(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    folder = folder,
-                )
+                vaultDiskSource.saveFolder(userId = userId, folder = folder)
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25478](https://bitwarden.atlassian.net/browse/PM-25478)

## 📔 Objective

This PR allows the upsert events from push notifications to update a vault Folder or Send without requiring the vault to be unlocked.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25478]: https://bitwarden.atlassian.net/browse/PM-25478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ