### PR TITLE
PM-26181: Minor clean up and adjustments for browser autofill integration

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/di/AutofillModule.kt
@@ -27,6 +27,7 @@ import com.x8bit.bitwarden.data.autofill.processor.AutofillProcessorImpl
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProvider
 import com.x8bit.bitwarden.data.autofill.provider.AutofillCipherProviderImpl
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ciphermatching.CipherMatchingManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
@@ -70,11 +71,13 @@ object AutofillModule {
         autofillEnabledManager: AutofillEnabledManager,
         browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
         clock: Clock,
+        firstTimeActionManager: FirstTimeActionManager,
         settingsDiskSource: SettingsDiskSource,
     ): BrowserAutofillDialogManager = BrowserAutofillDialogManagerImpl(
         autofillEnabledManager = autofillEnabledManager,
         browserThirdPartyAutofillEnabledManager = browserThirdPartyAutofillEnabledManager,
         clock = clock,
+        firstTimeActionManager = firstTimeActionManager,
         settingsDiskSource = settingsDiskSource,
     )
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManager.kt
@@ -5,6 +5,11 @@ package com.x8bit.bitwarden.data.autofill.manager.browser
  */
 interface BrowserAutofillDialogManager {
     /**
+     * Number of browsers installed that may need autofill enabled.
+     */
+    val browserCount: Int
+
+    /**
      * Indicates whether the dialog should be displayed to the user.
      */
     val shouldShowDialog: Boolean

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManagerImpl.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.autofill.manager.browser
 
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import java.time.Clock
 
 /**
@@ -16,13 +17,22 @@ internal class BrowserAutofillDialogManagerImpl(
     private val autofillEnabledManager: AutofillEnabledManager,
     private val browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
     private val clock: Clock,
+    private val firstTimeActionManager: FirstTimeActionManager,
     private val settingsDiskSource: SettingsDiskSource,
 ) : BrowserAutofillDialogManager {
+    override val browserCount: Int
+        get() = browserThirdPartyAutofillEnabledManager
+            .browserThirdPartyAutofillStatus
+            .availableCount
+
     override val shouldShowDialog: Boolean
         get() = autofillEnabledManager.isAutofillEnabled &&
             browserThirdPartyAutofillEnabledManager
                 .browserThirdPartyAutofillStatus
                 .isAnyIsAvailableAndDisabled &&
+            !firstTimeActionManager
+                .currentOrDefaultUserFirstTimeState
+                .showSetupBrowserAutofillCard &&
             settingsDiskSource.browserAutofillDialogReshowTime?.isBefore(clock.instant()) != false
 
     override fun delayDialog() {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserThirdPartyAutoFillData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserThirdPartyAutoFillData.kt
@@ -19,6 +19,14 @@ data class BrowserThirdPartyAutofillStatus(
     val chromeBetaChannelStatusData: BrowserThirdPartyAutoFillData,
 ) {
     /**
+     * The total number of available browsers.
+     */
+    val availableCount: Int
+        get() = (if (braveStableStatusData.isAvailable) 1 else 0) +
+            (if (chromeStableStatusData.isAvailable) 1 else 0) +
+            (if (chromeBetaChannelStatusData.isAvailable) 1 else 0)
+
+    /**
      * Whether any of the available browsers have third party autofill disabled.
      */
     val isAnyIsAvailableAndDisabled: Boolean

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerImpl.kt
@@ -174,7 +174,7 @@ class FirstTimeActionManagerImpl @Inject constructor(
                         showImportLoginsCardInSettings = settingsDiskSource
                             .getShowImportLoginsSettingBadge(it),
                         showSetupBrowserAutofillCard = settingsDiskSource
-                            .getShowUnlockSettingBadge(it),
+                            .getShowBrowserAutofillSettingBadge(it),
                     )
                 }
                 ?: FirstTimeState()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,6 +35,7 @@ import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenPlurals
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.data.autofill.model.browser.BrowserPackage
@@ -141,8 +143,9 @@ private fun SetupBrowserAutofillContent(
         )
         Spacer(Modifier.height(height = 8.dp))
         Text(
-            text = stringResource(
-                id = BitwardenString.youre_using_a_browser_that_requires_special_permissions,
+            text = pluralStringResource(
+                id = BitwardenPlurals.youre_using_a_browser_that_requires_special_permissions,
+                count = state.browserCount,
             ),
             style = BitwardenTheme.typography.bodyMedium,
             color = BitwardenTheme.colorScheme.text.primary,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillViewModel.kt
@@ -131,9 +131,14 @@ data class SetupBrowserAutofillState(
     val browserAutofillSettingsOptions: ImmutableList<BrowserAutofillSettingsOption>,
 ) : Parcelable {
     /**
+     * The number of browsers that can be configured.
+     */
+    val browserCount: Int get() = browserAutofillSettingsOptions.size
+
+    /**
      * Indicates if the Continue button should be enabled or not.
      */
-    val isContinueEnabled: Boolean get() = browserAutofillSettingsOptions.any { it.isEnabled }
+    val isContinueEnabled: Boolean get() = browserAutofillSettingsOptions.all { it.isEnabled }
 
     /**
      * Models dialogs that can be shown on the Setup Browser Autofill screen.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -54,6 +55,7 @@ import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenPlurals
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
@@ -197,9 +199,10 @@ private fun AutoFillScreenContent(
                 cardTitle = stringResource(
                     id = BitwardenString.turn_on_browser_autofill_integration,
                 ),
-                cardSubtitle = stringResource(
-                    id = BitwardenString
+                cardSubtitle = pluralStringResource(
+                    id = BitwardenPlurals
                         .youre_using_a_browser_that_requires_special_permissions_for_bitwarden,
+                    count = state.browserCount,
                 ),
                 actionText = stringResource(id = BitwardenString.get_started),
                 onActionClick = autoFillHandlers.onBrowserAutofillActionCardClick,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -306,6 +306,11 @@ data class AutoFillState(
     val showInlineAutofill: Boolean get() = isAutoFillServicesEnabled && showInlineAutofillOption
 
     /**
+     * The number of browsers that can be configured.
+     */
+    val browserCount: Int get() = browserAutofillSettingsOptions.size
+
+    /**
      * Whether or not the toggles for enabling 3rd-party autofill support should be displayed.
      */
     val showBrowserSettingOptions: Boolean

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -447,13 +447,14 @@ private fun VaultDialogs(
             )
         }
 
-        VaultState.DialogState.ThirdPartyBrowserAutofill -> {
+        is VaultState.DialogState.ThirdPartyBrowserAutofill -> {
             BitwardenTwoButtonDialog(
                 title = stringResource(
                     id = BitwardenString.enable_browser_autofill_to_keep_filling_passwords,
                 ),
-                message = stringResource(
-                    id = BitwardenString.your_browser_recently_updated_how_autofill_works,
+                message = pluralStringResource(
+                    id = BitwardenPlurals.your_browser_recently_updated_how_autofill_works,
+                    count = dialogState.browserCount,
                 ),
                 confirmButtonText = stringResource(id = BitwardenString.go_to_settings),
                 dismissButtonText = stringResource(id = BitwardenString.not_now),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -213,7 +213,8 @@ class VaultViewModel @Inject constructor(
             delay(timeMillis = BROWSER_AUTOFILL_DIALOG_DELAY)
             mutableStateFlow.update { vaultState ->
                 vaultState.copy(
-                    dialog = VaultState.DialogState.ThirdPartyBrowserAutofill
+                    dialog = VaultState.DialogState
+                        .ThirdPartyBrowserAutofill(browserAutofillDialogManager.browserCount)
                         .takeIf {
                             vaultState.dialog == null &&
                                 browserAutofillDialogManager.shouldShowDialog
@@ -953,7 +954,7 @@ class VaultViewModel @Inject constructor(
                     cipherCount = vaultData.data.decryptCipherListResult.failures.size,
                 )
             } else if (state.dialog is VaultState.DialogState.ThirdPartyBrowserAutofill) {
-                VaultState.DialogState.ThirdPartyBrowserAutofill
+                state.dialog
             } else {
                 null
             },
@@ -1495,7 +1496,9 @@ data class VaultState(
          * Represents a dialog indicating that a 3rd party browser required Autofill configuration.
          */
         @Parcelize
-        data object ThirdPartyBrowserAutofill : DialogState()
+        data class ThirdPartyBrowserAutofill(
+            val browserCount: Int,
+        ) : DialogState()
 
         /**
          * Represents a dialog indicating that there was a decryption error loading ciphers.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -585,7 +585,7 @@ class VaultScreenTest : BitwardenComposeTest() {
     fun `ThirdPartyBrowserAutofill should be displayed according to state`() {
         composeTestRule.assertNoDialogExists()
         mutableStateFlow.update {
-            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill)
+            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill(browserCount = 1))
         }
 
         composeTestRule
@@ -601,7 +601,7 @@ class VaultScreenTest : BitwardenComposeTest() {
     @Test
     fun `ThirdPartyBrowserAutofill dialog Not now button should emit DismissThirdPartyAutofillDialogClick`() {
         mutableStateFlow.update {
-            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill)
+            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill(browserCount = 2))
         }
 
         composeTestRule
@@ -619,7 +619,7 @@ class VaultScreenTest : BitwardenComposeTest() {
     @Test
     fun `ThirdPartyBrowserAutofill dialog Go to settings now button should emit EnableThirdPartyAutofillClick`() {
         mutableStateFlow.update {
-            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill)
+            it.copy(dialog = VaultState.DialogState.ThirdPartyBrowserAutofill(browserCount = 3))
         }
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -183,6 +183,7 @@ class VaultViewModelTest : BaseViewModelTest() {
     }
     private val browserAutofillDialogManager: BrowserAutofillDialogManager = mockk {
         every { shouldShowDialog } returns false
+        every { browserCount } returns 1
         every { delayDialog() } just runs
     }
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -760,8 +760,14 @@ Do you want to switch to this account?</string>
     <string name="turn_on_autofill">Turn on autofill</string>
     <string name="autofill_setup">Autofill setup</string>
     <string name="turn_on_browser_autofill_integration">Turn on browser autofill integration</string>
-    <string name="youre_using_a_browser_that_requires_special_permissions_for_bitwarden">You’re using a browser that requires special permissions for Bitwarden to autofill your passwords.</string>
-    <string name="youre_using_a_browser_that_requires_special_permissions">You’re using a browser that requires special permissions for Bitwarden to autofill your passwords. Enable your preferred autofill integration below.</string>
+    <plurals name="youre_using_a_browser_that_requires_special_permissions_for_bitwarden">
+        <item quantity="one">You’re using a browser that requires special permissions for Bitwarden to autofill your passwords.</item>
+        <item quantity="other">You’re using browsers that requires special permissions for Bitwarden to autofill your passwords.</item>
+    </plurals>
+    <plurals name="youre_using_a_browser_that_requires_special_permissions">
+        <item quantity="one">You’re using a browser that requires special permissions for Bitwarden to autofill your passwords. Enable your preferred autofill integration below.</item>
+        <item quantity="other">You’re using browsers that requires special permissions for Bitwarden to autofill your passwords. Enable autofill for all your installed browsers to continue.</item>
+    </plurals>
     <string name="use_autofill_to_log_into_your_accounts">Use autofill to log into your accounts with a single tap.</string>
     <string name="turn_on_later">Turn on later</string>
     <string name="turn_on_autofill_later">Turn on autofill later?</string>
@@ -1108,7 +1114,10 @@ Do you want to switch to this account?</string>
         <item quantity="other">%1$d items have been imported to your vault.</item>
     </plurals>
     <string name="enable_browser_autofill_to_keep_filling_passwords">Enable browser Autofill to keep filling passwords</string>
-    <string name="your_browser_recently_updated_how_autofill_works">Your browser recently updated how Autofill works. To continue filling your passwords with Bitwarden, enable browser Autofill in autofill settings.</string>
+    <plurals name="your_browser_recently_updated_how_autofill_works">
+        <item quantity="one">Your browser has recently updated, which has disabled Bitwarden autofill. To continue filling your passwords with Bitwarden, enable browser autofill in autofill settings.</item>
+        <item quantity="other">Your browsers have recently updated, which has disabled Bitwarden autofill. To continue filling your passwords with Bitwarden, enable browser autofill for all installed browsers in autofill settings.</item>
+    </plurals>
     <string name="not_now">Not now</string>
     <string name="import_from_bitwarden">Import from Bitwarden</string>
     <string name="select_account">Select account</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26181](https://bitwarden.atlassian.net/browse/PM-26181)

## 📔 Objective

This PR makes several minor adjustments to the Browser Autofill Integration components of the app.

* All copy uses plurals based on how many troublesome browsers are installed
* You must configure all browsers installed to be considered "done"
* The `VaultScreen` dialog will not be displayed of the browser autofill badge is being displayed

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26181]: https://bitwarden.atlassian.net/browse/PM-26181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ