### PR TITLE
[PM-20977] Handle new sdk exception type.

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -99,7 +99,9 @@ class VaultSdkSourceImpl(
                     is DeriveKeyConnectorException.WrongPassword -> {
                         DeriveKeyConnectorResult.WrongPasswordError
                     }
-                    else -> DeriveKeyConnectorResult.Error(error = ex)
+                    is DeriveKeyConnectorException.Crypto -> {
+                        DeriveKeyConnectorResult.Error(error = ex)
+                    }
                 }
             } catch (exception: BitwardenException) {
                 DeriveKeyConnectorResult.Error(error = exception)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.vault.datasource.sdk
 
 import com.bitwarden.collections.Collection
 import com.bitwarden.collections.CollectionView
+import com.bitwarden.core.DeriveKeyConnectorException
 import com.bitwarden.core.DeriveKeyConnectorRequest
 import com.bitwarden.core.DerivePinKeyResponse
 import com.bitwarden.core.InitOrgCryptoRequest
@@ -199,15 +200,61 @@ class VaultSdkSourceTest {
         }
 
     @Test
-    fun `deriveKeyConnector should call SDK and return a Result with wrong password`() =
+    @Suppress("MaxLineLength")
+    fun `deriveKeyConnector should call SDK with WrongPassword exception and return a Result with wrong password`() =
         runBlocking {
             val userId = "userId"
             val userKeyEncrypted = "userKeyEncrypted"
             val email = "email"
             val password = "password"
-            val error = mockk<BitwardenException> {
-                every { message } returns "Wrong password"
+            val kdf = mockk<Kdf>()
+            coEvery {
+                clientCrypto.deriveKeyConnector(
+                    request = DeriveKeyConnectorRequest(
+                        userKeyEncrypted = userKeyEncrypted,
+                        email = email,
+                        password = password,
+                        kdf = kdf,
+                    ),
+                )
+            } throws BitwardenException.DeriveKeyConnector(
+                v1 = DeriveKeyConnectorException.WrongPassword(message = "mock message"),
+            )
+            val result = vaultSdkSource.deriveKeyConnector(
+                userId = userId,
+                userKeyEncrypted = userKeyEncrypted,
+                email = email,
+                password = password,
+                kdf = kdf,
+            )
+            assertEquals(
+                DeriveKeyConnectorResult.WrongPasswordError,
+                result.getOrNull(),
+            )
+            coVerify(exactly = 1) {
+                sdkClientManager.getOrCreateClient(userId = userId)
+                clientCrypto.deriveKeyConnector(
+                    request = DeriveKeyConnectorRequest(
+                        userKeyEncrypted = userKeyEncrypted,
+                        email = email,
+                        password = password,
+                        kdf = kdf,
+                    ),
+                )
             }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `deriveKeyConnector should call SDK with Crypto exception return and return a Result with error`() =
+        runBlocking {
+            val userId = "userId"
+            val userKeyEncrypted = "userKeyEncrypted"
+            val email = "email"
+            val password = "password"
+            val error = BitwardenException.DeriveKeyConnector(
+                v1 = DeriveKeyConnectorException.Crypto(message = "mock message"),
+            )
             val kdf = mockk<Kdf>()
             coEvery {
                 clientCrypto.deriveKeyConnector(
@@ -227,7 +274,7 @@ class VaultSdkSourceTest {
                 kdf = kdf,
             )
             assertEquals(
-                DeriveKeyConnectorResult.WrongPasswordError,
+                DeriveKeyConnectorResult.Error(error = error),
                 result.getOrNull(),
             )
             coVerify(exactly = 1) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20977

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Update app to use new error type from sdk: 
https://github.com/bitwarden/android/pull/5922
https://bitwarden.atlassian.net/browse/PM-23785

#### Error handling improvements

* Catch `BitwardenException.DeriveKeyConnector` and check if the underlying exception is `DeriveKeyConnectorException.WrongPassword`, returning a dedicated error result for wrong passwords.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
