### PR TITLE
Update `registerExport` to return `RegisterExportResponse`

### DIFF
--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/ProviderEventsManager.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/ProviderEventsManager.kt
@@ -58,7 +58,7 @@ internal class StubProviderEventsManager : ProviderEventsManager {
                 responseJson = CANNED_RESPONSE,
             ),
             callingAppInfo = CallingAppInfo(
-                packageName = "${context.packageName}",
+                packageName = context.packageName,
                 signingInfo = SigningInfo(),
                 origin = null,
             ),

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/ProviderEventsManager.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/ProviderEventsManager.kt
@@ -2,11 +2,13 @@ package androidx.credentials.providerevents
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.pm.SigningInfo
 import androidx.credentials.provider.CallingAppInfo
 import androidx.credentials.providerevents.transfer.ImportCredentialsRequest
 import androidx.credentials.providerevents.transfer.ImportCredentialsResponse
 import androidx.credentials.providerevents.transfer.ProviderImportCredentialsResponse
 import androidx.credentials.providerevents.transfer.RegisterExportRequest
+import androidx.credentials.providerevents.transfer.RegisterExportResponse
 import com.bitwarden.annotation.OmitFromCoverage
 
 /**
@@ -17,7 +19,7 @@ interface ProviderEventsManager {
     /**
      * Register as a credential export source.
      */
-    fun registerExport(request: RegisterExportRequest): Boolean
+    fun registerExport(request: RegisterExportRequest): RegisterExportResponse
 
     /**
      * Begin the process of importing credentials.
@@ -42,8 +44,8 @@ interface ProviderEventsManager {
  */
 @OmitFromCoverage
 internal class StubProviderEventsManager : ProviderEventsManager {
-    override fun registerExport(request: RegisterExportRequest): Boolean {
-        return true
+    override fun registerExport(request: RegisterExportRequest): RegisterExportResponse {
+        return RegisterExportResponse()
     }
 
     override fun importCredentials(
@@ -53,13 +55,57 @@ internal class StubProviderEventsManager : ProviderEventsManager {
         @SuppressLint("VisibleForTests")
         return ProviderImportCredentialsResponse(
             response = ImportCredentialsResponse(
-                responseJson = "",
+                responseJson = CANNED_RESPONSE,
             ),
             callingAppInfo = CallingAppInfo(
-                packageName = "",
-                signatures = emptyList(),
+                packageName = "${context.packageName}",
+                signingInfo = SigningInfo(),
                 origin = null,
             ),
         )
     }
 }
+
+private val CANNED_RESPONSE = """
+    {
+      "id": "3zGV3pmoSs6mT7IEAPXfOw",
+      "username": "",
+      "email": "user@email.com",
+      "fullName": "Test User",
+      "collections": [],
+      "items": [
+        {
+          "id": "8cCs0RV_ViySk7KCACA",
+          "creationAt": 1739325421,
+          "modifiedAt": 1739325421,
+          "title": "test import credentials",
+          "favorite": false,
+          "scope": {
+            "urls": [
+              "https://www.sample-url.io/"
+            ],
+            "androidApps": []
+          },
+          "credentials": [
+            {
+              "type": "basic-auth",
+              "username": {
+                "fieldType": "string",
+                "value": "MyUsername"
+              }
+            },
+            {
+              "type": "passkey",
+              "credentialId": "xMA-5emp0WsQASnuNmuzQA",
+              "rpId": "www.sample-url.io",
+              "username": "user@email.com",
+              "userDisplayName": "user@email.com",
+              "userHandle": "lEn2KqNnS7SsUdVbrdoFiw",
+              "key": "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgQx8Smx_KdvQ7nJXt2_62Xrn-im9ibCOtsphj_xZo_uWhRANCAARUDaIFJIUaRyUehAy_d1_a-DK63Ws_d-zkYj-uqHdrGZI0dnhazQGva4tJZQFN35iLoLzFFj_CSjqeYAEOX7Ck"
+            }
+          ]
+        }
+      ]
+    }
+"""
+    .trimIndent()

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/RegisterExportResponse.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/RegisterExportResponse.kt
@@ -1,0 +1,6 @@
+package androidx.credentials.providerevents.transfer
+
+/**
+ * Placeholder class representing a response to registering as a credential export source.
+ */
+class RegisterExportResponse

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/registry/CredentialExchangeRegistry.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/registry/CredentialExchangeRegistry.kt
@@ -1,5 +1,6 @@
 package com.bitwarden.cxf.registry
 
+import androidx.credentials.providerevents.transfer.RegisterExportResponse
 import com.bitwarden.cxf.registry.model.RegistrationRequest
 
 /**
@@ -18,7 +19,7 @@ interface CredentialExchangeRegistry {
      * does not indicate if the application was added to the registry. Use the result value to check
      * if the application was added or not. [Result.isFailure] only indicates if an error occurred.
      */
-    suspend fun register(registrationRequest: RegistrationRequest): Result<Boolean>
+    suspend fun register(registrationRequest: RegistrationRequest): Result<RegisterExportResponse>
 
     /**
      * Unregister as a credential export source.
@@ -28,5 +29,5 @@ interface CredentialExchangeRegistry {
      *
      * @return True if the unregistration was successful, false otherwise.
      */
-    suspend fun unregister(): Boolean
+    suspend fun unregister(): RegisterExportResponse
 }

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/registry/CredentialExchangeRegistryImpl.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/registry/CredentialExchangeRegistryImpl.kt
@@ -6,6 +6,7 @@ import androidx.core.graphics.drawable.toBitmapOrNull
 import androidx.credentials.providerevents.ProviderEventsManager
 import androidx.credentials.providerevents.transfer.ExportEntry
 import androidx.credentials.providerevents.transfer.RegisterExportRequest
+import androidx.credentials.providerevents.transfer.RegisterExportResponse
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
@@ -24,7 +25,7 @@ internal class CredentialExchangeRegistryImpl(
 
     override suspend fun register(
         registrationRequest: RegistrationRequest,
-    ): Result<Boolean> {
+    ): Result<RegisterExportResponse> {
         val icon = ContextCompat
             .getDrawable(
                 application,
@@ -50,7 +51,7 @@ internal class CredentialExchangeRegistryImpl(
             .asSuccess()
     }
 
-    override suspend fun unregister(): Boolean =
+    override suspend fun unregister(): RegisterExportResponse =
         providerEventsManager.registerExport(
             // This is a workaround for unregistering an account since an explicit "unregister" API
             // is not currently available.


### PR DESCRIPTION
## 🎟️ Tracking

Internal change

## 📔 Objective

The `registerExport` function in `ProviderEventsManager` and `CredentialExchangeRegistry` now returns a `RegisterExportResponse` instead of a `Boolean`.

A placeholder `RegisterExportResponse` class has been added.

The `StubProviderEventsManager` has been updated to return a `RegisterExportResponse` and provide canned data for `importCredentials` for testing purposes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
