### PR TITLE
PM-24234: Add missing plurals

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -64,6 +65,7 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenPlurals
 import com.bitwarden.ui.platform.resource.BitwardenString
 import kotlinx.collections.immutable.toImmutableList
 
@@ -425,7 +427,11 @@ private fun LazyListScope.advancedOptions(
     item(key = "RefreshPeriodItemTypePicker") {
         val possibleRefreshPeriodOptions = AuthenticatorRefreshPeriodOption.entries
         val refreshPeriodOptionsWithStrings = possibleRefreshPeriodOptions.associateWith {
-            stringResource(id = BitwardenString.refresh_period_seconds, it.seconds)
+            pluralStringResource(
+                id = BitwardenPlurals.refresh_period_seconds,
+                count = it.seconds,
+                formatArgs = arrayOf(it.seconds),
+            )
         }
         Spacer(modifier = Modifier.height(8.dp))
         BitwardenMultiSelectButton(
@@ -436,9 +442,8 @@ private fun LazyListScope.advancedOptions(
                 .animateItem(),
             label = stringResource(id = BitwardenString.refresh_period),
             options = refreshPeriodOptionsWithStrings.values.toImmutableList(),
-            selectedOption = stringResource(
-                id = BitwardenString.refresh_period_seconds,
-                viewState.itemData.refreshPeriod.seconds,
+            selectedOption = refreshPeriodOptionsWithStrings.getValue(
+                key = viewState.itemData.refreshPeriod,
             ),
             onOptionSelected = remember(viewState) {
                 { selectedOption ->

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -998,7 +998,10 @@ Do you want to switch to this account?</string>
     <string name="advanced">Advanced</string>
     <string name="collapse_advanced_options">Collapse advanced options</string>
     <string name="number_of_digits">Number of digits</string>
-    <string name="refresh_period_seconds" tools:ignore="PluralsCandidate">%d seconds</string>
+    <plurals name="refresh_period_seconds">
+        <item quantity="one">%d second</item>
+        <item quantity="other">%d seconds</item>
+    </plurals>
     <string name="item_saved">Item saved</string>
     <string name="information">Information</string>
     <string name="otp_type">OTP type</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24234](https://bitwarden.atlassian.net/browse/PM-24234)

## 📔 Objective

This PR adds one last missing plurals translation to the app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24234]: https://bitwarden.atlassian.net/browse/PM-24234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ