### PR TITLE
PM-25908: Process 400 responses from verification code APIs

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -33,6 +33,8 @@ import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.TrustedDeviceUserDecryptionOptionsJson
 import com.bitwarden.network.model.TwoFactorAuthMethod
 import com.bitwarden.network.model.TwoFactorDataModel
+import com.bitwarden.network.model.VerificationCodeResponseJson
+import com.bitwarden.network.model.VerificationOtpResponseJson
 import com.bitwarden.network.model.VerifyEmailTokenRequestJson
 import com.bitwarden.network.model.VerifyEmailTokenResponseJson
 import com.bitwarden.network.service.AccountsService
@@ -740,7 +742,17 @@ class AuthRepositoryImpl(
             ?.let { jsonRequest ->
                 accountsService.resendVerificationCodeEmail(body = jsonRequest).fold(
                     onFailure = { ResendEmailResult.Error(message = it.message, error = it) },
-                    onSuccess = { ResendEmailResult.Success },
+                    onSuccess = {
+                        when (it) {
+                            VerificationCodeResponseJson.Success -> ResendEmailResult.Success
+                            is VerificationCodeResponseJson.Invalid -> {
+                                ResendEmailResult.Error(
+                                    message = it.firstValidationErrorMessage,
+                                    error = null,
+                                )
+                            }
+                        }
+                    },
                 )
             }
             ?: ResendEmailResult.Error(
@@ -753,7 +765,17 @@ class AuthRepositoryImpl(
             ?.let { jsonRequest ->
                 accountsService.resendNewDeviceOtp(body = jsonRequest).fold(
                     onFailure = { ResendEmailResult.Error(message = it.message, error = it) },
-                    onSuccess = { ResendEmailResult.Success },
+                    onSuccess = {
+                        when (it) {
+                            VerificationOtpResponseJson.Success -> ResendEmailResult.Success
+                            is VerificationOtpResponseJson.Invalid -> {
+                                ResendEmailResult.Error(
+                                    message = it.firstValidationErrorMessage,
+                                    error = null,
+                                )
+                            }
+                        }
+                    },
                 )
             }
             ?: ResendEmailResult.Error(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/ResendEmailResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/ResendEmailResult.kt
@@ -15,6 +15,6 @@ sealed class ResendEmailResult {
      */
     data class Error(
         val message: String?,
-        val error: Throwable,
+        val error: Throwable?,
     ) : ResendEmailResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -407,7 +407,8 @@ class TwoFactorLoginViewModel @Inject constructor(
                     it.copy(
                         dialogState = TwoFactorLoginState.DialogState.Error(
                             title = BitwardenString.an_error_has_occurred.asText(),
-                            message = BitwardenString.verification_email_not_sent.asText(),
+                            message = result.message?.asText()
+                                ?: BitwardenString.verification_email_not_sent.asText(),
                             error = result.error,
                         ),
                     )

--- a/network/src/main/kotlin/com/bitwarden/network/model/InvalidJsonResponse.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/InvalidJsonResponse.kt
@@ -21,8 +21,9 @@ sealed interface InvalidJsonResponse {
      * Returns the first error message found in [validationErrors], or [message] if there are no
      * [validationErrors] present.
      */
-    val firstValidationErrorMessage: String?
+    val firstValidationErrorMessage: String
         get() = validationErrors
             ?.flatMap { it.value }
-            ?.first()
+            ?.firstOrNull()
+            ?: message
 }

--- a/network/src/main/kotlin/com/bitwarden/network/model/VerificationCodeResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/VerificationCodeResponseJson.kt
@@ -1,0 +1,33 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models response bodies from verification code response.
+ */
+@Serializable
+sealed class VerificationCodeResponseJson {
+    /**
+     * The success body of the verification code response.
+     */
+    @Serializable
+    data object Success : VerificationCodeResponseJson()
+
+    /**
+     * Models the json body of verification code error.
+     *
+     * @param message a human readable error message.
+     * @param validationErrors a map where each value is a list of error messages for each key.
+     * The values in the array should be used for display to the user, since the keys tend to come
+     * back as nonsense. (eg: empty string key)
+     */
+    @Serializable
+    data class Invalid(
+        @SerialName("message")
+        override val message: String,
+
+        @SerialName("validationErrors")
+        override val validationErrors: Map<String, List<String>>?,
+    ) : VerificationCodeResponseJson(), InvalidJsonResponse
+}

--- a/network/src/main/kotlin/com/bitwarden/network/model/VerificationOtpResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/VerificationOtpResponseJson.kt
@@ -1,0 +1,33 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models response bodies from verification OTP response.
+ */
+@Serializable
+sealed class VerificationOtpResponseJson {
+    /**
+     * The success body of the verification OTP response.
+     */
+    @Serializable
+    data object Success : VerificationOtpResponseJson()
+
+    /**
+     * Models the json body of verification OTP error.
+     *
+     * @param message a human readable error message.
+     * @param validationErrors a map where each value is a list of error messages for each key.
+     * The values in the array should be used for display to the user, since the keys tend to come
+     * back as nonsense. (eg: empty string key)
+     */
+    @Serializable
+    data class Invalid(
+        @SerialName("message")
+        override val message: String,
+
+        @SerialName("validationErrors")
+        override val validationErrors: Map<String, List<String>>?,
+    ) : VerificationOtpResponseJson(), InvalidJsonResponse
+}

--- a/network/src/main/kotlin/com/bitwarden/network/service/AccountsService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/AccountsService.kt
@@ -8,6 +8,8 @@ import com.bitwarden.network.model.ResendEmailRequestJson
 import com.bitwarden.network.model.ResendNewDeviceOtpRequestJson
 import com.bitwarden.network.model.ResetPasswordRequestJson
 import com.bitwarden.network.model.SetPasswordRequestJson
+import com.bitwarden.network.model.VerificationCodeResponseJson
+import com.bitwarden.network.model.VerificationOtpResponseJson
 
 /**
  * Provides an API for querying accounts endpoints.
@@ -51,12 +53,16 @@ interface AccountsService {
     /**
      * Resend the email with the two-factor verification code.
      */
-    suspend fun resendVerificationCodeEmail(body: ResendEmailRequestJson): Result<Unit>
+    suspend fun resendVerificationCodeEmail(
+        body: ResendEmailRequestJson,
+    ): Result<VerificationCodeResponseJson>
 
     /**
      * Resend the email with the verification code for new devices
      */
-    suspend fun resendNewDeviceOtp(body: ResendNewDeviceOtpRequestJson): Result<Unit>
+    suspend fun resendNewDeviceOtp(
+        body: ResendNewDeviceOtpRequestJson,
+    ): Result<VerificationOtpResponseJson>
 
     /**
      * Reset the password.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25908](https://bitwarden.atlassian.net/browse/PM-25908)

## 📔 Objective

This PR processes the error responses with a 400 code from the `end-email-login` and `resend-new-device-otp` APIs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25908]: https://bitwarden.atlassian.net/browse/PM-25908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ