### PR TITLE
[PM-25640] Dialog flickers when switching accounts

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -77,7 +77,7 @@ import timber.log.Timber
 import java.time.Clock
 import javax.inject.Inject
 
-private const val VAULT_DATA_RECEIVED_DELAY: Long = 700L
+private const val VAULT_DATA_RECEIVED_DELAY: Long = 550L
 private const val LOGIN_SUCCESS_SNACKBAR_DELAY: Long = 550L
 
 /**
@@ -913,7 +913,9 @@ class VaultViewModel @Inject constructor(
 
         updateVaultState(
             vaultData = vaultData.data,
-            dialog = if (shouldShowDecryptionAlert) {
+            dialog = if (shouldShowDecryptionAlert ||
+                state.dialog is VaultState.DialogState.VaultLoadCipherDecryptionError
+            ) {
                 VaultState.DialogState.VaultLoadCipherDecryptionError(
                     title = BitwardenString.decryption_error.asText(),
                     cipherCount = vaultData.data.decryptCipherListResult.failures.size,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-25640

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix bug where decryption error dialog will flicker and disappear when user is changing between accounts. This is due to the activity being recreated and so we have to reassign the same dialog again to avoid this event.

## 📸 Screenshots

### OLD
https://github.com/user-attachments/assets/2de59dae-3e28-4844-b049-a7e68d742e69

### NEW
https://github.com/user-attachments/assets/706fe4f9-0fca-4c2b-bd5c-5f271405810b


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
