### PR TITLE
PM-20593: Always refresh the token before a sync request

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -303,8 +303,6 @@ class AuthRepositoryImpl(
             .syncOrgKeysFlow
             .onEach { userId ->
                 if (userId == activeUserId) {
-                    // TODO: [PM-20593] Investigate why tokens are explicitly refreshed.
-                    refreshAccessTokenSynchronously(userId = userId)
                     // We just sync now to get the latest data
                     vaultRepository.sync(forced = true)
                 } else {

--- a/network/src/main/kotlin/com/bitwarden/network/api/SyncApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/SyncApi.kt
@@ -3,6 +3,7 @@ package com.bitwarden.network.api
 import com.bitwarden.network.model.NetworkResult
 import com.bitwarden.network.model.SyncResponseJson
 import retrofit2.http.GET
+import retrofit2.http.Headers
 
 /**
  * This interface defines the API service for fetching vault data.
@@ -13,6 +14,7 @@ internal interface SyncApi {
      *
      * @return A [SyncResponseJson] containing the vault response model.
      */
+    @Headers("Access-Token-Sync: true")
     @GET("sync")
     suspend fun sync(): NetworkResult<SyncResponseJson>
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20593](https://bitwarden.atlassian.net/browse/PM-20593)

## 📔 Objective

This PR updates the authentication logic to always refresh the access token when syncing.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
