### PR TITLE
Move NativeLibraryManager to data module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerImpl.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.manager
 
 import android.os.Build
 import com.bitwarden.core.util.isBuildVersionAtLeast
+import com.bitwarden.data.manager.NativeLibraryManager
 import com.bitwarden.sdk.Client
 import com.x8bit.bitwarden.data.platform.manager.sdk.SdkRepositoryFactory
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -9,6 +9,7 @@ import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.manager.toast.ToastManagerImpl
 import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.data.manager.DispatcherManagerImpl
+import com.bitwarden.data.manager.NativeLibraryManager
 import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.network.BitwardenServiceClient
 import com.bitwarden.network.service.EventService
@@ -41,8 +42,6 @@ import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManagerImpl
-import com.x8bit.bitwarden.data.platform.manager.NativeLibraryManager
-import com.x8bit.bitwarden.data.platform.manager.NativeLibraryManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.PushManager
@@ -241,10 +240,6 @@ object PlatformManagerModule {
             serverConfigRepository = serverConfigRepository,
         )
     }
-
-    @Provides
-    @Singleton
-    fun provideNativeLibraryManager(): NativeLibraryManager = NativeLibraryManagerImpl()
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/ScopedVaultSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/ScopedVaultSdkSourceImpl.kt
@@ -3,8 +3,8 @@ package com.x8bit.bitwarden.data.vault.datasource.sdk
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.manager.DispatcherManager
+import com.bitwarden.data.manager.NativeLibraryManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
-import com.x8bit.bitwarden.data.platform.manager.NativeLibraryManager
 import com.x8bit.bitwarden.data.platform.manager.SdkClientManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.sdk.SdkRepositoryFactory
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerTest.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager
 
 import com.bitwarden.core.util.isBuildVersionAtLeast
+import com.bitwarden.data.manager.NativeLibraryManager
 import com.x8bit.bitwarden.data.platform.manager.sdk.SdkRepositoryFactory
 import io.mockk.every
 import io.mockk.mockk

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.google.hilt.android)
     ksp(libs.google.hilt.compiler)
     implementation(libs.kotlinx.serialization)
+    implementation(libs.timber)
 
     testImplementation(platform(libs.junit.bom))
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/data/src/main/kotlin/com/bitwarden/data/manager/NativeLibraryManager.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/NativeLibraryManager.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.manager
+package com.bitwarden.data.manager
 
 /**
  * Manager for loading native libraries.

--- a/data/src/main/kotlin/com/bitwarden/data/manager/NativeLibraryManagerImpl.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/NativeLibraryManagerImpl.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.manager
+package com.bitwarden.data.manager
 
 import com.bitwarden.annotation.OmitFromCoverage
 import timber.log.Timber
@@ -7,7 +7,7 @@ import timber.log.Timber
  * Primary implementation of [NativeLibraryManager].
  */
 @OmitFromCoverage
-class NativeLibraryManagerImpl : NativeLibraryManager {
+internal class NativeLibraryManagerImpl : NativeLibraryManager {
     override fun loadLibrary(libraryName: String): Result<Unit> {
         return try {
             System.loadLibrary(libraryName)

--- a/data/src/main/kotlin/com/bitwarden/data/manager/di/DataManagerModule.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/di/DataManagerModule.kt
@@ -3,6 +3,8 @@ package com.bitwarden.data.manager.di
 import android.content.Context
 import com.bitwarden.data.manager.BitwardenPackageManager
 import com.bitwarden.data.manager.BitwardenPackageManagerImpl
+import com.bitwarden.data.manager.NativeLibraryManager
+import com.bitwarden.data.manager.NativeLibraryManagerImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,4 +24,8 @@ object DataManagerModule {
     fun provideBitwardenPackageManager(
         @ApplicationContext context: Context,
     ): BitwardenPackageManager = BitwardenPackageManagerImpl(context = context)
+
+    @Provides
+    @Singleton
+    fun provideNativeLibraryManager(): NativeLibraryManager = NativeLibraryManagerImpl()
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Move `NativeLibraryManager` and its implementation `NativeLibraryManagerImpl` from the `app` module to the `data` module.
This change also involves updating import statements and dependency injection configurations.
The `data` module now includes `timber` as a new dependency.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
