### PR TITLE
Pm 25258 browser autofill dialog

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
@@ -16,6 +16,8 @@ import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManagerImpl
 import com.x8bit.bitwarden.data.autofill.manager.AutofillTotpManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillTotpManagerImpl
+import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserAutofillDialogManager
+import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserAutofillDialogManagerImpl
 import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserThirdPartyAutofillEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserThirdPartyAutofillEnabledManagerImpl
 import com.x8bit.bitwarden.data.autofill.parser.AutofillParser
@@ -24,6 +26,7 @@ import com.x8bit.bitwarden.data.autofill.processor.AutofillProcessor
 import com.x8bit.bitwarden.data.autofill.processor.AutofillProcessorImpl
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProvider
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProviderImpl
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
@@ -60,6 +63,20 @@ object AutofillModule {
     @Provides
     fun providesBrowserAutofillEnabledManager(): BrowserThirdPartyAutofillEnabledManager =
         BrowserThirdPartyAutofillEnabledManagerImpl()
+
+    @Singleton
+    @Provides
+    fun providesBrowserAutofillDialogManager(
+        autofillEnabledManager: AutofillEnabledManager,
+        browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
+        clock: Clock,
+        settingsDiskSource: SettingsDiskSource,
+    ): BrowserAutofillDialogManager = BrowserAutofillDialogManagerImpl(
+        autofillEnabledManager = autofillEnabledManager,
+        browserThirdPartyAutofillEnabledManager = browserThirdPartyAutofillEnabledManager,
+        clock = clock,
+        settingsDiskSource = settingsDiskSource,
+    )
 
     @Singleton
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManager.kt
@@ -1,0 +1,16 @@
+package com.x8bit.bitwarden.data.autofill.manager.browser
+
+/**
+ * Manager to handle whether the Browser Autofill Dialog should be displayed.
+ */
+interface BrowserAutofillDialogManager {
+    /**
+     * Indicates whether the dialog should be displayed to the user.
+     */
+    val shouldShowDialog: Boolean
+
+    /**
+     * The dialog has been dismissed and we should delay displaying it again.
+     */
+    fun delayDialog()
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManagerImpl.kt
@@ -1,0 +1,32 @@
+package com.x8bit.bitwarden.data.autofill.manager.browser
+
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import java.time.Clock
+
+/**
+ * We only show the dialog once per 24 hour period.
+ */
+private const val SHOW_DIALOG_DELAY_MS: Long = 24L * 60L * 60L * 1000L
+
+/**
+ * The default implementation of the [BrowserAutofillDialogManager].
+ */
+internal class BrowserAutofillDialogManagerImpl(
+    private val autofillEnabledManager: AutofillEnabledManager,
+    private val browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
+    private val clock: Clock,
+    private val settingsDiskSource: SettingsDiskSource,
+) : BrowserAutofillDialogManager {
+    override val shouldShowDialog: Boolean
+        get() = autofillEnabledManager.isAutofillEnabled &&
+            browserThirdPartyAutofillEnabledManager
+                .browserThirdPartyAutofillStatus
+                .isAnyIsAvailableAndDisabled &&
+            settingsDiskSource.browserAutofillDialogReshowTime?.isBefore(clock.instant()) != false
+
+    override fun delayDialog() {
+        settingsDiskSource.browserAutofillDialogReshowTime =
+            clock.instant().plusMillis(SHOW_DIALOG_DELAY_MS)
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserThirdPartyAutoFillData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserThirdPartyAutoFillData.kt
@@ -6,7 +6,9 @@ package com.x8bit.bitwarden.data.autofill.model.browser
 data class BrowserThirdPartyAutoFillData(
     val isAvailable: Boolean,
     val isThirdPartyEnabled: Boolean,
-)
+) {
+    val isAvailableButDisabled: Boolean = isAvailable && !isThirdPartyEnabled
+}
 
 /**
  * The overall status for all relevant browsers.
@@ -15,4 +17,12 @@ data class BrowserThirdPartyAutofillStatus(
     val braveStableStatusData: BrowserThirdPartyAutoFillData,
     val chromeStableStatusData: BrowserThirdPartyAutoFillData,
     val chromeBetaChannelStatusData: BrowserThirdPartyAutoFillData,
-)
+) {
+    /**
+     * Whether any of the available browsers have third party autofill disabled.
+     */
+    val isAnyIsAvailableAndDisabled: Boolean
+        get() = braveStableStatusData.isAvailableButDisabled ||
+            chromeStableStatusData.isAvailableButDisabled ||
+            chromeBetaChannelStatusData.isAvailableButDisabled
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -106,6 +106,11 @@ interface SettingsDiskSource {
     val flightRecorderDataFlow: Flow<FlightRecorderDataSet?>
 
     /**
+     * The time at which the browser autofill dialog is allowed to be shown to the user again.
+     */
+    var browserAutofillDialogReshowTime: Instant?
+
+    /**
      * Clears all the settings data for the given user.
      */
     fun clearData(userId: String)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -48,6 +48,7 @@ private const val SHOULD_SHOW_GENERATOR_COACH_MARK = "shouldShowGeneratorCoachMa
 private const val RESUME_SCREEN = "resumeScreen"
 private const val FLIGHT_RECORDER_KEY = "flightRecorderData"
 private const val IS_DYNAMIC_COLORS_ENABLED = "isDynamicColorsEnabled"
+private const val BROWSER_AUTOFILL_DIALOG_RESHOW_TIME = "browserAutofillDialogReshowTime"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -223,6 +224,12 @@ class SettingsDiskSourceImpl(
 
     override val flightRecorderDataFlow: Flow<FlightRecorderDataSet?>
         get() = mutableFlightRecorderDataFlow.onSubscription { emit(flightRecorderData) }
+
+    override var browserAutofillDialogReshowTime: Instant?
+        get() = getLong(key = BROWSER_AUTOFILL_DIALOG_RESHOW_TIME)?.let { Instant.ofEpochMilli(it) }
+        set(value) {
+            putLong(key = BROWSER_AUTOFILL_DIALOG_RESHOW_TIME, value = value?.toEpochMilli())
+        }
 
     override fun clearData(userId: String) {
         storeVaultTimeoutInMinutes(userId = userId, vaultTimeoutInMinutes = null)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -38,7 +38,7 @@ private const val KEY_STATE = "state"
 @HiltViewModel
 class AutoFillViewModel @Inject constructor(
     authRepository: AuthRepository,
-    chromeThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
+    browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
     private val savedStateHandle: SavedStateHandle,
     private val settingsRepository: SettingsRepository,
     private val firstTimeActionManager: FirstTimeActionManager,
@@ -66,7 +66,7 @@ class AutoFillViewModel @Inject constructor(
                 defaultUriMatchType = settingsRepository.defaultUriMatchType,
                 showAutofillActionCard = false,
                 activeUserId = userId,
-                browserAutofillSettingsOptions = chromeThirdPartyAutofillEnabledManager
+                browserAutofillSettingsOptions = browserThirdPartyAutofillEnabledManager
                     .browserThirdPartyAutofillStatus
                     .toBrowserAutoFillSettingsOptions(),
                 isUserManagedPrivilegedAppsEnabled =
@@ -103,7 +103,7 @@ class AutoFillViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
-        chromeThirdPartyAutofillEnabledManager
+        browserThirdPartyAutofillEnabledManager
             .browserThirdPartyAutofillStatusFlow
             .map { AutoFillAction.Internal.BrowserAutofillStatusReceive(status = it) }
             .onEach(::sendAction)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -28,6 +28,7 @@ import com.bitwarden.ui.platform.util.toObjectNavigationRoute
 import com.x8bit.bitwarden.ui.platform.components.util.rememberBitwardenNavController
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.platform.feature.settings.about.navigateToAbout
+import com.x8bit.bitwarden.ui.platform.feature.settings.autofill.navigateToAutoFill
 import com.x8bit.bitwarden.ui.platform.feature.settings.navigateToSettingsGraph
 import com.x8bit.bitwarden.ui.platform.feature.settings.navigateToSettingsGraphRoot
 import com.x8bit.bitwarden.ui.platform.feature.settings.settingsGraph
@@ -239,6 +240,10 @@ private fun VaultUnlockedNavBarScaffold(
                 onNavigateToAboutScreen = {
                     navController.navigateToSettingsGraphRoot()
                     navController.navigateToAbout(isPreAuth = false)
+                },
+                onNavigateToAutofillScreen = {
+                    navController.navigateToSettingsGraphRoot()
+                    navController.navigateToAutoFill()
                 },
             )
             sendGraph(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultGraphNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultGraphNavigation.kt
@@ -33,6 +33,7 @@ fun NavGraphBuilder.vaultGraph(
     onNavigateToImportLogins: () -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToAboutScreen: () -> Unit,
+    onNavigateToAutofillScreen: () -> Unit,
 ) {
     navigation<VaultGraphRoute>(
         startDestination = VaultRoute,
@@ -50,6 +51,7 @@ fun NavGraphBuilder.vaultGraph(
             onNavigateToImportLogins = onNavigateToImportLogins,
             onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
             onNavigateToAboutScreen = onNavigateToAboutScreen,
+            onNavigateToAutofillScreen = onNavigateToAutofillScreen,
         )
         vaultItemListingDestination(
             onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultNavigation.kt
@@ -31,6 +31,7 @@ fun NavGraphBuilder.vaultDestination(
     onNavigateToImportLogins: () -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToAboutScreen: () -> Unit,
+    onNavigateToAutofillScreen: () -> Unit,
 ) {
     composableWithRootPushTransitions<VaultRoute> {
         VaultScreen(
@@ -44,6 +45,7 @@ fun NavGraphBuilder.vaultDestination(
             onNavigateToImportLogins = onNavigateToImportLogins,
             onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
             onNavigateToAboutScreen = onNavigateToAboutScreen,
+            onNavigateToAutofillScreen = onNavigateToAutofillScreen,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -95,6 +95,7 @@ fun VaultScreen(
     onNavigateToImportLogins: () -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToAboutScreen: () -> Unit,
+    onNavigateToAutofillScreen: () -> Unit,
     exitManager: ExitManager = LocalExitManager.current,
     intentManager: IntentManager = LocalIntentManager.current,
     appReviewManager: AppReviewManager = LocalAppReviewManager.current,
@@ -178,6 +179,8 @@ fun VaultScreen(
             is VaultEvent.ShowShareSheet -> {
                 intentManager.shareText(event.content)
             }
+
+            VaultEvent.NavigateToAutofillSettings -> onNavigateToAutofillScreen()
         }
     }
     val vaultHandlers = remember(viewModel) { VaultHandlers.create(viewModel) }
@@ -404,6 +407,7 @@ private fun VaultScreenScaffold(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun VaultDialogs(
     dialogState: VaultState.DialogState?,
@@ -440,6 +444,24 @@ private fun VaultDialogs(
                 },
                 onDismissClick = vaultHandlers.dialogDismiss,
                 onDismissRequest = vaultHandlers.dialogDismiss,
+            )
+        }
+
+        VaultState.DialogState.ThirdPartyBrowserAutofill -> {
+            BitwardenTwoButtonDialog(
+                title = stringResource(
+                    id = BitwardenString.enable_browser_autofill_to_keep_filling_passwords,
+                ),
+                message = stringResource(
+                    id = BitwardenString.your_browser_recently_updated_how_autofill_works,
+                ),
+                confirmButtonText = stringResource(id = BitwardenString.go_to_settings),
+                dismissButtonText = stringResource(id = BitwardenString.not_now),
+                onConfirmClick = vaultHandlers.onEnabledThirdPartyAutofillClick,
+                onDismissClick = vaultHandlers.onDismissThirdPartyAutofillDialogClick,
+                onDismissRequest = vaultHandlers.onDismissThirdPartyAutofillDialogClick,
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false,
             )
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -26,6 +26,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
+import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserAutofillDialogManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
@@ -79,6 +80,7 @@ import javax.inject.Inject
 
 private const val VAULT_DATA_RECEIVED_DELAY: Long = 550L
 private const val LOGIN_SUCCESS_SNACKBAR_DELAY: Long = 550L
+private const val BROWSER_AUTOFILL_DIALOG_DELAY: Long = 550L
 
 /**
  * Manages [VaultState], handles [VaultAction], and launches [VaultEvent] for the [VaultScreen].
@@ -97,6 +99,7 @@ class VaultViewModel @Inject constructor(
     private val reviewPromptManager: ReviewPromptManager,
     private val specialCircumstanceManager: SpecialCircumstanceManager,
     private val networkConnectionManager: NetworkConnectionManager,
+    private val browserAutofillDialogManager: BrowserAutofillDialogManager,
     snackbarRelayManager: SnackbarRelayManager,
 ) : BaseViewModel<VaultState, VaultEvent, VaultAction>(
     initialState = run {
@@ -108,9 +111,8 @@ class VaultViewModel @Inject constructor(
                 .getActivePolicies(type = PolicyTypeJson.PERSONAL_OWNERSHIP)
                 .any(),
         )
-        val appBarTitle = vaultFilterData.toAppBarTitle()
         VaultState(
-            appBarTitle = appBarTitle,
+            appBarTitle = vaultFilterData.toAppBarTitle(),
             initials = activeAccountSummary.initials,
             avatarColorString = activeAccountSummary.avatarColorHex,
             accountSummaries = accountSummaries,
@@ -207,6 +209,20 @@ class VaultViewModel @Inject constructor(
             .map { VaultAction.Internal.PolicyUpdateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            delay(timeMillis = BROWSER_AUTOFILL_DIALOG_DELAY)
+            mutableStateFlow.update { vaultState ->
+                vaultState.copy(
+                    dialog = VaultState.DialogState.ThirdPartyBrowserAutofill
+                        .takeIf {
+                            vaultState.dialog == null &&
+                                browserAutofillDialogManager.shouldShowDialog
+                        }
+                        ?: vaultState.dialog,
+                )
+            }
+        }
     }
 
     override fun handleAction(action: VaultAction) {
@@ -257,6 +273,11 @@ class VaultViewModel @Inject constructor(
             VaultAction.ShareAllCipherDecryptionErrorsClick -> {
                 handleShareAllCipherDecryptionErrorsClick()
             }
+
+            VaultAction.EnableThirdPartyAutofillClick -> handleEnableThirdPartyAutofillClick()
+            VaultAction.DismissThirdPartyAutofillDialogClick -> {
+                handleDismissThirdPartyAutofillDialogClick()
+            }
         }
     }
 
@@ -286,6 +307,17 @@ class VaultViewModel @Inject constructor(
                     .joinToString(separator = "\n"),
             ),
         )
+    }
+
+    private fun handleEnableThirdPartyAutofillClick() {
+        browserAutofillDialogManager.delayDialog()
+        mutableStateFlow.update { it.copy(dialog = null) }
+        sendEvent(VaultEvent.NavigateToAutofillSettings)
+    }
+
+    private fun handleDismissThirdPartyAutofillDialogClick() {
+        browserAutofillDialogManager.delayDialog()
+        mutableStateFlow.update { it.copy(dialog = null) }
     }
 
     private fun handleSelectAddItemType() {
@@ -921,6 +953,8 @@ class VaultViewModel @Inject constructor(
                     title = BitwardenString.decryption_error.asText(),
                     cipherCount = vaultData.data.decryptCipherListResult.failures.size,
                 )
+            } else if (state.dialog is VaultState.DialogState.ThirdPartyBrowserAutofill) {
+                VaultState.DialogState.ThirdPartyBrowserAutofill
             } else {
                 null
             },
@@ -1459,6 +1493,12 @@ data class VaultState(
         ) : DialogState()
 
         /**
+         * Represents a dialog indicating that a 3rd party browser required Autofill configuration.
+         */
+        @Parcelize
+        data object ThirdPartyBrowserAutofill : DialogState()
+
+        /**
          * Represents a dialog indicating that there was a decryption error loading ciphers.
          */
         @Parcelize
@@ -1580,6 +1620,11 @@ sealed class VaultEvent {
      * Navigate to settings.
      */
     data object NavigateToAbout : VaultEvent()
+
+    /**
+     * Navigate to Autofill settings screen.
+     */
+    data object NavigateToAutofillSettings : VaultEvent()
 }
 
 /**
@@ -1708,6 +1753,16 @@ sealed class VaultAction {
      * User clicked the secure notes types button.
      */
     data object SecureNoteGroupClick : VaultAction()
+
+    /**
+     * Click to enabled 3rd party autofill for a browser.
+     */
+    data object EnableThirdPartyAutofillClick : VaultAction()
+
+    /**
+     * Click to dismiss 3rd party autofill dialog.
+     */
+    data object DismissThirdPartyAutofillDialogClick : VaultAction()
 
     /**
      * Click to share cipher decryption error details.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/handlers/VaultHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/handlers/VaultHandlers.kt
@@ -47,6 +47,8 @@ data class VaultHandlers(
     val dismissFlightRecorderSnackbar: () -> Unit,
     val onShareCipherDecryptionErrorClick: (selectedCipherId: String) -> Unit,
     val onShareAllCipherDecryptionErrorsClick: () -> Unit,
+    val onEnabledThirdPartyAutofillClick: () -> Unit,
+    val onDismissThirdPartyAutofillDialogClick: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -127,18 +129,18 @@ data class VaultHandlers(
                 dismissFlightRecorderSnackbar = {
                     viewModel.trySendAction(VaultAction.DismissFlightRecorderSnackbar)
                 },
-                onShareCipherDecryptionErrorClick =
-                    {
-                        viewModel.trySendAction(
-                            VaultAction.ShareCipherDecryptionErrorClick(it),
-                        )
-                    },
-                onShareAllCipherDecryptionErrorsClick =
-                    {
-                        viewModel.trySendAction(
-                            VaultAction.ShareAllCipherDecryptionErrorsClick,
-                        )
-                    },
+                onShareCipherDecryptionErrorClick = {
+                    viewModel.trySendAction(VaultAction.ShareCipherDecryptionErrorClick(it))
+                },
+                onShareAllCipherDecryptionErrorsClick = {
+                    viewModel.trySendAction(VaultAction.ShareAllCipherDecryptionErrorsClick)
+                },
+                onEnabledThirdPartyAutofillClick = {
+                    viewModel.trySendAction(VaultAction.EnableThirdPartyAutofillClick)
+                },
+                onDismissThirdPartyAutofillDialogClick = {
+                    viewModel.trySendAction(VaultAction.DismissThirdPartyAutofillDialogClick)
+                },
             )
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManagerTest.kt
@@ -1,0 +1,176 @@
+package com.x8bit.bitwarden.data.autofill.manager.browser
+
+import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.autofill.model.browser.BrowserThirdPartyAutoFillData
+import com.x8bit.bitwarden.data.autofill.model.browser.BrowserThirdPartyAutofillStatus
+import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+
+class BrowserAutofillDialogManagerTest {
+
+    private val autofillEnabledManager: AutofillEnabledManager = mockk()
+    private val thirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager = mockk()
+    private val fakeSettingsDiskSource: FakeSettingsDiskSource = FakeSettingsDiskSource()
+
+    private val manager: BrowserAutofillDialogManager = BrowserAutofillDialogManagerImpl(
+        autofillEnabledManager = autofillEnabledManager,
+        browserThirdPartyAutofillEnabledManager = thirdPartyAutofillEnabledManager,
+        clock = FIXED_CLOCK,
+        settingsDiskSource = fakeSettingsDiskSource,
+    )
+
+    @Test
+    fun `shouldShowDialog should be false when autofill is disabled`() {
+        every { autofillEnabledManager.isAutofillEnabled } returns false
+
+        assertFalse(manager.shouldShowDialog)
+
+        verify(exactly = 1) {
+            autofillEnabledManager.isAutofillEnabled
+        }
+        verify(exactly = 0) {
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        }
+    }
+
+    @Test
+    fun `shouldShowDialog should be false when no browsers are available`() {
+        val browserThirdPartyAutofillStatus = BrowserThirdPartyAutofillStatus(
+            braveStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
+                isThirdPartyEnabled = false,
+            ),
+            chromeStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
+                isThirdPartyEnabled = false,
+            ),
+            chromeBetaChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
+                isThirdPartyEnabled = false,
+            ),
+        )
+        every { autofillEnabledManager.isAutofillEnabled } returns true
+        every {
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        } returns browserThirdPartyAutofillStatus
+
+        assertFalse(manager.shouldShowDialog)
+
+        verify(exactly = 1) {
+            autofillEnabledManager.isAutofillEnabled
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        }
+    }
+
+    @Test
+    fun `shouldShowDialog should be false when all browsers are configured`() {
+        val browserThirdPartyAutofillStatus = BrowserThirdPartyAutofillStatus(
+            braveStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = true,
+            ),
+            chromeStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = true,
+            ),
+            chromeBetaChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = true,
+            ),
+        )
+        every { autofillEnabledManager.isAutofillEnabled } returns true
+        every {
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        } returns browserThirdPartyAutofillStatus
+
+        assertFalse(manager.shouldShowDialog)
+
+        verify(exactly = 1) {
+            autofillEnabledManager.isAutofillEnabled
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        }
+    }
+
+    @Test
+    fun `shouldShowDialog should be false when 24 hours have not passed since previous dialog`() {
+        val browserThirdPartyAutofillStatus = BrowserThirdPartyAutofillStatus(
+            braveStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+            chromeStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+            chromeBetaChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+        )
+        every { autofillEnabledManager.isAutofillEnabled } returns true
+        every {
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        } returns browserThirdPartyAutofillStatus
+        fakeSettingsDiskSource.browserAutofillDialogReshowTime = FIXED_CLOCK.instant()
+
+        assertFalse(manager.shouldShowDialog)
+
+        verify(exactly = 1) {
+            autofillEnabledManager.isAutofillEnabled
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        }
+    }
+
+    @Test
+    fun `shouldShowDialog should be true when all conditions are met`() {
+        val browserThirdPartyAutofillStatus = BrowserThirdPartyAutofillStatus(
+            braveStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+            chromeStableStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+            chromeBetaChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+        )
+        every { autofillEnabledManager.isAutofillEnabled } returns true
+        every {
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        } returns browserThirdPartyAutofillStatus
+        fakeSettingsDiskSource.browserAutofillDialogReshowTime = null
+
+        assertTrue(manager.shouldShowDialog)
+
+        verify(exactly = 1) {
+            autofillEnabledManager.isAutofillEnabled
+            thirdPartyAutofillEnabledManager.browserThirdPartyAutofillStatus
+        }
+    }
+
+    @Test
+    fun `delayDialog should set the correct time on the disk source`() {
+        fakeSettingsDiskSource.assertBrowserAutofillDialogReshowTime(null)
+        manager.delayDialog()
+        fakeSettingsDiskSource.assertBrowserAutofillDialogReshowTime(
+            FIXED_CLOCK.instant().plus(1L, ChronoUnit.DAYS),
+        )
+    }
+}
+
+private val FIXED_CLOCK: Clock = Clock.fixed(
+    Instant.parse("2023-10-27T12:00:00Z"),
+    ZoneOffset.UTC,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1482,4 +1482,33 @@ class SettingsDiskSourceTest {
             },
         )
     }
+
+    @Test
+    fun `browserAutofillDialogReshowTime should pull from SharedPreferences`() {
+        val browserAutofillDialogReshowTimeKey =
+            "bwPreferencesStorage:browserAutofillDialogReshowTime"
+        val expected = 11111L
+
+        // Verify initial value is null and disk source matches shared preferences.
+        assertNull(fakeSharedPreferences.getString(browserAutofillDialogReshowTimeKey, null))
+        assertNull(settingsDiskSource.browserAutofillDialogReshowTime)
+
+        // Updating the shared preferences should update disk source.
+        fakeSharedPreferences.edit {
+            putLong(browserAutofillDialogReshowTimeKey, expected)
+        }
+        val actual = settingsDiskSource.browserAutofillDialogReshowTime
+        assertEquals(Instant.ofEpochMilli(expected), actual)
+    }
+
+    @Test
+    fun `setting browserAutofillDialogReshowTime should update SharedPreferences`() {
+        val browserAutofillDialogReshowTimeKey =
+            "bwPreferencesStorage:browserAutofillDialogReshowTime"
+        val timeMs = 1111L
+        val timeInstant = Instant.ofEpochMilli(timeMs)
+        settingsDiskSource.browserAutofillDialogReshowTime = timeInstant
+        val actual = fakeSharedPreferences.getLong(browserAutofillDialogReshowTimeKey, 0L)
+        assertEquals(timeMs, actual)
+    }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -87,6 +87,7 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private var hasSeenGeneratorCoachMark: Boolean? = null
     private var storedFlightRecorderData: FlightRecorderDataSet? = null
     private var storedIsDynamicColorsEnabled: Boolean? = null
+    private var storedBrowserAutofillDialogReshowTime: Instant? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -205,6 +206,12 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     override val flightRecorderDataFlow: Flow<FlightRecorderDataSet?>
         get() = mutableFlightRecorderDataFlow
             .onSubscription { emit(storedFlightRecorderData) }
+
+    override var browserAutofillDialogReshowTime: Instant?
+        get() = storedBrowserAutofillDialogReshowTime
+        set(value) {
+            storedBrowserAutofillDialogReshowTime = value
+        }
 
     override fun getAccountBiometricIntegrityValidity(
         userId: String,
@@ -475,6 +482,13 @@ class FakeSettingsDiskSource : SettingsDiskSource {
      */
     fun assertLastSyncTime(userId: String, expected: Instant?) {
         assertEquals(expected, storedLastSyncTime[userId])
+    }
+
+    /**
+     * Asserts that the stored browser autofill dialog reshow time matches the [expected] one.
+     */
+    fun assertBrowserAutofillDialogReshowTime(expected: Instant?) {
+        assertEquals(expected, storedBrowserAutofillDialogReshowTime)
     }
 
     //region Private helper functions

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -470,7 +470,7 @@ class AutoFillViewModelTest : BaseViewModelTest() {
         settingsRepository = settingsRepository,
         authRepository = authRepository,
         firstTimeActionManager = firstTimeActionManager,
-        chromeThirdPartyAutofillEnabledManager = browserThirdPartyAutofillEnabledManager,
+        browserThirdPartyAutofillEnabledManager = browserThirdPartyAutofillEnabledManager,
         featureFlagManager = mockFeatureFlagManager,
     )
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -79,6 +79,7 @@ import org.junit.Test
 @Suppress("LargeClass")
 class VaultScreenTest : BitwardenComposeTest() {
     private var onNavigateToAboutCalled = false
+    private var onNavigateToAutofillCalled = false
     private var onNavigateToImportLoginsCalled = false
     private var onNavigateToVaultAddItemScreenCalled = false
     private var onNavigateToVaultItemArgs: VaultItemArgs? = null
@@ -123,6 +124,7 @@ class VaultScreenTest : BitwardenComposeTest() {
                     onNavigateToAddFolderParentFolderName = folderName
                 },
                 onNavigateToAboutScreen = { onNavigateToAboutCalled = true },
+                onNavigateToAutofillScreen = { onNavigateToAutofillCalled = true },
             )
         }
     }
@@ -577,6 +579,56 @@ class VaultScreenTest : BitwardenComposeTest() {
             .performClick()
 
         verify { viewModel.trySendAction(VaultAction.DialogDismiss) }
+    }
+
+    @Test
+    fun `ThirdPartyBrowserAutofill should be displayed according to state`() {
+        composeTestRule.assertNoDialogExists()
+        mutableStateFlow.update {
+            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Enable browser Autofill to keep filling passwords")
+            .assertIsDisplayed()
+            .assert(hasAnyAncestor(isDialog()))
+
+        mutableStateFlow.update { it.copy(dialog = null) }
+        composeTestRule.assertNoDialogExists()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ThirdPartyBrowserAutofill dialog Not now button should emit DismissThirdPartyAutofillDialogClick`() {
+        mutableStateFlow.update {
+            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Not now")
+            .assertIsDisplayed()
+            .assert(hasAnyAncestor(isDialog()))
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(VaultAction.DismissThirdPartyAutofillDialogClick)
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ThirdPartyBrowserAutofill dialog Go to settings now button should emit EnableThirdPartyAutofillClick`() {
+        mutableStateFlow.update {
+            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill)
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Go to settings")
+            .assertIsDisplayed()
+            .assert(hasAnyAncestor(isDialog()))
+            .performClick()
+
+        verify(exactly = 1) { viewModel.trySendAction(VaultAction.EnableThirdPartyAutofillClick) }
     }
 
     @Suppress("MaxLineLength")
@@ -2024,6 +2076,12 @@ class VaultScreenTest : BitwardenComposeTest() {
     fun `when NavigateToAbout is sent, it should call onNavigateToAbout`() {
         mutableEventFlow.tryEmit(VaultEvent.NavigateToAbout)
         assertTrue(onNavigateToAboutCalled)
+    }
+
+    @Test
+    fun `when NavigateToAutofillSettings is sent, it should call onNavigateToAutofillSettings`() {
+        mutableEventFlow.tryEmit(VaultEvent.NavigateToAutofillSettings)
+        assertTrue(onNavigateToAutofillCalled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
+import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserAutofillDialogManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
@@ -151,6 +152,7 @@ class VaultViewModelTest : BaseViewModelTest() {
         every { flightRecorderData } returns FlightRecorderDataSet(data = emptySet())
         every { flightRecorderDataFlow } returns mutableFlightRecorderDataFlow
         every { dismissFlightRecorderBanner() } just runs
+        every { isAutofillEnabledStateFlow } returns MutableStateFlow(false)
     }
 
     private val vaultRepository: VaultRepository =
@@ -178,6 +180,10 @@ class VaultViewModelTest : BaseViewModelTest() {
 
     private val networkConnectionManager: NetworkConnectionManager = mockk {
         every { isNetworkConnected } returns true
+    }
+    private val browserAutofillDialogManager: BrowserAutofillDialogManager = mockk {
+        every { shouldShowDialog } returns false
+        every { delayDialog() } just runs
     }
 
     @AfterEach
@@ -459,6 +465,30 @@ class VaultViewModelTest : BaseViewModelTest() {
 
         verify(exactly = 1) {
             settingsRepository.dismissFlightRecorderBanner()
+        }
+    }
+
+    @Test
+    fun `on EnableThirdPartyAutofillClick should send NavigateToAutofillSettings`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(VaultAction.EnableThirdPartyAutofillClick)
+            assertEquals(VaultEvent.NavigateToAutofillSettings, awaitItem())
+        }
+        verify(exactly = 1) {
+            browserAutofillDialogManager.delayDialog()
+        }
+    }
+
+    @Test
+    fun `on DismissThirdPartyAutofillDialogClick should call delay dialog`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.trySendAction(VaultAction.DismissThirdPartyAutofillDialogClick)
+
+        verify(exactly = 1) {
+            browserAutofillDialogManager.delayDialog()
         }
     }
 
@@ -2834,6 +2864,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             reviewPromptManager = reviewPromptManager,
             specialCircumstanceManager = specialCircumstanceManager,
             networkConnectionManager = networkConnectionManager,
+            browserAutofillDialogManager = browserAutofillDialogManager,
         )
 }
 

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dialog/BitwardenTwoButtonDialog.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dialog/BitwardenTwoButtonDialog.kt
@@ -57,10 +57,16 @@ fun BitwardenTwoButtonDialog(
     onDismissRequest: () -> Unit,
     confirmTextColor: Color = BitwardenTheme.colorScheme.outlineButton.foreground,
     dismissTextColor: Color = BitwardenTheme.colorScheme.outlineButton.foreground,
+    dismissOnBackPress: Boolean = true,
+    dismissOnClickOutside: Boolean = true,
 ) {
     Dialog(
         onDismissRequest = onDismissRequest,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+        properties = DialogProperties(
+            dismissOnBackPress = dismissOnBackPress,
+            dismissOnClickOutside = dismissOnClickOutside,
+            usePlatformDefaultWidth = false,
+        ),
     ) {
         val configuration = LocalConfiguration.current
         val scrollState = rememberScrollState()

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1102,4 +1102,7 @@ Do you want to switch to this account?</string>
         <item quantity="one">%1$d item has been imported to your vault.</item>
         <item quantity="other">%1$d items have been imported to your vault.</item>
     </plurals>
+    <string name="enable_browser_autofill_to_keep_filling_passwords">Enable browser Autofill to keep filling passwords</string>
+    <string name="your_browser_recently_updated_how_autofill_works">Your browser recently updated how Autofill works. To continue filling your passwords with Bitwarden, enable browser Autofill in autofill settings.</string>
+    <string name="not_now">Not now</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25258](https://bitwarden.atlassian.net/browse/PM-25908)

## 📔 Objective

This PR adds a dialog to the VaultScreen that lets the user know that Autofill is currently not configured properly for their browser and that they can fix it in Autofill settings. The takes them there.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/6662ee32-c075-496a-ae70-22acfda367b4" width="300" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25258]: https://bitwarden.atlassian.net/browse/PM-25258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ