### PR TITLE
[PM-22320] Default to SHA1 on 2fas importer if algorithm is missing

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/TwoFasExportParser.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/imports/parsers/TwoFasExportParser.kt
@@ -74,7 +74,8 @@ class TwoFasExportParser : ExportParser() {
                         entry.name.equals(other = algorithm, ignoreCase = true)
                     }
             }
-            ?: throw IllegalArgumentException("Unsupported algorithm: ${otp.algorithm}.")
+            // Default to SHA1 if not specified
+            ?: AuthenticatorItemAlgorithm.SHA1
 
         return AuthenticatorItemEntity(
             id = UUID.randomUUID().toString(),


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-22320

## 📔 Objective

On some scenarios the 2fas export is missing the algorithm. Defaulting to SHA1 solves the issue and makes it consistent with iOS authenticator

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
