### PR TITLE
PM-26026: save layout state through config change

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dialog/BitwardenTimePickerDialog.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dialog/BitwardenTimePickerDialog.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,7 +48,6 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  * with AM/PM.
  */
 @OptIn(ExperimentalMaterial3Api::class)
-@Suppress("LongMethod")
 @Composable
 fun BitwardenTimePickerDialog(
     initialHour: Int,
@@ -57,7 +56,7 @@ fun BitwardenTimePickerDialog(
     onDismissRequest: () -> Unit,
     is24Hour: Boolean,
 ) {
-    var showTimeInput by remember { mutableStateOf(false) }
+    var showTimeInput by rememberSaveable { mutableStateOf(value = false) }
     val timePickerState = rememberTimePickerState(
         initialHour = initialHour,
         initialMinute = initialMinute,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26026](https://bitwarden.atlassian.net/browse/PM-26026)

## 📔 Objective

This PR ensures that the Time Picker Dialog retains it's layout state through a configuration change.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7853030b-e29f-4959-960e-997ae123b5ba" width="400" /> | <video src="https://github.com/user-attachments/assets/630a77ae-20c4-453b-9638-f4b5508b5102" width="400" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26026]: https://bitwarden.atlassian.net/browse/PM-26026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ