### PR TITLE
[PM-25661] Add placeholder ProviderEvents API for credential import/export

### DIFF
--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/ProviderEventsManager.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/ProviderEventsManager.kt
@@ -1,0 +1,65 @@
+package androidx.credentials.providerevents
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.credentials.provider.CallingAppInfo
+import androidx.credentials.providerevents.transfer.ImportCredentialsRequest
+import androidx.credentials.providerevents.transfer.ImportCredentialsResponse
+import androidx.credentials.providerevents.transfer.ProviderImportCredentialsResponse
+import androidx.credentials.providerevents.transfer.RegisterExportRequest
+import com.bitwarden.annotation.OmitFromCoverage
+
+/**
+ * Placeholder interface representing a provider events manager.
+ */
+interface ProviderEventsManager {
+
+    /**
+     * Register as a credential export source.
+     */
+    fun registerExport(request: RegisterExportRequest): Boolean
+
+    /**
+     * Begin the process of importing credentials.
+     */
+    fun importCredentials(
+        context: Context,
+        request: ImportCredentialsRequest,
+    ): ProviderImportCredentialsResponse
+
+    @OmitFromCoverage
+    @Suppress("UndocumentedPublicClass")
+    companion object {
+        /**
+         * Create a new instance of [ProviderEventsManager].
+         */
+        fun create(context: Context): ProviderEventsManager = StubProviderEventsManager()
+    }
+}
+
+/**
+ * Stub implementation of [ProviderEventsManager].
+ */
+@OmitFromCoverage
+internal class StubProviderEventsManager : ProviderEventsManager {
+    override fun registerExport(request: RegisterExportRequest): Boolean {
+        return true
+    }
+
+    override fun importCredentials(
+        context: Context,
+        request: ImportCredentialsRequest,
+    ): ProviderImportCredentialsResponse {
+        @SuppressLint("VisibleForTests")
+        return ProviderImportCredentialsResponse(
+            response = ImportCredentialsResponse(
+                responseJson = "",
+            ),
+            callingAppInfo = CallingAppInfo(
+                packageName = "",
+                signatures = emptyList(),
+                origin = null,
+            ),
+        )
+    }
+}

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/exception/ImportCredentialsCancellationException.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/exception/ImportCredentialsCancellationException.kt
@@ -1,0 +1,6 @@
+package androidx.credentials.providerevents.exception
+
+/**
+ * Placeholder class representing a cancellation exception for importing credentials.
+ */
+class ImportCredentialsCancellationException : Exception()

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/playservices/IntentHandler.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/playservices/IntentHandler.kt
@@ -1,0 +1,45 @@
+@file:Suppress("unused")
+
+package androidx.credentials.providerevents.playservices
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import androidx.credentials.providerevents.exception.ImportCredentialsException
+import androidx.credentials.providerevents.transfer.ImportCredentialsResponse
+import androidx.credentials.providerevents.transfer.ProviderImportCredentialsRequest
+
+/**
+ * A stub implementation of the Credential Provider Events IntentHandler class.
+ */
+object IntentHandler {
+
+    /**
+     * Stub implementation of the setImportCredentialsException method.
+     */
+    fun setImportCredentialsException(intent: Intent, exception: ImportCredentialsException) {
+        // Stub implementation
+    }
+
+    /**
+     * Stub implementation of the setImportCredentialsResponse method.
+     */
+    fun setImportCredentialsResponse(
+        context: Activity,
+        uri: Uri,
+        response: ImportCredentialsResponse,
+    ) {
+        // Stub implementation
+    }
+
+    /**
+     * Stub implementation of the retrieveImportCredentialsException method.
+     */
+    @Suppress("FunctionOnlyReturningConstant")
+    fun retrieveProviderImportCredentialsRequest(
+        intent: Intent,
+    ): ProviderImportCredentialsRequest? {
+        // Stub implementation
+        return null
+    }
+}

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ExportEntry.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ExportEntry.kt
@@ -1,0 +1,14 @@
+package androidx.credentials.providerevents.transfer
+
+import android.graphics.Bitmap
+
+/**
+ * Placeholder class representing an entry in the export request.
+ */
+data class ExportEntry(
+    val id: String,
+    val accountDisplayName: CharSequence?,
+    val userDisplayName: CharSequence,
+    val icon: Bitmap,
+    val supportedCredentialTypes: Set<String>,
+)

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ImportCredentialsRequest.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ImportCredentialsRequest.kt
@@ -1,0 +1,6 @@
+package androidx.credentials.providerevents.transfer
+
+/**
+ * Placeholder class representing a request to import credentials.
+ */
+data class ImportCredentialsRequest(val requestJson: String)

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ProviderImportCredentialsRequest.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ProviderImportCredentialsRequest.kt
@@ -1,0 +1,15 @@
+package androidx.credentials.providerevents.transfer
+
+import android.net.Uri
+import androidx.credentials.provider.CallingAppInfo
+
+/**
+ * Placeholder class for the request received by the provider after the query phase of the import
+ * flow is complete i.e. the user was presented with a list of entries, and the user has now made
+ * a selection from the list of [ExportEntry] presented on the selector UI.
+ */
+data class ProviderImportCredentialsRequest(
+    val request: ImportCredentialsRequest,
+    val callingAppInfo: CallingAppInfo,
+    val uri: Uri,
+)

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ProviderImportCredentialsResponse.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ProviderImportCredentialsResponse.kt
@@ -1,0 +1,11 @@
+package androidx.credentials.providerevents.transfer
+
+import androidx.credentials.provider.CallingAppInfo
+
+/**
+ * Placeholder class representing the response to an import request.
+ */
+data class ProviderImportCredentialsResponse(
+    val response: ImportCredentialsResponse,
+    val callingAppInfo: CallingAppInfo,
+)

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/RegisterExportRequest.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/RegisterExportRequest.kt
@@ -1,0 +1,8 @@
+package androidx.credentials.providerevents.transfer
+
+/**
+ * Placeholder class representing a request to register as a credential export source.
+ */
+data class RegisterExportRequest(
+    val entries: List<ExportEntry>,
+)


### PR DESCRIPTION
## 🎟️ Tracking

PM-25661

## 📔 Objective

This commit introduces a stub implementation of the ProviderEvents API, focusing on credential import and export functionalities. This change facilitates continued development of CXF features while the official API is not available.

It includes:
- `ProviderEventsManager` interface and a stub implementation.
- Data classes for import/export requests and responses:
    - `ProviderImportCredentialsRequest`
    - `ProviderImportCredentialsResponse`
    - `RegisterExportRequest`
    - `ExportEntry`
    - `ImportCredentialsRequest`
- Utility class for handling Credential Exchange intents
    - `IntentHandler`
- Placeholder exception classes:
    - `ImportCredentialsCancellationException`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
