### PR TITLE
Fix sdk-update Test by using Java 21 in setup-android action

### DIFF
--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -4,7 +4,7 @@ inputs:
   java-version:
     description: 'Java version to use'
     required: false
-    default: '17'
+    default: '21'
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
## 🎟️ Tracking

n/a

## 📔 Objective

Fixes - https://github.com/bitwarden/android/actions/runs/17618247637

https://github.com/bitwarden/android/pull/5835 Updated Java to 21 but this recently introduced action is still using java 17.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
