### PR TITLE
[PM-26330] Correct owner data when individual vault is disabled

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.ui.vault.feature.addedit.util
 
+import com.bitwarden.collections.CollectionType
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.network.model.OrganizationType
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -453,7 +454,18 @@ class CipherViewExtensionsTest {
 
     @Test
     fun `appendFolderAndOwnerData should append folder and owner data`() {
-        val viewState = createSecureNoteViewState(withFolderAndOwnerData = false)
+        val viewState = createSecureNoteViewState(
+            availableOwners = listOf(
+                USER_OWNER,
+                ORGANIZATION_OWNER,
+            ),
+            availableFolders = listOf(
+                NO_FOLDER_ITEM,
+                MOCK_FOLDER_ITEM,
+            ),
+            selectedFolderId = null,
+            selectedOwnerId = null,
+        )
         val account = createAccount()
         val folderView = listOf(createMockFolderView(number = 1))
         val collectionList = listOf(createMockCollectionView(number = 1))
@@ -466,15 +478,74 @@ class CipherViewExtensionsTest {
             resourceManager = resourceManager,
         )
 
+        val expected = createSecureNoteViewState(
+            availableOwners = listOf(
+                USER_OWNER,
+                ORGANIZATION_OWNER,
+            ),
+            availableFolders = listOf(
+                NO_FOLDER_ITEM,
+                MOCK_FOLDER_ITEM,
+            ),
+            selectedFolderId = MOCK_FOLDER_ITEM.id,
+            selectedOwnerId = ORGANIZATION_OWNER.id,
+        )
         assertEquals(
-            createSecureNoteViewState(withFolderAndOwnerData = true),
+            expected,
+            result,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `appendFolderAndOwnerData should append correct owner data if individual vault is disabled`() {
+        val mockCipherView = createMockCipherView(number = 1, organizationId = null)
+        val viewState = createSecureNoteViewState(
+            cipherView = mockCipherView,
+            availableOwners = listOf(USER_OWNER, ORGANIZATION_OWNER),
+            availableFolders = emptyList(),
+            selectedOwnerId = null,
+            selectedFolderId = null,
+        )
+        val account = createAccount()
+        val collectionList = listOf(
+            createMockCollectionView(
+                number = 1,
+                type = CollectionType.DEFAULT_USER_COLLECTION,
+            ),
+        )
+        val result = viewState.appendFolderAndOwnerData(
+            folderViewList = emptyList(),
+            collectionViewList = collectionList,
+            activeAccount = account,
+            isIndividualVaultDisabled = true,
+            resourceManager = resourceManager,
+        )
+
+        val expected = createSecureNoteViewState(
+            cipherView = mockCipherView,
+            availableOwners = listOf(ORGANIZATION_OWNER),
+            availableFolders = listOf(NO_FOLDER_ITEM),
+        )
+
+        assertEquals(
+            expected,
             result,
         )
     }
 
     private fun createSecureNoteViewState(
         cipherView: CipherView = createMockCipherView(number = 1),
-        withFolderAndOwnerData: Boolean,
+        availableOwners: List<VaultAddEditState.Owner> = listOf(
+            USER_OWNER,
+            ORGANIZATION_OWNER,
+        ),
+        availableFolders: List<VaultAddEditState.Folder> = listOf(
+            NO_FOLDER_ITEM,
+            MOCK_FOLDER_ITEM,
+        ),
+        selectedFolderId: String? = availableFolders.firstOrNull()?.id,
+        selectedOwnerId: String? = availableOwners.firstOrNull()?.id,
     ): VaultAddEditState.ViewState.Content =
         VaultAddEditState.ViewState.Content(
             common = VaultAddEditState.ViewState.Content.Common(
@@ -504,39 +575,21 @@ class CipherViewExtensionsTest {
                 availableOwners = emptyList(),
             )
                 .let {
-                    if (withFolderAndOwnerData) {
+                    if (availableOwners.isNotEmpty()) {
                         it.copy(
-                            selectedFolderId = "mockId-1",
-                            selectedOwnerId = "mockOrganizationId-1",
-                            availableFolders = listOf(
-                                VaultAddEditState.Folder(
-                                    id = null,
-                                    name = "No Folder",
-                                ),
-                                VaultAddEditState.Folder(
-                                    id = "mockId-1",
-                                    name = "mockName-1",
-                                ),
-                            ),
+                            selectedOwnerId = selectedOwnerId,
                             hasOrganizations = true,
-                            availableOwners = listOf(
-                                VaultAddEditState.Owner(
-                                    id = null,
-                                    name = "activeEmail",
-                                    collections = emptyList(),
-                                ),
-                                VaultAddEditState.Owner(
-                                    id = "mockOrganizationId-1",
-                                    name = "organizationName",
-                                    collections = listOf(
-                                        VaultCollection(
-                                            id = "mockId-1",
-                                            name = "mockName-1",
-                                            isSelected = true,
-                                        ),
-                                    ),
-                                ),
-                            ),
+                            availableOwners = availableOwners,
+                        )
+                    } else {
+                        it
+                    }
+                }
+                .let {
+                    if (availableFolders.isNotEmpty()) {
+                        it.copy(
+                            selectedFolderId = selectedFolderId,
+                            availableFolders = availableFolders,
                         )
                     } else {
                         it
@@ -734,3 +787,27 @@ private val DEFAULT_SSH_KEY_CIPHER_VIEW: CipherView = DEFAULT_BASE_CIPHER_VIEW.c
 )
 
 private const val TEST_ID = "testID"
+private val NO_FOLDER_ITEM = VaultAddEditState.Folder(
+    id = null,
+    name = "No Folder",
+)
+private val MOCK_FOLDER_ITEM = VaultAddEditState.Folder(
+    id = "mockId-1",
+    name = "mockName-1",
+)
+private val ORGANIZATION_OWNER = VaultAddEditState.Owner(
+    id = "mockOrganizationId-1",
+    name = "organizationName",
+    collections = listOf(
+        VaultCollection(
+            id = "mockId-1",
+            name = "mockName-1",
+            isSelected = true,
+        ),
+    ),
+)
+private val USER_OWNER = VaultAddEditState.Owner(
+    id = null,
+    name = "activeEmail",
+    collections = emptyList(),
+)


### PR DESCRIPTION
## 🎟️ Tracking

PM-26330

## 📔 Objective

This commit fixes an issue where the owner data was not correctly set when the individual vault was disabled. The `appendFolderAndOwnerData` function in `CipherViewExtensions.kt` has been updated to correctly determine the default owner and collection when the individual vault is disabled.

Additionally, new tests have been added to `CipherViewExtensionsTest.kt` to cover this scenario.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
