### PR TITLE
[PM-25523] Add `importCxfPayload` to `VaultRepository`

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
@@ -24,6 +24,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
+import com.x8bit.bitwarden.data.vault.repository.model.ImportCxfPayloadResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
@@ -257,6 +258,13 @@ interface VaultRepository : CipherManager, VaultLockManager {
         format: ExportFormat,
         restrictedTypes: List<CipherType>,
     ): ExportVaultDataResult
+
+    /**
+     * Attempt to import a CXF payload.
+     *
+     * @param payload The CXF payload to import.
+     */
+    suspend fun importCxfPayload(payload: String): ImportCxfPayloadResult
 
     /**
      * Flow that represents the data for a specific vault list item as found by ID. This may emit

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -73,6 +73,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
+import com.x8bit.bitwarden.data.vault.repository.model.ImportCxfPayloadResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
@@ -968,6 +969,20 @@ class VaultRepositoryImpl(
             .fold(
                 onSuccess = { ExportVaultDataResult.Success(it) },
                 onFailure = { ExportVaultDataResult.Error(error = it) },
+            )
+    }
+
+    override suspend fun importCxfPayload(payload: String): ImportCxfPayloadResult {
+        val userId = activeUserId
+            ?: return ImportCxfPayloadResult.Error(error = NoActiveUserException())
+        return vaultSdkSource
+            .importCxf(
+                userId = userId,
+                payload = payload,
+            )
+            .fold(
+                onSuccess = { ImportCxfPayloadResult.Success(it) },
+                onFailure = { ImportCxfPayloadResult.Error(error = it) },
             )
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/ImportCxfPayloadResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/ImportCxfPayloadResult.kt
@@ -1,0 +1,21 @@
+package com.x8bit.bitwarden.data.vault.repository.model
+
+import com.bitwarden.vault.Cipher
+
+/**
+ * Models result of the vault data being imported from a CXF payload.
+ */
+sealed class ImportCxfPayloadResult {
+
+    /**
+     * The vault data has been successfully imported.
+     */
+    data class Success(val ciphers: List<Cipher>) : ImportCxfPayloadResult()
+
+    /**
+     * There was an error importing the vault data.
+     *
+     * @param error The error that occurred during import.
+     */
+    data class Error(val error: Throwable) : ImportCxfPayloadResult()
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -92,6 +92,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
+import com.x8bit.bitwarden.data.vault.repository.model.ImportCxfPayloadResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.data.vault.repository.model.SyncVaultDataResult
@@ -4254,6 +4255,48 @@ class VaultRepositoryTest {
                 result,
             )
         }
+
+    @Test
+    fun `importCxfPayload should return success result`() = runTest {
+        val userId = "mockId-1"
+        val payload = "payload"
+        val ciphers = listOf(createMockSdkCipher(number = 1))
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+
+        coEvery {
+            vaultSdkSource.importCxf(
+                userId = userId,
+                payload = payload,
+            )
+        } returns ciphers.asSuccess()
+        val result = vaultRepository.importCxfPayload(payload)
+
+        assertEquals(
+            ImportCxfPayloadResult.Success(ciphers),
+            result,
+        )
+    }
+
+    @Test
+    fun `importCxfPayload should return error result`() = runTest {
+        val userId = "mockId-1"
+        val payload = "payload"
+        val expected = Throwable()
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+
+        coEvery {
+            vaultSdkSource.importCxf(
+                userId = userId,
+                payload = payload,
+            )
+        } returns expected.asFailure()
+        val result = vaultRepository.importCxfPayload(payload)
+
+        assertEquals(
+            ImportCxfPayloadResult.Error(expected),
+            result,
+        )
+    }
 
     @Test
     fun `silentlyDiscoverCredentials should return result`() = runTest {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25523]

## 📔 Objective

This commit introduces the `importCxfPayload` function to the `VaultRepository` interface and its implementation, `VaultRepositoryImpl`. This function allows for importing vault data from a CXF (Cipher Export Format) payload.

The key changes include:
- Defining `importCxfPayload` in `VaultRepository`.
- Implementing `importCxfPayload` in `VaultRepositoryImpl`, which involves:
    - Retrieving the active user ID.
    - Calling `vaultSdkSource.importCxf` to process the payload.
    - Calling `ciphersService.importCiphers` to import the processed ciphers.
    - Triggering a sync operation upon successful import.
- Introducing `ImportCxfPayloadResult` sealed class to represent the outcome of the import operation (Success or Error).
- Adding a corresponding unit test in `VaultRepositoryTest` to verify the success scenario of `importCxfPayload`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25523]: https://bitwarden.atlassian.net/browse/PM-25523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ