### PR TITLE
Fully extract more sync logic into the VaultSyncManager

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManager.kt
@@ -1,6 +1,14 @@
 package com.x8bit.bitwarden.data.vault.manager
 
+import com.bitwarden.collections.CollectionView
+import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.vault.DecryptCipherListResult
+import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
+import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
+import com.x8bit.bitwarden.data.vault.repository.model.SendData
+import com.x8bit.bitwarden.data.vault.repository.model.VaultData
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Manages the synchronization of the user's vault data with the remote server.
@@ -9,21 +17,68 @@ import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
  */
 interface VaultSyncManager {
     /**
-     * Initiates a synchronization process for the user's vault data.
+     * Flow that represents the current vault data.
      *
-     * This function fetches the latest data from the remote server and updates the local
-     * vault cache. It can be a standard sync or a "forced" sync, which typically
-     * bypasses local cache checks and fetches everything anew.
-     *
-     * @param userId The unique identifier of the user whose vault is to be synchronized.
-     * @param forced If true, performs a full, forced synchronization, ignoring any recent sync
-     * timestamps. If false, performs a standard incremental sync.
-     *
-     * @return A [SyncVaultDataResult] indicating the outcome of the synchronization, such as
-     * success or failure with details.
+     * Note that the [StateFlow.value] will return the last known value but the [StateFlow] itself
+     * must be collected in order to trigger state changes.
      */
-    suspend fun sync(
-        userId: String,
-        forced: Boolean,
-    ): SyncVaultDataResult
+    val vaultDataStateFlow: StateFlow<DataState<VaultData>>
+
+    /**
+     * Flow that represents all ciphers for the active user, including references to ciphers that
+     * cannot be decrypted.
+     *
+     * Note that the [StateFlow.value] will return the last known value but the [StateFlow] itself
+     * must be collected in order to trigger state changes.
+     */
+    val decryptCipherListResultStateFlow: StateFlow<DataState<DecryptCipherListResult>>
+
+    /**
+     * Flow that represents all collections for the active user.
+     *
+     * Note that the [StateFlow.value] will return the last known value but the [StateFlow] itself
+     * must be collected in order to trigger state changes.
+     */
+    val collectionsStateFlow: StateFlow<DataState<List<CollectionView>>>
+
+    /**
+     * Flow that represents all domains for the active user.
+     *
+     * Note that the [StateFlow.value] will return the last known value but the [StateFlow] itself
+     * must be collected in order to trigger state changes.
+     */
+    val domainsStateFlow: StateFlow<DataState<DomainsData>>
+
+    /**
+     * Flow that represents all folders for the active user.
+     *
+     * Note that the [StateFlow.value] will return the last known value but the [StateFlow] itself
+     * must be collected in order to trigger state changes.
+     */
+    val foldersStateFlow: StateFlow<DataState<List<FolderView>>>
+
+    /**
+     * Flow that represents the current send data.
+     */
+    val sendDataStateFlow: StateFlow<DataState<SendData>>
+
+    /**
+     * Sync the vault data for the current user.
+     *
+     * Unlike [syncIfNecessary], this will always perform the requested sync and should only be
+     * utilized in cases where the user specifically requested the action.
+     */
+    fun sync(forced: Boolean = false)
+
+    /**
+     * Checks if conditions have been met to perform a sync request and, if so, syncs the vault
+     * data for the current user.
+     */
+    fun syncIfNecessary()
+
+    /**
+     * Syncs the vault data for the current user. This is an explicit request to sync and will
+     * return the result of the sync as a [SyncVaultDataResult].
+     */
+    suspend fun syncForResult(forced: Boolean = false): SyncVaultDataResult
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
@@ -1,24 +1,76 @@
 package com.x8bit.bitwarden.data.vault.manager
 
+import com.bitwarden.collections.CollectionView
 import com.bitwarden.core.InitOrgCryptoRequest
+import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.core.data.repository.util.combineDataStates
+import com.bitwarden.core.data.repository.util.map
+import com.bitwarden.core.data.repository.util.updateToPendingOrLoading
+import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.service.SyncService
+import com.bitwarden.network.util.isNoConnectionError
+import com.bitwarden.vault.DecryptCipherListResult
+import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.util.toUpdatedUserStateJson
+import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.error.SecurityStampMismatchException
+import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
+import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAndLoggedIn
+import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAndUnlocked
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
+import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
+import com.x8bit.bitwarden.data.vault.repository.model.SendData
+import com.x8bit.bitwarden.data.vault.repository.model.VaultData
+import com.x8bit.bitwarden.data.vault.repository.util.sortAlphabetically
+import com.x8bit.bitwarden.data.vault.repository.util.sortAlphabeticallyByTypeAndOrganization
+import com.x8bit.bitwarden.data.vault.repository.util.toDomainsData
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipherList
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCollectionList
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkFolderList
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkSendList
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import java.time.Clock
+import java.time.temporal.ChronoUnit
+
+/**
+ * A "stop timeout delay" in milliseconds used to let a shared coroutine continue to run for the
+ * specified period of time after it no longer has subscribers.
+ */
+private const val STOP_TIMEOUT_DELAY_MS: Long = 1000L
+private const val SYNC_IF_NECESSARY_DELAY_MIN: Long = 30L
 
 /**
  * Default implementation of [VaultSyncManager].
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class VaultSyncManagerImpl(
     private val syncService: SyncService,
     private val settingsDiskSource: SettingsDiskSource,
@@ -26,11 +78,186 @@ class VaultSyncManagerImpl(
     private val vaultDiskSource: VaultDiskSource,
     private val vaultSdkSource: VaultSdkSource,
     private val userLogoutManager: UserLogoutManager,
+    private val vaultLockManager: VaultLockManager,
     private val clock: Clock,
+    databaseSchemeManager: DatabaseSchemeManager,
+    pushManager: PushManager,
+    dispatcherManager: DispatcherManager,
 ) : VaultSyncManager {
+    private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
+    private val ioScope = CoroutineScope(dispatcherManager.io)
+
+    private var syncJob: Job = Job().apply { complete() }
+
+    private val activeUserId: String? get() = authDiskSource.userState?.activeUserId
+
+    private val mutableSendDataStateFlow = MutableStateFlow<DataState<SendData>>(DataState.Loading)
+
+    private val mutableDecryptCipherListResultFlow =
+        MutableStateFlow<DataState<DecryptCipherListResult>>(DataState.Loading)
+
+    private val mutableFoldersStateFlow =
+        MutableStateFlow<DataState<List<FolderView>>>(DataState.Loading)
+
+    private val mutableCollectionsStateFlow =
+        MutableStateFlow<DataState<List<CollectionView>>>(DataState.Loading)
+
+    private val mutableDomainsStateFlow =
+        MutableStateFlow<DataState<DomainsData>>(DataState.Loading)
+
+    override val decryptCipherListResultStateFlow: StateFlow<DataState<DecryptCipherListResult>>
+        get() = mutableDecryptCipherListResultFlow.asStateFlow()
+
+    override val domainsStateFlow: StateFlow<DataState<DomainsData>>
+        get() = mutableDomainsStateFlow.asStateFlow()
+
+    override val foldersStateFlow: StateFlow<DataState<List<FolderView>>>
+        get() = mutableFoldersStateFlow.asStateFlow()
+
+    override val collectionsStateFlow: StateFlow<DataState<List<CollectionView>>>
+        get() = mutableCollectionsStateFlow.asStateFlow()
+
+    override val sendDataStateFlow: StateFlow<DataState<SendData>>
+        get() = mutableSendDataStateFlow.asStateFlow()
+
+    override val vaultDataStateFlow: StateFlow<DataState<VaultData>> =
+        combine(
+            decryptCipherListResultStateFlow,
+            foldersStateFlow,
+            collectionsStateFlow,
+            sendDataStateFlow,
+        ) { ciphersDataState, foldersDataState, collectionsDataState, sendsDataState ->
+            combineDataStates(
+                ciphersDataState,
+                foldersDataState,
+                collectionsDataState,
+                sendsDataState,
+            ) { ciphersData, foldersData, collectionsData, sendsData ->
+                VaultData(
+                    decryptCipherListResult = ciphersData,
+                    collectionViewList = collectionsData,
+                    folderViewList = foldersData,
+                    sendViewList = sendsData.sendViewList,
+                )
+            }
+        }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = STOP_TIMEOUT_DELAY_MS),
+                initialValue = DataState.Loading,
+            )
+
+    init {
+        // Cancel any ongoing sync request and clear the vault data in memory every time
+        // the user switches or the vault is locked for the active user.
+        merge(
+            authDiskSource
+                .userSwitchingChangesFlow
+                .onEach {
+                    // DomainState is not part of the locked data but should still be cleared
+                    // when the user changes
+                    mutableDomainsStateFlow.update { DataState.Loading }
+                },
+            vaultLockManager
+                .vaultUnlockDataStateFlow
+                .filter { vaultUnlockDataList ->
+                    // Clear if the active user is not currently unlocking or unlocked
+                    vaultUnlockDataList.none { it.userId == activeUserId }
+                },
+        )
+            .onEach {
+                syncJob.cancel()
+                clearUnlockedData()
+            }
+            .launchIn(unconfinedScope)
+
+        // Setup ciphers MutableStateFlow
+        mutableDecryptCipherListResultFlow
+            .observeWhenSubscribedAndUnlocked(
+                userStateFlow = authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultLockManager.vaultUnlockDataStateFlow,
+            ) { activeUserId -> observeVaultDiskCiphersToCipherListView(userId = activeUserId) }
+            .launchIn(unconfinedScope)
+
+        // Setup domains MutableStateFlow
+        mutableDomainsStateFlow
+            .observeWhenSubscribedAndLoggedIn(
+                userStateFlow = authDiskSource.userStateFlow,
+            ) { activeUserId -> observeVaultDiskDomains(userId = activeUserId) }
+            .launchIn(unconfinedScope)
+        // Setup folders MutableStateFlow
+        mutableFoldersStateFlow
+            .observeWhenSubscribedAndUnlocked(
+                userStateFlow = authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultLockManager.vaultUnlockDataStateFlow,
+            ) { activeUserId -> observeVaultDiskFolders(userId = activeUserId) }
+            .launchIn(unconfinedScope)
+        // Setup collections MutableStateFlow
+        mutableCollectionsStateFlow
+            .observeWhenSubscribedAndUnlocked(
+                userStateFlow = authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultLockManager.vaultUnlockDataStateFlow,
+            ) { activeUserId -> observeVaultDiskCollections(userId = activeUserId) }
+            .launchIn(unconfinedScope)
+        // Setup sends MutableStateFlow
+        mutableSendDataStateFlow
+            .observeWhenSubscribedAndUnlocked(
+                userStateFlow = authDiskSource.userStateFlow,
+                vaultUnlockFlow = vaultLockManager.vaultUnlockDataStateFlow,
+            ) { activeUserId -> observeVaultDiskSends(userId = activeUserId) }
+            .launchIn(unconfinedScope)
+
+        pushManager
+            .fullSyncFlow
+            .onEach { sync(forced = false) }
+            .launchIn(unconfinedScope)
+
+        databaseSchemeManager
+            .databaseSchemeChangeFlow
+            .onEach { sync(forced = true) }
+            .launchIn(ioScope)
+    }
+
+    override fun sync(forced: Boolean) {
+        val userId = activeUserId ?: return
+        if (!syncJob.isCompleted) return
+        mutableDecryptCipherListResultFlow.updateToPendingOrLoading()
+        mutableDomainsStateFlow.updateToPendingOrLoading()
+        mutableFoldersStateFlow.updateToPendingOrLoading()
+        mutableCollectionsStateFlow.updateToPendingOrLoading()
+        mutableSendDataStateFlow.updateToPendingOrLoading()
+        syncJob = ioScope.launch { syncInternal(userId = userId, forced = forced) }
+    }
+
+    override fun syncIfNecessary() {
+        val userId = activeUserId ?: return
+        // Sync if we have never done so or the last time was at last 30 minutes ago.
+        val shouldSync = settingsDiskSource
+            .getLastSyncTime(userId = userId)
+            ?.let {
+                clock.instant().isAfter(it.plus(SYNC_IF_NECESSARY_DELAY_MIN, ChronoUnit.MINUTES))
+            }
+            ?: true
+        if (shouldSync) {
+            sync(forced = false)
+        }
+    }
+
+    override suspend fun syncForResult(forced: Boolean): SyncVaultDataResult {
+        val userId = activeUserId ?: return SyncVaultDataResult.Error(NoActiveUserException())
+        syncJob = ioScope
+            .async { syncInternal(userId = userId, forced = forced) }
+            .also {
+                return try {
+                    it.await()
+                } catch (e: CancellationException) {
+                    SyncVaultDataResult.Error(throwable = e)
+                }
+            }
+    }
 
     @Suppress("LongMethod")
-    override suspend fun sync(
+    private suspend fun syncInternal(
         userId: String,
         forced: Boolean,
     ): SyncVaultDataResult {
@@ -41,79 +268,74 @@ class VaultSyncManagerImpl(
                 ?.toEpochMilli()
             lastSyncInstant?.let { lastSyncTimeMs ->
                 // If the lasSyncState is null we just sync, no checks required.
-                syncService
-                    .getAccountRevisionDateMillis()
-                    .fold(
-                        onSuccess = { serverRevisionDate ->
-                            if (serverRevisionDate < lastSyncTimeMs) {
-                                // We can skip the actual sync call if there is no new data or
-                                // database scheme changes since the last sync.
-                                settingsDiskSource.storeLastSyncTime(
-                                    userId = userId,
-                                    lastSyncTime = clock.instant(),
-                                )
-                                vaultDiskSource.resyncVaultData(userId = userId)
-                                val itemsAvailable = vaultDiskSource
-                                    .getCiphersFlow(userId)
-                                    .firstOrNull()
-                                    ?.isNotEmpty() == true
-                                return SyncVaultDataResult.Success(itemsAvailable = itemsAvailable)
-                            }
-                        },
-                        onFailure = {
-                            return SyncVaultDataResult.Error(throwable = it)
-                        },
-                    )
+                syncService.getAccountRevisionDateMillis().fold(
+                    onSuccess = { serverRevisionDate ->
+                        if (serverRevisionDate < lastSyncTimeMs) {
+                            // We can skip the actual sync call if there is no new data or
+                            // database scheme changes since the last sync.
+                            settingsDiskSource.storeLastSyncTime(
+                                userId = userId,
+                                lastSyncTime = clock.instant(),
+                            )
+                            vaultDiskSource.resyncVaultData(userId = userId)
+                            val itemsAvailable = vaultDiskSource
+                                .getCiphersFlow(userId)
+                                .firstOrNull()
+                                ?.isNotEmpty() == true
+                            return SyncVaultDataResult.Success(itemsAvailable = itemsAvailable)
+                        }
+                    },
+                    onFailure = {
+                        updateVaultStateFlowsToError(throwable = it)
+                        return SyncVaultDataResult.Error(throwable = it)
+                    },
+                )
             }
         }
 
-        return syncService
-            .sync()
-            .fold(
-                onSuccess = { syncResponse ->
-                    val localSecurityStamp = authDiskSource.userState?.activeAccount?.profile?.stamp
-                    val serverSecurityStamp = syncResponse.profile.securityStamp
-
-                    // Log the user out if the stamps do not match
-                    localSecurityStamp?.let {
-                        if (serverSecurityStamp != localSecurityStamp) {
-                            userLogoutManager.softLogout(
-                                // Ensure UserLogoutManager is available
-                                userId = userId,
-                                reason = LogoutReason.SecurityStamp,
-                            )
-                            return SyncVaultDataResult.Error(
-                                throwable = SecurityStampMismatchException(),
-                            )
-                        }
+        return syncService.sync().fold(
+            onSuccess = { syncResponse ->
+                val localSecurityStamp = authDiskSource.userState?.activeAccount?.profile?.stamp
+                val serverSecurityStamp = syncResponse.profile.securityStamp
+                // Log the user out if the stamps do not match
+                localSecurityStamp?.let {
+                    if (serverSecurityStamp != localSecurityStamp) {
+                        // Ensure UserLogoutManager is available
+                        userLogoutManager.softLogout(
+                            userId = userId,
+                            reason = LogoutReason.SecurityStamp,
+                        )
+                        return SyncVaultDataResult.Error(SecurityStampMismatchException())
                     }
+                }
 
-                    // Update user information with additional information from sync response
-                    authDiskSource.userState = authDiskSource.userState?.toUpdatedUserStateJson(
-                        syncResponse = syncResponse,
-                    )
+                // Update user information with additional information from sync response
+                authDiskSource.userState = authDiskSource.userState?.toUpdatedUserStateJson(
+                    syncResponse = syncResponse,
+                )
 
-                    unlockVaultForOrganizationsIfNecessary(syncResponse = syncResponse)
-                    storeProfileData(syncResponse = syncResponse)
+                unlockVaultForOrganizationsIfNecessary(syncResponse = syncResponse)
+                storeProfileData(syncResponse = syncResponse)
 
-                    // Treat absent network policies as known empty data to
-                    // distinguish between unknown null data.
-                    authDiskSource.storePolicies(
-                        userId = userId,
-                        policies = syncResponse.policies.orEmpty(),
-                    )
-                    settingsDiskSource.storeLastSyncTime(
-                        userId = userId,
-                        lastSyncTime = clock.instant(),
-                    )
-                    vaultDiskSource.replaceVaultData(userId = userId, vault = syncResponse)
-                    val itemsAvailable = syncResponse.ciphers?.isNotEmpty() == true
-                    SyncVaultDataResult.Success(itemsAvailable = itemsAvailable)
-                },
-                onFailure = { throwable ->
-                    SyncVaultDataResult.Error(throwable = throwable)
-                },
-            )
+                // Treat absent network policies as known empty data to
+                // distinguish between unknown null data.
+                authDiskSource.storePolicies(
+                    userId = userId,
+                    policies = syncResponse.policies.orEmpty(),
+                )
+                settingsDiskSource.storeLastSyncTime(
+                    userId = userId,
+                    lastSyncTime = clock.instant(),
+                )
+                vaultDiskSource.replaceVaultData(userId = userId, vault = syncResponse)
+                val itemsAvailable = syncResponse.ciphers?.isNotEmpty() == true
+                SyncVaultDataResult.Success(itemsAvailable = itemsAvailable)
+            },
+            onFailure = {
+                updateVaultStateFlowsToError(throwable = it)
+                SyncVaultDataResult.Error(throwable = it)
+            },
+        )
     }
 
     private suspend fun unlockVaultForOrganizationsIfNecessary(
@@ -129,13 +351,10 @@ class VaultSyncManagerImpl(
 
         // There shouldn't be issues when unlocking directly from the syncResponse so we can ignore
         // the return type here.
-        vaultSdkSource
-            .initializeOrganizationCrypto(
-                userId = syncResponse.profile.id,
-                request = InitOrgCryptoRequest(
-                    organizationKeys = organizationKeys,
-                ),
-            )
+        vaultSdkSource.initializeOrganizationCrypto(
+            userId = syncResponse.profile.id,
+            request = InitOrgCryptoRequest(organizationKeys = organizationKeys),
+        )
     }
 
     private fun storeProfileData(
@@ -144,18 +363,9 @@ class VaultSyncManagerImpl(
         val profile = syncResponse.profile
         val userId = profile.id
         authDiskSource.apply {
-            storeUserKey(
-                userId = userId,
-                userKey = profile.key,
-            )
-            storePrivateKey(
-                userId = userId,
-                privateKey = profile.privateKey,
-            )
-            storeAccountKeys(
-                userId = userId,
-                accountKeys = profile.accountKeys,
-            )
+            storeUserKey(userId = userId, userKey = profile.key)
+            storePrivateKey(userId = userId, privateKey = profile.privateKey)
+            storeAccountKeys(userId = userId, accountKeys = profile.accountKeys)
             storeOrganizationKeys(
                 userId = userId,
                 organizationKeys = profile.organizations
@@ -167,10 +377,157 @@ class VaultSyncManagerImpl(
                 userId = userId,
                 shouldUseKeyConnector = profile.shouldUseKeyConnector,
             )
-            storeOrganizations(
-                userId = userId,
-                organizations = profile.organizations,
-            )
+            storeOrganizations(userId = userId, organizations = profile.organizations)
         }
     }
+
+    private fun observeVaultDiskCiphersToCipherListView(
+        userId: String,
+    ): Flow<DataState<DecryptCipherListResult>> =
+        vaultDiskSource
+            .getCiphersFlow(userId = userId)
+            .onStart { mutableDecryptCipherListResultFlow.updateToPendingOrLoading() }
+            .map {
+                vaultLockManager.waitUntilUnlocked(userId = userId)
+                vaultSdkSource
+                    .decryptCipherListWithFailures(
+                        userId = userId,
+                        cipherList = it.toEncryptedSdkCipherList(),
+                    )
+                    .fold(
+                        onSuccess = { result ->
+                            DataState.Loaded(
+                                result.copy(successes = result.successes.sortAlphabetically()),
+                            )
+                        },
+                        onFailure = { throwable -> DataState.Error(error = throwable) },
+                    )
+            }
+            .map {
+                it
+                    .takeUnless { settingsDiskSource.getLastSyncTime(userId = userId) == null }
+                    ?: DataState.Loading
+            }
+            .onEach { mutableDecryptCipherListResultFlow.value = it }
+
+    private fun observeVaultDiskDomains(
+        userId: String,
+    ): Flow<DataState<DomainsData>> =
+        vaultDiskSource
+            .getDomains(userId = userId)
+            .onStart { mutableDomainsStateFlow.updateToPendingOrLoading() }
+            .map { DataState.Loaded(data = it.toDomainsData()) }
+            .onEach { mutableDomainsStateFlow.value = it }
+
+    private fun observeVaultDiskFolders(
+        userId: String,
+    ): Flow<DataState<List<FolderView>>> =
+        vaultDiskSource
+            .getFolders(userId = userId)
+            .onStart { mutableFoldersStateFlow.updateToPendingOrLoading() }
+            .map {
+                vaultLockManager.waitUntilUnlocked(userId = userId)
+                vaultSdkSource
+                    .decryptFolderList(userId = userId, folderList = it.toEncryptedSdkFolderList())
+                    .fold(
+                        onSuccess = { folders -> DataState.Loaded(folders.sortAlphabetically()) },
+                        onFailure = { throwable -> DataState.Error(throwable) },
+                    )
+            }
+            .map { it.orLoadingIfNotSynced(userId = userId) }
+            .onEach { mutableFoldersStateFlow.value = it }
+
+    private fun observeVaultDiskCollections(
+        userId: String,
+    ): Flow<DataState<List<CollectionView>>> =
+        vaultDiskSource
+            .getCollections(userId = userId)
+            .onStart { mutableCollectionsStateFlow.updateToPendingOrLoading() }
+            .map {
+                vaultLockManager.waitUntilUnlocked(userId = userId)
+                vaultSdkSource
+                    .decryptCollectionList(
+                        userId = userId,
+                        collectionList = it.toEncryptedSdkCollectionList(),
+                    )
+                    .fold(
+                        onSuccess = { collections ->
+                            DataState.Loaded(
+                                data = collections.sortAlphabeticallyByTypeAndOrganization(
+                                    userOrganizations = authDiskSource
+                                        .getOrganizations(userId = userId)
+                                        .orEmpty(),
+                                ),
+                            )
+                        },
+                        onFailure = { throwable -> DataState.Error(error = throwable) },
+                    )
+            }
+            .map { it.orLoadingIfNotSynced(userId = userId) }
+            .onEach { mutableCollectionsStateFlow.value = it }
+
+    private fun observeVaultDiskSends(
+        userId: String,
+    ): Flow<DataState<SendData>> =
+        vaultDiskSource
+            .getSends(userId = userId)
+            .onStart { mutableSendDataStateFlow.updateToPendingOrLoading() }
+            .map {
+                vaultLockManager.waitUntilUnlocked(userId = userId)
+                vaultSdkSource
+                    .decryptSendList(userId = userId, sendList = it.toEncryptedSdkSendList())
+                    .fold(
+                        onSuccess = { sends -> DataState.Loaded(sends.sortAlphabetically()) },
+                        onFailure = { throwable -> DataState.Error(throwable) },
+                    )
+            }
+            .map { it.orLoadingIfNotSynced(userId = userId) }
+            .map { dataState -> dataState.map { SendData(sendViewList = it) } }
+            .onEach { mutableSendDataStateFlow.value = it }
+
+    private fun clearUnlockedData() {
+        mutableDecryptCipherListResultFlow.update { DataState.Loading }
+        mutableFoldersStateFlow.update { DataState.Loading }
+        mutableCollectionsStateFlow.update { DataState.Loading }
+        mutableSendDataStateFlow.update { DataState.Loading }
+    }
+
+    private fun updateVaultStateFlowsToError(throwable: Throwable) {
+        mutableDecryptCipherListResultFlow.update { currentState ->
+            throwable.toNetworkOrErrorState(data = currentState.data)
+        }
+        mutableDomainsStateFlow.update { currentState ->
+            throwable.toNetworkOrErrorState(data = currentState.data)
+        }
+        mutableFoldersStateFlow.update { currentState ->
+            throwable.toNetworkOrErrorState(data = currentState.data)
+        }
+        mutableCollectionsStateFlow.update { currentState ->
+            throwable.toNetworkOrErrorState(data = currentState.data)
+        }
+        mutableSendDataStateFlow.update { currentState ->
+            throwable.toNetworkOrErrorState(data = currentState.data)
+        }
+    }
+
+    /**
+     * Returns the given [DataState] as-is, or [DataState.Loading] if vault data for the given
+     * [userId] has not synced. This can be used to distinguish between empty data in the database
+     * because we are in the process of syncing from legitimately having no vault data.
+     */
+    private fun <T> DataState<List<T>>.orLoadingIfNotSynced(
+        userId: String,
+    ): DataState<List<T>> =
+        this
+            .takeUnless { settingsDiskSource.getLastSyncTime(userId = userId) == null }
+            ?: DataState.Loading
 }
+
+private fun <T> Throwable.toNetworkOrErrorState(
+    data: T?,
+): DataState<T> =
+    if (isNoConnectionError()) {
+        DataState.NoNetwork(data = data)
+    } else {
+        DataState.Error(error = this, data = data)
+    }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
@@ -14,6 +14,7 @@ import com.x8bit.bitwarden.data.auth.manager.TrustedDeviceManager
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.AppStateManager
+import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
@@ -177,7 +178,11 @@ object VaultManagerModule {
         vaultDiskSource: VaultDiskSource,
         vaultSdkSource: VaultSdkSource,
         userLogoutManager: UserLogoutManager,
+        vaultLockManager: VaultLockManager,
         clock: Clock,
+        databaseSchemeManager: DatabaseSchemeManager,
+        pushManager: PushManager,
+        dispatcherManager: DispatcherManager,
     ): VaultSyncManager = VaultSyncManagerImpl(
         syncService = syncService,
         settingsDiskSource = settingsDiskSource,
@@ -185,7 +190,11 @@ object VaultManagerModule {
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
         userLogoutManager = userLogoutManager,
+        vaultLockManager = vaultLockManager,
         clock = clock,
+        databaseSchemeManager = databaseSchemeManager,
+        pushManager = pushManager,
+        dispatcherManager = dispatcherManager,
     )
 
     @Provides
@@ -193,8 +202,10 @@ object VaultManagerModule {
     fun provideCredentialExchangeImportManager(
         vaultSdkSource: VaultSdkSource,
         ciphersService: CiphersService,
+        vaultSyncManager: VaultSyncManager,
     ): CredentialExchangeImportManager = CredentialExchangeImportManagerImpl(
         vaultSdkSource = vaultSdkSource,
         ciphersService = ciphersService,
+        vaultSyncManager = vaultSyncManager,
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/model/ImportCxfPayloadResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/model/ImportCxfPayloadResult.kt
@@ -16,6 +16,11 @@ sealed class ImportCxfPayloadResult {
     data object NoItems : ImportCxfPayloadResult()
 
     /**
+     * The sync process has failed after importing the CXF payload.
+     */
+    data class SyncFailed(val error: Throwable) : ImportCxfPayloadResult()
+
+    /**
      * There was an error importing the vault data.
      *
      * @param error The error that occurred during import.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.x8bit.bitwarden.data.vault.repository
 
-import com.bitwarden.collections.CollectionView
 import com.bitwarden.core.DateTime
 import com.bitwarden.core.InitUserCryptoMethod
 import com.bitwarden.core.data.repository.model.DataState
@@ -8,31 +7,22 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.repository.util.combineDataStates
 import com.bitwarden.core.data.repository.util.map
 import com.bitwarden.core.data.repository.util.mapNullable
-import com.bitwarden.core.data.repository.util.updateToPendingOrLoading
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.exporters.ExportFormat
 import com.bitwarden.fido.Fido2CredentialAutofillView
-import com.bitwarden.network.util.isNoConnectionError
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.send.SendView
 import com.bitwarden.vault.CipherListView
 import com.bitwarden.vault.CipherListViewType
 import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
-import com.bitwarden.vault.DecryptCipherListResult
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
-import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
 import com.x8bit.bitwarden.data.autofill.util.login
-import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.error.MissingPropertyException
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
-import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
-import com.x8bit.bitwarden.data.platform.manager.PushManager
-import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAndLoggedIn
-import com.x8bit.bitwarden.data.platform.repository.util.observeWhenSubscribedAndUnlocked
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.manager.CipherManager
@@ -44,247 +34,68 @@ import com.x8bit.bitwarden.data.vault.manager.VaultLockManager
 import com.x8bit.bitwarden.data.vault.manager.VaultSyncManager
 import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
 import com.x8bit.bitwarden.data.vault.manager.model.ImportCxfPayloadResult
-import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.manager.model.VerificationCodeItem
-import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
 import com.x8bit.bitwarden.data.vault.repository.model.ExportVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.ImportCredentialsResult
-import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.data.vault.repository.model.TotpCodeResult
-import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
-import com.x8bit.bitwarden.data.vault.repository.util.sortAlphabetically
-import com.x8bit.bitwarden.data.vault.repository.util.sortAlphabeticallyByTypeAndOrganization
-import com.x8bit.bitwarden.data.vault.repository.util.toDomainsData
 import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipher
-import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipherList
-import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCollectionList
 import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkFolder
-import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkFolderList
-import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkSendList
 import com.x8bit.bitwarden.data.vault.repository.util.toSdkAccount
 import com.x8bit.bitwarden.ui.vault.feature.vault.model.VaultFilterType
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.toFilteredList
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.security.GeneralSecurityException
-import java.time.Clock
-import java.time.temporal.ChronoUnit
 import javax.crypto.Cipher
-
-/**
- * A "stop timeout delay" in milliseconds used to let a shared coroutine continue to run for the
- * specified period of time after it no longer has subscribers.
- */
-private const val STOP_TIMEOUT_DELAY_MS: Long = 1000L
 
 /**
  * Default implementation of [VaultRepository].
  */
-@Suppress("TooManyFunctions", "LongParameterList", "LargeClass")
+@Suppress("TooManyFunctions", "LongParameterList")
 class VaultRepositoryImpl(
     private val vaultDiskSource: VaultDiskSource,
     private val vaultSdkSource: VaultSdkSource,
     private val authDiskSource: AuthDiskSource,
-    private val settingsDiskSource: SettingsDiskSource,
     private val cipherManager: CipherManager,
     private val folderManager: FolderManager,
     private val sendManager: SendManager,
     private val vaultLockManager: VaultLockManager,
     private val totpCodeManager: TotpCodeManager,
-    databaseSchemeManager: DatabaseSchemeManager,
-    pushManager: PushManager,
-    private val clock: Clock,
-    dispatcherManager: DispatcherManager,
     private val vaultSyncManager: VaultSyncManager,
     private val credentialExchangeImportManager: CredentialExchangeImportManager,
+    dispatcherManager: DispatcherManager,
 ) : VaultRepository,
     CipherManager by cipherManager,
     FolderManager by folderManager,
     SendManager by sendManager,
-    VaultLockManager by vaultLockManager {
+    VaultLockManager by vaultLockManager,
+    VaultSyncManager by vaultSyncManager {
 
     private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
     private val ioScope = CoroutineScope(dispatcherManager.io)
-
-    private var syncJob: Job = Job().apply { complete() }
 
     private val activeUserId: String? get() = authDiskSource.userState?.activeUserId
 
     private val mutableTotpCodeResultFlow = bufferedMutableSharedFlow<TotpCodeResult>()
 
-    private val mutableSendDataStateFlow = MutableStateFlow<DataState<SendData>>(DataState.Loading)
-
-    private val mutableDecryptCipherListResultFlow =
-        MutableStateFlow<DataState<DecryptCipherListResult>>(DataState.Loading)
-
-    private val mutableFoldersStateFlow =
-        MutableStateFlow<DataState<List<FolderView>>>(DataState.Loading)
-
-    private val mutableCollectionsStateFlow =
-        MutableStateFlow<DataState<List<CollectionView>>>(DataState.Loading)
-
-    private val mutableDomainsStateFlow =
-        MutableStateFlow<DataState<DomainsData>>(DataState.Loading)
-
     override var vaultFilterType: VaultFilterType = VaultFilterType.AllVaults
-
-    override val vaultDataStateFlow: StateFlow<DataState<VaultData>> =
-        combine(
-            decryptCipherListResultStateFlow,
-            foldersStateFlow,
-            collectionsStateFlow,
-            sendDataStateFlow,
-        ) { ciphersDataState, foldersDataState, collectionsDataState, sendsDataState ->
-            combineDataStates(
-                ciphersDataState,
-                foldersDataState,
-                collectionsDataState,
-                sendsDataState,
-            ) { ciphersData, foldersData, collectionsData, sendsData ->
-                VaultData(
-                    decryptCipherListResult = ciphersData,
-                    collectionViewList = collectionsData,
-                    folderViewList = foldersData,
-                    sendViewList = sendsData.sendViewList,
-                )
-            }
-        }
-            .stateIn(
-                scope = unconfinedScope,
-                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = STOP_TIMEOUT_DELAY_MS),
-                initialValue = DataState.Loading,
-            )
 
     override val totpCodeFlow: Flow<TotpCodeResult>
         get() = mutableTotpCodeResultFlow.asSharedFlow()
-
-    override val decryptCipherListResultStateFlow: StateFlow<DataState<DecryptCipherListResult>>
-        get() = mutableDecryptCipherListResultFlow.asStateFlow()
-
-    override val domainsStateFlow: StateFlow<DataState<DomainsData>>
-        get() = mutableDomainsStateFlow.asStateFlow()
-
-    override val foldersStateFlow: StateFlow<DataState<List<FolderView>>>
-        get() = mutableFoldersStateFlow.asStateFlow()
-
-    override val collectionsStateFlow: StateFlow<DataState<List<CollectionView>>>
-        get() = mutableCollectionsStateFlow.asStateFlow()
-
-    override val sendDataStateFlow: StateFlow<DataState<SendData>>
-        get() = mutableSendDataStateFlow.asStateFlow()
-
-    init {
-        // Cancel any ongoing sync request and clear the vault data in memory every time
-        // the user switches or the vault is locked for the active user.
-        merge(
-            authDiskSource
-                .userSwitchingChangesFlow
-                .onEach {
-                    // DomainState is not part of the locked data but should still be cleared
-                    // when the user changes
-                    mutableDomainsStateFlow.update { DataState.Loading }
-                },
-            vaultLockManager
-                .vaultUnlockDataStateFlow
-                .filter { vaultUnlockDataList ->
-                    // Clear if the active user is not currently unlocking or unlocked
-                    vaultUnlockDataList.none { it.userId == activeUserId }
-                },
-        )
-            .onEach {
-                syncJob.cancel()
-                clearUnlockedData()
-            }
-            .launchIn(unconfinedScope)
-
-        // Setup ciphers MutableStateFlow
-        mutableDecryptCipherListResultFlow
-            .observeWhenSubscribedAndUnlocked(
-                userStateFlow = authDiskSource.userStateFlow,
-                vaultUnlockFlow = vaultUnlockDataStateFlow,
-            ) { activeUserId ->
-                observeVaultDiskCiphersToCipherListView(activeUserId)
-            }
-            .launchIn(unconfinedScope)
-
-        // Setup domains MutableStateFlow
-        mutableDomainsStateFlow
-            .observeWhenSubscribedAndLoggedIn(
-                userStateFlow = authDiskSource.userStateFlow,
-            ) { activeUserId ->
-                observeVaultDiskDomains(activeUserId)
-            }
-            .launchIn(unconfinedScope)
-        // Setup folders MutableStateFlow
-        mutableFoldersStateFlow
-            .observeWhenSubscribedAndUnlocked(
-                userStateFlow = authDiskSource.userStateFlow,
-                vaultUnlockFlow = vaultUnlockDataStateFlow,
-            ) { activeUserId ->
-                observeVaultDiskFolders(activeUserId)
-            }
-            .launchIn(unconfinedScope)
-        // Setup collections MutableStateFlow
-        mutableCollectionsStateFlow
-            .observeWhenSubscribedAndUnlocked(
-                userStateFlow = authDiskSource.userStateFlow,
-                vaultUnlockFlow = vaultUnlockDataStateFlow,
-            ) { activeUserId ->
-                observeVaultDiskCollections(activeUserId)
-            }
-            .launchIn(unconfinedScope)
-        // Setup sends MutableStateFlow
-        mutableSendDataStateFlow
-            .observeWhenSubscribedAndUnlocked(
-                authDiskSource.userStateFlow,
-                vaultUnlockFlow = vaultUnlockDataStateFlow,
-            ) { activeUserId ->
-                observeVaultDiskSends(activeUserId)
-            }
-            .launchIn(unconfinedScope)
-
-        pushManager
-            .fullSyncFlow
-            .onEach { sync(forced = false) }
-            .launchIn(unconfinedScope)
-
-        databaseSchemeManager
-            .databaseSchemeChangeFlow
-            .onEach { sync(forced = true) }
-            .launchIn(ioScope)
-    }
-
-    private fun clearUnlockedData() {
-        mutableDecryptCipherListResultFlow.update { DataState.Loading }
-        mutableFoldersStateFlow.update { DataState.Loading }
-        mutableCollectionsStateFlow.update { DataState.Loading }
-        mutableSendDataStateFlow.update { DataState.Loading }
-    }
 
     override fun deleteVaultData(userId: String) {
         ioScope.launch {
@@ -292,48 +103,9 @@ class VaultRepositoryImpl(
         }
     }
 
-    override fun sync(forced: Boolean) {
-        val userId = activeUserId ?: return
-        if (!syncJob.isCompleted) return
-        mutableDecryptCipherListResultFlow.updateToPendingOrLoading()
-        mutableDomainsStateFlow.updateToPendingOrLoading()
-        mutableFoldersStateFlow.updateToPendingOrLoading()
-        mutableCollectionsStateFlow.updateToPendingOrLoading()
-        mutableSendDataStateFlow.updateToPendingOrLoading()
-        syncJob = ioScope.launch { syncInternal(userId = userId, forced = forced) }
-    }
-
-    @Suppress("MagicNumber")
-    override fun syncIfNecessary() {
-        val userId = activeUserId ?: return
-        val currentInstant = clock.instant()
-        val lastSyncInstant = settingsDiskSource.getLastSyncTime(userId = userId)
-
-        // Sync if we have never done so, the last time was at last 30 minutes ago, or the database
-        // scheme changed since the last sync.
-        if (lastSyncInstant == null ||
-            currentInstant.isAfter(lastSyncInstant.plus(30, ChronoUnit.MINUTES))
-        ) {
-            sync(forced = false)
-        }
-    }
-
-    override suspend fun syncForResult(): SyncVaultDataResult {
-        val userId = activeUserId
-            ?: return SyncVaultDataResult.Error(throwable = NoActiveUserException())
-        syncJob = ioScope
-            .async { syncInternal(userId = userId, forced = false) }
-            .also {
-                return try {
-                    it.await()
-                } catch (e: CancellationException) {
-                    SyncVaultDataResult.Error(throwable = e)
-                }
-            }
-    }
-
     override fun getVaultItemStateFlow(itemId: String): StateFlow<DataState<CipherView?>> =
-        vaultDataStateFlow
+        vaultSyncManager
+            .vaultDataStateFlow
             .map { dataState ->
                 dataState.map { vaultData ->
                     val getCipherResult = vaultData
@@ -354,7 +126,8 @@ class VaultRepositoryImpl(
             )
 
     override fun getVaultListItemStateFlow(itemId: String): StateFlow<DataState<CipherListView?>> =
-        vaultDataStateFlow
+        vaultSyncManager
+            .vaultDataStateFlow
             .map { dataState ->
                 dataState.map { vaultData ->
                     vaultData
@@ -370,7 +143,8 @@ class VaultRepositoryImpl(
             )
 
     override fun getVaultFolderStateFlow(folderId: String): StateFlow<DataState<FolderView?>> =
-        vaultDataStateFlow
+        vaultSyncManager
+            .vaultDataStateFlow
             .map { dataState ->
                 dataState.map { vaultData ->
                     vaultData
@@ -385,7 +159,8 @@ class VaultRepositoryImpl(
             )
 
     override fun getSendStateFlow(sendId: String): StateFlow<DataState<SendView?>> =
-        sendDataStateFlow
+        vaultSyncManager
+            .sendDataStateFlow
             .map { dataState ->
                 dataState.map { sendData ->
                     sendData.sendViewList.find { it.id == sendId }
@@ -402,7 +177,8 @@ class VaultRepositoryImpl(
         val userId = activeUserId ?: return MutableStateFlow(
             DataState.Error(IllegalStateException("No active user"), null),
         )
-        return vaultDataStateFlow
+        return vaultSyncManager
+            .vaultDataStateFlow
             .map { dataState ->
                 dataState.map { vaultData ->
                     vaultData
@@ -446,7 +222,7 @@ class VaultRepositoryImpl(
         val userId = activeUserId ?: return MutableStateFlow(
             DataState.Error(IllegalStateException("No active user"), null),
         )
-        return getVaultListItemStateFlow(cipherId)
+        return this.getVaultListItemStateFlow(cipherId)
             .flatMapLatest { cipherDataState ->
                 cipherDataState
                     .data
@@ -489,7 +265,7 @@ class VaultRepositoryImpl(
     override suspend fun unlockVaultWithDecryptedUserKey(
         userId: String,
         decryptedUserKey: String,
-    ): VaultUnlockResult = unlockVaultForUser(
+    ): VaultUnlockResult = this.unlockVaultForUser(
         userId = userId,
         initUserCryptoMethod = InitUserCryptoMethod.DecryptedKey(
             decryptedUserKey = decryptedUserKey,
@@ -564,13 +340,14 @@ class VaultRepositoryImpl(
             ?: return VaultUnlockResult.InvalidStateError(
                 error = MissingPropertyException("User key"),
             )
-        return unlockVaultForUser(
-            userId = userId,
-            initUserCryptoMethod = InitUserCryptoMethod.Password(
-                password = masterPassword,
-                userKey = userKey,
-            ),
-        )
+        return this
+            .unlockVaultForUser(
+                userId = userId,
+                initUserCryptoMethod = InitUserCryptoMethod.Password(
+                    password = masterPassword,
+                    userKey = userKey,
+                ),
+            )
             .also {
                 if (it is VaultUnlockResult.Success) {
                     deriveTemporaryPinProtectedUserKeyIfNecessary(userId = userId)
@@ -587,7 +364,7 @@ class VaultRepositoryImpl(
             ?: return VaultUnlockResult.InvalidStateError(
                 error = MissingPropertyException("Pin protected key"),
             )
-        return unlockVaultForUser(
+        return this.unlockVaultForUser(
             userId = userId,
             initUserCryptoMethod = InitUserCryptoMethod.Pin(
                 pin = pin,
@@ -682,16 +459,12 @@ class VaultRepositoryImpl(
                 ImportCredentialsResult.NoItems
             }
 
-            is ImportCxfPayloadResult.Success -> {
-                when (val syncResult = syncInternal(userId = userId, forced = true)) {
-                    is SyncVaultDataResult.Error -> {
-                        ImportCredentialsResult.SyncFailed(error = syncResult.throwable)
-                    }
+            is ImportCxfPayloadResult.SyncFailed -> {
+                ImportCredentialsResult.SyncFailed(error = importResult.error)
+            }
 
-                    is SyncVaultDataResult.Success -> {
-                        ImportCredentialsResult.Success(itemCount = importResult.itemCount)
-                    }
-                }
+            is ImportCxfPayloadResult.Success -> {
+                ImportCredentialsResult.Success(itemCount = importResult.itemCount)
             }
         }
     }
@@ -763,7 +536,7 @@ class VaultRepositoryImpl(
         val securityState = accountKeys?.securityState?.securityState
         val organizationKeys = authDiskSource
             .getOrganizationKeys(userId = userId)
-        return unlockVault(
+        return vaultLockManager.unlockVault(
             userId = userId,
             email = account.profile.email,
             kdf = account.profile.toSdkParams(),
@@ -774,182 +547,4 @@ class VaultRepositoryImpl(
             organizationKeys = organizationKeys,
         )
     }
-
-    private fun observeVaultDiskCiphersToCipherListView(
-        userId: String,
-    ): Flow<DataState<DecryptCipherListResult>> =
-        vaultDiskSource
-            .getCiphersFlow(userId = userId)
-            .onStart { mutableDecryptCipherListResultFlow.updateToPendingOrLoading() }
-            .map {
-                waitUntilUnlocked(userId = userId)
-                vaultSdkSource
-                    .decryptCipherListWithFailures(
-                        userId = userId,
-                        cipherList = it.toEncryptedSdkCipherList(),
-                    )
-                    .fold(
-                        onSuccess = { result ->
-                            DataState.Loaded(
-                                result.copy(successes = result.successes.sortAlphabetically()),
-                            )
-                        },
-                        onFailure = { throwable -> DataState.Error(throwable) },
-                    )
-            }
-            .map {
-                it
-                    .takeUnless { settingsDiskSource.getLastSyncTime(userId = userId) == null }
-                    ?: DataState.Loading
-            }
-            .onEach { mutableDecryptCipherListResultFlow.value = it }
-
-    private fun observeVaultDiskDomains(
-        userId: String,
-    ): Flow<DataState<DomainsData>> =
-        vaultDiskSource
-            .getDomains(userId = userId)
-            .onStart { mutableDomainsStateFlow.updateToPendingOrLoading() }
-            .map {
-                DataState.Loaded(
-                    data = it.toDomainsData(),
-                )
-            }
-            .onEach { mutableDomainsStateFlow.value = it }
-
-    private fun observeVaultDiskFolders(
-        userId: String,
-    ): Flow<DataState<List<FolderView>>> =
-        vaultDiskSource
-            .getFolders(userId = userId)
-            .onStart { mutableFoldersStateFlow.updateToPendingOrLoading() }
-            .map {
-                waitUntilUnlocked(userId = userId)
-                vaultSdkSource
-                    .decryptFolderList(
-                        userId = userId,
-                        folderList = it.toEncryptedSdkFolderList(),
-                    )
-                    .fold(
-                        onSuccess = { folders -> DataState.Loaded(folders.sortAlphabetically()) },
-                        onFailure = { throwable -> DataState.Error(throwable) },
-                    )
-            }
-            .map { it.orLoadingIfNotSynced(userId = userId) }
-            .onEach { mutableFoldersStateFlow.value = it }
-
-    private fun observeVaultDiskCollections(
-        userId: String,
-    ): Flow<DataState<List<CollectionView>>> =
-        vaultDiskSource
-            .getCollections(userId = userId)
-            .onStart { mutableCollectionsStateFlow.updateToPendingOrLoading() }
-            .map {
-                waitUntilUnlocked(userId = userId)
-                vaultSdkSource
-                    .decryptCollectionList(
-                        userId = userId,
-                        collectionList = it.toEncryptedSdkCollectionList(),
-                    )
-                    .fold(
-                        onSuccess = { collections ->
-                            DataState.Loaded(
-                                collections.sortAlphabeticallyByTypeAndOrganization(
-                                    userOrganizations = authDiskSource
-                                        .getOrganizations(userId = userId)
-                                        .orEmpty(),
-                                ),
-                            )
-                        },
-                        onFailure = { throwable -> DataState.Error(throwable) },
-                    )
-            }
-            .map { it.orLoadingIfNotSynced(userId = userId) }
-            .onEach { mutableCollectionsStateFlow.value = it }
-
-    private fun observeVaultDiskSends(
-        userId: String,
-    ): Flow<DataState<SendData>> =
-        vaultDiskSource
-            .getSends(userId = userId)
-            .onStart { mutableSendDataStateFlow.updateToPendingOrLoading() }
-            .map {
-                waitUntilUnlocked(userId = userId)
-                vaultSdkSource
-                    .decryptSendList(
-                        userId = userId,
-                        sendList = it.toEncryptedSdkSendList(),
-                    )
-                    .fold(
-                        onSuccess = { sends -> DataState.Loaded(sends.sortAlphabetically()) },
-                        onFailure = { throwable -> DataState.Error(throwable) },
-                    )
-            }
-            .map { it.orLoadingIfNotSynced(userId = userId) }
-            .map { dataState -> dataState.map { SendData(it) } }
-            .onEach { mutableSendDataStateFlow.value = it }
-
-    private fun updateVaultStateFlowsToError(throwable: Throwable) {
-        mutableDecryptCipherListResultFlow.update { currentState ->
-            throwable.toNetworkOrErrorState(
-                data = currentState.data,
-            )
-        }
-        mutableDomainsStateFlow.update { currentState ->
-            throwable.toNetworkOrErrorState(
-                data = currentState.data,
-            )
-        }
-        mutableFoldersStateFlow.update { currentState ->
-            throwable.toNetworkOrErrorState(
-                data = currentState.data,
-            )
-        }
-        mutableCollectionsStateFlow.update { currentState ->
-            throwable.toNetworkOrErrorState(
-                data = currentState.data,
-            )
-        }
-        mutableSendDataStateFlow.update { currentState ->
-            throwable.toNetworkOrErrorState(
-                data = currentState.data,
-            )
-        }
-    }
-
-    /**
-     * Returns the given [DataState] as-is, or [DataState.Loading] if vault data for the given
-     * [userId] has not synced. This can be used to distinguish between empty data in the database
-     * because we are in the process of syncing from legitimately having no vault data.
-     */
-    private fun <T> DataState<List<T>>.orLoadingIfNotSynced(
-        userId: String,
-    ): DataState<List<T>> =
-        this
-            .takeUnless {
-                settingsDiskSource.getLastSyncTime(userId = userId) == null
-            }
-            ?: DataState.Loading
-
-    private suspend fun syncInternal(
-        userId: String,
-        forced: Boolean,
-    ): SyncVaultDataResult =
-        vaultSyncManager
-            .sync(userId = userId, forced = forced)
-            .also { result ->
-                if (result is SyncVaultDataResult.Error) {
-                    updateVaultStateFlowsToError(throwable = result.throwable)
-                }
-            }
 }
-
-private fun <T> Throwable.toNetworkOrErrorState(data: T?): DataState<T> =
-    if (isNoConnectionError()) {
-        DataState.NoNetwork(data = data)
-    } else {
-        DataState.Error(
-            error = this,
-            data = data,
-        )
-    }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
@@ -2,9 +2,6 @@ package com.x8bit.bitwarden.data.vault.repository.di
 
 import com.bitwarden.data.manager.DispatcherManager
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
-import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
-import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
-import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.manager.CipherManager
@@ -20,7 +17,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -36,32 +32,24 @@ object VaultRepositoryModule {
         vaultDiskSource: VaultDiskSource,
         vaultSdkSource: VaultSdkSource,
         authDiskSource: AuthDiskSource,
-        settingsDiskSource: SettingsDiskSource,
         cipherManager: CipherManager,
         folderManager: FolderManager,
         sendManager: SendManager,
         vaultLockManager: VaultLockManager,
         dispatcherManager: DispatcherManager,
         totpCodeManager: TotpCodeManager,
-        pushManager: PushManager,
-        databaseSchemeManager: DatabaseSchemeManager,
-        clock: Clock,
         vaultSyncManager: VaultSyncManager,
         credentialExchangeImportManager: CredentialExchangeImportManager,
     ): VaultRepository = VaultRepositoryImpl(
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
         authDiskSource = authDiskSource,
-        settingsDiskSource = settingsDiskSource,
         cipherManager = cipherManager,
         folderManager = folderManager,
         sendManager = sendManager,
         vaultLockManager = vaultLockManager,
         dispatcherManager = dispatcherManager,
         totpCodeManager = totpCodeManager,
-        pushManager = pushManager,
-        databaseSchemeManager = databaseSchemeManager,
-        clock = clock,
         vaultSyncManager = vaultSyncManager,
         credentialExchangeImportManager = credentialExchangeImportManager,
     )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerTest.kt
@@ -1,16 +1,29 @@
 package com.x8bit.bitwarden.data.vault.manager
 
+import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.bitwarden.collections.CollectionView
 import com.bitwarden.core.InitOrgCryptoRequest
+import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
+import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.createMockCipher
+import com.bitwarden.network.model.createMockCollection
+import com.bitwarden.network.model.createMockDomains
+import com.bitwarden.network.model.createMockFolder
 import com.bitwarden.network.model.createMockOrganization
 import com.bitwarden.network.model.createMockOrganizationKeys
 import com.bitwarden.network.model.createMockPolicy
 import com.bitwarden.network.model.createMockProfile
+import com.bitwarden.network.model.createMockSend
 import com.bitwarden.network.model.createMockSyncResponse
 import com.bitwarden.network.service.SyncService
+import com.bitwarden.send.SendView
+import com.bitwarden.vault.DecryptCipherListResult
+import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
@@ -18,26 +31,59 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
 import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.error.MissingPropertyException
+import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
+import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
+import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.InitializeCryptoResult
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCollectionView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDecryptCipherListResult
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFolderView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCipher
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCollection
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFolder
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkSend
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSendView
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
+import com.x8bit.bitwarden.data.vault.repository.model.DomainsData
+import com.x8bit.bitwarden.data.vault.repository.model.SendData
+import com.x8bit.bitwarden.data.vault.repository.model.VaultData
+import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
+import com.x8bit.bitwarden.data.vault.repository.model.createMockDomainsData
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipherList
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCollectionList
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkFolderList
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkSendList
+import io.mockk.awaits
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.runs
+import io.mockk.unmockkConstructor
+import io.mockk.verify
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.net.UnknownHostException
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
+@Suppress("LargeClass")
 class VaultSyncManagerTest {
 
     private val clock: Clock = Clock.fixed(
@@ -63,25 +109,576 @@ class VaultSyncManagerTest {
     private val vaultSdkSource: VaultSdkSource = mockk {
         every { clearCrypto(userId = any()) } just runs
     }
+    private val mutableVaultStateFlow = MutableStateFlow<List<VaultUnlockData>>(emptyList())
+    private val mutableUnlockedUserIdsStateFlow = MutableStateFlow<Set<String>>(emptySet())
+    private val vaultLockManager: VaultLockManager = mockk {
+        every { vaultUnlockDataStateFlow } returns mutableVaultStateFlow
+        every { isVaultUnlocked(userId = any()) } answers { call ->
+            call.invocation.args.first() in mutableUnlockedUserIdsStateFlow.value
+        }
+        every { isVaultUnlocking(userId = any()) } returns false
+        every { lockVault(userId = any(), isUserInitiated = any()) } just runs
+        every { lockVaultForCurrentUser(isUserInitiated = any()) } just runs
+        coEvery { waitUntilUnlocked(userId = any()) } coAnswers { call ->
+            mutableUnlockedUserIdsStateFlow.first { call.invocation.args.first() in it }
+        }
+    }
     private val userLogoutManager: UserLogoutManager = mockk {
         every { softLogout(any(), any()) } just runs
     }
-    private val vaultSyncManager = VaultSyncManagerImpl(
+    private val mutableFullSyncFlow = bufferedMutableSharedFlow<Unit>()
+    private val pushManager: PushManager = mockk {
+        every { fullSyncFlow } returns mutableFullSyncFlow
+    }
+    private val mutableDatabaseSchemeChangeFlow = bufferedMutableSharedFlow<Unit>()
+    private val databaseSchemeManager: DatabaseSchemeManager = mockk {
+        every { databaseSchemeChangeFlow } returns mutableDatabaseSchemeChangeFlow
+    }
+
+    private val vaultSyncManager: VaultSyncManager = VaultSyncManagerImpl(
         syncService = syncService,
         settingsDiskSource = settingsDiskSource,
         authDiskSource = fakeAuthDiskSource,
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
         userLogoutManager = userLogoutManager,
+        vaultLockManager = vaultLockManager,
         clock = clock,
+        databaseSchemeManager = databaseSchemeManager,
+        pushManager = pushManager,
+        dispatcherManager = FakeDispatcherManager(),
     )
 
+    @BeforeEach
+    fun setup() {
+        mockkConstructor(NoActiveUserException::class, MissingPropertyException::class)
+        every {
+            anyConstructed<NoActiveUserException>() == any<NoActiveUserException>()
+        } returns true
+        every {
+            anyConstructed<MissingPropertyException>() == any<MissingPropertyException>()
+        } returns true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkConstructor(NoActiveUserException::class, MissingPropertyException::class)
+    }
+
     @Test
-    fun `sync with forced should skip checks and call the syncService sync`() = runTest {
+    fun `userSwitchingChangesFlow should cancel any pending sync call`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        coEvery { syncService.sync() } just awaits
+
+        vaultSyncManager.sync()
+        vaultSyncManager.sync()
+        coVerify(exactly = 1) {
+            // Despite being called twice, we only allow 1 sync
+            syncService.sync()
+        }
+
+        fakeAuthDiskSource.userState = UserStateJson(
+            activeUserId = "mockId-2",
+            accounts = mapOf("mockId-2" to mockk()),
+        )
+        vaultSyncManager.sync()
+        coVerify(exactly = 2) {
+            // A second sync should have happened now since it was cancelled by the userState change
+            syncService.getAccountRevisionDateMillis()
+            syncService.sync()
+        }
+    }
+
+    @Test
+    fun `userSwitchingChangesFlow should clear unlocked data`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val userId = "mockId-1"
+        coEvery {
+            vaultSdkSource.decryptCipherListWithFailures(
+                userId = userId,
+                cipherList = listOf(createMockSdkCipher(number = 1, clock = clock)),
+            )
+        } returns createMockDecryptCipherListResult(number = 1).asSuccess()
+        coEvery {
+            vaultSdkSource.decryptFolderList(
+                userId = userId,
+                folderList = listOf(createMockSdkFolder(number = 1)),
+            )
+        } returns listOf(createMockFolderView(number = 1)).asSuccess()
+        coEvery {
+            vaultSdkSource.decryptCollectionList(
+                userId = userId,
+                collectionList = listOf(createMockSdkCollection(number = 1)),
+            )
+        } returns listOf(createMockCollectionView(number = 1)).asSuccess()
+        coEvery {
+            vaultSdkSource.decryptSendList(
+                userId = userId,
+                sendList = listOf(createMockSdkSend(number = 1)),
+            )
+        } returns listOf(createMockSendView(number = 1)).asSuccess()
+        val ciphersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>()
+        val collectionsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>()
+        val foldersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>()
+        val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
+        val domainsFlow = bufferedMutableSharedFlow<SyncResponseJson.Domains>()
+        setupVaultDiskSourceFlows(
+            ciphersFlow = ciphersFlow,
+            collectionsFlow = collectionsFlow,
+            foldersFlow = foldersFlow,
+            sendsFlow = sendsFlow,
+            domainsFlow = domainsFlow,
+        )
+
+        turbineScope {
+            val ciphersStateFlow = vaultSyncManager
+                .decryptCipherListResultStateFlow
+                .testIn(backgroundScope)
+            val collectionsStateFlow = vaultSyncManager.collectionsStateFlow.testIn(backgroundScope)
+            val foldersStateFlow = vaultSyncManager.foldersStateFlow.testIn(backgroundScope)
+            val sendsStateFlow = vaultSyncManager.sendDataStateFlow.testIn(backgroundScope)
+            val domainsStateFlow = vaultSyncManager.domainsStateFlow.testIn(backgroundScope)
+
+            assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
+            assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
+            assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
+            assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
+            assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
+
+            ciphersFlow.tryEmit(listOf(createMockCipher(number = 1)))
+            collectionsFlow.tryEmit(listOf(createMockCollection(number = 1)))
+            foldersFlow.tryEmit(listOf(createMockFolder(number = 1)))
+            sendsFlow.tryEmit(listOf(createMockSend(number = 1)))
+            domainsFlow.tryEmit(createMockDomains(number = 1))
+
+            // No events received until unlocked
+            ciphersStateFlow.expectNoEvents()
+            collectionsStateFlow.expectNoEvents()
+            foldersStateFlow.expectNoEvents()
+            sendsStateFlow.expectNoEvents()
+            // Domains does not care about being unlocked
+            assertEquals(
+                DataState.Loaded(createMockDomainsData(number = 1)),
+                domainsStateFlow.awaitItem(),
+            )
+
+            setVaultToUnlocked(userId = userId)
+
+            ciphersFlow.tryEmit(listOf(createMockCipher(number = 1)))
+            collectionsFlow.tryEmit(listOf(createMockCollection(number = 1)))
+            foldersFlow.tryEmit(listOf(createMockFolder(number = 1)))
+            sendsFlow.tryEmit(listOf(createMockSend(number = 1)))
+            domainsFlow.tryEmit(createMockDomains(number = 1))
+
+            assertEquals(
+                DataState.Loaded(createMockDecryptCipherListResult(number = 1)),
+                ciphersStateFlow.awaitItem(),
+            )
+            assertEquals(
+                DataState.Loaded(listOf(createMockCollectionView(number = 1))),
+                collectionsStateFlow.awaitItem(),
+            )
+            assertEquals(
+                DataState.Loaded(listOf(createMockFolderView(number = 1))),
+                foldersStateFlow.awaitItem(),
+            )
+            assertEquals(
+                DataState.Loaded(SendData(listOf(createMockSendView(number = 1)))),
+                sendsStateFlow.awaitItem(),
+            )
+            // Domain data has not changed
+            domainsStateFlow.expectNoEvents()
+
+            fakeAuthDiskSource.userState = null
+
+            assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
+            assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
+            assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
+            assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
+            assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `mutableVaultStateFlow should clear unlocked data when it does not contain the active user`() =
+        runTest {
+            fakeAuthDiskSource.userState = UserStateJson(
+                activeUserId = "mockId-1",
+                accounts = mapOf(
+                    "mockId-1" to MOCK_ACCOUNT,
+                    "mockId-2" to mockk(),
+                ),
+            )
+            mutableVaultStateFlow.value = listOf(
+                VaultUnlockData(userId = "mockId-1", status = VaultUnlockData.Status.UNLOCKING),
+                VaultUnlockData(userId = "mockId-2", status = VaultUnlockData.Status.UNLOCKED),
+            )
+            val userId = "mockId-1"
+            coEvery {
+                vaultSdkSource.decryptCipherListWithFailures(
+                    userId = userId,
+                    cipherList = listOf(createMockSdkCipher(number = 1, clock = clock)),
+                )
+            } returns createMockDecryptCipherListResult(number = 1).asSuccess()
+            coEvery {
+                vaultSdkSource.decryptFolderList(
+                    userId = userId,
+                    folderList = listOf(createMockSdkFolder(number = 1)),
+                )
+            } returns listOf(createMockFolderView(number = 1)).asSuccess()
+            coEvery {
+                vaultSdkSource.decryptCollectionList(
+                    userId = userId,
+                    collectionList = listOf(createMockSdkCollection(1)),
+                )
+            } returns listOf(createMockCollectionView(number = 1)).asSuccess()
+            coEvery {
+                vaultSdkSource.decryptSendList(
+                    userId = userId,
+                    sendList = listOf(createMockSdkSend(number = 1)),
+                )
+            } returns listOf(createMockSendView(number = 1)).asSuccess()
+            val ciphersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>()
+            val collectionsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>()
+            val foldersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>()
+            val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
+            val domainsFlow = bufferedMutableSharedFlow<SyncResponseJson.Domains>()
+            setupVaultDiskSourceFlows(
+                ciphersFlow = ciphersFlow,
+                collectionsFlow = collectionsFlow,
+                foldersFlow = foldersFlow,
+                sendsFlow = sendsFlow,
+                domainsFlow = domainsFlow,
+            )
+
+            turbineScope {
+                val ciphersStateFlow = vaultSyncManager
+                    .decryptCipherListResultStateFlow
+                    .testIn(backgroundScope)
+                val collectionsStateFlow = vaultSyncManager
+                    .collectionsStateFlow
+                    .testIn(backgroundScope)
+                val foldersStateFlow = vaultSyncManager.foldersStateFlow.testIn(backgroundScope)
+                val sendsStateFlow = vaultSyncManager.sendDataStateFlow.testIn(backgroundScope)
+                val domainsStateFlow = vaultSyncManager.domainsStateFlow.testIn(backgroundScope)
+
+                assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
+                assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
+                assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
+                assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
+                assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
+
+                ciphersFlow.tryEmit(listOf(createMockCipher(number = 1)))
+                collectionsFlow.tryEmit(listOf(createMockCollection(number = 1)))
+                foldersFlow.tryEmit(listOf(createMockFolder(number = 1)))
+                sendsFlow.tryEmit(listOf(createMockSend(number = 1)))
+                domainsFlow.tryEmit(createMockDomains(number = 1))
+
+                // No events received until unlocked
+                ciphersStateFlow.expectNoEvents()
+                collectionsStateFlow.expectNoEvents()
+                foldersStateFlow.expectNoEvents()
+                sendsStateFlow.expectNoEvents()
+                // Domains does not care about being unlocked
+                assertEquals(
+                    DataState.Loaded(createMockDomainsData(number = 1)),
+                    domainsStateFlow.awaitItem(),
+                )
+                setVaultToUnlocked(userId = userId)
+
+                assertEquals(
+                    DataState.Loaded(createMockDecryptCipherListResult(number = 1)),
+                    ciphersStateFlow.awaitItem(),
+                )
+                assertEquals(
+                    DataState.Loaded(listOf(createMockCollectionView(number = 1))),
+                    collectionsStateFlow.awaitItem(),
+                )
+                assertEquals(
+                    DataState.Loaded(listOf(createMockFolderView(number = 1))),
+                    foldersStateFlow.awaitItem(),
+                )
+                assertEquals(
+                    DataState.Loaded(SendData(listOf(createMockSendView(number = 1)))),
+                    sendsStateFlow.awaitItem(),
+                )
+                // Domain data has not changed
+                domainsStateFlow.expectNoEvents()
+
+                mutableVaultStateFlow.value = listOf(
+                    VaultUnlockData(userId = "mockId-2", status = VaultUnlockData.Status.UNLOCKED),
+                )
+
+                assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
+                assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
+                assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
+                assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
+                domainsStateFlow.expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `ciphersStateFlow should emit decrypted list of ciphers when decryptCipherList succeeds`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val userId = "mockId-1"
+            val mockCipherList = listOf(createMockCipher(number = 1))
+            val mockEncryptedCipherList = mockCipherList.toEncryptedSdkCipherList()
+            val mockDecryptCipherListResult = createMockDecryptCipherListResult(number = 1)
+            val mutableCiphersStateFlow =
+                bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>(replay = 1)
+            setupVaultDiskSourceFlows(ciphersFlow = mutableCiphersStateFlow)
+            coEvery {
+                vaultSdkSource.decryptCipherListWithFailures(
+                    userId = userId,
+                    cipherList = mockEncryptedCipherList,
+                )
+            } returns mockDecryptCipherListResult.asSuccess()
+
+            vaultSyncManager
+                .decryptCipherListResultStateFlow
+                .test {
+                    assertEquals(DataState.Loading, awaitItem())
+                    mutableCiphersStateFlow.tryEmit(mockCipherList)
+
+                    // No additional emissions until vault is unlocked
+                    expectNoEvents()
+                    setVaultToUnlocked(userId = userId)
+
+                    assertEquals(DataState.Loaded(mockDecryptCipherListResult), awaitItem())
+                }
+        }
+
+    @Test
+    fun `ciphersStateFlow should emit an error when decryptCipherList fails`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val userId = "mockId-1"
+        val throwable = Throwable("Fail")
+        val mockCipherList = listOf(createMockCipher(number = 1))
+        val mockEncryptedCipherList = mockCipherList.toEncryptedSdkCipherList()
+        val mutableCiphersStateFlow =
+            bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>(replay = 1)
+        setupVaultDiskSourceFlows(ciphersFlow = mutableCiphersStateFlow)
+        coEvery {
+            vaultSdkSource.decryptCipherListWithFailures(
+                userId = userId,
+                cipherList = mockEncryptedCipherList,
+            )
+        } returns throwable.asFailure()
+
+        vaultSyncManager
+            .decryptCipherListResultStateFlow
+            .test {
+                assertEquals(DataState.Loading, awaitItem())
+                mutableCiphersStateFlow.tryEmit(mockCipherList)
+
+                // No additional emissions until vault is unlocked
+                expectNoEvents()
+                setVaultToUnlocked(userId = userId)
+
+                assertEquals(DataState.Error<DecryptCipherListResult>(throwable), awaitItem())
+            }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `collectionsStateFlow should emit decrypted list of collections when decryptCollectionList succeeds`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val userId = "mockId-1"
+            val mockCollectionList = listOf(createMockCollection(number = 1))
+            val mockEncryptedCollectionList = mockCollectionList.toEncryptedSdkCollectionList()
+            val mockCollectionViewList = listOf(createMockCollectionView(number = 1))
+            val mutableCollectionsStateFlow =
+                bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>(replay = 1)
+            setupVaultDiskSourceFlows(collectionsFlow = mutableCollectionsStateFlow)
+            coEvery {
+                vaultSdkSource.decryptCollectionList(
+                    userId = userId,
+                    collectionList = mockEncryptedCollectionList,
+                )
+            } returns mockCollectionViewList.asSuccess()
+
+            vaultSyncManager
+                .collectionsStateFlow
+                .test {
+                    assertEquals(DataState.Loading, awaitItem())
+                    mutableCollectionsStateFlow.tryEmit(mockCollectionList)
+
+                    // No additional emissions until vault is unlocked
+                    expectNoEvents()
+                    setVaultToUnlocked(userId = userId)
+
+                    assertEquals(DataState.Loaded(mockCollectionViewList), awaitItem())
+                }
+        }
+
+    @Test
+    fun `collectionsStateFlow should emit an error when decryptCollectionList fails`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val userId = "mockId-1"
+        val throwable = Throwable("Fail")
+        val mockCollectionList = listOf(createMockCollection(number = 1))
+        val mockEncryptedCollectionList = mockCollectionList.toEncryptedSdkCollectionList()
+        val mutableCollectionStateFlow =
+            bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>(replay = 1)
+        setupVaultDiskSourceFlows(collectionsFlow = mutableCollectionStateFlow)
+        coEvery {
+            vaultSdkSource.decryptCollectionList(
+                userId = userId,
+                collectionList = mockEncryptedCollectionList,
+            )
+        } returns throwable.asFailure()
+
+        vaultSyncManager
+            .collectionsStateFlow
+            .test {
+                assertEquals(DataState.Loading, awaitItem())
+                mutableCollectionStateFlow.tryEmit(mockCollectionList)
+
+                // No additional emissions until vault is unlocked
+                expectNoEvents()
+                setVaultToUnlocked(userId = userId)
+
+                assertEquals(DataState.Error<List<CollectionView>>(throwable), awaitItem())
+            }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `foldersStateFlow should emit decrypted list of folders when decryptFolderList succeeds`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val userId = "mockId-1"
+            val mockFolderList = listOf(createMockFolder(number = 1))
+            val mockEncryptedFolderList = mockFolderList.toEncryptedSdkFolderList()
+            val mockFolderViewList = listOf(createMockFolderView(number = 1))
+            val mutableFoldersStateFlow =
+                bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>(replay = 1)
+            setupVaultDiskSourceFlows(foldersFlow = mutableFoldersStateFlow)
+            coEvery {
+                vaultSdkSource.decryptFolderList(
+                    userId = userId,
+                    folderList = mockEncryptedFolderList,
+                )
+            } returns mockFolderViewList.asSuccess()
+
+            vaultSyncManager
+                .foldersStateFlow
+                .test {
+                    assertEquals(DataState.Loading, awaitItem())
+                    mutableFoldersStateFlow.tryEmit(mockFolderList)
+
+                    // No additional emissions until vault is unlocked
+                    expectNoEvents()
+                    setVaultToUnlocked(userId = userId)
+
+                    assertEquals(DataState.Loaded(mockFolderViewList), awaitItem())
+                }
+        }
+
+    @Test
+    fun `foldersStateFlow should emit an error when decryptFolderList fails`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val userId = "mockId-1"
+        val throwable = Throwable("Fail")
+        val mockFolderList = listOf(createMockFolder(number = 1))
+        val mockEncryptedFolderList = mockFolderList.toEncryptedSdkFolderList()
+        val mutableFoldersStateFlow =
+            bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>(replay = 1)
+        setupVaultDiskSourceFlows(foldersFlow = mutableFoldersStateFlow)
+        coEvery {
+            vaultSdkSource.decryptFolderList(userId = userId, folderList = mockEncryptedFolderList)
+        } returns throwable.asFailure()
+
+        vaultSyncManager
+            .foldersStateFlow
+            .test {
+                assertEquals(DataState.Loading, awaitItem())
+                mutableFoldersStateFlow.tryEmit(mockFolderList)
+
+                // No additional emissions until vault is unlocked
+                expectNoEvents()
+                setVaultToUnlocked(userId = userId)
+
+                assertEquals(DataState.Error<List<FolderView>>(throwable), awaitItem())
+            }
+    }
+
+    @Test
+    fun `sendDataStateFlow should emit decrypted list of sends when decryptSendsList succeeds`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val userId = "mockId-1"
+            val mockSendList = listOf(createMockSend(number = 1))
+            val mockEncryptedSendList = mockSendList.toEncryptedSdkSendList()
+            val mockSendViewList = listOf(createMockSendView(number = 1))
+            val mutableSendsStateFlow =
+                bufferedMutableSharedFlow<List<SyncResponseJson.Send>>(replay = 1)
+            setupVaultDiskSourceFlows(sendsFlow = mutableSendsStateFlow)
+            coEvery {
+                vaultSdkSource.decryptSendList(userId = userId, sendList = mockEncryptedSendList)
+            } returns mockSendViewList.asSuccess()
+
+            vaultSyncManager
+                .sendDataStateFlow
+                .test {
+                    assertEquals(DataState.Loading, awaitItem())
+                    mutableSendsStateFlow.tryEmit(mockSendList)
+
+                    // No additional emissions until vault is unlocked
+                    expectNoEvents()
+                    setVaultToUnlocked(userId = userId)
+
+                    assertEquals(DataState.Loaded(SendData(mockSendViewList)), awaitItem())
+                }
+        }
+
+    @Test
+    fun `sendDataStateFlow should emit an error when decryptSendsList fails`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val userId = "mockId-1"
+        val throwable = Throwable("Fail")
+        val mockSendList = listOf(createMockSend(number = 1))
+        val mockEncryptedSendList = mockSendList.toEncryptedSdkSendList()
+        val mutableSendsStateFlow =
+            bufferedMutableSharedFlow<List<SyncResponseJson.Send>>(replay = 1)
+        setupVaultDiskSourceFlows(sendsFlow = mutableSendsStateFlow)
+        coEvery {
+            vaultSdkSource.decryptSendList(userId = userId, sendList = mockEncryptedSendList)
+        } returns throwable.asFailure()
+
+        vaultSyncManager
+            .sendDataStateFlow
+            .test {
+                assertEquals(DataState.Loading, awaitItem())
+                mutableSendsStateFlow.tryEmit(mockSendList)
+
+                // No additional emissions until vault is unlocked
+                expectNoEvents()
+                setVaultToUnlocked(userId = userId)
+
+                assertEquals(DataState.Error<SendData>(throwable), awaitItem())
+            }
+    }
+
+    @Test
+    fun `databaseSchemeChangeFlow should trigger sync on emission`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        coEvery { syncService.sync() } just awaits
+
+        mutableDatabaseSchemeChangeFlow.tryEmit(Unit)
+
+        coVerify(exactly = 1) { syncService.sync() }
+    }
+
+    @Test
+    fun `sync with forced should skip checks and call the syncService sync`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         coEvery { syncService.sync() } returns Throwable("failure").asFailure()
 
-        vaultSyncManager.sync(userId = "mockId-1", forced = true)
+        vaultSyncManager.sync(forced = true)
 
         coVerify(exactly = 0) {
             syncService.getAccountRevisionDateMillis()
@@ -103,72 +700,57 @@ class VaultSyncManagerTest {
                 vaultSdkSource.initializeOrganizationCrypto(
                     userId = userId,
                     request = InitOrgCryptoRequest(
-                        organizationKeys = createMockOrganizationKeys(1),
+                        organizationKeys = createMockOrganizationKeys(number = 1),
                     ),
                 )
             } returns InitializeCryptoResult.Success.asSuccess()
             coEvery {
-                vaultDiskSource.replaceVaultData(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    vault = mockSyncResponse,
-                )
+                vaultDiskSource.replaceVaultData(userId = userId, vault = mockSyncResponse)
             } just runs
             every {
-                settingsDiskSource.storeLastSyncTime(MOCK_USER_STATE.activeUserId, clock.instant())
+                settingsDiskSource.storeLastSyncTime(
+                    userId = userId,
+                    lastSyncTime = clock.instant(),
+                )
             } just runs
 
-            vaultSyncManager.sync(
-                userId = MOCK_USER_STATE.activeUserId,
-                forced = false,
-            )
+            vaultSyncManager.sync()
 
-            val updatedUserState = MOCK_USER_STATE
-                .copy(
-                    accounts = mapOf(
-                        "mockId-1" to MOCK_ACCOUNT.copy(
-                            profile = MOCK_PROFILE.copy(
-                                avatarColorHex = "mockAvatarColor-1",
-                                stamp = "mockSecurityStamp-1",
-                            ),
+            val updatedUserState = MOCK_USER_STATE.copy(
+                accounts = mapOf(
+                    userId to MOCK_ACCOUNT.copy(
+                        profile = MOCK_PROFILE.copy(
+                            avatarColorHex = "mockAvatarColor-1",
+                            stamp = "mockSecurityStamp-1",
                         ),
                     ),
-                )
-            fakeAuthDiskSource.assertUserState(
-                userState = updatedUserState,
+                ),
             )
-            fakeAuthDiskSource.assertUserKey(
-                userId = "mockId-1",
-                userKey = "mockKey-1",
-            )
-            fakeAuthDiskSource.assertPrivateKey(
-                userId = "mockId-1",
-                privateKey = "mockPrivateKey-1",
-            )
+            fakeAuthDiskSource.assertUserState(userState = updatedUserState)
+            fakeAuthDiskSource.assertUserKey(userId = userId, userKey = "mockKey-1")
+            fakeAuthDiskSource.assertPrivateKey(userId = userId, privateKey = "mockPrivateKey-1")
             fakeAuthDiskSource.assertOrganizationKeys(
-                userId = "mockId-1",
-                organizationKeys = mapOf("mockId-1" to "mockKey-1"),
+                userId = userId,
+                organizationKeys = mapOf(userId to "mockKey-1"),
             )
             fakeAuthDiskSource.assertOrganizations(
-                userId = "mockId-1",
+                userId = userId,
                 organizations = listOf(createMockOrganization(number = 1)),
             )
             fakeAuthDiskSource.assertPolicies(
-                userId = "mockId-1",
+                userId = userId,
                 policies = listOf(createMockPolicy(number = 1)),
             )
             fakeAuthDiskSource.assertShouldUseKeyConnector(
-                userId = "mockId-1",
+                userId = userId,
                 shouldUseKeyConnector = false,
             )
             coVerify {
-                vaultDiskSource.replaceVaultData(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    vault = mockSyncResponse,
-                )
+                vaultDiskSource.replaceVaultData(userId = userId, vault = mockSyncResponse)
                 vaultSdkSource.initializeOrganizationCrypto(
                     userId = userId,
                     request = InitOrgCryptoRequest(
-                        organizationKeys = createMockOrganizationKeys(1),
+                        organizationKeys = createMockOrganizationKeys(number = 1),
                     ),
                 )
             }
@@ -180,24 +762,21 @@ class VaultSyncManagerTest {
         runTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val userId = "mockId-1"
-            val mockSyncResponse = createMockSyncResponse(number = 1)
-            coEvery { syncService.sync() } returns mockSyncResponse
-                .copy(profile = createMockProfile(number = 1).copy(securityStamp = "newStamp"))
-                .asSuccess()
-
+            val mockSyncResponse = createMockSyncResponse(
+                number = 1,
+                profile = createMockProfile(number = 1, securityStamp = "newStamp"),
+            )
+            coEvery { syncService.sync() } returns mockSyncResponse.asSuccess()
             coEvery {
                 vaultSdkSource.initializeOrganizationCrypto(
                     userId = userId,
                     request = InitOrgCryptoRequest(
-                        organizationKeys = createMockOrganizationKeys(1),
+                        organizationKeys = createMockOrganizationKeys(number = 1),
                     ),
                 )
             } returns InitializeCryptoResult.Success.asSuccess()
 
-            vaultSyncManager.sync(
-                userId = MOCK_USER_STATE.activeUserId,
-                forced = false,
-            )
+            vaultSyncManager.sync()
 
             coVerify(exactly = 1) {
                 userLogoutManager.softLogout(userId = userId, reason = LogoutReason.SecurityStamp)
@@ -211,29 +790,196 @@ class VaultSyncManagerTest {
                 vaultSdkSource.initializeOrganizationCrypto(
                     userId = userId,
                     request = InitOrgCryptoRequest(
-                        organizationKeys = createMockOrganizationKeys(1),
+                        organizationKeys = createMockOrganizationKeys(number = 1),
                     ),
                 )
             }
         }
 
     @Test
-    fun `sync should return error when getAccountRevisionDateMillis fails`() =
+    fun `sync with syncService Failure should update DataStateFlow with an Error`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val mockException = IllegalStateException("sad")
+        coEvery { syncService.sync() } returns mockException.asFailure()
+
+        vaultSyncManager.sync()
+
+        assertEquals(
+            DataState.Error<DecryptCipherListResult>(mockException),
+            vaultSyncManager.decryptCipherListResultStateFlow.value,
+        )
+        assertEquals(
+            DataState.Error<List<CollectionView>>(mockException),
+            vaultSyncManager.collectionsStateFlow.value,
+        )
+        assertEquals(
+            DataState.Error<DomainsData>(mockException),
+            vaultSyncManager.domainsStateFlow.value,
+        )
+        assertEquals(
+            DataState.Error<List<FolderView>>(mockException),
+            vaultSyncManager.foldersStateFlow.value,
+        )
+        assertEquals(
+            DataState.Error<SendData>(mockException),
+            vaultSyncManager.sendDataStateFlow.value,
+        )
+    }
+
+    @Test
+    fun `sync with syncService Failure should update vaultDataStateFlow with an Error`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val mockException = IllegalStateException("sad")
+        coEvery { syncService.sync() } returns mockException.asFailure()
+        setupVaultDiskSourceFlows()
+
+        vaultSyncManager
+            .vaultDataStateFlow
+            .test {
+                assertEquals(DataState.Loading, awaitItem())
+                vaultSyncManager.sync()
+                assertEquals(DataState.Error<VaultData>(mockException), awaitItem())
+            }
+    }
+
+    @Test
+    fun `sync with NoNetwork should update DataStateFlows to NoNetwork`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        coEvery { syncService.sync() } returns UnknownHostException().asFailure()
+
+        vaultSyncManager.sync()
+
+        assertEquals(
+            DataState.NoNetwork(data = null),
+            vaultSyncManager.decryptCipherListResultStateFlow.value,
+        )
+        assertEquals(
+            DataState.NoNetwork(data = null),
+            vaultSyncManager.collectionsStateFlow.value,
+        )
+        assertEquals(
+            DataState.NoNetwork(data = null),
+            vaultSyncManager.domainsStateFlow.value,
+        )
+        assertEquals(
+            DataState.NoNetwork(data = null),
+            vaultSyncManager.foldersStateFlow.value,
+        )
+        assertEquals(
+            DataState.NoNetwork(data = null),
+            vaultSyncManager.sendDataStateFlow.value,
+        )
+    }
+
+    @Test
+    fun `sync with NoNetwork should update vaultDataStateFlow to NoNetwork`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        coEvery { syncService.sync() } returns UnknownHostException().asFailure()
+        setupVaultDiskSourceFlows()
+
+        vaultSyncManager
+            .vaultDataStateFlow
+            .test {
+                assertEquals(DataState.Loading, awaitItem())
+                vaultSyncManager.sync()
+                assertEquals(DataState.NoNetwork(data = null), awaitItem())
+            }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `sync with NoNetwork data should update sendDataStateFlow to Pending and NoNetwork with data`() =
         runTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val throwable = Throwable()
+            val userId = "mockId-1"
+            setVaultToUnlocked(userId = userId)
+            coEvery { syncService.sync() } returns UnknownHostException().asFailure()
+            val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
+            setupVaultDiskSourceFlows(sendsFlow = sendsFlow)
             coEvery {
-                syncService.getAccountRevisionDateMillis()
-            } returns throwable.asFailure()
-            val syncResult = vaultSyncManager.sync(
-                userId = MOCK_USER_STATE.activeUserId,
-                forced = false,
-            )
-            assertEquals(
-                SyncVaultDataResult.Error(throwable = throwable),
-                syncResult,
-            )
+                vaultSdkSource.decryptSendList(
+                    userId = userId,
+                    sendList = listOf(createMockSdkSend(1)),
+                )
+            } returns listOf(createMockSendView(1)).asSuccess()
+
+            vaultSyncManager
+                .sendDataStateFlow
+                .test {
+                    assertEquals(DataState.Loading, awaitItem())
+                    sendsFlow.tryEmit(listOf(createMockSend(1)))
+                    assertEquals(
+                        DataState.Loaded(data = SendData(listOf(createMockSendView(1)))),
+                        awaitItem(),
+                    )
+                    vaultSyncManager.sync()
+                    assertEquals(
+                        DataState.Pending(data = SendData(listOf(createMockSendView(1)))),
+                        awaitItem(),
+                    )
+                    assertEquals(
+                        DataState.NoNetwork(data = SendData(listOf(createMockSendView(1)))),
+                        awaitItem(),
+                    )
+                }
         }
+
+    @Test
+    fun `syncIfNecessary when there is no last sync time should sync the vault`() {
+        val userId = "mockId-1"
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        every { settingsDiskSource.getLastSyncTime(userId = userId) } returns null
+        coEvery { syncService.sync() } just awaits
+
+        vaultSyncManager.syncIfNecessary()
+
+        coVerify { syncService.sync() }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `syncIfNecessary when the current time is greater than 30 minutes after the last sync time should sync the vault`() {
+        val userId = "mockId-1"
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        every {
+            settingsDiskSource.getLastSyncTime(userId = userId)
+        } returns clock.instant().minus(31, ChronoUnit.MINUTES)
+        coEvery { syncService.sync() } just awaits
+
+        vaultSyncManager.syncIfNecessary()
+
+        coVerify { syncService.sync() }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `syncIfNecessary when the current time is less than 30 minutes after the last sync time should not sync the vault`() {
+        val userId = "mockId-1"
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        every {
+            settingsDiskSource.getLastSyncTime(userId = userId)
+        } returns clock.instant().minus(29, ChronoUnit.MINUTES)
+        coEvery { syncService.sync() } just awaits
+
+        vaultSyncManager.syncIfNecessary()
+
+        coVerify(exactly = 0) { syncService.sync() }
+    }
+
+    @Test
+    fun `sync when the last sync time is older than the revision date should sync the vault`() {
+        val userId = "mockId-1"
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        every {
+            settingsDiskSource.getLastSyncTime(userId = userId)
+        } returns clock.instant().minus(1, ChronoUnit.MINUTES)
+
+        coEvery { syncService.sync() } just awaits
+
+        vaultSyncManager.sync()
+
+        coVerify { syncService.sync() }
+    }
 
     @Test
     fun `sync when the last sync time is more recent than the revision date should not sync `() =
@@ -244,13 +990,296 @@ class VaultSyncManagerTest {
                 settingsDiskSource.getLastSyncTime(userId = userId)
             } returns clock.instant().plus(2, ChronoUnit.MINUTES)
 
-            vaultSyncManager.sync(
-                userId = userId,
-                forced = false,
-            )
+            vaultSyncManager.sync()
 
+            verify(exactly = 1) {
+                settingsDiskSource.storeLastSyncTime(
+                    userId = userId,
+                    lastSyncTime = clock.instant(),
+                )
+            }
             coVerify(exactly = 0) { syncService.sync() }
         }
+
+    @Test
+    fun `vaultDataStateFlow should return empty when last sync time is populated`() =
+        runTest {
+            val userId = "mockId-1"
+            coEvery { vaultLockManager.waitUntilUnlocked(userId = userId) } just runs
+            every { settingsDiskSource.getLastSyncTime(userId = userId) } returns clock.instant()
+
+            mutableVaultStateFlow.update {
+                listOf(VaultUnlockData(userId = userId, status = VaultUnlockData.Status.UNLOCKED))
+            }
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            setupEmptyDecryptionResults()
+            setupVaultDiskSourceFlows(
+                ciphersFlow = flowOf(emptyList()),
+                collectionsFlow = flowOf(emptyList()),
+                domainsFlow = flowOf(
+                    SyncResponseJson.Domains(
+                        globalEquivalentDomains = emptyList(),
+                        equivalentDomains = emptyList(),
+                    ),
+                ),
+                foldersFlow = flowOf(emptyList()),
+                sendsFlow = flowOf(emptyList()),
+            )
+
+            turbineScope {
+                val ciphersStateFlow = vaultSyncManager
+                    .decryptCipherListResultStateFlow
+                    .testIn(backgroundScope)
+                val collectionsStateFlow = vaultSyncManager
+                    .collectionsStateFlow
+                    .testIn(backgroundScope)
+                val foldersStateFlow = vaultSyncManager.foldersStateFlow.testIn(backgroundScope)
+                val sendsStateFlow = vaultSyncManager.sendDataStateFlow.testIn(backgroundScope)
+                val domainsStateFlow = vaultSyncManager.domainsStateFlow.testIn(backgroundScope)
+
+                assertEquals(
+                    DataState.Loaded(
+                        createMockDecryptCipherListResult(
+                            number = 1,
+                            successes = emptyList(),
+                        ),
+                    ),
+                    ciphersStateFlow.awaitItem(),
+                )
+                assertEquals(
+                    DataState.Loaded(emptyList<CollectionView>()),
+                    collectionsStateFlow.awaitItem(),
+                )
+                assertEquals(
+                    DataState.Loaded(emptyList<FolderView>()),
+                    foldersStateFlow.awaitItem(),
+                )
+                assertEquals(
+                    DataState.Loaded(SendData(sendViewList = emptyList())),
+                    sendsStateFlow.awaitItem(),
+                )
+                assertEquals(
+                    DataState.Loaded(
+                        DomainsData(
+                            equivalentDomains = emptyList(),
+                            globalEquivalentDomains = emptyList(),
+                        ),
+                    ),
+                    domainsStateFlow.awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `vaultDataStateFlow should return loading when last sync time is null`() =
+        runTest {
+            val userId = "mockId-1"
+            coEvery { vaultLockManager.waitUntilUnlocked(userId = userId) } just runs
+            every { settingsDiskSource.getLastSyncTime(userId = userId) } returns null
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            setupEmptyDecryptionResults()
+            setupVaultDiskSourceFlows(
+                ciphersFlow = flowOf(emptyList()),
+                collectionsFlow = flowOf(emptyList()),
+                domainsFlow = flowOf(),
+                foldersFlow = flowOf(emptyList()),
+                sendsFlow = flowOf(emptyList()),
+            )
+            turbineScope {
+                val ciphersStateFlow = vaultSyncManager
+                    .decryptCipherListResultStateFlow
+                    .testIn(backgroundScope)
+                val collectionsStateFlow = vaultSyncManager
+                    .collectionsStateFlow
+                    .testIn(backgroundScope)
+                val foldersStateFlow = vaultSyncManager.foldersStateFlow.testIn(backgroundScope)
+                val sendsStateFlow = vaultSyncManager.sendDataStateFlow.testIn(backgroundScope)
+                val domainsStateFlow = vaultSyncManager.domainsStateFlow.testIn(backgroundScope)
+
+                assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
+                assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
+                assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
+                assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
+                assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
+            }
+        }
+
+    @Test
+    fun `fullSyncFlow emission should trigger unforced sync`() {
+        val userId = "mockId-1"
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        every { settingsDiskSource.getLastSyncTime(userId = userId) } returns null
+        coEvery { syncService.sync() } just awaits
+
+        mutableFullSyncFlow.tryEmit(Unit)
+
+        coVerify { syncService.sync() }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `syncForResult should return success result with itemsAvailable = true when sync succeeds and ciphers list is not empty`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val userId = "mockId-1"
+            val mockSyncResponse = createMockSyncResponse(number = 1)
+            coEvery { syncService.sync() } returns mockSyncResponse.asSuccess()
+            coEvery {
+                vaultSdkSource.initializeOrganizationCrypto(
+                    userId = userId,
+                    request = InitOrgCryptoRequest(
+                        organizationKeys = createMockOrganizationKeys(number = 1),
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                vaultDiskSource.replaceVaultData(
+                    userId = userId,
+                    vault = mockSyncResponse,
+                )
+            } just runs
+
+            every {
+                settingsDiskSource.storeLastSyncTime(
+                    userId = userId,
+                    lastSyncTime = clock.instant(),
+                )
+            } just runs
+
+            val syncResult = vaultSyncManager.syncForResult()
+            assertEquals(SyncVaultDataResult.Success(itemsAvailable = true), syncResult)
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `syncForResult should return success result with itemsAvailable = false when sync succeeds and ciphers list is empty`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val userId = "mockId-1"
+            val mockSyncResponse = createMockSyncResponse(number = 1, ciphers = emptyList())
+            coEvery { syncService.sync() } returns mockSyncResponse.asSuccess()
+            coEvery {
+                vaultSdkSource.initializeOrganizationCrypto(
+                    userId = userId,
+                    request = InitOrgCryptoRequest(
+                        organizationKeys = createMockOrganizationKeys(number = 1),
+                    ),
+                )
+            } returns InitializeCryptoResult.Success.asSuccess()
+            coEvery {
+                vaultDiskSource.replaceVaultData(userId = userId, vault = mockSyncResponse)
+            } just runs
+
+            every {
+                settingsDiskSource.storeLastSyncTime(
+                    userId = userId,
+                    lastSyncTime = clock.instant(),
+                )
+            } just runs
+
+            val syncResult = vaultSyncManager.syncForResult()
+            assertEquals(SyncVaultDataResult.Success(itemsAvailable = false), syncResult)
+        }
+
+    @Test
+    fun `syncForResult should return error when getAccountRevisionDateMillis fails`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            val throwable = Throwable()
+            coEvery { syncService.getAccountRevisionDateMillis() } returns throwable.asFailure()
+            val syncResult = vaultSyncManager.syncForResult()
+            assertEquals(
+                SyncVaultDataResult.Error(throwable = throwable),
+                syncResult,
+            )
+        }
+
+    @Test
+    fun `syncForResult should return error when sync fails`() = runTest {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val throwable = Throwable()
+        coEvery { syncService.sync() } returns throwable.asFailure()
+        val syncResult = vaultSyncManager.syncForResult()
+        assertEquals(
+            SyncVaultDataResult.Error(throwable = throwable),
+            syncResult,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `syncForResult when the last sync time is more recent than the revision date should return result from disk source data`() =
+        runTest {
+            val userId = "mockId-1"
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            every {
+                settingsDiskSource.getLastSyncTime(userId = userId)
+            } returns clock.instant().plus(2, ChronoUnit.MINUTES)
+            mutableGetCiphersFlow.update { emptyList() }
+            val result = vaultSyncManager.syncForResult()
+            assertEquals(
+                SyncVaultDataResult.Success(itemsAvailable = false),
+                result,
+            )
+            verify(exactly = 1) {
+                settingsDiskSource.storeLastSyncTime(
+                    userId = userId,
+                    lastSyncTime = clock.instant(),
+                )
+            }
+            coVerify(exactly = 0) { syncService.sync() }
+        }
+
+    //region Helper functions
+
+    /**
+     * Ensures the vault for the given [userId] is unlocked and can pass any
+     * [VaultLockManager.waitUntilUnlocked] or [VaultLockManager.isVaultUnlocked] checks.
+     */
+    private fun setVaultToUnlocked(userId: String) {
+        mutableUnlockedUserIdsStateFlow.update { it + userId }
+        mutableVaultStateFlow.tryEmit(
+            listOf(VaultUnlockData(userId, VaultUnlockData.Status.UNLOCKED)),
+        )
+    }
+
+    /**
+     * Helper setup all flows required to properly subscribe to the
+     * [VaultSyncManager.vaultDataStateFlow].
+     */
+    @Suppress("LongParameterList")
+    private fun setupVaultDiskSourceFlows(
+        userId: String = MOCK_USER_STATE.activeUserId,
+        ciphersFlow: Flow<List<SyncResponseJson.Cipher>> = bufferedMutableSharedFlow(),
+        collectionsFlow: Flow<List<SyncResponseJson.Collection>> = bufferedMutableSharedFlow(),
+        domainsFlow: Flow<SyncResponseJson.Domains> = bufferedMutableSharedFlow(),
+        foldersFlow: Flow<List<SyncResponseJson.Folder>> = bufferedMutableSharedFlow(),
+        sendsFlow: Flow<List<SyncResponseJson.Send>> = bufferedMutableSharedFlow(),
+    ) {
+        coEvery { vaultDiskSource.getCiphersFlow(userId = userId) } returns ciphersFlow
+        coEvery { vaultDiskSource.getCollections(userId = userId) } returns collectionsFlow
+        coEvery { vaultDiskSource.getDomains(userId = userId) } returns domainsFlow
+        coEvery { vaultDiskSource.getFolders(userId = userId) } returns foldersFlow
+        coEvery { vaultDiskSource.getSends(userId = userId) } returns sendsFlow
+    }
+
+    private fun setupEmptyDecryptionResults(
+        userId: String = MOCK_USER_STATE.activeUserId,
+    ) {
+        coEvery {
+            vaultSdkSource.decryptCipherListWithFailures(userId = userId, cipherList = emptyList())
+        } returns createMockDecryptCipherListResult(number = 1, successes = emptyList()).asSuccess()
+        coEvery {
+            vaultSdkSource.decryptFolderList(userId = userId, folderList = emptyList())
+        } returns emptyList<FolderView>().asSuccess()
+        coEvery {
+            vaultSdkSource.decryptCollectionList(userId = userId, collectionList = emptyList())
+        } returns emptyList<CollectionView>().asSuccess()
+        coEvery {
+            vaultSdkSource.decryptSendList(userId = userId, sendList = emptyList())
+        } returns emptyList<SendView>().asSuccess()
+    }
+    //endregion Helper functions
 }
 
 private val MOCK_PROFILE = AccountJson.Profile(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -1,13 +1,10 @@
 package com.x8bit.bitwarden.data.vault.repository
 
-import android.util.Base64
 import app.cash.turbine.test
-import app.cash.turbine.turbineScope
 import com.bitwarden.collections.CollectionView
 import com.bitwarden.core.DateTime
 import com.bitwarden.core.InitUserCryptoMethod
 import com.bitwarden.core.data.repository.model.DataState
-import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
@@ -17,11 +14,8 @@ import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.network.model.CipherTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.createMockCipher
-import com.bitwarden.network.model.createMockCollection
-import com.bitwarden.network.model.createMockDomains
 import com.bitwarden.network.model.createMockFolder
 import com.bitwarden.network.model.createMockOrganizationKeys
-import com.bitwarden.network.model.createMockSend
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.send.SendView
 import com.bitwarden.vault.CipherType
@@ -34,21 +28,12 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
-import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.error.MissingPropertyException
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
-import com.x8bit.bitwarden.data.platform.manager.DatabaseSchemeManager
-import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockAccount
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCollectionView
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockDecryptCipherListResult
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFolderView
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCipher
-import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkCollection
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFolder
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkSend
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSendView
@@ -65,127 +50,79 @@ import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.ImportCredentialsResult
 import com.x8bit.bitwarden.data.vault.repository.model.SendData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
-import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
-import com.x8bit.bitwarden.data.vault.repository.model.createMockDomainsData
-import com.x8bit.bitwarden.data.vault.repository.util.toDomainsData
 import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipher
-import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipherList
-import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCollectionList
-import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkFolderList
-import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkSendList
 import com.x8bit.bitwarden.ui.vault.feature.verificationcode.util.createVerificationCodeItem
-import io.mockk.awaits
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
-import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkConstructor
-import io.mockk.unmockkStatic
-import io.mockk.verify
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.net.UnknownHostException
 import java.security.GeneralSecurityException
-import java.security.MessageDigest
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.time.temporal.ChronoUnit
 import javax.crypto.BadPaddingException
 import javax.crypto.Cipher
 
 @Suppress("LargeClass")
 class VaultRepositoryTest {
-    private val clock: Clock = Clock.fixed(
-        Instant.parse("2023-10-27T12:00:00Z"),
-        ZoneOffset.UTC,
-    )
     private val dispatcherManager: DispatcherManager = FakeDispatcherManager()
     private val fakeAuthDiskSource = FakeAuthDiskSource()
-    private val settingsDiskSource = mockk<SettingsDiskSource> {
-        every { getLastSyncTime(userId = any()) } returns clock.instant()
-    }
     private val mutableGetCiphersFlow: MutableStateFlow<List<SyncResponseJson.Cipher>> =
         MutableStateFlow(listOf(createMockCipher(1)))
     private val vaultDiskSource: VaultDiskSource = mockk {
-        coEvery { resyncVaultData(any()) } just runs
         every { getCiphersFlow(any()) } returns mutableGetCiphersFlow
     }
     private val totpCodeManager: TotpCodeManager = mockk()
-    private val vaultSdkSource: VaultSdkSource = mockk {
-        every { clearCrypto(userId = any()) } just runs
+    private val vaultSdkSource: VaultSdkSource = mockk()
+    private val vaultLockManager: VaultLockManager = mockk()
+    private val mutableVaultDataStateFlow =
+        MutableStateFlow<DataState<VaultData>>(DataState.Loading)
+    private val mutableCollectionsStateFlow =
+        MutableStateFlow<DataState<List<CollectionView>>>(DataState.Loading)
+    private val mutableDecryptCipherListResultStateFlow =
+        MutableStateFlow<DataState<DecryptCipherListResult>>(DataState.Loading)
+    private val mutableDomainsStateFlow =
+        MutableStateFlow<DataState<DomainsData>>(DataState.Loading)
+    private val mutableFoldersStateFlow =
+        MutableStateFlow<DataState<List<FolderView>>>(DataState.Loading)
+    private val mutableSendDataStateFlow = MutableStateFlow<DataState<SendData>>(DataState.Loading)
+    private val vaultSyncManager: VaultSyncManager = mockk {
+        every { vaultDataStateFlow } returns mutableVaultDataStateFlow
+        every { collectionsStateFlow } returns mutableCollectionsStateFlow
+        every { decryptCipherListResultStateFlow } returns mutableDecryptCipherListResultStateFlow
+        every { domainsStateFlow } returns mutableDomainsStateFlow
+        every { foldersStateFlow } returns mutableFoldersStateFlow
+        every { sendDataStateFlow } returns mutableSendDataStateFlow
     }
-    private val mutableVaultStateFlow = MutableStateFlow<List<VaultUnlockData>>(
-        emptyList(),
-    )
-    private val mutableUnlockedUserIdsStateFlow = MutableStateFlow<Set<String>>(emptySet())
-    private val vaultLockManager: VaultLockManager = mockk {
-        every { vaultUnlockDataStateFlow } returns mutableVaultStateFlow
-        every {
-            isVaultUnlocked(any())
-        } answers { call ->
-            val userId = call.invocation.args.first()
-            userId in mutableUnlockedUserIdsStateFlow.value
-        }
-        every { isVaultUnlocking(any()) } returns false
-        every { lockVault(any(), any()) } just runs
-        every { lockVaultForCurrentUser(any()) } just runs
-        coEvery {
-            waitUntilUnlocked(any())
-        } coAnswers { call ->
-            val userId = call.invocation.args.first()
-            mutableUnlockedUserIdsStateFlow.first { userId in it }
-        }
-    }
-    private val mutableDatabaseSchemeChangeFlow = bufferedMutableSharedFlow<Unit>()
-    private val databaseSchemeManager: DatabaseSchemeManager = mockk {
-        every { databaseSchemeChangeFlow } returns mutableDatabaseSchemeChangeFlow
-    }
-    private val mutableFullSyncFlow = bufferedMutableSharedFlow<Unit>()
-    private val pushManager: PushManager = mockk {
-        every { fullSyncFlow } returns mutableFullSyncFlow
-    }
-    private val vaultSyncManager: VaultSyncManager = mockk()
     private val credentialExchangeImportManager: CredentialExchangeImportManager = mockk()
 
     private val vaultRepository = VaultRepositoryImpl(
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
         authDiskSource = fakeAuthDiskSource,
-        settingsDiskSource = settingsDiskSource,
         vaultLockManager = vaultLockManager,
         dispatcherManager = dispatcherManager,
         totpCodeManager = totpCodeManager,
-        pushManager = pushManager,
         cipherManager = mockk(),
         folderManager = mockk(),
         sendManager = mockk(),
-        clock = clock,
-        databaseSchemeManager = databaseSchemeManager,
         vaultSyncManager = vaultSyncManager,
         credentialExchangeImportManager = credentialExchangeImportManager,
     )
 
     @BeforeEach
     fun setup() {
-        mockkStatic(SyncResponseJson.Domains::toDomainsData)
-        mockkStatic(MessageDigest::class)
-        mockkStatic(Base64::class)
         mockkConstructor(NoActiveUserException::class)
         mockkConstructor(MissingPropertyException::class)
         every {
@@ -198,531 +135,8 @@ class VaultRepositoryTest {
 
     @AfterEach
     fun tearDown() {
-        unmockkStatic(SyncResponseJson.Domains::toDomainsData)
-        unmockkStatic(MessageDigest::class)
-        unmockkStatic(Base64::class)
         unmockkConstructor(NoActiveUserException::class)
         unmockkConstructor(MissingPropertyException::class)
-    }
-
-    @Test
-    fun `userSwitchingChangesFlow should cancel any pending sync call`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        coEvery { vaultSyncManager.sync(any(), any()) } just awaits
-
-        vaultRepository.sync()
-        vaultRepository.sync()
-        coVerify(exactly = 1) {
-            // Despite being called twice, we only allow 1 sync
-            vaultSyncManager.sync(any(), any())
-        }
-
-        fakeAuthDiskSource.userState = UserStateJson(
-            activeUserId = "mockId-2",
-            accounts = mapOf("mockId-2" to mockk()),
-        )
-        vaultRepository.sync()
-        coVerify {
-            // A second sync should have happened now since it was cancelled by the userState change
-            vaultSyncManager.sync(userId = "mockId-1", forced = any())
-            vaultSyncManager.sync(userId = "mockId-2", forced = any())
-        }
-    }
-
-    @Test
-    fun `userSwitchingChangesFlow should clear unlocked data`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        val userId = "mockId-1"
-        coEvery {
-            vaultSdkSource.decryptCipherListWithFailures(
-                userId = userId,
-                cipherList = listOf(createMockSdkCipher(1, clock)),
-            )
-        } returns createMockDecryptCipherListResult(number = 1).asSuccess()
-        coEvery {
-            vaultSdkSource.decryptFolderList(
-                userId = userId,
-                folderList = listOf(createMockSdkFolder(1)),
-            )
-        } returns listOf(createMockFolderView(number = 1)).asSuccess()
-        coEvery {
-            vaultSdkSource.decryptCollectionList(
-                userId = userId,
-                collectionList = listOf(createMockSdkCollection(1)),
-            )
-        } returns listOf(createMockCollectionView(number = 1)).asSuccess()
-        coEvery {
-            vaultSdkSource.decryptSendList(
-                userId = userId,
-                sendList = listOf(createMockSdkSend(number = 1)),
-            )
-        } returns listOf(createMockSendView(number = 1)).asSuccess()
-        val ciphersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>()
-        val collectionsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>()
-        val foldersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>()
-        val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-        val domainsFlow = bufferedMutableSharedFlow<SyncResponseJson.Domains>()
-        setupVaultDiskSourceFlows(
-            ciphersFlow = ciphersFlow,
-            collectionsFlow = collectionsFlow,
-            foldersFlow = foldersFlow,
-            sendsFlow = sendsFlow,
-            domainsFlow = domainsFlow,
-        )
-
-        turbineScope {
-            val ciphersStateFlow =
-                vaultRepository.decryptCipherListResultStateFlow.testIn(backgroundScope)
-            val collectionsStateFlow = vaultRepository.collectionsStateFlow.testIn(backgroundScope)
-            val foldersStateFlow = vaultRepository.foldersStateFlow.testIn(backgroundScope)
-            val sendsStateFlow = vaultRepository.sendDataStateFlow.testIn(backgroundScope)
-            val domainsStateFlow = vaultRepository.domainsStateFlow.testIn(backgroundScope)
-
-            assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
-            assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
-            assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
-            assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
-            assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
-
-            ciphersFlow.tryEmit(listOf(createMockCipher(number = 1)))
-            collectionsFlow.tryEmit(listOf(createMockCollection(number = 1)))
-            foldersFlow.tryEmit(listOf(createMockFolder(number = 1)))
-            sendsFlow.tryEmit(listOf(createMockSend(number = 1)))
-            domainsFlow.tryEmit(createMockDomains(number = 1))
-
-            // No events received until unlocked
-            ciphersStateFlow.expectNoEvents()
-            collectionsStateFlow.expectNoEvents()
-            foldersStateFlow.expectNoEvents()
-            sendsStateFlow.expectNoEvents()
-            // Domains does not care about being unlocked
-            assertEquals(
-                DataState.Loaded(createMockDomainsData(number = 1)),
-                domainsStateFlow.awaitItem(),
-            )
-
-            setVaultToUnlocked(userId = userId)
-
-            ciphersFlow.tryEmit(listOf(createMockCipher(number = 1)))
-            collectionsFlow.tryEmit(listOf(createMockCollection(number = 1)))
-            foldersFlow.tryEmit(listOf(createMockFolder(number = 1)))
-            sendsFlow.tryEmit(listOf(createMockSend(number = 1)))
-            domainsFlow.tryEmit(createMockDomains(number = 1))
-
-            assertEquals(
-                DataState.Loaded(createMockDecryptCipherListResult(number = 1)),
-                ciphersStateFlow.awaitItem(),
-            )
-            assertEquals(
-                DataState.Loaded(listOf(createMockCollectionView(number = 1))),
-                collectionsStateFlow.awaitItem(),
-            )
-            assertEquals(
-                DataState.Loaded(listOf(createMockFolderView(number = 1))),
-                foldersStateFlow.awaitItem(),
-            )
-            assertEquals(
-                DataState.Loaded(SendData(listOf(createMockSendView(number = 1)))),
-                sendsStateFlow.awaitItem(),
-            )
-            // Domain data has not changed
-            domainsStateFlow.expectNoEvents()
-
-            fakeAuthDiskSource.userState = null
-
-            assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
-            assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
-            assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
-            assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
-            assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
-        }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `mutableVaultStateFlow should clear unlocked data when it does not contain the active user`() =
-        runTest {
-            fakeAuthDiskSource.userState = UserStateJson(
-                activeUserId = "mockId-1",
-                accounts = mapOf(
-                    "mockId-1" to MOCK_ACCOUNT,
-                    "mockId-2" to mockk(),
-                ),
-            )
-            mutableVaultStateFlow.value = listOf(
-                VaultUnlockData(userId = "mockId-1", status = VaultUnlockData.Status.UNLOCKING),
-                VaultUnlockData(userId = "mockId-2", status = VaultUnlockData.Status.UNLOCKED),
-            )
-            val userId = "mockId-1"
-            coEvery {
-                vaultSdkSource.decryptCipherListWithFailures(
-                    userId = userId,
-                    cipherList = listOf(createMockSdkCipher(1, clock)),
-                )
-            } returns createMockDecryptCipherListResult(number = 1).asSuccess()
-            coEvery {
-                vaultSdkSource.decryptFolderList(
-                    userId = userId,
-                    folderList = listOf(createMockSdkFolder(1)),
-                )
-            } returns listOf(createMockFolderView(number = 1)).asSuccess()
-            coEvery {
-                vaultSdkSource.decryptCollectionList(
-                    userId = userId,
-                    collectionList = listOf(createMockSdkCollection(1)),
-                )
-            } returns listOf(createMockCollectionView(number = 1)).asSuccess()
-            coEvery {
-                vaultSdkSource.decryptSendList(
-                    userId = userId,
-                    sendList = listOf(createMockSdkSend(number = 1)),
-                )
-            } returns listOf(createMockSendView(number = 1)).asSuccess()
-            val ciphersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>()
-            val collectionsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>()
-            val foldersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>()
-            val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-            val domainsFlow = bufferedMutableSharedFlow<SyncResponseJson.Domains>()
-            setupVaultDiskSourceFlows(
-                ciphersFlow = ciphersFlow,
-                collectionsFlow = collectionsFlow,
-                foldersFlow = foldersFlow,
-                sendsFlow = sendsFlow,
-                domainsFlow = domainsFlow,
-            )
-
-            turbineScope {
-                val ciphersStateFlow =
-                    vaultRepository.decryptCipherListResultStateFlow.testIn(backgroundScope)
-                val collectionsStateFlow =
-                    vaultRepository.collectionsStateFlow.testIn(backgroundScope)
-                val foldersStateFlow = vaultRepository.foldersStateFlow.testIn(backgroundScope)
-                val sendsStateFlow = vaultRepository.sendDataStateFlow.testIn(backgroundScope)
-                val domainsStateFlow = vaultRepository.domainsStateFlow.testIn(backgroundScope)
-
-                assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
-                assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
-                assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
-                assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
-                assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
-
-                ciphersFlow.tryEmit(listOf(createMockCipher(number = 1)))
-                collectionsFlow.tryEmit(listOf(createMockCollection(number = 1)))
-                foldersFlow.tryEmit(listOf(createMockFolder(number = 1)))
-                sendsFlow.tryEmit(listOf(createMockSend(number = 1)))
-                domainsFlow.tryEmit(createMockDomains(number = 1))
-
-                // No events received until unlocked
-                ciphersStateFlow.expectNoEvents()
-                collectionsStateFlow.expectNoEvents()
-                foldersStateFlow.expectNoEvents()
-                sendsStateFlow.expectNoEvents()
-                // Domains does not care about being unlocked
-                assertEquals(
-                    DataState.Loaded(createMockDomainsData(number = 1)),
-                    domainsStateFlow.awaitItem(),
-                )
-                setVaultToUnlocked(userId = userId)
-
-                assertEquals(
-                    DataState.Loaded(createMockDecryptCipherListResult(number = 1)),
-                    ciphersStateFlow.awaitItem(),
-                )
-                assertEquals(
-                    DataState.Loaded(listOf(createMockCollectionView(number = 1))),
-                    collectionsStateFlow.awaitItem(),
-                )
-                assertEquals(
-                    DataState.Loaded(listOf(createMockFolderView(number = 1))),
-                    foldersStateFlow.awaitItem(),
-                )
-                assertEquals(
-                    DataState.Loaded(SendData(listOf(createMockSendView(number = 1)))),
-                    sendsStateFlow.awaitItem(),
-                )
-                // Domain data has not changed
-                domainsStateFlow.expectNoEvents()
-
-                mutableVaultStateFlow.value = listOf(
-                    VaultUnlockData(userId = "mockId-2", status = VaultUnlockData.Status.UNLOCKED),
-                )
-
-                assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
-                assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
-                assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
-                assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
-                domainsStateFlow.expectNoEvents()
-            }
-        }
-
-    @Test
-    fun `ciphersStateFlow should emit decrypted list of ciphers when decryptCipherList succeeds`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val userId = "mockId-1"
-            val mockCipherList = listOf(createMockCipher(number = 1))
-            val mockEncryptedCipherList = mockCipherList.toEncryptedSdkCipherList()
-            val mockDecryptCipherListResult = createMockDecryptCipherListResult(number = 1)
-            val mutableCiphersStateFlow =
-                bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>(replay = 1)
-            every {
-                vaultDiskSource.getCiphersFlow(userId = MOCK_USER_STATE.activeUserId)
-            } returns mutableCiphersStateFlow
-            coEvery {
-                vaultSdkSource.decryptCipherListWithFailures(
-                    userId = userId,
-                    cipherList = mockEncryptedCipherList,
-                )
-            } returns mockDecryptCipherListResult.asSuccess()
-
-            vaultRepository
-                .decryptCipherListResultStateFlow
-                .test {
-                    assertEquals(DataState.Loading, awaitItem())
-                    mutableCiphersStateFlow.tryEmit(mockCipherList)
-
-                    // No additional emissions until vault is unlocked
-                    expectNoEvents()
-                    setVaultToUnlocked(userId = userId)
-
-                    assertEquals(DataState.Loaded(mockDecryptCipherListResult), awaitItem())
-                }
-        }
-
-    @Test
-    fun `ciphersStateFlow should emit an error when decryptCipherList fails`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        val userId = "mockId-1"
-        val throwable = Throwable("Fail")
-        val mockCipherList = listOf(createMockCipher(number = 1))
-        val mockEncryptedCipherList = mockCipherList.toEncryptedSdkCipherList()
-        val mutableCiphersStateFlow =
-            bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>(replay = 1)
-        every {
-            vaultDiskSource.getCiphersFlow(userId = MOCK_USER_STATE.activeUserId)
-        } returns mutableCiphersStateFlow
-        coEvery {
-            vaultSdkSource.decryptCipherListWithFailures(
-                userId = userId,
-                cipherList = mockEncryptedCipherList,
-            )
-        } returns throwable.asFailure()
-
-        vaultRepository
-            .decryptCipherListResultStateFlow
-            .test {
-                assertEquals(DataState.Loading, awaitItem())
-                mutableCiphersStateFlow.tryEmit(mockCipherList)
-
-                // No additional emissions until vault is unlocked
-                expectNoEvents()
-                setVaultToUnlocked(userId = userId)
-
-                assertEquals(DataState.Error<DecryptCipherListResult>(throwable), awaitItem())
-            }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `collectionsStateFlow should emit decrypted list of collections when decryptCollectionList succeeds`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val userId = "mockId-1"
-            val mockCollectionList = listOf(createMockCollection(number = 1))
-            val mockEncryptedCollectionList = mockCollectionList.toEncryptedSdkCollectionList()
-            val mockCollectionViewList = listOf(createMockCollectionView(number = 1))
-            val mutableCollectionsStateFlow =
-                bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>(replay = 1)
-            every {
-                vaultDiskSource.getCollections(userId = MOCK_USER_STATE.activeUserId)
-            } returns mutableCollectionsStateFlow
-            coEvery {
-                vaultSdkSource.decryptCollectionList(
-                    userId = userId,
-                    collectionList = mockEncryptedCollectionList,
-                )
-            } returns mockCollectionViewList.asSuccess()
-
-            vaultRepository
-                .collectionsStateFlow
-                .test {
-                    assertEquals(DataState.Loading, awaitItem())
-                    mutableCollectionsStateFlow.tryEmit(mockCollectionList)
-
-                    // No additional emissions until vault is unlocked
-                    expectNoEvents()
-                    setVaultToUnlocked(userId = userId)
-
-                    assertEquals(DataState.Loaded(mockCollectionViewList), awaitItem())
-                }
-        }
-
-    @Test
-    fun `collectionsStateFlow should emit an error when decryptCollectionList fails`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        val userId = "mockId-1"
-        val throwable = Throwable("Fail")
-        val mockCollectionList = listOf(createMockCollection(number = 1))
-        val mockEncryptedCollectionList = mockCollectionList.toEncryptedSdkCollectionList()
-        val mutableCollectionStateFlow =
-            bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>(replay = 1)
-        every {
-            vaultDiskSource.getCollections(userId = MOCK_USER_STATE.activeUserId)
-        } returns mutableCollectionStateFlow
-        coEvery {
-            vaultSdkSource.decryptCollectionList(
-                userId = userId,
-                collectionList = mockEncryptedCollectionList,
-            )
-        } returns throwable.asFailure()
-
-        vaultRepository
-            .collectionsStateFlow
-            .test {
-                assertEquals(DataState.Loading, awaitItem())
-                mutableCollectionStateFlow.tryEmit(mockCollectionList)
-
-                // No additional emissions until vault is unlocked
-                expectNoEvents()
-                setVaultToUnlocked(userId = userId)
-
-                assertEquals(DataState.Error<List<CollectionView>>(throwable), awaitItem())
-            }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `foldersStateFlow should emit decrypted list of folders when decryptFolderList succeeds`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val userId = "mockId-1"
-            val mockFolderList = listOf(createMockFolder(number = 1))
-            val mockEncryptedFolderList = mockFolderList.toEncryptedSdkFolderList()
-            val mockFolderViewList = listOf(createMockFolderView(number = 1))
-            val mutableFoldersStateFlow =
-                bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>(replay = 1)
-            every {
-                vaultDiskSource.getFolders(userId = MOCK_USER_STATE.activeUserId)
-            } returns mutableFoldersStateFlow
-            coEvery {
-                vaultSdkSource.decryptFolderList(
-                    userId = userId,
-                    folderList = mockEncryptedFolderList,
-                )
-            } returns mockFolderViewList.asSuccess()
-
-            vaultRepository
-                .foldersStateFlow
-                .test {
-                    assertEquals(DataState.Loading, awaitItem())
-                    mutableFoldersStateFlow.tryEmit(mockFolderList)
-
-                    // No additional emissions until vault is unlocked
-                    expectNoEvents()
-                    setVaultToUnlocked(userId = userId)
-
-                    assertEquals(DataState.Loaded(mockFolderViewList), awaitItem())
-                }
-        }
-
-    @Test
-    fun `foldersStateFlow should emit an error when decryptFolderList fails`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        val userId = "mockId-1"
-        val throwable = Throwable("Fail")
-        val mockFolderList = listOf(createMockFolder(number = 1))
-        val mockEncryptedFolderList = mockFolderList.toEncryptedSdkFolderList()
-        val mutableFoldersStateFlow =
-            bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>(replay = 1)
-        every {
-            vaultDiskSource.getFolders(userId = MOCK_USER_STATE.activeUserId)
-        } returns mutableFoldersStateFlow
-        coEvery {
-            vaultSdkSource.decryptFolderList(
-                userId = userId,
-                folderList = mockEncryptedFolderList,
-            )
-        } returns throwable.asFailure()
-
-        vaultRepository
-            .foldersStateFlow
-            .test {
-                assertEquals(DataState.Loading, awaitItem())
-                mutableFoldersStateFlow.tryEmit(mockFolderList)
-
-                // No additional emissions until vault is unlocked
-                expectNoEvents()
-                setVaultToUnlocked(userId = userId)
-
-                assertEquals(DataState.Error<List<FolderView>>(throwable), awaitItem())
-            }
-    }
-
-    @Test
-    fun `sendDataStateFlow should emit decrypted list of sends when decryptSendsList succeeds`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val userId = "mockId-1"
-            val mockSendList = listOf(createMockSend(number = 1))
-            val mockEncryptedSendList = mockSendList.toEncryptedSdkSendList()
-            val mockSendViewList = listOf(createMockSendView(number = 1))
-            val mutableSendsStateFlow =
-                bufferedMutableSharedFlow<List<SyncResponseJson.Send>>(replay = 1)
-            every {
-                vaultDiskSource.getSends(userId = MOCK_USER_STATE.activeUserId)
-            } returns mutableSendsStateFlow
-            coEvery {
-                vaultSdkSource.decryptSendList(
-                    userId = userId,
-                    sendList = mockEncryptedSendList,
-                )
-            } returns mockSendViewList.asSuccess()
-
-            vaultRepository
-                .sendDataStateFlow
-                .test {
-                    assertEquals(DataState.Loading, awaitItem())
-                    mutableSendsStateFlow.tryEmit(mockSendList)
-
-                    // No additional emissions until vault is unlocked
-                    expectNoEvents()
-                    setVaultToUnlocked(userId = userId)
-
-                    assertEquals(DataState.Loaded(SendData(mockSendViewList)), awaitItem())
-                }
-        }
-
-    @Test
-    fun `sendDataStateFlow should emit an error when decryptSendsList fails`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        val userId = "mockId-1"
-        val throwable = Throwable("Fail")
-        val mockSendList = listOf(createMockSend(number = 1))
-        val mockEncryptedSendList = mockSendList.toEncryptedSdkSendList()
-        val mutableSendsStateFlow =
-            bufferedMutableSharedFlow<List<SyncResponseJson.Send>>(replay = 1)
-        every {
-            vaultDiskSource.getSends(userId = MOCK_USER_STATE.activeUserId)
-        } returns mutableSendsStateFlow
-        coEvery {
-            vaultSdkSource.decryptSendList(
-                userId = userId,
-                sendList = mockEncryptedSendList,
-            )
-        } returns throwable.asFailure()
-
-        vaultRepository
-            .sendDataStateFlow
-            .test {
-                assertEquals(DataState.Loading, awaitItem())
-                mutableSendsStateFlow.tryEmit(mockSendList)
-
-                // No additional emissions until vault is unlocked
-                expectNoEvents()
-                setVaultToUnlocked(userId = userId)
-
-                assertEquals(DataState.Error<SendData>(throwable), awaitItem())
-            }
     }
 
     @Test
@@ -738,238 +152,10 @@ class VaultRepositoryTest {
     }
 
     @Test
-    fun `databaseSchemeChangeFlow should trigger sync on emission`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        coEvery { vaultSyncManager.sync(any(), any()) } just awaits
-
-        mutableDatabaseSchemeChangeFlow.tryEmit(Unit)
-
-        coVerify(exactly = 1) { vaultSyncManager.sync(any(), any()) }
-    }
-
-    @Test
-    fun `sync should update DataStateFlow with an Error when vaultSyncManager result is Error`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val mockException = IllegalStateException("sad")
-            coEvery {
-                vaultSyncManager.sync(
-                    userId = MOCK_USER_STATE.activeUserId,
-                    forced = false,
-                )
-            } returns SyncVaultDataResult.Error(throwable = mockException)
-
-            vaultRepository.sync()
-
-            assertEquals(
-                DataState.Error<DecryptCipherListResult>(mockException),
-                vaultRepository.decryptCipherListResultStateFlow.value,
-            )
-            assertEquals(
-                DataState.Error<List<CollectionView>>(mockException),
-                vaultRepository.collectionsStateFlow.value,
-            )
-            assertEquals(
-                DataState.Error<DomainsData>(mockException),
-                vaultRepository.domainsStateFlow.value,
-            )
-            assertEquals(
-                DataState.Error<List<FolderView>>(mockException),
-                vaultRepository.foldersStateFlow.value,
-            )
-            assertEquals(
-                DataState.Error<SendData>(mockException),
-                vaultRepository.sendDataStateFlow.value,
-            )
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `sync should update vaultDataStateFlow with an Error when vaultSyncManager result is Error`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val mockException = IllegalStateException("sad")
-            coEvery {
-                vaultSyncManager.sync(any(), any())
-            } returns SyncVaultDataResult.Error(mockException)
-            setupVaultDiskSourceFlows()
-
-            vaultRepository
-                .vaultDataStateFlow
-                .test {
-                    assertEquals(DataState.Loading, awaitItem())
-                    vaultRepository.sync()
-                    assertEquals(DataState.Error<VaultData>(mockException), awaitItem())
-                }
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `sync should update DataStateFlows to NoNetwork when vaultSyncManager result is Error with `() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            coEvery {
-                vaultSyncManager.sync(any(), any())
-            } returns SyncVaultDataResult.Error(throwable = UnknownHostException())
-
-            vaultRepository.sync()
-
-            assertEquals(
-                DataState.NoNetwork(data = null),
-                vaultRepository.decryptCipherListResultStateFlow.value,
-            )
-            assertEquals(
-                DataState.NoNetwork(data = null),
-                vaultRepository.collectionsStateFlow.value,
-            )
-            assertEquals(
-                DataState.NoNetwork(data = null),
-                vaultRepository.domainsStateFlow.value,
-            )
-            assertEquals(
-                DataState.NoNetwork(data = null),
-                vaultRepository.foldersStateFlow.value,
-            )
-            assertEquals(
-                DataState.NoNetwork(data = null),
-                vaultRepository.sendDataStateFlow.value,
-            )
-        }
-
-    @Test
-    fun `sync with NoNetwork should update vaultDataStateFlow to NoNetwork`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        coEvery {
-            vaultSyncManager.sync(any(), any())
-        } returns SyncVaultDataResult.Error(UnknownHostException())
-        setupVaultDiskSourceFlows()
-
-        vaultRepository
-            .vaultDataStateFlow
-            .test {
-                assertEquals(DataState.Loading, awaitItem())
-                vaultRepository.sync()
-                assertEquals(DataState.NoNetwork(data = null), awaitItem())
-            }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `sync with NoNetwork data should update sendDataStateFlow to Pending and NoNetwork with data`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val userId = "mockId-1"
-            setVaultToUnlocked(userId = userId)
-            coEvery {
-                vaultSyncManager.sync(
-                    userId = userId,
-                    forced = false,
-                )
-            } returns SyncVaultDataResult.Error(throwable = UnknownHostException())
-            val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-            setupVaultDiskSourceFlows(sendsFlow = sendsFlow)
-            coEvery {
-                vaultSdkSource.decryptSendList(
-                    userId = userId,
-                    sendList = listOf(createMockSdkSend(1)),
-                )
-            } returns listOf(createMockSendView(1)).asSuccess()
-
-            vaultRepository
-                .sendDataStateFlow
-                .test {
-                    assertEquals(DataState.Loading, awaitItem())
-                    sendsFlow.tryEmit(listOf(createMockSend(1)))
-                    assertEquals(
-                        DataState.Loaded(data = SendData(listOf(createMockSendView(1)))),
-                        awaitItem(),
-                    )
-                    vaultRepository.sync()
-                    assertEquals(
-                        DataState.Pending(data = SendData(listOf(createMockSendView(1)))),
-                        awaitItem(),
-                    )
-                    assertEquals(
-                        DataState.NoNetwork(data = SendData(listOf(createMockSendView(1)))),
-                        awaitItem(),
-                    )
-                }
-        }
-
-    @Test
-    fun `syncIfNecessary when there is no last sync time should sync the vault`() {
-        val userId = "mockId-1"
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        every {
-            settingsDiskSource.getLastSyncTime(userId = userId)
-        } returns null
-        coEvery { vaultSyncManager.sync(userId = userId, forced = false) } just awaits
-
-        vaultRepository.syncIfNecessary()
-
-        coVerify { vaultSyncManager.sync(userId = userId, forced = false) }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `syncIfNecessary when the current time is greater than 30 minutes after the last sync time should sync the vault`() {
-        val userId = "mockId-1"
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        every {
-            settingsDiskSource.getLastSyncTime(userId = userId)
-        } returns clock.instant().minus(31, ChronoUnit.MINUTES)
-        coEvery { vaultSyncManager.sync(userId = userId, forced = false) } just awaits
-
-        vaultRepository.syncIfNecessary()
-
-        coVerify { vaultSyncManager.sync(userId = userId, forced = false) }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `syncIfNecessary when the current time is less than 30 minutes after the last sync time should not sync the vault`() {
-        val userId = "mockId-1"
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        every {
-            settingsDiskSource.getLastSyncTime(userId = userId)
-        } returns clock.instant().minus(29, ChronoUnit.MINUTES)
-        coEvery { vaultSyncManager.sync(userId = userId, forced = false) } just awaits
-
-        vaultRepository.syncIfNecessary()
-
-        coVerify(exactly = 0) { vaultSyncManager.sync(userId = any(), forced = any()) }
-    }
-
-    @Test
-    fun `sync when the last sync time is older than the revision date should sync the vault`() {
-        val userId = "mockId-1"
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        every {
-            settingsDiskSource.getLastSyncTime(userId = userId)
-        } returns clock.instant().minus(1, ChronoUnit.MINUTES)
-
-        coEvery { vaultSyncManager.sync(userId = userId, forced = false) } just awaits
-
-        vaultRepository.sync()
-
-        coVerify { vaultSyncManager.sync(userId = userId, forced = false) }
-    }
-
-    @Test
-    fun `lockVaultForCurrentUser should delegate to the VaultLockManager`() {
-        vaultRepository.lockVaultForCurrentUser(isUserInitiated = true)
-        verify { vaultLockManager.lockVaultForCurrentUser(isUserInitiated = true) }
-    }
-
-    @Test
     fun `unlockVaultWithBiometrics with missing user state should return InvalidStateError`() =
         runTest {
             fakeAuthDiskSource.userState = null
             val cipher = mockk<Cipher>()
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
 
             val result = vaultRepository.unlockVaultWithBiometrics(cipher = cipher)
 
@@ -977,19 +163,11 @@ class VaultRepositoryTest {
                 VaultUnlockResult.InvalidStateError(error = NoActiveUserException()),
                 result,
             )
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
         }
 
     @Test
     fun `unlockVaultWithBiometrics with missing biometrics key should return InvalidStateError`() =
         runTest {
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val cipher = mockk<Cipher>()
             val userId = MOCK_USER_STATE.activeUserId
@@ -1000,10 +178,6 @@ class VaultRepositoryTest {
             assertEquals(
                 VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
                 result,
-            )
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
             )
         }
 
@@ -1375,10 +549,6 @@ class VaultRepositoryTest {
     fun `unlockVaultWithMasterPassword with missing user state should return InvalidStateError`() =
         runTest {
             fakeAuthDiskSource.userState = null
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
 
             val result = vaultRepository.unlockVaultWithMasterPassword(masterPassword = "")
 
@@ -1386,20 +556,11 @@ class VaultRepositoryTest {
                 VaultUnlockResult.InvalidStateError(error = NoActiveUserException()),
                 result,
             )
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
         }
 
     @Test
     fun `unlockVaultWithMasterPassword with missing user key should return InvalidStateError`() =
         runTest {
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
-
             val result = vaultRepository.unlockVaultWithMasterPassword(masterPassword = "")
             fakeAuthDiskSource.storeUserKey(
                 userId = "mockId-1",
@@ -1414,20 +575,12 @@ class VaultRepositoryTest {
                 VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
                 result,
             )
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
         }
 
     @Suppress("MaxLineLength")
     @Test
     fun `unlockVaultWithMasterPassword with missing private key should return InvalidStateError`() =
         runTest {
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
             val result = vaultRepository.unlockVaultWithMasterPassword(masterPassword = "")
             fakeAuthDiskSource.storeUserKey(
                 userId = "mockId-1",
@@ -1441,11 +594,6 @@ class VaultRepositoryTest {
             assertEquals(
                 VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
                 result,
-            )
-
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
             )
         }
 
@@ -1596,10 +744,6 @@ class VaultRepositoryTest {
     @Test
     fun `unlockVaultWithPin with missing user state should return InvalidStateError`() = runTest {
         fakeAuthDiskSource.userState = null
-        assertEquals(
-            emptyList<VaultUnlockData>(),
-            vaultRepository.vaultUnlockDataStateFlow.value,
-        )
 
         val result = vaultRepository.unlockVaultWithPin(pin = "1234")
 
@@ -1607,21 +751,12 @@ class VaultRepositoryTest {
             VaultUnlockResult.InvalidStateError(error = NoActiveUserException()),
             result,
         )
-        assertEquals(
-            emptyList<VaultUnlockData>(),
-            vaultRepository.vaultUnlockDataStateFlow.value,
-        )
     }
 
     @Suppress("MaxLineLength")
     @Test
     fun `unlockVaultWithPin with missing pin-protected user key should return InvalidStateError`() =
         runTest {
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
-
             val result = vaultRepository.unlockVaultWithPin(pin = "1234")
             fakeAuthDiskSource.storePinProtectedUserKey(
                 userId = "mockId-1",
@@ -1636,18 +771,10 @@ class VaultRepositoryTest {
                 VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
                 result,
             )
-            assertEquals(
-                emptyList<VaultUnlockData>(),
-                vaultRepository.vaultUnlockDataStateFlow.value,
-            )
         }
 
     @Test
     fun `unlockVaultWithPin with missing private key should return InvalidStateError`() = runTest {
-        assertEquals(
-            emptyList<VaultUnlockData>(),
-            vaultRepository.vaultUnlockDataStateFlow.value,
-        )
         val result = vaultRepository.unlockVaultWithPin(pin = "1234")
         fakeAuthDiskSource.storePinProtectedUserKey(
             userId = "mockId-1",
@@ -1661,10 +788,6 @@ class VaultRepositoryTest {
         assertEquals(
             VaultUnlockResult.InvalidStateError(error = MissingPropertyException("Foo")),
             result,
-        )
-        assertEquals(
-            emptyList<VaultUnlockData>(),
-            vaultRepository.vaultUnlockDataStateFlow.value,
         )
     }
 
@@ -1731,199 +854,60 @@ class VaultRepositoryTest {
         }
 
     @Test
-    fun `getVaultItemStateFlow should update to Error when a sync fails generically`() =
+    fun `getVaultItemStateFlow should update to Error when error state is emitted`() =
         runTest {
             val folderId = 1234
             val folderIdString = "mockId-$folderId"
             val throwable = Throwable("Fail")
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            coEvery {
-                vaultSyncManager.sync(any(), any())
-            } returns SyncVaultDataResult.Error(throwable)
-            setupVaultDiskSourceFlows()
 
             vaultRepository.getVaultItemStateFlow(folderIdString).test {
                 assertEquals(DataState.Loading, awaitItem())
-                vaultRepository.sync()
+                mutableVaultDataStateFlow.value = DataState.Error(throwable)
                 assertEquals(DataState.Error<CipherView>(throwable), awaitItem())
-            }
-
-            coVerify(exactly = 1) {
-                vaultSyncManager.sync(any(), any())
             }
         }
 
     @Test
-    fun `getVaultItemStateFlow should update to NoNetwork when a sync fails from no network`() =
+    fun `getVaultItemStateFlow should update to NoNetwork when a NoNetwork value is emitted`() =
         runTest {
             val itemId = 1234
             val itemIdString = "mockId-$itemId"
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            coEvery {
-                vaultSyncManager.sync(any(), any())
-            } returns SyncVaultDataResult.Error(UnknownHostException())
-            setupVaultDiskSourceFlows()
 
             vaultRepository.getVaultItemStateFlow(itemIdString).test {
                 assertEquals(DataState.Loading, awaitItem())
-                vaultRepository.sync()
+                mutableVaultDataStateFlow.value = DataState.NoNetwork()
                 assertEquals(DataState.NoNetwork<CipherView>(), awaitItem())
             }
-
-            coVerify(exactly = 1) {
-                vaultSyncManager.sync(any(), any())
-            }
         }
 
     @Test
-    fun `vaultDataStateFlow should return empty when last sync time is populated`() =
-        runTest {
-            val userId = "mockId-1"
-            coEvery {
-                vaultLockManager.waitUntilUnlocked(userId = userId)
-            } just runs
-            every {
-                settingsDiskSource.getLastSyncTime(userId = userId)
-            } returns clock.instant()
-
-            mutableVaultStateFlow.update {
-                listOf(VaultUnlockData(userId, VaultUnlockData.Status.UNLOCKED))
-            }
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            setupEmptyDecryptionResults()
-            setupVaultDiskSourceFlows(
-                ciphersFlow = flowOf(emptyList()),
-                collectionsFlow = flowOf(emptyList()),
-                domainsFlow = flowOf(
-                    SyncResponseJson.Domains(
-                        globalEquivalentDomains = emptyList(),
-                        equivalentDomains = emptyList(),
-                    ),
-                ),
-                foldersFlow = flowOf(emptyList()),
-                sendsFlow = flowOf(emptyList()),
-            )
-
-            turbineScope {
-                val ciphersStateFlow =
-                    vaultRepository.decryptCipherListResultStateFlow.testIn(backgroundScope)
-                val collectionsStateFlow =
-                    vaultRepository.collectionsStateFlow.testIn(backgroundScope)
-                val foldersStateFlow = vaultRepository.foldersStateFlow.testIn(backgroundScope)
-                val sendsStateFlow = vaultRepository.sendDataStateFlow.testIn(backgroundScope)
-                val domainsStateFlow = vaultRepository.domainsStateFlow.testIn(backgroundScope)
-
-                assertEquals(
-                    DataState.Loaded(
-                        createMockDecryptCipherListResult(
-                            number = 1,
-                            successes = emptyList(),
-                        ),
-                    ),
-                    ciphersStateFlow.awaitItem(),
-                )
-                assertEquals(
-                    DataState.Loaded(emptyList<CollectionView>()),
-                    collectionsStateFlow.awaitItem(),
-                )
-                assertEquals(
-                    DataState.Loaded(emptyList<FolderView>()),
-                    foldersStateFlow.awaitItem(),
-                )
-                assertEquals(
-                    DataState.Loaded(SendData(sendViewList = emptyList())),
-                    sendsStateFlow.awaitItem(),
-                )
-                assertEquals(
-                    DataState.Loaded(
-                        DomainsData(
-                            equivalentDomains = emptyList(),
-                            globalEquivalentDomains = emptyList(),
-                        ),
-                    ),
-                    domainsStateFlow.awaitItem(),
-                )
-            }
-        }
-
-    @Test
-    fun `vaultDataStateFlow should return loading when last sync time is null`() =
-        runTest {
-            val userId = "mockId-1"
-            coEvery {
-                vaultLockManager.waitUntilUnlocked(userId = userId)
-            } just runs
-            every {
-                settingsDiskSource.getLastSyncTime(userId = userId)
-            } returns null
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            setupEmptyDecryptionResults()
-            setupVaultDiskSourceFlows(
-                ciphersFlow = flowOf(emptyList()),
-                collectionsFlow = flowOf(emptyList()),
-                domainsFlow = flowOf(),
-                foldersFlow = flowOf(emptyList()),
-                sendsFlow = flowOf(emptyList()),
-            )
-            turbineScope {
-                val ciphersStateFlow =
-                    vaultRepository.decryptCipherListResultStateFlow.testIn(backgroundScope)
-                val collectionsStateFlow =
-                    vaultRepository.collectionsStateFlow.testIn(backgroundScope)
-                val foldersStateFlow = vaultRepository.foldersStateFlow.testIn(backgroundScope)
-                val sendsStateFlow = vaultRepository.sendDataStateFlow.testIn(backgroundScope)
-                val domainsStateFlow = vaultRepository.domainsStateFlow.testIn(backgroundScope)
-
-                assertEquals(DataState.Loading, ciphersStateFlow.awaitItem())
-                assertEquals(DataState.Loading, collectionsStateFlow.awaitItem())
-                assertEquals(DataState.Loading, foldersStateFlow.awaitItem())
-                assertEquals(DataState.Loading, sendsStateFlow.awaitItem())
-                assertEquals(DataState.Loading, domainsStateFlow.awaitItem())
-            }
-        }
-
-    @Test
-    fun `getVaultFolderStateFlow should update to NoNetwork when a sync fails from no network`() =
+    fun `getVaultFolderStateFlow should update to NoNetwork when no network value is emitted`() =
         runTest {
             val folderId = 1234
             val folderIdString = "mockId-$folderId"
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            coEvery {
-                vaultSyncManager.sync(any(), any())
-            } returns SyncVaultDataResult.Error(UnknownHostException())
-            setupVaultDiskSourceFlows()
 
             vaultRepository.getVaultFolderStateFlow(folderIdString).test {
                 assertEquals(DataState.Loading, awaitItem())
-                vaultRepository.sync()
+                mutableVaultDataStateFlow.value = DataState.NoNetwork()
                 assertEquals(DataState.NoNetwork<FolderView>(), awaitItem())
-            }
-
-            coVerify(exactly = 1) {
-                vaultSyncManager.sync(any(), any())
             }
         }
 
     @Test
-    fun `getVaultFolderStateFlow should update to Error when a sync fails generically`() =
+    fun `getVaultFolderStateFlow should update to Error when an error is emitted`() =
         runTest {
             val folderId = 1234
             val folderIdString = "mockId-$folderId"
             val throwable = Throwable("Fail")
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            coEvery {
-                vaultSyncManager.sync(any(), any())
-            } returns SyncVaultDataResult.Error(throwable)
-            setupVaultDiskSourceFlows()
 
             vaultRepository.getVaultFolderStateFlow(folderIdString).test {
                 assertEquals(DataState.Loading, awaitItem())
-                vaultRepository.sync()
+                mutableVaultDataStateFlow.value = DataState.Error(throwable)
                 assertEquals(DataState.Error<FolderView>(throwable), awaitItem())
-            }
-
-            coVerify(exactly = 1) {
-                vaultSyncManager.sync(any(), any())
             }
         }
 
@@ -1932,77 +916,40 @@ class VaultRepositoryTest {
         val sendId = 1
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         val sendView = createMockSendView(number = sendId)
-        coEvery {
-            vaultSdkSource.decryptSendList(
-                userId = MOCK_USER_STATE.activeUserId,
-                sendList = emptyList(),
-            )
-        } returns emptyList<SendView>().asSuccess()
-        coEvery {
-            vaultSdkSource.decryptSendList(
-                userId = MOCK_USER_STATE.activeUserId,
-                sendList = listOf(createMockSdkSend(number = sendId)),
-            )
-        } returns listOf(sendView).asSuccess()
-
-        val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-        setupVaultDiskSourceFlows(sendsFlow = sendsFlow)
 
         vaultRepository.getSendStateFlow("mockId-$sendId").test {
             assertEquals(DataState.Loading, awaitItem())
-            sendsFlow.tryEmit(emptyList())
-
-            // No additional emissions until vault is unlocked
-            expectNoEvents()
-            setVaultToUnlocked(userId = MOCK_USER_STATE.activeUserId)
-
-            sendsFlow.tryEmit(emptyList())
+            mutableSendDataStateFlow.value = DataState.Loaded(SendData(emptyList()))
             assertEquals(DataState.Loaded<SendView?>(null), awaitItem())
-            sendsFlow.tryEmit(listOf(createMockSend(number = sendId)))
+            mutableSendDataStateFlow.value = DataState.Loaded(SendData(listOf(sendView)))
             assertEquals(DataState.Loaded<SendView?>(sendView), awaitItem())
         }
     }
 
     @Test
-    fun `getSendStateFlow should update to NoNetwork when a sync fails from no network`() =
+    fun `getSendStateFlow should update to NoNetwork when NoNetwork value is emitted`() =
         runTest {
             val sendId = 1234
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            coEvery {
-                vaultSyncManager.sync(any(), any())
-            } returns SyncVaultDataResult.Error(UnknownHostException())
-            setupVaultDiskSourceFlows()
 
             vaultRepository.getSendStateFlow("mockId-$sendId").test {
                 assertEquals(DataState.Loading, awaitItem())
-                vaultRepository.sync()
+                mutableSendDataStateFlow.value = DataState.NoNetwork()
                 assertEquals(DataState.NoNetwork<SendView?>(), awaitItem())
-            }
-
-            coVerify(exactly = 1) {
-                vaultSyncManager.sync(any(), any())
             }
         }
 
     @Test
-    fun `getSendStateFlow should update to Error when a sync fails generically`() =
+    fun `getSendStateFlow should update to Error when an error is emitted`() =
         runTest {
             val sendId = 1234
             val throwable = Throwable("Fail")
             fakeAuthDiskSource.userState = MOCK_USER_STATE
-            coEvery {
-                vaultSyncManager.sync(any(), any())
-            } returns SyncVaultDataResult.Error(throwable)
-            setupVaultDiskSourceFlows()
 
             vaultRepository.getSendStateFlow("mockId-$sendId").test {
                 assertEquals(DataState.Loading, awaitItem())
-                vaultRepository.sync()
+                mutableSendDataStateFlow.value = DataState.Error(throwable)
                 assertEquals(DataState.Error<SendView?>(throwable), awaitItem())
-            }
-
-            coVerify(exactly = 1) {
-                vaultSyncManager.sync(any(), any())
             }
         }
 
@@ -2025,13 +972,18 @@ class VaultRepositoryTest {
     @Test
     fun `generateTotp should return a success result on getting a code`() = runTest {
         val totpResponse = TotpResponse("Testcode", 30u)
-        val userId = "mockId-1"
         coEvery {
             vaultSdkSource.generateTotpForCipherListView(any(), any(), any())
         } returns totpResponse.asSuccess()
+        mutableDecryptCipherListResultStateFlow.value = DataState.Loaded(
+            DecryptCipherListResult(
+                successes = listOf(
+                    createMockCipherListView(number = 1),
+                ),
+                failures = emptyList(),
+            ),
+        )
         fakeAuthDiskSource.userState = MOCK_USER_STATE
-        setVaultToUnlocked(userId = userId)
-        setupDataStateFlow(userId = userId)
 
         val result = vaultRepository.generateTotp(
             cipherId = "mockId-1",
@@ -2058,23 +1010,24 @@ class VaultRepositoryTest {
         runTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             val userId = "mockId-1"
-            setVaultToUnlocked(userId = userId)
-
-            coEvery {
-                vaultSyncManager.sync(userId = userId, forced = false)
-            } returns SyncVaultDataResult.Success(itemsAvailable = true)
-
-            val stateFlow = MutableStateFlow<DataState<VerificationCodeItem?>>(
-                DataState.Loading,
-            )
+            val stateFlow = MutableStateFlow<DataState<VerificationCodeItem?>>(DataState.Loading)
 
             every {
                 totpCodeManager.getTotpCodeStateFlow(userId = userId, cipherListView = any())
             } returns stateFlow
+            mutableVaultDataStateFlow.value = DataState.Loaded(
+                data = VaultData(
+                    decryptCipherListResult = DecryptCipherListResult(
+                        successes = listOf(createMockCipherListView(number = 1)),
+                        failures = emptyList(),
+                    ),
+                    collectionViewList = emptyList(),
+                    folderViewList = emptyList(),
+                    sendViewList = emptyList(),
+                ),
+            )
 
-            setupDataStateFlow(userId = userId)
-
-            vaultRepository.getAuthCodeFlow(createMockCipherView(1).id.toString()).test {
+            vaultRepository.getAuthCodeFlow(userId).test {
                 assertEquals(
                     DataState.Loading,
                     awaitItem(),
@@ -2084,13 +1037,6 @@ class VaultRepositoryTest {
 
                 assertEquals(
                     DataState.Loaded(createVerificationCodeItem()),
-                    awaitItem(),
-                )
-
-                vaultRepository.sync()
-
-                assertEquals(
-                    DataState.Pending(createVerificationCodeItem()),
                     awaitItem(),
                 )
             }
@@ -2106,15 +1052,7 @@ class VaultRepositoryTest {
     fun `getAuthCodesFlow should update data state when state changes`() = runTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         val userId = "mockId-1"
-        setVaultToUnlocked(userId = userId)
-
-        coEvery {
-            vaultSyncManager.sync(any(), any())
-        } returns SyncVaultDataResult.Success(itemsAvailable = true)
-
-        val stateFlow = MutableStateFlow<DataState<List<VerificationCodeItem>>>(
-            DataState.Loading,
-        )
+        val stateFlow = MutableStateFlow<DataState<List<VerificationCodeItem>>>(DataState.Loading)
 
         every {
             totpCodeManager.getTotpCodesForCipherListViewsStateFlow(
@@ -2122,8 +1060,17 @@ class VaultRepositoryTest {
                 cipherListViews = any(),
             )
         } returns stateFlow
-
-        setupDataStateFlow(userId = userId)
+        mutableVaultDataStateFlow.value = DataState.Loaded(
+            data = VaultData(
+                decryptCipherListResult = DecryptCipherListResult(
+                    successes = listOf(createMockCipherListView(number = 1)),
+                    failures = emptyList(),
+                ),
+                collectionViewList = emptyList(),
+                folderViewList = emptyList(),
+                sendViewList = emptyList(),
+            ),
+        )
 
         vaultRepository.getAuthCodesFlow().test {
             assertEquals(
@@ -2137,28 +1084,7 @@ class VaultRepositoryTest {
                 DataState.Loaded(listOf(createVerificationCodeItem())),
                 awaitItem(),
             )
-
-            vaultRepository.sync()
-
-            assertEquals(
-                DataState.Pending(listOf(createVerificationCodeItem())),
-                awaitItem(),
-            )
         }
-    }
-
-    @Test
-    fun `fullSyncFlow emission should trigger unforced sync`() {
-        val userId = "mockId-1"
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        every {
-            settingsDiskSource.getLastSyncTime(userId = userId)
-        } returns null
-        coEvery { vaultSyncManager.sync(any(), any()) } just awaits
-
-        mutableFullSyncFlow.tryEmit(Unit)
-
-        coVerify { vaultSyncManager.sync(any(), any()) }
     }
 
     @Suppress("MaxLineLength")
@@ -2293,9 +1219,8 @@ class VaultRepositoryTest {
             )
         }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `importCxfPayload should return success result when payload is successfully imported and vault sync is successful`() =
+    fun `importCxfPayload should return success result when payload is successfully imported`() =
         runTest {
             val userId = "mockId-1"
             val payload = "payload"
@@ -2307,18 +1232,12 @@ class VaultRepositoryTest {
                     payload = payload,
                 )
             } returns ImportCxfPayloadResult.Success(itemCount = 1)
-            coEvery {
-                vaultSyncManager.sync(userId = userId, forced = true)
-            } returns SyncVaultDataResult.Success(itemsAvailable = true)
             val result = vaultRepository.importCxfPayload(payload)
 
             assertEquals(
                 ImportCredentialsResult.Success(itemCount = 1),
                 result,
             )
-            coVerify(exactly = 1) {
-                vaultSyncManager.sync(userId = userId, forced = true)
-            }
         }
 
     @Test
@@ -2349,9 +1268,6 @@ class VaultRepositoryTest {
             ImportCredentialsResult.Error(expected),
             result,
         )
-        coVerify(exactly = 0) {
-            vaultSyncManager.sync(userId = userId, forced = true)
-        }
     }
 
     @Test
@@ -2373,9 +1289,6 @@ class VaultRepositoryTest {
             ImportCredentialsResult.NoItems,
             result,
         )
-        coVerify(exactly = 0) {
-            vaultSyncManager.sync(userId = userId, forced = true)
-        }
     }
 
     @Test
@@ -2390,11 +1303,7 @@ class VaultRepositoryTest {
                 userId = userId,
                 payload = payload,
             )
-        } returns ImportCxfPayloadResult.Success(itemCount = 1)
-
-        coEvery {
-            vaultSyncManager.sync(userId = userId, forced = true)
-        } returns SyncVaultDataResult.Error(throwable)
+        } returns ImportCxfPayloadResult.SyncFailed(throwable)
 
         val result = vaultRepository.importCxfPayload(payload)
 
@@ -2491,51 +1400,6 @@ class VaultRepositoryTest {
         }
     }
 
-    @Suppress("MaxLineLength")
-    @Test
-    fun `syncForResult should return success result with itemsAvailable = true when sync succeeds and ciphers list is not empty`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val userId = "mockId-1"
-            coEvery {
-                vaultSyncManager.sync(
-                    userId = userId,
-                    forced = false,
-                )
-            } returns SyncVaultDataResult.Success(itemsAvailable = true)
-
-            val syncResult = vaultRepository.syncForResult()
-            assertEquals(SyncVaultDataResult.Success(itemsAvailable = true), syncResult)
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `syncForResult should return success result with itemsAvailable = false when sync succeeds and ciphers list is empty`() =
-        runTest {
-            fakeAuthDiskSource.userState = MOCK_USER_STATE
-            val userId = "mockId-1"
-            coEvery {
-                vaultSyncManager.sync(userId = userId, forced = false)
-            } returns SyncVaultDataResult.Success(itemsAvailable = false)
-
-            val syncResult = vaultRepository.syncForResult()
-            assertEquals(SyncVaultDataResult.Success(itemsAvailable = false), syncResult)
-        }
-
-    @Test
-    fun `syncForResult should return error when VaultSyncManager sync result is Error`() = runTest {
-        fakeAuthDiskSource.userState = MOCK_USER_STATE
-        val throwable = Throwable()
-        coEvery {
-            vaultSyncManager.sync(any(), any())
-        } returns SyncVaultDataResult.Error(throwable)
-        val syncResult = vaultRepository.syncForResult()
-        assertEquals(
-            SyncVaultDataResult.Error(throwable = throwable),
-            syncResult,
-        )
-    }
-
     //region Helper functions
 
     /**
@@ -2548,7 +1412,7 @@ class VaultRepositoryTest {
     ) {
         val userId = "mockId-1"
         coEvery {
-            vaultSyncManager.sync(any(), any())
+            vaultSyncManager.syncForResult(forced = any())
         } returns SyncVaultDataResult.Success(itemsAvailable = true)
         coEvery {
             vaultSdkSource.decryptSendList(
@@ -2608,128 +1472,6 @@ class VaultRepositoryTest {
             )
         } returns unlockResult
     }
-
-    /**
-     * Ensures the vault for the given [userId] is unlocked and can pass any
-     * [VaultLockManager.waitUntilUnlocked] or [VaultLockManager.isVaultUnlocked] checks.
-     */
-    private fun setVaultToUnlocked(userId: String) {
-        mutableUnlockedUserIdsStateFlow.update { it + userId }
-        mutableVaultStateFlow.tryEmit(
-            listOf(
-                VaultUnlockData(
-                    userId,
-                    VaultUnlockData.Status.UNLOCKED,
-                ),
-            ),
-        )
-    }
-
-    /**
-     * Helper setup all flows required to properly subscribe to the
-     * [VaultRepository.vaultDataStateFlow].
-     */
-    private fun setupVaultDiskSourceFlows(
-        ciphersFlow: Flow<List<SyncResponseJson.Cipher>> = bufferedMutableSharedFlow(),
-        collectionsFlow: Flow<List<SyncResponseJson.Collection>> = bufferedMutableSharedFlow(),
-        domainsFlow: Flow<SyncResponseJson.Domains> = bufferedMutableSharedFlow(),
-        foldersFlow: Flow<List<SyncResponseJson.Folder>> = bufferedMutableSharedFlow(),
-        sendsFlow: Flow<List<SyncResponseJson.Send>> = bufferedMutableSharedFlow(),
-    ) {
-        coEvery { vaultDiskSource.getCiphersFlow(MOCK_USER_STATE.activeUserId) } returns ciphersFlow
-        coEvery {
-            vaultDiskSource.getCollections(MOCK_USER_STATE.activeUserId)
-        } returns collectionsFlow
-        coEvery { vaultDiskSource.getDomains(MOCK_USER_STATE.activeUserId) } returns domainsFlow
-        coEvery { vaultDiskSource.getFolders(MOCK_USER_STATE.activeUserId) } returns foldersFlow
-        coEvery { vaultDiskSource.getSends(MOCK_USER_STATE.activeUserId) } returns sendsFlow
-    }
-
-    private fun setupEmptyDecryptionResults() {
-        coEvery {
-            vaultSdkSource.decryptCipherListWithFailures(
-                userId = MOCK_USER_STATE.activeUserId,
-                cipherList = emptyList(),
-            )
-        } returns createMockDecryptCipherListResult(number = 1, successes = emptyList()).asSuccess()
-        coEvery {
-            vaultSdkSource.decryptFolderList(
-                userId = MOCK_USER_STATE.activeUserId,
-                folderList = emptyList(),
-            )
-        } returns emptyList<FolderView>().asSuccess()
-        coEvery {
-            vaultSdkSource.decryptCollectionList(
-                userId = MOCK_USER_STATE.activeUserId,
-                collectionList = emptyList(),
-            )
-        } returns emptyList<CollectionView>().asSuccess()
-
-        coEvery {
-            vaultSdkSource.decryptSendList(
-                userId = MOCK_USER_STATE.activeUserId,
-                sendList = emptyList(),
-            )
-        } returns emptyList<SendView>().asSuccess()
-    }
-
-    private suspend fun setupDataStateFlow(userId: String) {
-        coEvery {
-            vaultSdkSource.decryptCipherListWithFailures(
-                userId = userId,
-                cipherList = listOf(createMockSdkCipher(1, clock)),
-            )
-        } returns createMockDecryptCipherListResult(number = 1).asSuccess()
-        coEvery {
-            vaultSdkSource.decryptFolderList(
-                userId = userId,
-                folderList = listOf(createMockSdkFolder(1)),
-            )
-        } returns listOf(createMockFolderView(number = 1)).asSuccess()
-        coEvery {
-            vaultSdkSource.decryptCollectionList(
-                userId = userId,
-                collectionList = listOf(createMockSdkCollection(1)),
-            )
-        } returns listOf(createMockCollectionView(number = 1)).asSuccess()
-        coEvery {
-            vaultSdkSource.decryptSendList(
-                userId = userId,
-                sendList = listOf(createMockSdkSend(number = 1)),
-            )
-        } returns listOf(createMockSendView(number = 1)).asSuccess()
-        val ciphersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Cipher>>()
-        val collectionsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Collection>>()
-        val foldersFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Folder>>()
-        val sendsFlow = bufferedMutableSharedFlow<List<SyncResponseJson.Send>>()
-        setupVaultDiskSourceFlows(
-            ciphersFlow = ciphersFlow,
-            collectionsFlow = collectionsFlow,
-            foldersFlow = foldersFlow,
-            sendsFlow = sendsFlow,
-        )
-
-        vaultRepository.vaultDataStateFlow.test {
-            ciphersFlow.tryEmit(listOf(createMockCipher(1)))
-            collectionsFlow.tryEmit(listOf(createMockCollection(number = 1)))
-            foldersFlow.tryEmit(listOf(createMockFolder(number = 1)))
-            sendsFlow.tryEmit(listOf(createMockSend(number = 1)))
-            assertEquals(DataState.Loading, awaitItem())
-
-            assertEquals(
-                DataState.Loaded(
-                    data = VaultData(
-                        decryptCipherListResult = createMockDecryptCipherListResult(number = 1),
-                        collectionViewList = listOf(createMockCollectionView(number = 1)),
-                        folderViewList = listOf(createMockFolderView(number = 1)),
-                        sendViewList = listOf(createMockSendView(number = 1)),
-                    ),
-                ),
-                awaitItem(),
-            )
-        }
-    }
-
     //endregion Helper functions
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR extracts the remaining Sync logic into the `VaultSyncManager`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
