### PR TITLE
PM-25162: Fix a navigation bug in bottom navigation

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -24,6 +24,7 @@ import com.bitwarden.ui.platform.components.navigation.model.NavigationItem
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.components.scaffold.model.ScaffoldNavigationData
 import com.bitwarden.ui.platform.theme.RootTransitionProviders
+import com.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.ui.platform.components.util.rememberBitwardenNavController
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.platform.feature.settings.about.navigateToAbout
@@ -272,14 +273,15 @@ private fun VaultUnlockedNavBarScaffold(
  * If direct navigation is required, the [navigate] lambda will be invoked with the appropriate
  * [NavOptions].
  */
+@Suppress("MaxLineLength")
 private fun NavController.navigateToTabOrRoot(
     tabToNavigateTo: VaultUnlockedNavBarTab,
     navigate: (NavOptions) -> Unit,
 ) {
-    if (tabToNavigateTo.startDestinationRoute == currentDestination?.route) {
+    if (tabToNavigateTo.startDestinationRoute.toObjectNavigationRoute() == currentDestination?.route) {
         // We are at the start destination already, so nothing to do.
         return
-    } else if (currentDestination?.parent?.route == tabToNavigateTo.graphRoute) {
+    } else if (currentDestination?.parent?.route == tabToNavigateTo.graphRoute.toObjectNavigationRoute()) {
         // We are not at the start destination but we are in the correct graph,
         // so lets pop up to the start destination.
         popBackStack(route = tabToNavigateTo.startDestinationRoute, inclusive = false)
@@ -300,8 +302,8 @@ private fun NavController.navigateToTabOrRoot(
 /**
  * Determine if the current destination is the same as the given tab.
  */
-private fun NavBackStackEntry?.isCurrentRoute(route: String): Boolean =
+private fun NavBackStackEntry?.isCurrentRoute(route: Any): Boolean =
     this
         ?.destination
         ?.hierarchy
-        ?.any { it.route == route } == true
+        ?.any { it.route == route.toObjectNavigationRoute() } == true

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/model/VaultUnlockedNavBarTab.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import com.bitwarden.ui.platform.components.navigation.model.NavigationItem
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
-import com.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.ui.platform.feature.settings.SettingsGraphRoute
 import com.x8bit.bitwarden.ui.platform.feature.settings.SettingsRoute
 import com.x8bit.bitwarden.ui.tools.feature.generator.GeneratorGraphRoute
@@ -35,8 +34,8 @@ sealed class VaultUnlockedNavBarTab : NavigationItem, Parcelable {
         override val iconRes get() = BitwardenDrawable.ic_generator
         override val labelRes get() = BitwardenString.generator
         override val contentDescriptionRes get() = BitwardenString.generator
-        override val graphRoute get() = GeneratorGraphRoute.toObjectNavigationRoute()
-        override val startDestinationRoute get() = GeneratorRoute.Standard.toObjectNavigationRoute()
+        override val graphRoute get() = GeneratorGraphRoute
+        override val startDestinationRoute get() = GeneratorRoute.Standard
         override val testTag get() = "GeneratorTab"
         override val notificationCount get() = 0
     }
@@ -50,8 +49,8 @@ sealed class VaultUnlockedNavBarTab : NavigationItem, Parcelable {
         override val iconRes get() = BitwardenDrawable.ic_send
         override val labelRes get() = BitwardenString.send
         override val contentDescriptionRes get() = BitwardenString.send
-        override val graphRoute get() = SendGraphRoute.toObjectNavigationRoute()
-        override val startDestinationRoute get() = SendRoute.toObjectNavigationRoute()
+        override val graphRoute get() = SendGraphRoute
+        override val startDestinationRoute get() = SendRoute
         override val testTag get() = "SendTab"
         override val notificationCount get() = 0
     }
@@ -66,8 +65,8 @@ sealed class VaultUnlockedNavBarTab : NavigationItem, Parcelable {
     ) : VaultUnlockedNavBarTab() {
         override val iconResSelected get() = BitwardenDrawable.ic_vault_filled
         override val iconRes get() = BitwardenDrawable.ic_vault
-        override val graphRoute get() = VaultGraphRoute.toObjectNavigationRoute()
-        override val startDestinationRoute get() = VaultRoute.toObjectNavigationRoute()
+        override val graphRoute get() = VaultGraphRoute
+        override val startDestinationRoute get() = VaultRoute
         override val testTag get() = "VaultTab"
         override val notificationCount get() = 0
     }
@@ -83,8 +82,8 @@ sealed class VaultUnlockedNavBarTab : NavigationItem, Parcelable {
         override val iconRes get() = BitwardenDrawable.ic_settings
         override val labelRes get() = BitwardenString.settings
         override val contentDescriptionRes get() = BitwardenString.settings
-        override val graphRoute get() = SettingsGraphRoute.toObjectNavigationRoute()
-        override val startDestinationRoute get() = SettingsRoute.Standard.toObjectNavigationRoute()
+        override val graphRoute get() = SettingsGraphRoute
+        override val startDestinationRoute get() = SettingsRoute.Standard
         override val testTag get() = "SettingsTab"
     }
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/model/NavigationItem.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/navigation/model/NavigationItem.kt
@@ -27,12 +27,12 @@ interface NavigationItem {
     /**
      * Route of the tab's graph.
      */
-    val graphRoute: String
+    val graphRoute: Any
 
     /**
      * Route of the tab's start destination.
      */
-    val startDestinationRoute: String
+    val startDestinationRoute: Any
 
     /**
      * The test tag of the tab.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25162](https://bitwarden.atlassian.net/browse/PM-25162)

## 📔 Objective

This PR addresses a bug in the Bottom Nav navigation that was causing the Settings tab to not navigate up when clicked.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/6f8563e9-381e-4df0-abfb-4f776a7d168e" width="300" /> | <video src="https://github.com/user-attachments/assets/bbfb39cc-871d-4b65-80d7-8dc5298dc473" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25162]: https://bitwarden.atlassian.net/browse/PM-25162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ