### PR TITLE
[PM-23280] Save MasterPasswordUnlockData to local state

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/util/TrustDeviceResponseExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/util/TrustDeviceResponseExtensions.kt
@@ -26,6 +26,7 @@ fun TrustDeviceResponse.toUserStateJson(
             hasMasterPassword = false,
             trustedDeviceUserDecryptionOptions = null,
             keyConnectorUserDecryptionOptions = null,
+            masterPasswordUnlock = null,
         )
     val deviceOptions = decryptionOptions
         .trustedDeviceUserDecryptionOptions

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensions.kt
@@ -32,6 +32,7 @@ fun UserStateJson.toRemovedPasswordUserStateJson(
             hasMasterPassword = false,
             trustedDeviceUserDecryptionOptions = null,
             keyConnectorUserDecryptionOptions = null,
+            masterPasswordUnlock = null,
         )
     val updatedProfile = profile.copy(userDecryptionOptions = updatedUserDecryptionOptions)
     val updatedAccount = account.copy(profile = updatedProfile)
@@ -54,6 +55,23 @@ fun UserStateJson.toUpdatedUserStateJson(
     val userId = syncProfile.id
     val account = this.accounts[userId] ?: return this
     val profile = account.profile
+    val userDecryptionOptions = syncResponse
+        .userDecryption
+        ?.let { syncUserDecryption ->
+            profile
+                .userDecryptionOptions
+                ?.copy(masterPasswordUnlock = syncUserDecryption.masterPasswordUnlock)
+                ?: UserDecryptionOptionsJson(
+                    hasMasterPassword = syncUserDecryption.masterPasswordUnlock != null,
+                    trustedDeviceUserDecryptionOptions = null,
+                    keyConnectorUserDecryptionOptions = null,
+                    masterPasswordUnlock = syncUserDecryption.masterPasswordUnlock,
+                )
+        }
+        ?: profile
+            .userDecryptionOptions
+            ?.copy(masterPasswordUnlock = null)
+
     val updatedProfile = profile
         .copy(
             avatarColorHex = syncProfile.avatarColor,
@@ -61,6 +79,7 @@ fun UserStateJson.toUpdatedUserStateJson(
             hasPremium = syncProfile.isPremium || syncProfile.isPremiumFromOrganization,
             isTwoFactorEnabled = syncProfile.isTwoFactorEnabled,
             creationDate = syncProfile.creationDate,
+            userDecryptionOptions = userDecryptionOptions,
         )
     val updatedAccount = account.copy(profile = updatedProfile)
     return this
@@ -90,6 +109,7 @@ fun UserStateJson.toUserStateJsonWithPassword(): UserStateJson {
                     hasMasterPassword = true,
                     keyConnectorUserDecryptionOptions = null,
                     trustedDeviceUserDecryptionOptions = null,
+                    masterPasswordUnlock = null,
                 ),
         )
     val updatedAccount = account.copy(profile = updatedProfile)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -1463,6 +1463,7 @@ private val USER_STATE = UserStateJson(
                     keyConnectorUserDecryptionOptions = KeyConnectorUserDecryptionOptionsJson(
                         keyConnectorUrl = "keyConnectorUrl",
                     ),
+                    masterPasswordUnlock = null,
                 ),
             ),
             tokens = AccountTokensJson(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/TrustedDeviceManagerTests.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/TrustedDeviceManagerTests.kt
@@ -273,12 +273,14 @@ private val DEFAULT_USER_DECRYPTION_OPTIONS: UserDecryptionOptionsJson = UserDec
     hasMasterPassword = false,
     trustedDeviceUserDecryptionOptions = DEFAULT_TRUSTED_DEVICE_USER_DECRYPTION_OPTIONS,
     keyConnectorUserDecryptionOptions = null,
+    masterPasswordUnlock = null,
 )
 
 private val UPDATED_USER_DECRYPTION_OPTIONS: UserDecryptionOptionsJson = UserDecryptionOptionsJson(
     hasMasterPassword = false,
     trustedDeviceUserDecryptionOptions = UPDATED_TRUSTED_DEVICE_USER_DECRYPTION_OPTIONS,
     keyConnectorUserDecryptionOptions = null,
+    masterPasswordUnlock = null,
 )
 
 private val DEFAULT_ACCOUNT = AccountJson(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/util/TrustDeviceResponseExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/util/TrustDeviceResponseExtensionsTest.kt
@@ -55,12 +55,14 @@ private val DEFAULT_USER_DECRYPTION_OPTIONS: UserDecryptionOptionsJson = UserDec
     hasMasterPassword = false,
     trustedDeviceUserDecryptionOptions = DEFAULT_TRUSTED_DEVICE_USER_DECRYPTION_OPTIONS,
     keyConnectorUserDecryptionOptions = null,
+    masterPasswordUnlock = null,
 )
 
 private val UPDATED_USER_DECRYPTION_OPTIONS: UserDecryptionOptionsJson = UserDecryptionOptionsJson(
     hasMasterPassword = false,
     trustedDeviceUserDecryptionOptions = UPDATED_TRUSTED_DEVICE_USER_DECRYPTION_OPTIONS,
     keyConnectorUserDecryptionOptions = null,
+    masterPasswordUnlock = null,
 )
 
 private val DEFAULT_ACCOUNT = AccountJson(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -2008,6 +2008,7 @@ class AuthRepositoryTest {
                     hasMasterPassword = false,
                     keyConnectorUserDecryptionOptions = null,
                     trustedDeviceUserDecryptionOptions = null,
+                    masterPasswordUnlock = null,
                 ),
             )
             coEvery {
@@ -7030,6 +7031,7 @@ class AuthRepositoryTest {
             hasMasterPassword = false,
             trustedDeviceUserDecryptionOptions = TRUSTED_DEVICE_DECRYPTION_OPTIONS,
             keyConnectorUserDecryptionOptions = null,
+            masterPasswordUnlock = null,
         )
 
         @Deprecated(
@@ -7138,6 +7140,7 @@ class AuthRepositoryTest {
                             hasMasterPassword = true,
                             keyConnectorUserDecryptionOptions = null,
                             trustedDeviceUserDecryptionOptions = null,
+                            masterPasswordUnlock = null,
                         ),
                     ),
                 ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/GetTokenResponseExtensionsTest.kt
@@ -128,6 +128,7 @@ private val USER_DECRYPTION_OPTIONS = UserDecryptionOptionsJson(
         hasManageResetPasswordPermission = true,
     ),
     keyConnectorUserDecryptionOptions = null,
+    masterPasswordUnlock = null,
 )
 private val PROFILE_1 = AccountJson.Profile(
     userId = USER_ID_1,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/UserStateJsonExtensionsTest.kt
@@ -4,8 +4,11 @@ import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.network.model.KdfTypeJson
 import com.bitwarden.network.model.KeyConnectorUserDecryptionOptionsJson
+import com.bitwarden.network.model.MasterPasswordUnlockDataJson
 import com.bitwarden.network.model.OrganizationType
+import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.TrustedDeviceUserDecryptionOptionsJson
+import com.bitwarden.network.model.UserDecryptionJson
 import com.bitwarden.network.model.UserDecryptionOptionsJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
@@ -83,6 +86,7 @@ class UserStateJsonExtensionsTest {
                                 hasMasterPassword = false,
                                 trustedDeviceUserDecryptionOptions = null,
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             ),
                         ),
                     ),
@@ -112,6 +116,7 @@ class UserStateJsonExtensionsTest {
                 hasMasterPassword = true,
                 trustedDeviceUserDecryptionOptions = null,
                 keyConnectorUserDecryptionOptions = null,
+                masterPasswordUnlock = null,
             ),
             isTwoFactorEnabled = false,
             creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
@@ -136,6 +141,7 @@ class UserStateJsonExtensionsTest {
                                 hasMasterPassword = false,
                                 trustedDeviceUserDecryptionOptions = null,
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             ),
                         ),
                     ),
@@ -266,6 +272,7 @@ class UserStateJsonExtensionsTest {
                                 hasMasterPassword = true,
                                 keyConnectorUserDecryptionOptions = null,
                                 trustedDeviceUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             ),
                         ),
                     ),
@@ -309,6 +316,7 @@ class UserStateJsonExtensionsTest {
                 hasMasterPassword = true,
                 keyConnectorUserDecryptionOptions = keyConnectorOptionsJson,
                 trustedDeviceUserDecryptionOptions = trustedDeviceOptionsJson,
+                masterPasswordUnlock = null,
             ),
             isTwoFactorEnabled = false,
             creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
@@ -328,6 +336,7 @@ class UserStateJsonExtensionsTest {
                                 hasMasterPassword = true,
                                 keyConnectorUserDecryptionOptions = keyConnectorOptionsJson,
                                 trustedDeviceUserDecryptionOptions = trustedDeviceOptionsJson,
+                                masterPasswordUnlock = null,
                             ),
                         ),
                     ),
@@ -396,6 +405,7 @@ class UserStateJsonExtensionsTest {
                                 hasMasterPassword = true,
                                 trustedDeviceUserDecryptionOptions = null,
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = AccountTokensJson(
@@ -509,6 +519,7 @@ class UserStateJsonExtensionsTest {
                                 hasMasterPassword = false,
                                 trustedDeviceUserDecryptionOptions = null,
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = AccountTokensJson(
@@ -629,6 +640,7 @@ class UserStateJsonExtensionsTest {
                                     hasManageResetPasswordPermission = false,
                                 ),
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = null,
@@ -746,6 +758,7 @@ class UserStateJsonExtensionsTest {
                                     hasManageResetPasswordPermission = false,
                                 ),
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = null,
@@ -863,6 +876,7 @@ class UserStateJsonExtensionsTest {
                                     hasManageResetPasswordPermission = false,
                                 ),
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = null,
@@ -984,6 +998,7 @@ class UserStateJsonExtensionsTest {
                                     hasManageResetPasswordPermission = false,
                                 ),
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = null,
@@ -1082,6 +1097,7 @@ class UserStateJsonExtensionsTest {
                                 keyConnectorUserDecryptionOptions = KeyConnectorUserDecryptionOptionsJson(
                                     keyConnectorUrl = "keyConnectorUrl",
                                 ),
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = null,
@@ -1157,6 +1173,7 @@ class UserStateJsonExtensionsTest {
                                 hasMasterPassword = false,
                                 trustedDeviceUserDecryptionOptions = null,
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = null,
@@ -1262,6 +1279,7 @@ class UserStateJsonExtensionsTest {
                                     hasManageResetPasswordPermission = false,
                                 ),
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = null,
@@ -1381,6 +1399,7 @@ class UserStateJsonExtensionsTest {
                                     hasManageResetPasswordPermission = false,
                                 ),
                                 keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = null,
                             )
                         },
                         tokens = null,
@@ -1432,4 +1451,239 @@ class UserStateJsonExtensionsTest {
                 ),
         )
     }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `toUpdatedUserStateJson should create UserDecryptionOptionsJson when null and syncResponse has masterPasswordUnlock`() {
+        val originalProfile = AccountJson.Profile(
+            userId = "activeUserId",
+            email = "email",
+            isEmailVerified = true,
+            name = "name",
+            stamp = null,
+            organizationId = null,
+            avatarColorHex = null,
+            hasPremium = true,
+            forcePasswordResetReason = null,
+            kdfType = KdfTypeJson.ARGON2_ID,
+            kdfIterations = 600000,
+            kdfMemory = 16,
+            kdfParallelism = 4,
+            userDecryptionOptions = null,
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+        )
+        val originalAccount = AccountJson(
+            profile = originalProfile,
+            tokens = null,
+            settings = AccountJson.Settings(environmentUrlData = null),
+        )
+        val originalUserState = UserStateJson(
+            activeUserId = "activeUserId",
+            accounts = mapOf("activeUserId" to originalAccount),
+        )
+
+        val syncResponse = mockk<SyncResponseJson>(relaxed = true) {
+            every { profile } returns mockk {
+                every { id } returns "activeUserId"
+                every { avatarColor } returns "avatarColor"
+                every { securityStamp } returns "securityStamp"
+                every { isPremium } returns false
+                every { isPremiumFromOrganization } returns false
+                every { isTwoFactorEnabled } returns true
+                every { creationDate } returns ZonedDateTime.parse("2024-09-13T01:00:00.00Z")
+            }
+            every { userDecryption } returns UserDecryptionJson(
+                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+            )
+        }
+
+        assertEquals(
+            UserStateJson(
+                activeUserId = "activeUserId",
+                accounts = mapOf(
+                    "activeUserId" to originalAccount.copy(
+                        profile = originalProfile.copy(
+                            avatarColorHex = "avatarColor",
+                            stamp = "securityStamp",
+                            hasPremium = false,
+                            isTwoFactorEnabled = true,
+                            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+                            userDecryptionOptions = UserDecryptionOptionsJson(
+                                hasMasterPassword = true,
+                                trustedDeviceUserDecryptionOptions = null,
+                                keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            originalUserState.toUpdatedUserStateJson(syncResponse),
+        )
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `toUpdatedUserStateJson should update existing UserDecryptionOptionsJson with masterPasswordUnlock`() {
+        val trustedDeviceOptions = TrustedDeviceUserDecryptionOptionsJson(
+            encryptedPrivateKey = "encryptedPrivateKey",
+            encryptedUserKey = "encryptedUserKey",
+            hasAdminApproval = true,
+            hasLoginApprovingDevice = false,
+            hasManageResetPasswordPermission = true,
+        )
+        val originalProfile = AccountJson.Profile(
+            userId = "activeUserId",
+            email = "email",
+            isEmailVerified = true,
+            name = "name",
+            stamp = null,
+            organizationId = null,
+            avatarColorHex = null,
+            hasPremium = true,
+            forcePasswordResetReason = null,
+            kdfType = KdfTypeJson.ARGON2_ID,
+            kdfIterations = 600000,
+            kdfMemory = 16,
+            kdfParallelism = 4,
+            userDecryptionOptions = UserDecryptionOptionsJson(
+                hasMasterPassword = true,
+                trustedDeviceUserDecryptionOptions = trustedDeviceOptions,
+                keyConnectorUserDecryptionOptions = null,
+                masterPasswordUnlock = null,
+            ),
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+        )
+        val originalAccount = AccountJson(
+            profile = originalProfile,
+            tokens = null,
+            settings = AccountJson.Settings(environmentUrlData = null),
+        )
+        val originalUserState = UserStateJson(
+            activeUserId = "activeUserId",
+            accounts = mapOf("activeUserId" to originalAccount),
+        )
+
+        val syncResponse = mockk<SyncResponseJson> {
+            every { profile } returns mockk {
+                every { id } returns "activeUserId"
+                every { avatarColor } returns "newAvatarColor"
+                every { securityStamp } returns "newSecurityStamp"
+                every { isPremium } returns true
+                every { isPremiumFromOrganization } returns false
+                every { isTwoFactorEnabled } returns true
+                every { creationDate } returns ZonedDateTime.parse("2024-09-13T01:00:00.00Z")
+            }
+            every { userDecryption } returns UserDecryptionJson(
+                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+            )
+        }
+
+        assertEquals(
+            UserStateJson(
+                activeUserId = "activeUserId",
+                accounts = mapOf(
+                    "activeUserId" to originalAccount.copy(
+                        profile = originalProfile.copy(
+                            avatarColorHex = "newAvatarColor",
+                            stamp = "newSecurityStamp",
+                            hasPremium = true,
+                            isTwoFactorEnabled = true,
+                            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+                            userDecryptionOptions = UserDecryptionOptionsJson(
+                                hasMasterPassword = true,
+                                trustedDeviceUserDecryptionOptions = trustedDeviceOptions,
+                                keyConnectorUserDecryptionOptions = null,
+                                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            originalUserState.toUpdatedUserStateJson(syncResponse),
+        )
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `toUpdatedUserStateJson should update existing UserDecryptionOptionsJson when syncResponse has no userDecryption`() {
+        val keyConnectorOptions = KeyConnectorUserDecryptionOptionsJson("keyConnectorUrl")
+        val originalProfile = AccountJson.Profile(
+            userId = "activeUserId",
+            email = "email",
+            isEmailVerified = true,
+            name = "name",
+            stamp = null,
+            organizationId = null,
+            avatarColorHex = null,
+            hasPremium = true,
+            forcePasswordResetReason = null,
+            kdfType = KdfTypeJson.ARGON2_ID,
+            kdfIterations = 600000,
+            kdfMemory = 16,
+            kdfParallelism = 4,
+            userDecryptionOptions = UserDecryptionOptionsJson(
+                hasMasterPassword = true,
+                trustedDeviceUserDecryptionOptions = null,
+                keyConnectorUserDecryptionOptions = keyConnectorOptions,
+                masterPasswordUnlock = MOCK_MASTER_PASSWORD_UNLOCK_DATA,
+            ),
+            isTwoFactorEnabled = false,
+            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+        )
+        val originalAccount = AccountJson(
+            profile = originalProfile,
+            tokens = null,
+            settings = AccountJson.Settings(environmentUrlData = null),
+        )
+        val originalUserState = UserStateJson(
+            activeUserId = "activeUserId",
+            accounts = mapOf("activeUserId" to originalAccount),
+        )
+
+        val syncResponse = mockk<SyncResponseJson> {
+            every { profile } returns mockk {
+                every { id } returns "activeUserId"
+                every { avatarColor } returns "updatedAvatarColor"
+                every { securityStamp } returns "updatedSecurityStamp"
+                every { isPremium } returns false
+                every { isPremiumFromOrganization } returns true
+                every { isTwoFactorEnabled } returns false
+                every { creationDate } returns ZonedDateTime.parse("2024-09-13T01:00:00.00Z")
+            }
+            every { userDecryption } returns null
+        }
+
+        assertEquals(
+            UserStateJson(
+                activeUserId = "activeUserId",
+                accounts = mapOf(
+                    "activeUserId" to originalAccount.copy(
+                        profile = originalProfile.copy(
+                            avatarColorHex = "updatedAvatarColor",
+                            stamp = "updatedSecurityStamp",
+                            hasPremium = true,
+                            isTwoFactorEnabled = false,
+                            creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),
+                            userDecryptionOptions = UserDecryptionOptionsJson(
+                                hasMasterPassword = true,
+                                trustedDeviceUserDecryptionOptions = null,
+                                keyConnectorUserDecryptionOptions = keyConnectorOptions,
+                                masterPasswordUnlock = null,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            originalUserState.toUpdatedUserStateJson(syncResponse),
+        )
+    }
 }
+
+private val MOCK_MASTER_PASSWORD_UNLOCK_DATA = MasterPasswordUnlockDataJson(
+    salt = "mockSalt",
+    kdf = mockk(),
+    masterKeyWrappedUserKey = "masterKeyWrappedUserKeyMock",
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -421,6 +421,7 @@ private val MOCK_USER_DECRYPTION_OPTIONS: UserDecryptionOptionsJson = UserDecryp
     hasMasterPassword = false,
     trustedDeviceUserDecryptionOptions = MOCK_TRUSTED_DEVICE_USER_DECRYPTION_OPTIONS,
     keyConnectorUserDecryptionOptions = null,
+    masterPasswordUnlock = null,
 )
 
 private val MOCK_PROFILE = AccountJson.Profile(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -1292,6 +1292,7 @@ private val MOCK_USER_DECRYPTION_OPTIONS: UserDecryptionOptionsJson = UserDecryp
     hasMasterPassword = false,
     trustedDeviceUserDecryptionOptions = MOCK_TRUSTED_DEVICE_USER_DECRYPTION_OPTIONS,
     keyConnectorUserDecryptionOptions = null,
+    masterPasswordUnlock = null,
 )
 
 private val MOCK_PROFILE = AccountJson.Profile(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/tools/generator/repository/GeneratorRepositoryTest.kt
@@ -804,6 +804,7 @@ private val USER_STATE = UserStateJson(
                     keyConnectorUserDecryptionOptions = KeyConnectorUserDecryptionOptionsJson(
                         keyConnectorUrl = "keyConnectorUrl",
                     ),
+                    masterPasswordUnlock = null,
                 ),
                 isTwoFactorEnabled = false,
                 creationDate = ZonedDateTime.parse("2024-09-13T01:00:00.00Z"),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -356,6 +356,7 @@ private val VAULT_DATA: SyncResponseJson = SyncResponseJson(
     policies = null,
     domains = DOMAINS_1,
     sends = listOf(SEND_1),
+    userDecryption = null,
 )
 
 private const val CIPHER_JSON = """

--- a/network/src/main/kotlin/com/bitwarden/network/model/KdfJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/KdfJson.kt
@@ -1,0 +1,22 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the data used to create the kdf settings.
+ */
+@Serializable
+data class KdfJson(
+    @SerialName("KdfType")
+    val kdfType: KdfTypeJson,
+
+    @SerialName("Iterations")
+    val iterations: Int,
+
+    @SerialName("Memory")
+    val memory: Int?,
+
+    @SerialName("Parallelism")
+    val parallelism: Int?,
+)

--- a/network/src/main/kotlin/com/bitwarden/network/model/MasterPasswordUnlockDataJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/MasterPasswordUnlockDataJson.kt
@@ -1,0 +1,19 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the data used to unlock with the master password.
+ */
+@Serializable
+data class MasterPasswordUnlockDataJson(
+    @SerialName("MasterPasswordSalt")
+    val salt: String,
+
+    @SerialName("EncryptedPrivateKey")
+    val kdf: KdfJson,
+
+    @SerialName("MasterKeyWrappedUserKey")
+    val masterKeyWrappedUserKey: String,
+)

--- a/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
@@ -48,6 +48,9 @@ data class SyncResponseJson(
 
     @SerialName("sends")
     val sends: List<Send>?,
+
+    @SerialName("UserDecryption")
+    val userDecryption: UserDecryptionJson?,
 ) {
     /**
      * Represents domains in the vault response.

--- a/network/src/main/kotlin/com/bitwarden/network/model/UserDecryptionJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/UserDecryptionJson.kt
@@ -1,0 +1,13 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the user decryption options received on sync.
+ */
+@Serializable
+data class UserDecryptionJson(
+    @SerialName("MasterPasswordUnlock")
+    val masterPasswordUnlock: MasterPasswordUnlockDataJson?,
+)

--- a/network/src/main/kotlin/com/bitwarden/network/model/UserDecryptionOptionsJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/UserDecryptionOptionsJson.kt
@@ -21,6 +21,10 @@ data class UserDecryptionOptionsJson(
     @JsonNames("HasMasterPassword")
     val hasMasterPassword: Boolean,
 
+    @SerialName("masterPasswordUnlock")
+    @JsonNames("MasterPasswordUnlock")
+    val masterPasswordUnlock: MasterPasswordUnlockDataJson?,
+
     @SerialName("trustedDeviceOption")
     @JsonNames("TrustedDeviceOption")
     val trustedDeviceUserDecryptionOptions: TrustedDeviceUserDecryptionOptionsJson?,

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/SyncResponseUtil.kt
@@ -13,6 +13,7 @@ fun createMockSyncResponse(
     policies: List<SyncResponseJson.Policy> = listOf(createMockPolicy(number = number)),
     domains: SyncResponseJson.Domains = createMockDomains(number = number),
     sends: List<SyncResponseJson.Send> = listOf(createMockSend(number = number)),
+    userDecryption: UserDecryptionJson? = null,
 ): SyncResponseJson =
     SyncResponseJson(
         folders = folders,
@@ -22,4 +23,5 @@ fun createMockSyncResponse(
         policies = policies,
         domains = domains,
         sends = sends,
+        userDecryption = userDecryption,
     )


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-23280

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This pull request introduces support for the new `masterPasswordUnlock` property within the `UserDecryptionOptionsJson` model and ensures it is properly handled. The main changes focus on updating extension functions to correctly set this property, as well as updating test cases to reflect the new field.

* Added handling of the `masterPasswordUnlock` field in the `toUserStateJson`, `toRemovedPasswordUserStateJson`, and `toUserStateJsonWithPassword` extension functions to ensure this property is set appropriately during user state transformations. 
* Updated the `toUpdatedUserStateJson` function to copy or set the `masterPasswordUnlock` property based on the latest sync response, ensuring user state remains consistent with backend data.

These changes ensure the codebase is ready to handle the new master password unlock data property.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
