### PR TITLE
[PM-15055] Add SDK support for exporting vault data to CXF

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
@@ -9,6 +9,7 @@ import com.bitwarden.core.InitUserCryptoRequest
 import com.bitwarden.core.UpdatePasswordResponse
 import com.bitwarden.crypto.Kdf
 import com.bitwarden.crypto.TrustDeviceResponse
+import com.bitwarden.exporters.Account
 import com.bitwarden.exporters.ExportFormat
 import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.fido.PublicKeyCredentialAuthenticatorAssertionResponse
@@ -426,6 +427,15 @@ interface VaultSdkSource {
         folders: List<Folder>,
         ciphers: List<Cipher>,
         format: ExportFormat,
+    ): Result<String>
+
+    /**
+     * Exports the users vault data to a CXF formatted string.
+     */
+    suspend fun exportVaultDataToCxf(
+        userId: String,
+        account: Account,
+        ciphers: List<Cipher>,
     ): Result<String>
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -10,6 +10,7 @@ import com.bitwarden.core.UpdatePasswordResponse
 import com.bitwarden.crypto.Kdf
 import com.bitwarden.crypto.TrustDeviceResponse
 import com.bitwarden.data.manager.DispatcherManager
+import com.bitwarden.exporters.Account
 import com.bitwarden.exporters.ExportFormat
 import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.fido.PublicKeyCredentialAuthenticatorAssertionResponse
@@ -488,6 +489,19 @@ class VaultSdkSourceImpl(
                 folders = folders,
                 ciphers = ciphers,
                 format = format,
+            )
+    }
+
+    override suspend fun exportVaultDataToCxf(
+        userId: String,
+        account: Account,
+        ciphers: List<Cipher>,
+    ): Result<String> = runCatchingWithLogs {
+        getClient(userId = userId)
+            .exporters()
+            .exportCxf(
+                account = account,
+                ciphers = ciphers,
             )
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
@@ -12,6 +12,7 @@ import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.crypto.Kdf
 import com.bitwarden.crypto.TrustDeviceResponse
 import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
+import com.bitwarden.exporters.Account
 import com.bitwarden.exporters.ExportFormat
 import com.bitwarden.fido.ClientData
 import com.bitwarden.fido.Fido2CredentialAutofillView
@@ -1123,6 +1124,40 @@ class VaultSdkSourceTest {
                     folders = folders,
                     ciphers = ciphers,
                     format = format,
+                )
+            }
+
+            assertEquals(
+                expected.asSuccess(),
+                result,
+            )
+        }
+
+    @Test
+    fun `exportVaultDataToCxf should call SDK and return a Result with the correct data`() =
+        runTest {
+            val userId = "userId"
+            val account = mockk<Account>()
+            val ciphers = listOf(createMockSdkCipher(1))
+            val expected = "TestResult"
+
+            coEvery {
+                clientExporters.exportCxf(
+                    account = account,
+                    ciphers = ciphers,
+                )
+            } returns expected
+
+            val result = vaultSdkSource.exportVaultDataToCxf(
+                userId = userId,
+                account = account,
+                ciphers = ciphers,
+            )
+
+            coVerify {
+                clientExporters.exportCxf(
+                    account = account,
+                    ciphers = ciphers,
                 )
             }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-15055

## 📔 Objective

Add a new function `exportVaultDataToCxf` to `VaultSdkSource` and its implementation `VaultSdkSourceImpl` to enable exporting vault data in CXF format.

Corresponding tests have been added to `VaultSdkSourceTest` to verify the new functionality.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
