### PR TITLE
PM-26312: Add browser integration help link

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -14,6 +15,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.pluralStringResource
@@ -21,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.ui.platform.base.util.EventsEffect
@@ -31,6 +34,7 @@ import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.ui.platform.components.text.BitwardenClickableText
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
@@ -62,6 +66,12 @@ fun SetupBrowserAutofillScreen(
             is SetupBrowserAutofillEvent.NavigateToBrowserAutofillSettings -> {
                 intentManager.startBrowserAutofillSettingsActivity(
                     browserPackage = event.browserPackage,
+                )
+            }
+
+            SetupBrowserAutofillEvent.NavigateToBrowserIntegrationsInfo -> {
+                intentManager.launchUri(
+                    "https://bitwarden.com/help/auto-fill-android/#browser-integrations/".toUri(),
                 )
             }
         }
@@ -106,6 +116,9 @@ fun SetupBrowserAutofillScreen(
     ) {
         SetupBrowserAutofillContent(
             state = state,
+            onWhyIsThisStepRequiredClick = remember(viewModel) {
+                { viewModel.trySendAction(SetupBrowserAutofillAction.WhyIsThisStepRequiredClick) }
+            },
             onBrowserClick = remember(viewModel) {
                 { viewModel.trySendAction(SetupBrowserAutofillAction.BrowserIntegrationClick(it)) }
             },
@@ -120,9 +133,11 @@ fun SetupBrowserAutofillScreen(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun SetupBrowserAutofillContent(
     state: SetupBrowserAutofillState,
+    onWhyIsThisStepRequiredClick: () -> Unit,
     onBrowserClick: (BrowserPackage) -> Unit,
     onContinueClick: () -> Unit,
     onTurnOnLaterClick: () -> Unit,
@@ -154,7 +169,16 @@ private fun SetupBrowserAutofillContent(
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
         )
-        Spacer(modifier = Modifier.height(height = 24.dp))
+        BitwardenClickableText(
+            label = stringResource(id = BitwardenString.why_is_this_step_required),
+            style = BitwardenTheme.typography.labelMedium,
+            onClick = onWhyIsThisStepRequiredClick,
+            modifier = Modifier
+                .wrapContentWidth()
+                .align(alignment = Alignment.CenterHorizontally)
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(height = 8.dp))
         BrowserAutofillSettingsCard(
             options = state.browserAutofillSettingsOptions,
             onOptionClicked = onBrowserClick,
@@ -221,6 +245,7 @@ private fun SetupBrowserAutofillContent_preview() {
                     BrowserAutofillSettingsOption.ChromeBeta(enabled = true),
                 ),
             ),
+            onWhyIsThisStepRequiredClick = { },
             onBrowserClick = { },
             onContinueClick = { },
             onTurnOnLaterClick = { },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillViewModel.kt
@@ -56,6 +56,10 @@ class SetupBrowserAutofillViewModel @Inject constructor(
                 handleBrowserIntegrationClick(action)
             }
 
+            SetupBrowserAutofillAction.WhyIsThisStepRequiredClick -> {
+                handleWhyIsThisStepRequiredClick()
+            }
+
             SetupBrowserAutofillAction.CloseClick -> handleCloseClick()
             SetupBrowserAutofillAction.DismissDialog -> handleDismissDialog()
             SetupBrowserAutofillAction.ContinueClick -> handleContinueClick()
@@ -79,6 +83,10 @@ class SetupBrowserAutofillViewModel @Inject constructor(
         sendEvent(
             SetupBrowserAutofillEvent.NavigateToBrowserAutofillSettings(action.browserPackage),
         )
+    }
+
+    private fun handleWhyIsThisStepRequiredClick() {
+        sendEvent(SetupBrowserAutofillEvent.NavigateToBrowserIntegrationsInfo)
     }
 
     private fun handleCloseClick() {
@@ -167,6 +175,11 @@ sealed class SetupBrowserAutofillEvent {
     data class NavigateToBrowserAutofillSettings(
         val browserPackage: BrowserPackage,
     ) : SetupBrowserAutofillEvent()
+
+    /**
+     * Navigates to the browser integrations info page.
+     */
+    data object NavigateToBrowserIntegrationsInfo : SetupBrowserAutofillEvent()
 }
 
 /**
@@ -204,6 +217,11 @@ sealed class SetupBrowserAutofillAction {
      * Indicates that the confirmation button was clicked to turn on later.
      */
     data object TurnOnLaterConfirmClick : SetupBrowserAutofillAction()
+
+    /**
+     * Indicates that the "Why is this step required?" button was clicked.
+     */
+    data object WhyIsThisStepRequiredClick : SetupBrowserAutofillAction()
 
     /**
      * Models actions the [SetupBrowserAutofillViewModel] itself may send.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillViewModelTest.kt
@@ -102,6 +102,19 @@ class SetupBrowserAutofillViewModelTest {
     }
 
     @Test
+    fun `WhyIsThisStepRequiredClick should send NavigateToBrowserIntegrationsInfo event`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(SetupBrowserAutofillAction.WhyIsThisStepRequiredClick)
+                assertEquals(
+                    SetupBrowserAutofillEvent.NavigateToBrowserIntegrationsInfo,
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
     fun `BrowserIntegrationClick should send NavigateToBrowserAutofillSettings event`() = runTest {
         val browserPackage = BrowserPackage.BRAVE_RELEASE
         val viewModel = createViewModel()

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1130,4 +1130,5 @@ Do you want to switch to this account?</string>
     <string name="passwords">Passwords</string>
     <string name="passkeys">Passkeys</string>
     <string name="import_verb">Import</string>
+    <string name="why_is_this_step_required">Why is this step required?</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26312](https://bitwarden.atlassian.net/browse/PM-26312)

## 📔 Objective

This PR adds the browser integration help link to to the browser integration onboarding screen.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5c1ed77d-e298-4be3-ab64-676d52f560e5" width="300" /> | <img src="https://github.com/user-attachments/assets/43aa1628-d6e6-4b98-ae6c-0e4f554ccf96" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26312]: https://bitwarden.atlassian.net/browse/PM-26312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ