### PR TITLE
PM-25642: Force sync or clear last sync time on sync notification

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManager.kt
@@ -15,9 +15,9 @@ import kotlinx.coroutines.flow.Flow
  */
 interface PushManager {
     /**
-     * Flow that represents requests intended for full syncs.
+     * Flow that represents requests intended for full syncs for the user ID provided.
      */
-    val fullSyncFlow: Flow<Unit>
+    val fullSyncFlow: Flow<String>
 
     /**
      * Flow that represents requests intended to log a user out.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerImpl.kt
@@ -55,7 +55,7 @@ class PushManagerImpl @Inject constructor(
     private val ioScope = CoroutineScope(dispatcherManager.io)
     private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
 
-    private val mutableFullSyncSharedFlow = bufferedMutableSharedFlow<Unit>()
+    private val mutableFullSyncSharedFlow = bufferedMutableSharedFlow<String>()
     private val mutableLogoutSharedFlow = bufferedMutableSharedFlow<NotificationLogoutData>()
     private val mutablePasswordlessRequestSharedFlow =
         bufferedMutableSharedFlow<PasswordlessRequestData>()
@@ -73,7 +73,7 @@ class PushManagerImpl @Inject constructor(
     private val mutableSyncSendUpsertSharedFlow =
         bufferedMutableSharedFlow<SyncSendUpsertData>()
 
-    override val fullSyncFlow: SharedFlow<Unit>
+    override val fullSyncFlow: SharedFlow<String>
         get() = mutableFullSyncSharedFlow.asSharedFlow()
 
     override val logoutFlow: SharedFlow<NotificationLogoutData>
@@ -204,7 +204,10 @@ class PushManagerImpl @Inject constructor(
             NotificationType.SYNC_SETTINGS,
             NotificationType.SYNC_VAULT,
                 -> {
-                mutableFullSyncSharedFlow.tryEmit(Unit)
+                json
+                    .decodeFromString<NotificationPayload.SyncNotification>(notification.payload)
+                    .userId
+                    ?.let { mutableFullSyncSharedFlow.tryEmit(it) }
             }
 
             NotificationType.SYNC_FOLDER_CREATE,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/NotificationPayload.kt
@@ -83,4 +83,12 @@ sealed class NotificationPayload {
         @JsonNames("UserId", "userId") override val userId: String?,
         @JsonNames("Id", "id") val loginRequestId: String?,
     ) : NotificationPayload()
+
+    /**
+     * A notification payload for syncing a users vault.
+     */
+    @Serializable
+    data class SyncNotification(
+        @JsonNames("UserId", "userId") override val userId: String?,
+    ) : NotificationPayload()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
@@ -209,7 +209,13 @@ class VaultSyncManagerImpl(
 
         pushManager
             .fullSyncFlow
-            .onEach { sync(forced = false) }
+            .onEach { userId ->
+                if (userId == activeUserId) {
+                    sync(forced = false)
+                } else {
+                    settingsDiskSource.storeLastSyncTime(userId = userId, lastSyncTime = null)
+                }
+            }
             .launchIn(unconfinedScope)
 
         databaseSchemeManager

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModel.kt
@@ -205,7 +205,7 @@ class ImportLoginsViewModel @Inject constructor(
 
     private fun syncVault() {
         viewModelScope.launch {
-            val result = vaultRepository.syncForResult()
+            val result = vaultRepository.syncForResult(forced = true)
             sendAction(ImportLoginsAction.Internal.VaultSyncResultReceived(result))
         }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
@@ -161,7 +161,7 @@ class PushManagerTest {
                 pushManager.fullSyncFlow.test {
                     pushManager.onMessageReceived(SYNC_CIPHERS_NOTIFICATION_MAP)
                     assertEquals(
-                        Unit,
+                        "078966a2-93c2-4618-ae2a-0a2394c88d37",
                         awaitItem(),
                     )
                 }
@@ -180,7 +180,7 @@ class PushManagerTest {
                 pushManager.fullSyncFlow.test {
                     pushManager.onMessageReceived(SYNC_SETTINGS_NOTIFICATION_MAP)
                     assertEquals(
-                        Unit,
+                        "078966a2-93c2-4618-ae2a-0a2394c88d37",
                         awaitItem(),
                     )
                 }
@@ -191,7 +191,7 @@ class PushManagerTest {
                 pushManager.fullSyncFlow.test {
                     pushManager.onMessageReceived(SYNC_VAULT_NOTIFICATION_MAP)
                     assertEquals(
-                        Unit,
+                        "078966a2-93c2-4618-ae2a-0a2394c88d37",
                         awaitItem(),
                     )
                 }
@@ -580,7 +580,7 @@ class PushManagerTest {
                 pushManager.fullSyncFlow.test {
                     pushManager.onMessageReceived(SYNC_CIPHERS_NOTIFICATION_MAP)
                     assertEquals(
-                        Unit,
+                        "078966a2-93c2-4618-ae2a-0a2394c88d37",
                         awaitItem(),
                     )
                 }
@@ -599,7 +599,7 @@ class PushManagerTest {
                 pushManager.fullSyncFlow.test {
                     pushManager.onMessageReceived(SYNC_SETTINGS_NOTIFICATION_MAP)
                     assertEquals(
-                        Unit,
+                        "078966a2-93c2-4618-ae2a-0a2394c88d37",
                         awaitItem(),
                     )
                 }
@@ -610,7 +610,7 @@ class PushManagerTest {
                 pushManager.fullSyncFlow.test {
                     pushManager.onMessageReceived(SYNC_VAULT_NOTIFICATION_MAP)
                     assertEquals(
-                        Unit,
+                        "078966a2-93c2-4618-ae2a-0a2394c88d37",
                         awaitItem(),
                     )
                 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/importlogins/ImportLoginsViewModelTest.kt
@@ -33,7 +33,9 @@ import org.junit.jupiter.api.Test
 class ImportLoginsViewModelTest : BaseViewModelTest() {
 
     private val vaultRepository: VaultRepository = mockk {
-        coEvery { syncForResult() } returns SyncVaultDataResult.Success(itemsAvailable = true)
+        coEvery {
+            syncForResult(forced = true)
+        } returns SyncVaultDataResult.Success(itemsAvailable = true)
     }
 
     private val firstTimeActionManager: FirstTimeActionManager = mockk {
@@ -312,21 +314,23 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
             )
             cancelAndIgnoreRemainingEvents()
         }
-        coVerify { vaultRepository.syncForResult() }
+        coVerify(exactly = 1) { vaultRepository.syncForResult(forced = true) }
     }
 
     @Suppress("MaxLineLength")
     @Test
     fun `RetryVaultSync sets isVaultSyncing to true and clears dialog state and calls syncForResult`() =
         runTest {
-            coEvery { vaultRepository.syncForResult() } returns SyncVaultDataResult.Error(Exception())
+            coEvery {
+                vaultRepository.syncForResult(forced = true)
+            } returns SyncVaultDataResult.Error(Exception())
             val viewModel = createViewModel()
             viewModel.trySendAction(ImportLoginsAction.MoveToSyncInProgress)
             viewModel.stateFlow.test {
                 assertNotNull(awaitItem().dialogState)
-                coEvery { vaultRepository.syncForResult() } returns SyncVaultDataResult.Success(
-                    itemsAvailable = true,
-                )
+                coEvery {
+                    vaultRepository.syncForResult(forced = true)
+                } returns SyncVaultDataResult.Success(itemsAvailable = true)
                 viewModel.trySendAction(ImportLoginsAction.RetryVaultSync)
                 assertEquals(
                     ImportLoginsState(
@@ -339,7 +343,7 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
                 )
                 cancelAndIgnoreRemainingEvents()
             }
-            coVerify { vaultRepository.syncForResult() }
+            coVerify(exactly = 2) { vaultRepository.syncForResult(forced = true) }
         }
 
     @Suppress("MaxLineLength")
@@ -367,7 +371,7 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
     fun `MoveToSyncInProgress should set no items imported error dialog state when sync succeeds but no items are available`() =
         runTest {
             coEvery {
-                vaultRepository.syncForResult()
+                vaultRepository.syncForResult(forced = true)
             } returns SyncVaultDataResult.Success(itemsAvailable = false)
             val viewModel = createViewModel()
             viewModel.stateFlow.test {
@@ -402,7 +406,9 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `SyncVaultDataResult Error should remove loading state and show error dialog`() = runTest {
-        coEvery { vaultRepository.syncForResult() } returns SyncVaultDataResult.Error(Exception())
+        coEvery {
+            vaultRepository.syncForResult(forced = true)
+        } returns SyncVaultDataResult.Error(Exception())
         val viewModel = createViewModel()
         viewModel.trySendAction(ImportLoginsAction.MoveToSyncInProgress)
         assertEquals(
@@ -420,7 +426,7 @@ class ImportLoginsViewModelTest : BaseViewModelTest() {
     fun `FailSyncAcknowledged should remove dialog state and send NavigateBack event`() =
         runTest {
             coEvery {
-                vaultRepository.syncForResult()
+                vaultRepository.syncForResult(forced = true)
             } returns SyncVaultDataResult.Error(Exception())
             val viewModel = createViewModel()
             viewModel.eventFlow.test {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25642](https://bitwarden.atlassian.net/browse/PM-25642)

## 📔 Objective

This PR updates the background sync and import logins sync to be a forced sync.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25642]: https://bitwarden.atlassian.net/browse/PM-25642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ