### PR TITLE
PM-26358: Integrate the token auth logic with the SDK

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/AuthTokenManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/AuthTokenManagerImpl.kt
@@ -10,19 +10,20 @@ class AuthTokenManagerImpl(
     private val authDiskSource: AuthDiskSource,
 ) : AuthTokenManager {
 
+    override fun getAuthTokenDataOrNull(userId: String): AuthTokenData? =
+        authDiskSource
+            .getAccountTokens(userId = userId)
+            ?.takeIf { it.accessToken != null }
+            ?.let {
+                AuthTokenData(
+                    userId = userId,
+                    accessToken = requireNotNull(it.accessToken),
+                    expiresAtSec = it.expiresAtSec,
+                )
+            }
+
     override fun getAuthTokenDataOrNull(): AuthTokenData? = authDiskSource
         .userState
         ?.activeUserId
-        ?.let { userId ->
-            authDiskSource
-                .getAccountTokens(userId = userId)
-                ?.takeIf { it.accessToken != null }
-                ?.let {
-                    AuthTokenData(
-                        userId = userId,
-                        accessToken = requireNotNull(it.accessToken),
-                        expiresAtSec = it.expiresAtSec,
-                    )
-                }
-        }
+        ?.let(::getAuthTokenDataOrNull)
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerImpl.kt
@@ -1,20 +1,10 @@
 package com.x8bit.bitwarden.data.platform.manager
 
 import android.os.Build
-import com.bitwarden.core.ClientManagedTokens
 import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.data.manager.NativeLibraryManager
 import com.bitwarden.sdk.Client
 import com.x8bit.bitwarden.data.platform.manager.sdk.SdkRepositoryFactory
-
-/**
- * The token provider to pass to the SDK.
- */
-class Token : ClientManagedTokens {
-    override suspend fun getAccessToken(): String? {
-        return null
-    }
-}
 
 /**
  * Primary implementation of [SdkClientManager].
@@ -24,14 +14,18 @@ class SdkClientManagerImpl(
     sdkRepoFactory: SdkRepositoryFactory,
     private val featureFlagManager: FeatureFlagManager,
     private val clientProvider: suspend (userId: String?) -> Client = { userId ->
-        Client(tokenProvider = Token(), settings = null).apply {
-            platform().loadFlags(featureFlagManager.sdkFeatureFlags)
-            userId?.let {
-                platform().state().apply {
-                    registerCipherRepository(sdkRepoFactory.getCipherRepository(userId = it))
+        Client(
+            tokenProvider = sdkRepoFactory.getClientManagedTokens(userId = userId),
+            settings = null,
+        )
+            .apply {
+                platform().loadFlags(featureFlagManager.sdkFeatureFlags)
+                userId?.let {
+                    platform().state().apply {
+                        registerCipherRepository(sdkRepoFactory.getCipherRepository(userId = it))
+                    }
                 }
             }
-        }
     },
 ) : SdkClientManager {
     private val userIdToClientMap = mutableMapOf<String?, Client>()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -389,8 +389,10 @@ object PlatformManagerModule {
     @Singleton
     fun provideSdkRepositoryFactory(
         vaultDiskSource: VaultDiskSource,
+        bitwardenServiceClient: BitwardenServiceClient,
     ): SdkRepositoryFactory = SdkRepositoryFactoryImpl(
         vaultDiskSource = vaultDiskSource,
+        bitwardenServiceClient = bitwardenServiceClient,
     )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactory.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactory.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.platform.manager.sdk
 
+import com.bitwarden.core.ClientManagedTokens
 import com.bitwarden.sdk.CipherRepository
 
 /**
@@ -10,4 +11,9 @@ interface SdkRepositoryFactory {
      * Retrieves or creates a [CipherRepository] for use with the Bitwarden SDK.
      */
     fun getCipherRepository(userId: String): CipherRepository
+
+    /**
+     * Retrieves or creates a [ClientManagedTokens] for use with the Bitwarden SDK.
+     */
+    fun getClientManagedTokens(userId: String?): ClientManagedTokens
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryImpl.kt
@@ -1,7 +1,10 @@
 package com.x8bit.bitwarden.data.platform.manager.sdk
 
+import com.bitwarden.core.ClientManagedTokens
+import com.bitwarden.network.BitwardenServiceClient
 import com.bitwarden.sdk.CipherRepository
 import com.x8bit.bitwarden.data.platform.manager.sdk.repository.SdkCipherRepository
+import com.x8bit.bitwarden.data.platform.manager.sdk.repository.SdkTokenRepository
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 
 /**
@@ -9,6 +12,7 @@ import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
  */
 class SdkRepositoryFactoryImpl(
     private val vaultDiskSource: VaultDiskSource,
+    private val bitwardenServiceClient: BitwardenServiceClient,
 ) : SdkRepositoryFactory {
     override fun getCipherRepository(
         userId: String,
@@ -16,5 +20,13 @@ class SdkRepositoryFactoryImpl(
         SdkCipherRepository(
             userId = userId,
             vaultDiskSource = vaultDiskSource,
+        )
+
+    override fun getClientManagedTokens(
+        userId: String?,
+    ): ClientManagedTokens =
+        SdkTokenRepository(
+            userId = userId,
+            tokenProvider = bitwardenServiceClient.tokenProvider,
         )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkTokenRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkTokenRepository.kt
@@ -1,0 +1,15 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk.repository
+
+import com.bitwarden.core.ClientManagedTokens
+import com.bitwarden.network.provider.TokenProvider
+
+/**
+ * A user-scoped implementation of a Bitwarden SDK [ClientManagedTokens].
+ */
+class SdkTokenRepository(
+    private val userId: String?,
+    private val tokenProvider: TokenProvider,
+) : ClientManagedTokens {
+    override suspend fun getAccessToken(): String? =
+        userId?.let { tokenProvider.getAccessToken(userId = it) }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryTests.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryTests.kt
@@ -1,6 +1,8 @@
 package com.x8bit.bitwarden.data.platform.manager.sdk
 
+import com.bitwarden.network.BitwardenServiceClient
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
@@ -8,9 +10,13 @@ import org.junit.jupiter.api.Test
 class SdkRepositoryFactoryTests {
 
     private val vaultDiskSource: VaultDiskSource = mockk()
+    private val bitwardenServiceClient: BitwardenServiceClient = mockk {
+        every { tokenProvider } returns mockk()
+    }
 
     private val sdkRepoFactory: SdkRepositoryFactory = SdkRepositoryFactoryImpl(
         vaultDiskSource = vaultDiskSource,
+        bitwardenServiceClient = bitwardenServiceClient,
     )
 
     @Test
@@ -25,6 +31,21 @@ class SdkRepositoryFactoryTests {
         // Additional calls for different userIds should return a different repo
         val otherUserId = "otherUserId"
         val thirdClient = sdkRepoFactory.getCipherRepository(userId = otherUserId)
+        assertNotEquals(firstClient, thirdClient)
+    }
+
+    @Test
+    fun `getClientManagedTokens should create a new client`() {
+        val userId = "userId"
+        val firstClient = sdkRepoFactory.getClientManagedTokens(userId = userId)
+
+        // Additional calls for the same userId should create a repo
+        val secondClient = sdkRepoFactory.getClientManagedTokens(userId = userId)
+        assertNotEquals(firstClient, secondClient)
+
+        // Additional calls for different userIds should return a different repo
+        val otherUserId = "otherUserId"
+        val thirdClient = sdkRepoFactory.getClientManagedTokens(userId = otherUserId)
         assertNotEquals(firstClient, thirdClient)
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkTokenRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkTokenRepositoryTest.kt
@@ -1,0 +1,57 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk.repository
+
+import com.bitwarden.network.provider.TokenProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SdkTokenRepositoryTest {
+
+    private val tokenProvider: TokenProvider = mockk()
+
+    @Test
+    fun `getAccessToken should return null when userId is null`() = runTest {
+        val repository = createSdkTokenRepository(userId = null)
+        assertNull(repository.getAccessToken())
+        verify(exactly = 0) {
+            tokenProvider.getAccessToken(userId = any())
+        }
+    }
+
+    @Test
+    fun `getAccessToken should return null when userId is valid and tokenProvider returns null`() =
+        runTest {
+            every { tokenProvider.getAccessToken(userId = USER_ID) } returns null
+            val repository = createSdkTokenRepository()
+            assertNull(repository.getAccessToken())
+            verify(exactly = 1) {
+                tokenProvider.getAccessToken(userId = USER_ID)
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getAccessToken should return access token when userId is valid and tokenProvider returns an access token`() =
+        runTest {
+            val accessToken = "access_token"
+            every { tokenProvider.getAccessToken(userId = USER_ID) } returns accessToken
+            val repository = createSdkTokenRepository()
+            assertEquals(accessToken, repository.getAccessToken())
+            verify(exactly = 1) {
+                tokenProvider.getAccessToken(userId = USER_ID)
+            }
+        }
+
+    private fun createSdkTokenRepository(
+        userId: String? = USER_ID,
+    ): SdkTokenRepository = SdkTokenRepository(
+        userId = userId,
+        tokenProvider = tokenProvider,
+    )
+}
+
+private const val USER_ID: String = "userId"

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/network/di/PlatformNetworkModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/network/di/PlatformNetworkModule.kt
@@ -56,6 +56,7 @@ object PlatformNetworkModule {
             enableHttpBodyLogging = BuildConfig.DEBUG,
             authTokenProvider = object : AuthTokenProvider {
                 override fun getAuthTokenDataOrNull(): AuthTokenData? = null
+                override fun getAuthTokenDataOrNull(userId: String): AuthTokenData? = null
             },
             certificateProvider = object : CertificateProvider {
                 override fun chooseClientAlias(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/SdkClientManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/SdkClientManagerImpl.kt
@@ -9,7 +9,9 @@ import com.bitwarden.sdk.Client
 class SdkClientManagerImpl(
     private val clientProvider: suspend () -> Client = {
         Client(
-            tokenProvider = Token(),
+            tokenProvider = object : ClientManagedTokens {
+                override suspend fun getAccessToken(): String? = null
+            },
             settings = null,
         )
     },
@@ -20,14 +22,5 @@ class SdkClientManagerImpl(
 
     override fun destroyClient() {
         client = null
-    }
-
-    /**
-     * The token provider to pass to the SDK.
-     */
-    private class Token : ClientManagedTokens {
-        override suspend fun getAccessToken(): String? {
-            return null
-        }
     }
 }

--- a/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClient.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClient.kt
@@ -5,6 +5,7 @@ package com.bitwarden.network
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.network.model.BitwardenServiceClientConfig
 import com.bitwarden.network.provider.RefreshTokenProvider
+import com.bitwarden.network.provider.TokenProvider
 import com.bitwarden.network.service.AccountsService
 import com.bitwarden.network.service.AuthRequestsService
 import com.bitwarden.network.service.CiphersService
@@ -48,6 +49,10 @@ import com.bitwarden.network.service.SyncService
  * ```
  */
 interface BitwardenServiceClient {
+    /**
+     * Provides access to the token provider.
+     */
+    val tokenProvider: TokenProvider
 
     /**
      * Provides access to the Accounts service.

--- a/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClientImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClientImpl.kt
@@ -7,6 +7,7 @@ import com.bitwarden.network.interceptor.BaseUrlInterceptors
 import com.bitwarden.network.interceptor.HeadersInterceptor
 import com.bitwarden.network.model.BitwardenServiceClientConfig
 import com.bitwarden.network.provider.RefreshTokenProvider
+import com.bitwarden.network.provider.TokenProvider
 import com.bitwarden.network.retrofit.Retrofits
 import com.bitwarden.network.retrofit.RetrofitsImpl
 import com.bitwarden.network.service.AccountsServiceImpl
@@ -55,6 +56,7 @@ internal class BitwardenServiceClientImpl(
         clock = bitwardenServiceClientConfig.clock,
         authTokenProvider = bitwardenServiceClientConfig.authTokenProvider,
     )
+    override val tokenProvider: TokenProvider = authTokenManager
     private val clientJson = Json {
 
         // If there are keys returned by the server not modeled by a serializable class,

--- a/network/src/main/kotlin/com/bitwarden/network/interceptor/AuthTokenProvider.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/interceptor/AuthTokenProvider.kt
@@ -6,6 +6,10 @@ import com.bitwarden.network.model.AuthTokenData
  * A provider for all the functionality needed to properly refresh the users access token.
  */
 interface AuthTokenProvider {
+    /**
+     * The specified user's auth token data.
+     */
+    fun getAuthTokenDataOrNull(userId: String): AuthTokenData?
 
     /**
      * The currently active user's auth token data.

--- a/network/src/main/kotlin/com/bitwarden/network/provider/TokenProvider.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/provider/TokenProvider.kt
@@ -1,0 +1,11 @@
+package com.bitwarden.network.provider
+
+/**
+ * A provider for authentication tokens.
+ */
+interface TokenProvider {
+    /**
+     * Retrieves an up-to-date token for the specified user.
+     */
+    fun getAccessToken(userId: String): String?
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26358](https://bitwarden.atlassian.net/browse/PM-26358)

## 📔 Objective

This PR creates a bridge between the SDK and the network layer in order to allow the SDK to retrieve an updated auth token.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26358]: https://bitwarden.atlassian.net/browse/PM-26358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ