### PR TITLE
[PM-17870] Always include clientExtensionResults in Fido2AttestationResponse

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/model/Fido2AttestationResponse.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/model/Fido2AttestationResponse.kt
@@ -20,7 +20,7 @@ data class Fido2AttestationResponse(
     @SerialName("response")
     val response: RegistrationResponse,
     @SerialName("clientExtensionResults")
-    val clientExtensionResults: ClientExtensionResults?,
+    val clientExtensionResults: ClientExtensionResults,
     @SerialName("authenticatorAttachment")
     val authenticatorAttachment: String?,
 ) {
@@ -50,7 +50,7 @@ data class Fido2AttestationResponse(
     @Serializable
     data class ClientExtensionResults(
         @SerialName("credProps")
-        val credentialProperties: CredentialProperties,
+        val credentialProperties: CredentialProperties? = null,
     ) {
         /**
          * Represents properties for newly created credential.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/util/PublicKeyCredentialAuthenticatorAttestationResponseExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/util/PublicKeyCredentialAuthenticatorAttestationResponseExtensions.kt
@@ -31,7 +31,7 @@ fun PublicKeyCredentialAuthenticatorAttestationResponse.toAndroidAttestationResp
                         .ClientExtensionResults
                         .CredentialProperties(residentKey = residentKey),
                 )
-            },
+            } ?: Fido2AttestationResponse.ClientExtensionResults(),
         authenticatorAttachment = authenticatorAttachment,
     )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/util/PublicKeyCredentialAuthenticatorAttestationResponseExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/util/PublicKeyCredentialAuthenticatorAttestationResponseExtensionsTest.kt
@@ -1,0 +1,93 @@
+package com.x8bit.bitwarden.data.vault.datasource.sdk.util
+
+import android.util.Base64
+import com.bitwarden.fido.AuthenticatorAttestationResponse
+import com.bitwarden.fido.ClientExtensionResults
+import com.bitwarden.fido.CredPropsResult
+import com.bitwarden.fido.PublicKeyCredentialAuthenticatorAttestationResponse
+import com.bitwarden.fido.SelectedCredential
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockFido2CredentialView
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PublicKeyCredentialAuthenticatorAttestationResponseExtensionsTest {
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(Base64::class)
+        every { Base64.encodeToString(any(), any()) } returns ""
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Base64::class)
+    }
+
+    @Test
+    fun `authenticatorAttachment should be null when SDK value is null`() {
+        val mockSdkResponse = createMockSdkAttestationResponse(number = 1)
+        val result = mockSdkResponse.toAndroidAttestationResponse()
+        assertNull(result.authenticatorAttachment)
+    }
+
+    @Test
+    fun `authenticatorAttachment should be populated when SDK value is non-null`() {
+        val mockSdkResponse = createMockSdkAttestationResponse(
+            number = 1,
+            authenticatorAttachment = "mockAuthenticatorAttachment",
+        )
+        val result = mockSdkResponse.toAndroidAttestationResponse()
+        assertNotNull(result.authenticatorAttachment)
+    }
+
+    @Test
+    fun `clientExtensionResults should be populated when SDK value is null`() {
+        val mockSdkResponse = createMockSdkAttestationResponse(number = 1)
+        val result = mockSdkResponse.toAndroidAttestationResponse()
+        assertNotNull(result.clientExtensionResults)
+    }
+
+    @Test
+    fun `residentKey should be populated when SDK value is non-null`() {
+        val mockSdkResponse = createMockSdkAttestationResponse(
+            number = 1,
+            credProps = CredPropsResult(
+                rk = true,
+                authenticatorDisplayName = null,
+            ),
+        )
+        val result = mockSdkResponse.toAndroidAttestationResponse()
+        assert(result.clientExtensionResults.credentialProperties?.residentKey ?: false)
+    }
+}
+
+private fun createMockSdkAttestationResponse(
+    number: Int,
+    authenticatorAttachment: String? = null,
+    credProps: CredPropsResult? = null,
+) = PublicKeyCredentialAuthenticatorAttestationResponse(
+    id = "mockId-$number",
+    rawId = byteArrayOf(0),
+    ty = "mockTy-$number",
+    authenticatorAttachment = authenticatorAttachment,
+    clientExtensionResults = ClientExtensionResults(credProps),
+    response = AuthenticatorAttestationResponse(
+        clientDataJson = byteArrayOf(0),
+        authenticatorData = byteArrayOf(0),
+        publicKey = byteArrayOf(0),
+        publicKeyAlgorithm = Long.MIN_VALUE,
+        attestationObject = byteArrayOf(0),
+        transports = listOf("internal"),
+    ),
+    selectedCredential = SelectedCredential(
+        cipher = createMockCipherView(number = 1),
+        credential = createMockFido2CredentialView(number = 1),
+    ),
+)


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-17870

## 📔 Objective

When the SDK did not return information about the resident key (rk), we omitted the `clientExtensionResults` field from the jsonResponse. This caused Chromium to fail parsing the credential response

This PR updates the implementation to always include `clientExtensionResults`, defaulting to an empty object.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
