### PR TITLE
Fixed an error in the dutch translations

### DIFF
--- a/ui/src/main/res/values-nl-rNL/strings.xml
+++ b/ui/src/main/res/values-nl-rNL/strings.xml
@@ -664,7 +664,7 @@ Wilt u naar dit account wisselen?</string>
     <string name="session_timeout_action">Actie voor sessie time-out</string>
     <string name="account_fingerprint_phrase">Vingerafdrukzin van je account</string>
     <string name="passkey_management_explanation_long">Gebruik Bitwarden voor het opslaan van nieuwe passkeys en inloggen met passkeys die zijn opgeslagen in je kluis.</string>
-    <string name="autofill_services_explanation_long">Het Android Autofill Framework helpt het het invullen van inloggegevens in andere apps op je apparaat.</string>
+    <string name="autofill_services_explanation_long">Het Android Autofill Framework helpt het invullen van inloggegevens in andere apps op je apparaat.</string>
     <string name="use_inline_autofill_explanation_long">Gebruik inline automatisch aanvullen als het geselecteerde toetsenbord dit ondersteunt. Gebruik anders de standaard overlay.</string>
     <string name="additional_options">Extra instellingen</string>
     <string name="continue_to_web_app">Doorgaan naar web-app?</string>


### PR DESCRIPTION
Removed duplicate use of the dutch article 'het'

## 🎟️ Tracking

N/A

## 📔 Objective

This fixes an error in the dutch translation. The article 'het' is repeated in the following sentence:
'... helpt **het het** invullen van inloggegevens ...'

## 📸 Screenshots

N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
