### PR TITLE
[PM-25522] Add `importCxf` function to `VaultSdkSource`

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
@@ -439,6 +439,14 @@ interface VaultSdkSource {
     ): Result<String>
 
     /**
+     * Imports the given CXF formatted [payload] into the users vault.
+     *
+     * @return Result of the import. If successful, a list of [Cipher]s deciphered from the CXF
+     * payload.
+     */
+    suspend fun importCxf(userId: String, payload: String): Result<List<Cipher>>
+
+    /**
      * Register a new FIDO 2 credential to a cipher.
      *
      * @return Result of the FIDO 2 credential registration. If successful, a

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -505,6 +505,15 @@ class VaultSdkSourceImpl(
             )
     }
 
+    override suspend fun importCxf(
+        userId: String,
+        payload: String,
+    ): Result<List<Cipher>> = runCatchingWithLogs {
+        getClient(userId = userId)
+            .exporters()
+            .importCxf(payload = payload)
+    }
+
     override suspend fun registerFido2Credential(
         request: RegisterFido2CredentialRequest,
         fido2CredentialStore: Fido2CredentialStore,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
@@ -1167,6 +1167,35 @@ class VaultSdkSourceTest {
             )
         }
 
+    @Test
+    fun `importCxf should call SDK and return a Result with the correct data`() = runTest {
+        val userId = "userId"
+        val expected = listOf(createMockSdkCipher(number = 1))
+        val cxf = "cxf"
+
+        coEvery {
+            clientExporters.importCxf(
+                payload = cxf,
+            )
+        } returns expected
+
+        val result = vaultSdkSource.importCxf(
+            userId = userId,
+            payload = cxf,
+        )
+
+        coVerify {
+            clientExporters.importCxf(
+                payload = cxf,
+            )
+        }
+
+        assertEquals(
+            expected.asSuccess(),
+            result,
+        )
+    }
+
     @Suppress("MaxLineLength")
     @Test
     fun `registerFido2Credential should return attestation response when registration completes`() =


### PR DESCRIPTION
## 🎟️ Tracking

PM-25522

## 📔 Objective

Add a new function `importCxf` to the `VaultSdkSource` interface and its implementation `VaultSdkSourceImpl`. This function allows importing data in CXF format into the user's vault.

The `importCxf` function takes a user ID and a CXF payload as input and returns a `Result` containing a list of `Cipher` objects if the import is successful.

Unit tests have been added to verify the functionality of the new function.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
