### PR TITLE
Update Credential Provider Events APIs

### DIFF
--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/IntentHandler.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/IntentHandler.kt
@@ -1,6 +1,4 @@
-@file:Suppress("unused")
-
-package androidx.credentials.providerevents.playservices
+package androidx.credentials.providerevents
 
 import android.app.Activity
 import android.content.Intent
@@ -8,10 +6,12 @@ import android.net.Uri
 import androidx.credentials.providerevents.exception.ImportCredentialsException
 import androidx.credentials.providerevents.transfer.ImportCredentialsResponse
 import androidx.credentials.providerevents.transfer.ProviderImportCredentialsRequest
+import com.bitwarden.annotation.OmitFromCoverage
 
 /**
  * A stub implementation of the Credential Provider Events IntentHandler class.
  */
+@OmitFromCoverage
 object IntentHandler {
 
     /**

--- a/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ProviderImportCredentialsRequest.kt
+++ b/cxf/src/main/kotlin/androidx/credentials/providerevents/transfer/ProviderImportCredentialsRequest.kt
@@ -12,4 +12,5 @@ data class ProviderImportCredentialsRequest(
     val request: ImportCredentialsRequest,
     val callingAppInfo: CallingAppInfo,
     val uri: Uri,
+    val credId: String,
 )

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/manager/CredentialExchangeCompletionManagerImpl.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/manager/CredentialExchangeCompletionManagerImpl.kt
@@ -2,7 +2,7 @@ package com.bitwarden.cxf.manager
 
 import android.app.Activity
 import android.content.Intent
-import androidx.credentials.providerevents.playservices.IntentHandler
+import androidx.credentials.providerevents.IntentHandler
 import androidx.credentials.providerevents.transfer.ImportCredentialsResponse
 import com.bitwarden.cxf.manager.model.ExportCredentialsResult
 

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/model/ImportCredentialsRequestData.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/model/ImportCredentialsRequestData.kt
@@ -1,17 +1,17 @@
 package com.bitwarden.cxf.model
 
 import android.net.Uri
-import androidx.credentials.provider.CallingAppInfo
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
 /**
  * A request to import the provider's credentials.
  *
  * @property uri the FileProvider uri that the importer will read the response from.
  * @property requestJson the request to import the provider's credentials.
- * @property callingAppInfo the caller's app info.
  */
-data class BitwardenImportCredentialsRequest(
+@Parcelize
+data class ImportCredentialsRequestData(
     val uri: Uri,
     val requestJson: String,
-    val callingAppInfo: CallingAppInfo,
-)
+) : Parcelable

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/util/CredentialExchangeIntentUtils.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/util/CredentialExchangeIntentUtils.kt
@@ -3,19 +3,12 @@
 package com.bitwarden.cxf.util
 
 import android.content.Intent
-import androidx.credentials.providerevents.playservices.IntentHandler
+ import androidx.credentials.providerevents.IntentHandler
+import androidx.credentials.providerevents.transfer.ProviderImportCredentialsRequest
 import com.bitwarden.annotation.OmitFromCoverage
-import com.bitwarden.cxf.model.BitwardenImportCredentialsRequest
 
 /**
- * Retrieves the [BitwardenImportCredentialsRequest] from the intent.
+ * Retrieves the [ProviderImportCredentialsRequest] from the intent.
  */
-fun Intent.getProviderImportCredentialsRequest(): BitwardenImportCredentialsRequest? = IntentHandler
+fun Intent.getProviderImportCredentialsRequest(): ProviderImportCredentialsRequest? = IntentHandler
     .retrieveProviderImportCredentialsRequest(this)
-    ?.let {
-        BitwardenImportCredentialsRequest(
-            uri = it.uri,
-            requestJson = it.request.requestJson,
-            callingAppInfo = it.callingAppInfo,
-        )
-    }

--- a/cxf/src/test/kotlin/com/bitwarden/cxf/manager/CredentialExchangeCompletionManagerTest.kt
+++ b/cxf/src/test/kotlin/com/bitwarden/cxf/manager/CredentialExchangeCompletionManagerTest.kt
@@ -2,8 +2,8 @@ package com.bitwarden.cxf.manager
 
 import android.app.Activity
 import android.net.Uri
+import androidx.credentials.providerevents.IntentHandler
 import androidx.credentials.providerevents.exception.ImportCredentialsException
-import androidx.credentials.providerevents.playservices.IntentHandler
 import com.bitwarden.cxf.manager.model.ExportCredentialsResult
 import io.mockk.Ordering
 import io.mockk.every


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This commit moves the `IntentHandler` from `androidx.credentials.providerevents.playservices` to `androidx.credentials.providerevents`.

It also introduces `credId` to `ProviderImportCredentialsRequest` and renames `BitwardenImportCredentialsRequest` to `ImportCredentialsRequestData`, removing `callingAppInfo` from it.

The `getProviderImportCredentialsRequest` extension function on `Intent` now directly returns `ProviderImportCredentialsRequest` instead of mapping it to the Bitwarden-specific model.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
