### PR TITLE
[PM-15056] Add `exportVaultDataToCxf` function to `VaultRepository`

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
@@ -25,6 +25,14 @@ interface VaultDiskSource {
     suspend fun getCiphers(userId: String): List<SyncResponseJson.Cipher>
 
     /**
+     * Retrieves all ciphers with the given [cipherIds] from the data source for a given [userId].
+     */
+    suspend fun getSelectedCiphers(
+        userId: String,
+        cipherIds: List<String>,
+    ): List<SyncResponseJson.Cipher>
+
+    /**
      * Retrieves all ciphers from the data source for a given [userId] that contain TOTP codes.
      */
     suspend fun getTotpCiphers(userId: String): List<SyncResponseJson.Cipher>

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/CiphersDao.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/CiphersDao.kt
@@ -38,6 +38,15 @@ interface CiphersDao {
     ): List<CipherEntity>
 
     /**
+     * Retrieves all ciphers from the database with the given [cipherIds] for a given [userId].
+     */
+    @Query("SELECT * FROM ciphers WHERE user_id = :userId AND id IN (:cipherIds)")
+    suspend fun getSelectedCiphers(
+        userId: String,
+        cipherIds: List<String>,
+    ): List<CipherEntity>
+
+    /**
      * Retrieves all ciphers from the database for a given [userId].
      */
     @Query("SELECT * FROM ciphers WHERE user_id = :userId AND has_totp = 1")

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepository.kt
@@ -267,6 +267,13 @@ interface VaultRepository : CipherManager, VaultLockManager {
     suspend fun importCxfPayload(payload: String): ImportCxfPayloadResult
 
     /**
+     * Attempt to export the vault data to a CXF file.
+     *
+     * @param ciphers Ciphers selected for export.
+     */
+    suspend fun exportVaultDataToCxf(ciphers: List<CipherListView>): Result<String>
+
+    /**
      * Flow that represents the data for a specific vault list item as found by ID. This may emit
      * `null` if the item cannot be found.
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/AccountJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/AccountJsonExtensions.kt
@@ -1,0 +1,13 @@
+package com.x8bit.bitwarden.data.vault.repository.util
+
+import com.bitwarden.exporters.Account
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
+
+/**
+ * Converts a [AccountJson] to a [Account] for use in the SDK.
+ */
+fun AccountJson.toSdkAccount(): Account = Account(
+    id = profile.userId,
+    email = profile.email,
+    name = profile.name,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -106,6 +106,22 @@ class VaultDiskSourceTest {
     }
 
     @Test
+    fun `getSelectedCiphers should return selected CiphersDao ciphers`() = runTest {
+        val cipherEntities = listOf(
+            CIPHER_ENTITY,
+            CIPHER_ENTITY.copy(id = "otherCipherId"),
+        )
+        val ciphers = listOf(CIPHER_1)
+        val cipherIds = listOf("mockId-1")
+
+        val result1 = vaultDiskSource.getSelectedCiphers(USER_ID, cipherIds)
+        assertEquals(emptyList<SyncResponseJson.Cipher>(), result1)
+        ciphersDao.insertCiphers(cipherEntities)
+        val result2 = vaultDiskSource.getSelectedCiphers(USER_ID, cipherIds)
+        assertEquals(ciphers, result2)
+    }
+
+    @Test
     fun `getTotpCiphers should return all CiphersDao totp ciphers`() = runTest {
         val cipherEntities = listOf(
             CIPHER_ENTITY,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeCiphersDao.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeCiphersDao.kt
@@ -41,6 +41,12 @@ class FakeCiphersDao : CiphersDao {
     override suspend fun getAllCiphers(userId: String): List<CipherEntity> =
         storedCiphers.filter { it.userId == userId }
 
+    override suspend fun getSelectedCiphers(
+        userId: String,
+        cipherIds: List<String>,
+    ): List<CipherEntity> =
+        storedCiphers.filter { it.userId == userId && it.id in cipherIds }
+
     override suspend fun getAllTotpCiphers(userId: String): List<CipherEntity> =
         storedCiphers.filter { it.userId == userId && it.hasTotp }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/AccountUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/AccountUtil.kt
@@ -1,0 +1,16 @@
+package com.x8bit.bitwarden.data.vault.datasource.sdk.model
+
+import com.bitwarden.exporters.Account
+
+/**
+ * Creates a mock [com.bitwarden.exporters.Account] for testing purposes
+ */
+fun createMockAccount(
+    number: Int,
+    email: String = "mockEmail-$number",
+    name: String? = "mockName-$number",
+): Account = Account(
+    id = "mockId-$number",
+    email = email,
+    name = name,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/model/AccountJsonUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/model/AccountJsonUtil.kt
@@ -1,0 +1,68 @@
+package com.x8bit.bitwarden.data.vault.repository.model
+
+import com.bitwarden.network.model.KdfTypeJson
+import com.bitwarden.network.model.UserDecryptionOptionsJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.ForcePasswordResetReason
+import java.time.ZonedDateTime
+
+/**
+ * Creates a mock [AccountJson.Profile] for testing purposes.
+ */
+@Suppress("LongParameterList")
+fun createMockAccountJsonProfile(
+    number: Int,
+    userId: String = "mockId-$number",
+    email: String = "mockEmail-$number",
+    isEmailVerified: Boolean = true,
+    name: String? = "mockName-$number",
+    stamp: String = "mockSecurityStamp-$number",
+    organizationId: String? = "mockOrganizationId-$number",
+    avatarColorHex: String? = "mockAvatarColorHex-$number",
+    hasPremium: Boolean = false,
+    forcePasswordResetReason: ForcePasswordResetReason? = null,
+    kdfType: KdfTypeJson? = null,
+    kdfIterations: Int? = null,
+    kdfMemory: Int? = null,
+    kdfParallelism: Int? = null,
+    userDecryptionOptions: UserDecryptionOptionsJson? = null,
+    isTwoFactorEnabled: Boolean = false,
+    creationDate: ZonedDateTime = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+): AccountJson.Profile = AccountJson.Profile(
+    userId = userId,
+    email = email,
+    isEmailVerified = isEmailVerified,
+    name = name,
+    stamp = stamp,
+    organizationId = organizationId,
+    avatarColorHex = avatarColorHex,
+    hasPremium = hasPremium,
+    forcePasswordResetReason = forcePasswordResetReason,
+    kdfType = kdfType,
+    kdfIterations = kdfIterations,
+    kdfMemory = kdfMemory,
+    kdfParallelism = kdfParallelism,
+    userDecryptionOptions = userDecryptionOptions,
+    isTwoFactorEnabled = isTwoFactorEnabled,
+    creationDate = creationDate,
+)
+
+/**
+ * Creates a mock [AccountJson] for testing purposes.
+ */
+fun createMockAccountJson(
+    number: Int,
+    profile: AccountJson.Profile = createMockAccountJsonProfile(number),
+    tokens: AccountTokensJson = AccountTokensJson(
+        accessToken = "accessToken-$number",
+        refreshToken = "refreshToken-$number",
+    ),
+    settings: AccountJson.Settings = AccountJson.Settings(
+        environmentUrlData = null,
+    ),
+): AccountJson = AccountJson(
+    profile = profile,
+    tokens = tokens,
+    settings = settings,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/AccountJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/AccountJsonExtensionsTest.kt
@@ -1,0 +1,22 @@
+package com.x8bit.bitwarden.data.vault.repository.util
+
+import com.bitwarden.exporters.Account
+import com.x8bit.bitwarden.data.vault.repository.model.createMockAccountJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AccountJsonExtensionsTest {
+
+    @Test
+    fun `toAccountData returns populated AccountData when account is non-null`() {
+        val account = createMockAccountJson(number = 1)
+        assertEquals(
+            Account(
+                id = "mockId-1",
+                email = "mockEmail-1",
+                name = "mockName-1",
+            ),
+            account.toSdkAccount(),
+        )
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-15056

## 📔 Objective

Introduce the `exportVaultDataToCxf` function to the `VaultRepository` and its implementation. This function allows exporting selected ciphers to a CXF file.

The following changes were made:
- Added `getSelectedCiphers` to `CiphersDao` and `VaultDiskSource` to retrieve specific ciphers by their IDs.
- Created an `AccountJson.toSdkAccount()` extension function to convert `AccountJson` to the SDK's `Account` model.
- Implemented `exportVaultDataToCxf` in `VaultRepositoryImpl` to utilize the new data source methods and the SDK for CXF export.
- Added corresponding tests for the new functionalities.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
