### PR TITLE
[PM-25665] Add BitwardenImportCredentialsRequest and helper

### DIFF
--- a/cxf/src/main/kotlin/com/bitwarden/cxf/model/BitwardenImportCredentialsRequest.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/model/BitwardenImportCredentialsRequest.kt
@@ -1,0 +1,17 @@
+package com.bitwarden.cxf.model
+
+import android.net.Uri
+import androidx.credentials.provider.CallingAppInfo
+
+/**
+ * A request to import the provider's credentials.
+ *
+ * @property uri the FileProvider uri that the importer will read the response from.
+ * @property requestJson the request to import the provider's credentials.
+ * @property callingAppInfo the caller's app info.
+ */
+data class BitwardenImportCredentialsRequest(
+    val uri: Uri,
+    val requestJson: String,
+    val callingAppInfo: CallingAppInfo,
+)

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/util/CredentialExchangeIntentUtils.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/util/CredentialExchangeIntentUtils.kt
@@ -1,0 +1,21 @@
+@file:OmitFromCoverage
+
+package com.bitwarden.cxf.util
+
+import android.content.Intent
+import androidx.credentials.providerevents.playservices.IntentHandler
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.cxf.model.BitwardenImportCredentialsRequest
+
+/**
+ * Retrieves the [BitwardenImportCredentialsRequest] from the intent.
+ */
+fun Intent.getProviderImportCredentialsRequest(): BitwardenImportCredentialsRequest? = IntentHandler
+    .retrieveProviderImportCredentialsRequest(this)
+    ?.let {
+        BitwardenImportCredentialsRequest(
+            uri = it.uri,
+            requestJson = it.request.requestJson,
+            callingAppInfo = it.callingAppInfo,
+        )
+    }


### PR DESCRIPTION
## 🎟️ Tracking

PM-25665

## 📔 Objective

Add a new data class `BitwardenImportCredentialsRequest` to represent a request to import credentials.
Also, add an extension function `getProviderImportCredentialsRequest` for `Intent` to simplify retrieving this request.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
