### PR TITLE
Cleanup minor lint warnings in string resources

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -249,7 +249,7 @@
             android:name="com.x8bit.bitwarden.AutofillTileService"
             android:exported="true"
             android:icon="@drawable/ic_notification"
-            android:label="@string/autofill"
+            android:label="@string/autofill_title"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             tools:ignore="MissingClass">
             <intent-filter>

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
@@ -219,7 +219,7 @@ private fun AutofillSelectionDialog(
         selectionItems = {
             if (AutofillSelectionOption.AUTOFILL in displayItem.autofillSelectionOptions) {
                 BitwardenBasicDialogRow(
-                    text = stringResource(id = BitwardenString.autofill),
+                    text = stringResource(id = BitwardenString.autofill_title),
                     onClick = {
                         selectionCallback(
                             displayItem,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
@@ -241,7 +241,7 @@ enum class Settings(
         testTag = "AccountSecuritySettingsButton",
     ),
     AUTO_FILL(
-        text = BitwardenString.autofill.asText(),
+        text = BitwardenString.autofill_title.asText(),
         vectorIconRes = BitwardenDrawable.ic_check_mark,
         testTag = "AutofillSettingsButton",
     ),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -141,7 +141,7 @@ fun AutoFillScreen(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BitwardenTopAppBar(
-                title = stringResource(id = BitwardenString.autofill),
+                title = stringResource(id = BitwardenString.autofill_title),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
@@ -187,7 +187,7 @@ private fun AutoFillScreenContent(
             )
         }
         BitwardenListHeaderText(
-            label = stringResource(id = BitwardenString.autofill),
+            label = stringResource(id = BitwardenString.autofill_title),
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsScreenTest.kt
@@ -353,7 +353,7 @@ class ImportLoginsScreenTest : BitwardenComposeTest() {
             it.copy(dialogState = ImportLoginsState.DialogState.Syncing)
         }
         composeTestRule
-            .onNodeWithText(text = "Syncing logins...")
+            .onNodeWithText(text = "Syncing logins…")
             .assertIsDisplayed()
             .assert(hasAnyAncestor(isDialog()))
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -431,7 +431,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
 
             // Verify only the first collection name is shown
             composeTestRule
-                .onNodeWithText("My collection...")
+                .onNodeWithText("My collection…")
                 .assertIsDisplayed()
 
             // Verify other collection names are not shown by default.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -794,7 +794,7 @@ class VaultScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithText("Syncing...")
+            .onNodeWithText("Syncing…")
             .assertIsDisplayed()
             .assert(hasAnyAncestor(isDialog()))
     }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="copy_password">Copy password</string>
     <string name="copy_username">Copy username</string>
     <string name="delete">Delete</string>
-    <string name="deleting">Deleting...</string>
+    <string name="deleting">Deleting…</string>
     <string name="do_you_really_want_to_delete">Do you really want to delete? This cannot be undone.</string>
     <string name="edit">Edit</string>
     <string name="edit_folder">Edit folder</string>
@@ -55,7 +55,7 @@
     <string name="password">Password</string>
     <string name="save">Save</string>
     <string name="move">Move</string>
-    <string name="saving">Saving...</string>
+    <string name="saving">Saving…</string>
     <string name="settings">Settings</string>
     <string name="show">Show</string>
     <string name="item_deleted">Item deleted</string>
@@ -104,7 +104,7 @@
     <string name="immediately">Immediately</string>
     <string name="vault_timeout_log_out_confirmation_title">Set session timeout to \"Log out\"?</string>
     <string name="vault_timeout_log_out_confirmation_message">After the timeout period, you will be logged out. You will need to be connected to the internet to log in and access your vault again. Your settings and PIN saved on this device won\'t change.</string>
-    <string name="logging_in">Logging in...</string>
+    <string name="logging_in">Logging in…</string>
     <string name="login_to_bitwarden">Log in to Bitwarden</string>
     <string name="master_password_confirmation_val_message">Password confirmation is not correct.</string>
     <string name="master_password_description">The master password is the password you use to access your vault. It is very important that you do not forget your master password. There is no way to recover the password in the event that you forget it.</string>
@@ -146,8 +146,8 @@
     <string name="select">Select</string>
     <string name="item_details">Item details</string>
     <string name="item_updated">Item saved</string>
-    <string name="submitting">Submitting...</string>
-    <string name="syncing">Syncing...</string>
+    <string name="submitting">Submitting…</string>
+    <string name="syncing">Syncing…</string>
     <string name="syncing_complete">Syncing complete</string>
     <string name="two_step_login">Two-step login</string>
     <string name="unlock_with_biometrics">Unlock with Biometrics</string>
@@ -166,7 +166,7 @@
     <string name="search_for_a_login_or_add_a_new_login">Search for a login or add a new login</string>
     <string name="disabled">Disabled</string>
     <string name="bitwarden_autofill_service_alert2">The easiest way to add new logins to your vault is from the Bitwarden Autofill Service. Learn more about using the Bitwarden Autofill Service by navigating to the \"Settings\" screen.</string>
-    <string name="autofill">Autofill</string>
+    <string name="autofill_title">Autofill</string>
     <string name="autofill_or_view">Do you want to autofill or view this item?</string>
     <string name="search">Search</string>
     <string name="learn_org">Learn about organizations</string>
@@ -185,7 +185,7 @@
     <string name="add_new_attachment">Add new attachment</string>
     <string name="attachments">Attachments</string>
     <string name="unable_to_download_file">Unable to download file.</string>
-    <string name="downloading">Downloading...</string>
+    <string name="downloading">Downloading…</string>
     <string name="attachment_large_warning">This attachment is %1$s in size. Are you sure you want to download it onto your device?</string>
     <string name="authenticator_key">Authenticator key</string>
     <string name="verification_code_totp">Verification code (TOTP)</string>
@@ -399,10 +399,10 @@ Scanning will happen automatically.</string>
     <string name="save_attachment_success">Attachment saved successfully</string>
     <string name="autofill_tile_accessibility_required">Please turn on \"Autofill Accessibility Service\" from Bitwarden Settings to use the Autofill tile.</string>
     <string name="autofill_tile_uri_not_found">No password fields detected</string>
-    <string name="soft_deleting">Sending to trash...</string>
+    <string name="soft_deleting">Sending to trash…</string>
     <string name="item_soft_deleted">Item has been sent to trash.</string>
     <string name="restore">Restore</string>
-    <string name="restoring">Restoring...</string>
+    <string name="restoring">Restoring…</string>
     <string name="item_restored">Item restored</string>
     <string name="trash">Trash</string>
     <string name="do_you_really_want_to_permanently_delete_cipher">Do you really want to permanently delete? This cannot be undone.</string>
@@ -811,7 +811,7 @@ Do you want to switch to this account?</string>
     <string name="need_help_check_out_import_help">Need help? Check out <annotation link="importHelp">import help</annotation>.</string>
     <string name="save_the_exported_file_somewhere_on_your_computer_you_can_find_easily"><annotation emphasis="bold">Save the exported file</annotation> somewhere on your computer you can find easily.</string>
     <string name="this_is_not_a_recognized_bitwarden_server_you_may_need_to_check_with_your_provider_or_update_your_server">This is not a recognized Bitwarden server. You may need to check with your provider or update your server.</string>
-    <string name="syncing_logins_loading_message">Syncing logins...</string>
+    <string name="syncing_logins_loading_message">Syncing logins…</string>
     <string name="download_the_browser_extension">Download the browser extension</string>
     <string name="go_to_bitwarden_com_download_to_integrate_bitwarden_into_browser">Go to bitwarden.com/download to integrate Bitwarden into your favorite browser for a seamless experience.</string>
     <string name="use_the_web_app">Use the web app</string>
@@ -920,7 +920,7 @@ Do you want to switch to this account?</string>
     <string name="no_folder">No folder</string>
     <string name="show_less">Show less</string>
     <string name="add_field">Add field</string>
-    <string name="x_ellipses">%s...</string>
+    <string name="x_ellipses">%s…</string>
     <string name="share_error_details">Share error details</string>
     <string name="flight_recorder">Flight recorder</string>
     <string name="flight_recorder_help">Flight recorder help</string>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Cleanup lint warnings in string resources.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
