### PR TITLE
PM-20593: sync-org-keys notification should allow token to be refreshed on next request

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -302,9 +302,14 @@ class AuthRepositoryImpl(
         pushManager
             .syncOrgKeysFlow
             .onEach { userId ->
+                // This will force the next authenticated request to refresh the auth token.
+                authDiskSource.storeAccountTokens(
+                    userId = userId,
+                    accountTokens = authDiskSource
+                        .getAccountTokens(userId = userId)
+                        ?.copy(expiresAtSec = 0L),
+                )
                 if (userId == activeUserId) {
-                    // TODO: [PM-20593] Investigate why tokens are explicitly refreshed.
-                    refreshAccessTokenSynchronously(userId = userId)
                     // We just sync now to get the latest data
                     vaultRepository.sync(forced = true)
                 } else {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -6439,34 +6439,39 @@ class AuthRepositoryTest {
     fun `syncOrgKeysFlow emissions for active user should refresh access token and force sync`() {
         fakeAuthDiskSource.userState = MULTI_USER_STATE
         fakeAuthDiskSource.storeAccountTokens(userId = USER_ID_1, accountTokens = ACCOUNT_TOKENS_1)
-        coEvery {
-            identityService.refreshTokenSynchronously(REFRESH_TOKEN)
-        } returns REFRESH_TOKEN_RESPONSE_JSON.asSuccess()
-        coEvery { vaultRepository.sync(forced = true) } just runs
+        every { vaultRepository.sync(forced = true) } just runs
 
         mutableSyncOrgKeysFlow.tryEmit(USER_ID_1)
 
-        coVerify(exactly = 1) {
-            identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+        verify(exactly = 1) {
             vaultRepository.sync(forced = true)
         }
+        fakeAuthDiskSource.assertAccountTokens(
+            userId = USER_ID_1,
+            accountTokens = ACCOUNT_TOKENS_1.copy(expiresAtSec = 0L),
+        )
     }
 
     @Test
     fun `syncOrgKeysFlow emissions for inactive user should clear the last sync time`() {
         fakeAuthDiskSource.userState = MULTI_USER_STATE
+        fakeAuthDiskSource.storeAccountTokens(userId = USER_ID_2, accountTokens = ACCOUNT_TOKENS_2)
         fakeSettingsDiskSource.storeLastSyncTime(
             userId = USER_ID_2,
             lastSyncTime = FIXED_CLOCK.instant(),
         )
+        every { vaultRepository.sync(forced = true) } just runs
 
         mutableSyncOrgKeysFlow.tryEmit(USER_ID_2)
 
-        coVerify(exactly = 0) {
-            identityService.refreshTokenSynchronously(REFRESH_TOKEN)
+        verify(exactly = 0) {
             vaultRepository.sync(forced = true)
         }
         fakeSettingsDiskSource.assertLastSyncTime(userId = USER_ID_2, null)
+        fakeAuthDiskSource.assertAccountTokens(
+            userId = USER_ID_2,
+            accountTokens = ACCOUNT_TOKENS_2.copy(expiresAtSec = 0L),
+        )
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

[PM-20593](https://bitwarden.atlassian.net/browse/PM-20593)

## 📔 Objective

This PR ensures that the auth token is marked as invalidated so it will be refreshed on the next authenticated request.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20593]: https://bitwarden.atlassian.net/browse/PM-20593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ