### PR TITLE
Enable CXP via debug menu

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -7,6 +7,8 @@ import com.bitwarden.core.data.manager.realtime.RealtimeManager
 import com.bitwarden.core.data.manager.realtime.RealtimeManagerImpl
 import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.manager.toast.ToastManagerImpl
+import com.bitwarden.cxf.registry.CredentialExchangeRegistry
+import com.bitwarden.cxf.registry.dsl.credentialExchangeRegistry
 import com.bitwarden.data.manager.DispatcherManager
 import com.bitwarden.data.manager.DispatcherManagerImpl
 import com.bitwarden.data.manager.NativeLibraryManager
@@ -420,4 +422,12 @@ object PlatformManagerModule {
             clock = clock,
         )
     }
+
+    @Provides
+    @Singleton
+    fun provideCredentialExchangeRegistry(
+        application: Application,
+    ): CredentialExchangeRegistry = credentialExchangeRegistry(
+        application = application,
+    )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
@@ -1,8 +1,13 @@
 package com.x8bit.bitwarden.ui.platform.feature.debugmenu
 
+import androidx.credentials.providerevents.transfer.CredentialTypes
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.manager.model.FlagKey
+import com.bitwarden.cxf.registry.CredentialExchangeRegistry
+import com.bitwarden.cxf.registry.model.RegistrationRequest
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
@@ -18,6 +23,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -29,6 +35,7 @@ class DebugMenuViewModel @Inject constructor(
     private val debugMenuRepository: DebugMenuRepository,
     private val authRepository: AuthRepository,
     private val logsManager: LogsManager,
+    private val credentialExchangeRegistry: CredentialExchangeRegistry,
 ) : BaseViewModel<DebugMenuState, DebugMenuEvent, DebugMenuAction>(
     initialState = DebugMenuState(featureFlags = persistentMapOf()),
 ) {
@@ -104,6 +111,31 @@ class DebugMenuViewModel @Inject constructor(
 
     private fun handleUpdateFeatureFlag(action: DebugMenuAction.UpdateFeatureFlag<*>) {
         debugMenuRepository.updateFeatureFlag(action.flagKey, action.newValue)
+        viewModelScope.launch {
+            if (action.flagKey is FlagKey.CredentialExchangeProtocolExport &&
+                action.newValue is Boolean &&
+                action.newValue
+            ) {
+                Timber.d("Registering credential exchange")
+                credentialExchangeRegistry.register(
+                    registrationRequest = RegistrationRequest(
+                        appName = R.string.app_name,
+                        credentialTypes = setOf(
+                            CredentialTypes.BASIC_AUTH,
+                            CredentialTypes.PUBLIC_KEY,
+                            CredentialTypes.TOTP,
+                            CredentialTypes.CREDIT_CARD,
+                            CredentialTypes.SSH_KEY,
+                            CredentialTypes.ADDRESS,
+                        ),
+                        iconResId = BitwardenDrawable.icon,
+                    ),
+                )
+            } else {
+                Timber.d("Unregistering credential exchange")
+                credentialExchangeRegistry.unregister()
+            }
+        }
     }
 }
 

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/registry/CredentialExchangeRegistryImpl.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/registry/CredentialExchangeRegistryImpl.kt
@@ -40,7 +40,7 @@ internal class CredentialExchangeRegistryImpl(
                 ExportEntry(
                     id = UUID.randomUUID().toString(),
                     accountDisplayName = null,
-                    userDisplayName = registrationRequest.appName,
+                    userDisplayName = application.getString(registrationRequest.appName),
                     icon = icon,
                     supportedCredentialTypes = registrationRequest.credentialTypes,
                 ),

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/registry/model/RegistrationRequest.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/registry/model/RegistrationRequest.kt
@@ -1,6 +1,7 @@
 package com.bitwarden.cxf.registry.model
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 
 /**
  * Represents a request to register as a credential provider that allows exporting credentials.
@@ -11,8 +12,9 @@ import androidx.annotation.DrawableRes
  * when credential import is requested.
  */
 data class RegistrationRequest(
-    val appName: String,
-    val credentialTypes: Set<String>,
+    @field:StringRes
+    val appName: Int,
     @field:DrawableRes
     val iconResId: Int,
+    val credentialTypes: Set<String>,
 )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This commit introduces the ability to enable and disable Credential Exchange Protocol (CXP)
functionality through the debug menu.

Specifically, it:

- Modifies `CredentialExchangeRegistryImpl` to retrieve the application name from string resources.
- Adds `CredentialExchangeRegistry` to the `PlatformManagerModule` for dependency injection.
- Updates `DebugMenuViewModel` to register or unregister with the `CredentialExchangeRegistry` when
  the CXP feature flag is toggled.
- Adjusts `RegistrationRequest` to accept a string resource ID for the application name.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
