### PR TITLE
PM-26151: Disable continue button for Autofill onboarding flow when autofill is disabled

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreen.kt
@@ -182,6 +182,7 @@ private fun SetupAutoFillContent(
         BitwardenFilledButton(
             label = stringResource(id = BitwardenString.continue_text),
             onClick = onContinueClick,
+            isEnabled = state.autofillEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreenTest.kt
@@ -1,6 +1,8 @@
 package com.x8bit.bitwarden.ui.auth.feature.accountsetup
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
@@ -77,6 +79,7 @@ class SetupAutofillScreenTest : BitwardenComposeTest() {
 
     @Test
     fun `Continue click should send correct action`() {
+        mutableStateFlow.update { it.copy(autofillEnabled = true) }
         composeTestRule
             .onNodeWithText("Continue")
             .performScrollTo()
@@ -125,6 +128,14 @@ class SetupAutofillScreenTest : BitwardenComposeTest() {
             mutableEventFlow.tryEmit(SetupAutoFillEvent.NavigateToAutofillSettings)
             verify { viewModel.trySendAction(SetupAutoFillAction.AutoFillServiceFallback) }
         }
+    }
+
+    @Test
+    fun `Continue button is enabled according to state`() {
+        mutableStateFlow.update { it.copy(autofillEnabled = false) }
+        composeTestRule.onNodeWithText(text = "Continue").assertIsNotEnabled()
+        mutableStateFlow.update { it.copy(autofillEnabled = true) }
+        composeTestRule.onNodeWithText(text = "Continue").assertIsEnabled()
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

PM-26151

## 📔 Objective

This PR updates the onboarding screen for Autofill to disable the `Continu`e button until the user enabled Autofill. They can still select the `Turn on later` option.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
