### PR TITLE
[PM-26112] Handle Credential Exchange export requests 

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -20,6 +20,18 @@
                 <data android:host="*.bitwarden.pw" />
                 <data android:pathPattern="/redirect-connector.*" />
             </intent-filter>
+
+            <!-- Handle Credential Exchange transfer requests -->
+            <intent-filter
+                android:autoVerify="true"
+                tools:ignore="AppLinkUrlError">
+                <action android:name="androidx.identitycredentials.action.IMPORT_CREDENTIALS" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:mimeType="application/octet-stream"
+                    android:scheme="content"
+                    tools:ignore="AppLinkUriRelativeFilterGroupError" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -5,6 +5,8 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.manager.toast.ToastManager
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
+import com.bitwarden.cxf.util.getProviderImportCredentialsRequest
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.manager.IntentManager
@@ -295,6 +297,7 @@ class MainViewModel @Inject constructor(
         val getCredentialsRequest = intent.getGetCredentialsRequestOrNull()
         val fido2AssertCredentialRequest = intent.getFido2AssertionRequestOrNull()
         val providerGetPasswordRequest = intent.getProviderGetPasswordRequestOrNull()
+        val importCredentialsRequest = intent.getProviderImportCredentialsRequest()
         when {
             passwordlessRequestData != null -> {
                 authRepository.activeUserId?.let {
@@ -417,6 +420,16 @@ class MainViewModel @Inject constructor(
             hasAccountSecurityShortcut -> {
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.AccountSecurityShortcut
+            }
+
+            importCredentialsRequest != null -> {
+                specialCircumstanceManager.specialCircumstance =
+                    SpecialCircumstance.CredentialExchangeExport(
+                        data = ImportCredentialsRequestData(
+                            uri = importCredentialsRequest.uri,
+                            requestJson = importCredentialsRequest.request.requestJson,
+                        ),
+                    )
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.manager.model
 
 import android.os.Parcelable
 import androidx.credentials.CredentialManager
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
@@ -132,6 +133,14 @@ sealed class SpecialCircumstance : Parcelable {
      */
     @Parcelize
     data object VerificationCodeShortcut : SpecialCircumstance()
+
+    /**
+     * The app was launched to select an account to export credentials from.
+     */
+    @Parcelize
+    data class CredentialExchangeExport(
+        val data: ImportCredentialsRequestData,
+    ) : SpecialCircumstance()
 
     /**
      * A subset of [SpecialCircumstance] that are only relevant in a pre-login state and should be

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensions.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.platform.manager.util
 
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
@@ -69,5 +70,14 @@ fun SpecialCircumstance.toGetCredentialsRequestOrNull(): GetCredentialsRequest? 
 fun SpecialCircumstance.toTotpDataOrNull(): TotpData? =
     when (this) {
         is SpecialCircumstance.AddTotpLoginItem -> this.data
+        else -> null
+    }
+
+/**
+ * Returns [ImportCredentialsRequestData] when contained in the given [SpecialCircumstance].
+ */
+fun SpecialCircumstance.toImportCredentialsRequestDataOrNull(): ImportCredentialsRequestData? =
+    when (this) {
+        is SpecialCircumstance.CredentialExchangeExport -> this.data
         else -> null
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -62,6 +62,8 @@ import com.x8bit.bitwarden.ui.tools.feature.send.addedit.navigateToAddEditSend
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditArgs
 import com.x8bit.bitwarden.ui.vault.feature.addedit.navigateToVaultAddEdit
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.toVaultItemCipherType
+import com.x8bit.bitwarden.ui.vault.feature.exportitems.exportItemsGraph
+import com.x8bit.bitwarden.ui.vault.feature.exportitems.navigateToExportItemsGraph
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.navigateToVaultItemListingAsRoot
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
 import com.x8bit.bitwarden.ui.vault.model.VaultItemListingType
@@ -107,6 +109,7 @@ fun RootNavScreen(
         setupUnlockDestinationAsRoot()
         setupAutoFillDestinationAsRoot()
         setupCompleteDestination()
+        exportItemsGraph()
     }
 
     val targetRoute = when (state) {
@@ -132,6 +135,7 @@ fun RootNavScreen(
         is RootNavState.VaultUnlockedForFido2Assertion,
         is RootNavState.VaultUnlockedForPasswordGet,
         is RootNavState.VaultUnlockedForProviderGetCredentials,
+        is RootNavState.CredentialExchangeExport,
             -> VaultUnlockedGraphRoute
 
         RootNavState.OnboardingAccountLockSetup -> SetupUnlockRoute.AsRoot
@@ -269,6 +273,10 @@ fun RootNavScreen(
 
             RootNavState.OnboardingStepsComplete -> {
                 navController.navigateToSetupCompleteScreen(rootNavOptions)
+            }
+
+            is RootNavState.CredentialExchangeExport -> {
+                navController.navigateToExportItemsGraph(rootNavOptions)
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -88,6 +88,10 @@ class RootNavViewModel @Inject constructor(
                 }
             }
 
+            specialCircumstance is SpecialCircumstance.CredentialExchangeExport -> {
+                RootNavState.CredentialExchangeExport
+            }
+
             userState.activeAccount.isVaultUnlocked &&
                 userState.shouldShowRemovePassword(authState = action.authState) -> {
                 RootNavState.RemovePassword
@@ -181,7 +185,9 @@ class RootNavViewModel @Inject constructor(
                     null,
                         -> RootNavState.VaultUnlocked(activeUserId = userState.activeAccount.userId)
 
-                    is SpecialCircumstance.RegistrationEvent -> {
+                    is SpecialCircumstance.CredentialExchangeExport,
+                    is SpecialCircumstance.RegistrationEvent,
+                        -> {
                         throw IllegalStateException(
                             "Special circumstance should have been already handled.",
                         )
@@ -401,6 +407,12 @@ sealed class RootNavState : Parcelable {
      */
     @Parcelize
     data object OnboardingStepsComplete : RootNavState()
+
+    /**
+     * App should begin the export items flow.
+     */
+    @Parcelize
+    data object CredentialExchangeExport : RootNavState()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/ExportItemsNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/ExportItemsNavigation.kt
@@ -1,0 +1,43 @@
+@file:OmitFromCoverage
+
+package com.x8bit.bitwarden.ui.vault.feature.exportitems
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.navigation
+import com.bitwarden.annotation.OmitFromCoverage
+import com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount.SelectAccountRoute
+import com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount.selectAccountDestination
+import kotlinx.serialization.Serializable
+
+/**
+ * The type-safe route for the export items graph.
+ */
+@OmitFromCoverage
+@Serializable
+data object ExportItemsRoute
+
+/**
+ * Add export items destinations to the nav graph.
+ */
+fun NavGraphBuilder.exportItemsGraph() {
+    navigation<ExportItemsRoute>(
+        startDestination = SelectAccountRoute,
+    ) {
+        selectAccountDestination(
+            onAccountSelected = {
+                // TODO: [PM-26110] Navigate to verify password screen.
+            },
+        )
+    }
+}
+
+/**
+ * Navigate to the export items graph.
+ */
+fun NavController.navigateToExportItemsGraph(
+    navOptions: NavOptions? = null,
+) {
+    navigate(route = ExportItemsRoute, navOptions = navOptions)
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/selectaccount/SelectAccountNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/selectaccount/SelectAccountNavigation.kt
@@ -1,0 +1,42 @@
+@file:OmitFromCoverage
+
+package com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.ui.platform.base.util.composableWithRootPushTransitions
+import kotlinx.serialization.Serializable
+
+/**
+ * The type-safe route for the select account screen.
+ */
+@OmitFromCoverage
+@Serializable
+data object SelectAccountRoute
+
+/**
+ * Add the [SelectAccountScreen] to the nav graph.
+ */
+fun NavGraphBuilder.selectAccountDestination(
+    onAccountSelected: (id: String) -> Unit,
+) {
+    composableWithRootPushTransitions<SelectAccountRoute> {
+        SelectAccountScreen(
+            onAccountSelected = onAccountSelected,
+        )
+    }
+}
+
+/**
+ * Navigate to the [SelectAccountScreen].
+ */
+fun NavController.navigateToSelectAccountScreen(
+    navOptions: NavOptions? = null,
+) {
+    navigate(
+        route = SelectAccountRoute,
+        navOptions = navOptions,
+    )
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/selectaccount/SelectAccountScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/selectaccount/SelectAccountScreen.kt
@@ -1,0 +1,15 @@
+package com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+
+/**
+ * Top level screen for selecting an account to export items from.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectAccountScreen(
+    onAccountSelected: (id: String) -> Unit,
+) {
+    // TODO: [PM-26095] Implement select account screen.
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.platform.manager.util
 
 import androidx.core.os.bundleOf
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
@@ -346,5 +347,57 @@ class SpecialCircumstanceExtensionsTest {
             .forEach { specialCircumstance ->
                 assertNull(specialCircumstance.toTotpDataOrNull())
             }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toImportCredentialsRequestDataOrNull should return a non-null value for ImportCredentials`() {
+        val importCredentialsRequest = ImportCredentialsRequestData(
+            uri = mockk(),
+            requestJson = "",
+        )
+        assertEquals(
+            importCredentialsRequest,
+            SpecialCircumstance
+                .CredentialExchangeExport(
+                    data = importCredentialsRequest,
+                )
+                .toImportCredentialsRequestDataOrNull(),
+        )
+    }
+
+    @Test
+    fun `toImportCredentialsRequestDataOrNull should return a null value for other types`() {
+        listOf(
+            SpecialCircumstance.AutofillSelection(
+                autofillSelectionData = mockk(),
+                shouldFinishWhenComplete = true,
+            ),
+            SpecialCircumstance.AutofillSave(
+                autofillSaveItem = mockk(),
+            ),
+            SpecialCircumstance.ShareNewSend(
+                data = mockk(),
+                shouldFinishWhenComplete = true,
+            ),
+            mockk<SpecialCircumstance.AddTotpLoginItem>(),
+            SpecialCircumstance.PasswordlessRequest(
+                passwordlessRequestData = mockk(),
+                shouldFinishWhenComplete = true,
+            ),
+            SpecialCircumstance.ProviderCreateCredential(
+                createCredentialRequest = mockk(),
+            ),
+            SpecialCircumstance.ProviderGetCredentials(
+                getCredentialsRequest = mockk(),
+            ),
+            SpecialCircumstance.Fido2Assertion(
+                fido2AssertionRequest = mockk(),
+            ),
+            SpecialCircumstance.GeneratorShortcut,
+            SpecialCircumstance.VaultShortcut,
+        ).forEach { specialCircumstance ->
+            assertNull(specialCircumstance.toImportCredentialsRequestDataOrNull())
+        }
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -23,6 +23,7 @@ import com.x8bit.bitwarden.ui.tools.feature.send.addedit.ModeType
 import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditMode
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditRoute
+import com.x8bit.bitwarden.ui.vault.feature.exportitems.ExportItemsRoute
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.ItemListingType
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.VaultItemListingRoute
 import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
@@ -422,6 +423,17 @@ class RootNavScreenTest : BitwardenComposeTest() {
             verify {
                 mockNavHostController.navigate(
                     route = SetupCompleteRoute,
+                    navOptions = expectedNavOptions,
+                )
+            }
+        }
+
+        // Make sure navigating to export items graph works as expected:
+        rootNavStateFlow.value = RootNavState.CredentialExchangeExport
+        composeTestRule.runOnIdle {
+            verify {
+                mockNavHostController.navigate(
+                    route = ExportItemsRoute,
                     navOptions = expectedNavOptions,
                 )
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.platform.feature.rootnav
 
 import androidx.core.os.bundleOf
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.bitwarden.data.datasource.disk.base.FakeDispatcherManager
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.network.model.JwtTokenDataJson
@@ -1388,6 +1389,24 @@ class RootNavViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         assertEquals(
             RootNavState.VaultUnlocked(activeUserId = "activeUserId"),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `when SpecialCircumstance is CredentialExchangeExport the nav state should be CredentialExchangeExport`() {
+        specialCircumstanceManager.specialCircumstance =
+            SpecialCircumstance.CredentialExchangeExport(
+                data = ImportCredentialsRequestData(
+                    uri = mockk(),
+                    requestJson = "mockRequestJson",
+                ),
+            )
+        mutableUserStateFlow.tryEmit(MOCK_VAULT_UNLOCKED_USER_STATE)
+        val viewModel = createViewModel()
+        assertEquals(
+            RootNavState.CredentialExchangeExport,
             viewModel.stateFlow.value,
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking

PM-26112

## 📔 Objective

This commit introduces the ability to handle Credential Exchange export requests.

When a `ProviderImportCredentialsRequest` is received they will be navigated to the Export Items graph.

It includes the following changes:

- Added `SpecialCircumstance.CredentialExchangeExport` to represent the app being launched for
  credential export.
- Updated `RootNavViewModel` to navigate to a new `RootNavState.CredentialExchangeExport` when this
  special circumstance is detected.
- Created a new `exportItemsGraph` for managing navigation related to exporting items, starting with
  a `SelectAccountScreen` (placeholder).
- Modified `MainViewModel` to parse `ProviderImportCredentialsRequest` from the intent and set the
  appropriate special circumstance.
- Added an intent filter in the debug `AndroidManifest.xml` to handle
  `androidx.identitycredentials.action.IMPORT_CREDENTIALS`.

## 📸 Screenshots

Coming soon!
  
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
