### PR TITLE
[PM-26716] Validate credential exchange request

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
@@ -19,6 +19,9 @@ import com.bitwarden.cxf.manager.CredentialExchangeCompletionManager
 import com.bitwarden.cxf.manager.dsl.credentialExchangeCompletionManager
 import com.bitwarden.cxf.ui.composition.LocalCredentialExchangeCompletionManager
 import com.bitwarden.cxf.ui.composition.LocalCredentialExchangeImporter
+import com.bitwarden.cxf.ui.composition.LocalCredentialExchangeRequestValidator
+import com.bitwarden.cxf.validator.CredentialExchangeRequestValidator
+import com.bitwarden.cxf.validator.dsl.credentialExchangeRequestValidator
 import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.x8bit.bitwarden.R
@@ -73,6 +76,8 @@ fun LocalManagerProvider(
             exporterRpId = activity.packageName
             exporterDisplayName = activity.getString(R.string.app_name)
         },
+    credentialExchangeRequestValidator: CredentialExchangeRequestValidator =
+        credentialExchangeRequestValidator(activity = activity),
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
@@ -89,6 +94,7 @@ fun LocalManagerProvider(
         LocalPermissionsManager provides permissionsManager,
         LocalCredentialExchangeImporter provides credentialExchangeImporter,
         LocalCredentialExchangeCompletionManager provides credentialExchangeCompletionManager,
+        LocalCredentialExchangeRequestValidator provides credentialExchangeRequestValidator,
         content = content,
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportScreen.kt
@@ -304,7 +304,7 @@ private fun ReviewExportContent_preview() {
     BitwardenTheme {
         ReviewExportContent(
             state = ReviewExportState(
-                importCredentialsRequest = ImportCredentialsRequestData(
+                importCredentialsRequestData = ImportCredentialsRequestData(
                     uri = Uri.EMPTY,
                     requestJson = "",
                 ),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModel.kt
@@ -48,7 +48,7 @@ class ReviewExportViewModel @Inject constructor(
     specialCircumstanceManager: SpecialCircumstanceManager,
 ) : BaseViewModel<ReviewExportState, ReviewExportEvent, ReviewExportAction>(
     initialState = ReviewExportState(
-        importCredentialsRequest = requireNotNull(
+        importCredentialsRequestData = requireNotNull(
             specialCircumstanceManager
                 .specialCircumstance
                 ?.toImportCredentialsRequestDataOrNull(),
@@ -96,7 +96,7 @@ class ReviewExportViewModel @Inject constructor(
                             onSuccess = { payload ->
                                 ExportCredentialsResult.Success(
                                     payload = payload,
-                                    uri = state.importCredentialsRequest.uri,
+                                    uri = state.importCredentialsRequestData.uri,
                                 )
                             },
                             onFailure = { error ->
@@ -274,7 +274,7 @@ data class ReviewExportState(
     val viewState: ViewState,
     val dialog: DialogState? = null,
     // Internally used properties
-    val importCredentialsRequest: ImportCredentialsRequestData,
+    val importCredentialsRequestData: ImportCredentialsRequestData,
 ) : Parcelable {
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/selectaccount/SelectAccountViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/selectaccount/SelectAccountViewModel.kt
@@ -2,12 +2,19 @@ package com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount
 
 import android.os.Parcelable
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.util.Text
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
+import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.model.AccountSelectionListItem
 import com.x8bit.bitwarden.ui.vault.feature.vault.util.initials
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,7 +25,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
-import kotlinx.serialization.Serializable
 import javax.inject.Inject
 
 /**
@@ -26,32 +32,35 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class SelectAccountViewModel @Inject constructor(
-    authRepository: AuthRepository,
-    policyManager: PolicyManager,
+    private val authRepository: AuthRepository,
+    private val policyManager: PolicyManager,
+    specialCircumstanceManager: SpecialCircumstanceManager,
 ) : BaseViewModel<SelectAccountState, SelectAccountEvent, SelectAccountAction>(
-    initialState = SelectAccountState(
-        viewState = SelectAccountState.ViewState.Loading,
-    ),
+    initialState = run {
+        val importRequest = specialCircumstanceManager.specialCircumstance
+            as SpecialCircumstance.CredentialExchangeExport
+
+        SelectAccountState(
+            importRequest = importRequest.data,
+            viewState = SelectAccountState.ViewState.Loading,
+        )
+    },
 ) {
 
     init {
-        combine(
-            authRepository.userStateFlow,
-            policyManager.getActivePoliciesFlow(PolicyTypeJson.RESTRICT_ITEM_TYPES),
-            policyManager.getActivePoliciesFlow(PolicyTypeJson.PERSONAL_OWNERSHIP),
-        ) { userState, itemRestrictedOrgs, personalOwnershipOrgs ->
-            SelectAccountAction.Internal.SelectionDataReceive(
-                userState,
-                itemRestrictedOrgs,
-                personalOwnershipOrgs,
-            )
-        }
-            .onEach(::handleAction)
-            .launchIn(viewModelScope)
+        sendEvent(
+            SelectAccountEvent.ValidateImportRequest(
+                importCredentialsRequestData = state.importRequest,
+            ),
+        )
     }
 
     override fun handleAction(action: SelectAccountAction) {
         when (action) {
+            is SelectAccountAction.ValidateImportRequestResultReceive -> {
+                handleValidateImportRequestResultReceive(action)
+            }
+
             SelectAccountAction.CloseClick -> {
                 handleCloseClick()
             }
@@ -62,6 +71,24 @@ class SelectAccountViewModel @Inject constructor(
 
             is SelectAccountAction.Internal -> {
                 handleInternalAction(action)
+            }
+        }
+    }
+
+    private fun handleValidateImportRequestResultReceive(
+        action: SelectAccountAction.ValidateImportRequestResultReceive,
+    ) {
+        if (action.isValid) {
+            observeSelectionData()
+        } else {
+            mutableStateFlow.update {
+                it.copy(
+                    viewState = SelectAccountState.ViewState.Error(
+                        message = BitwardenString
+                            .the_import_request_could_not_be_processed
+                            .asText(),
+                    ),
+                )
             }
         }
     }
@@ -132,14 +159,30 @@ class SelectAccountViewModel @Inject constructor(
             )
         }
     }
+
+    private fun observeSelectionData() {
+        combine(
+            authRepository.userStateFlow,
+            policyManager.getActivePoliciesFlow(PolicyTypeJson.RESTRICT_ITEM_TYPES),
+            policyManager.getActivePoliciesFlow(PolicyTypeJson.PERSONAL_OWNERSHIP),
+        ) { userState, itemRestrictedOrgs, personalOwnershipOrgs ->
+            SelectAccountAction.Internal.SelectionDataReceive(
+                userState = userState,
+                itemRestrictedOrgs = itemRestrictedOrgs,
+                personalOwnershipOrgs = personalOwnershipOrgs,
+            )
+        }
+            .onEach(::handleAction)
+            .launchIn(viewModelScope)
+    }
 }
 
 /**
  * Represents the state for the select account screen.
  */
 @Parcelize
-@Serializable
 data class SelectAccountState(
+    val importRequest: ImportCredentialsRequestData,
     val viewState: ViewState,
 ) : Parcelable {
 
@@ -147,7 +190,6 @@ data class SelectAccountState(
      * Represents the different states for the select account screen.
      */
     @Parcelize
-    @Serializable
     sealed class ViewState : Parcelable {
         /**
          * Represents the loading state for the select account screen.
@@ -168,6 +210,11 @@ data class SelectAccountState(
          * Represents the no items state for the select account screen.
          */
         data object NoItems : ViewState()
+
+        /**
+         * Represents the error state for the select account screen.
+         */
+        data class Error(val message: Text) : ViewState()
     }
 }
 
@@ -175,6 +222,15 @@ data class SelectAccountState(
  * Represents the actions that can be performed on the select account screen.
  */
 sealed class SelectAccountAction {
+
+    /**
+     * Indicates the validate import request result was received.
+     *
+     * @param isValid Whether the import request is valid.
+     */
+    data class ValidateImportRequestResultReceive(
+        val isValid: Boolean,
+    ) : SelectAccountAction()
 
     /**
      * Indicates the top-bar close button was clicked.
@@ -208,6 +264,13 @@ sealed class SelectAccountAction {
  * Models events for the select account screen.
  */
 sealed class SelectAccountEvent {
+
+    /**
+     * Validates the import request.
+     */
+    data class ValidateImportRequest(
+        val importCredentialsRequestData: ImportCredentialsRequestData,
+    ) : SelectAccountEvent(), BackgroundEvent
 
     /**
      * Navigates back to the previous screen.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/util/SpecialCircumstanceExtensionsTest.kt
@@ -352,15 +352,15 @@ class SpecialCircumstanceExtensionsTest {
     @Suppress("MaxLineLength")
     @Test
     fun `toImportCredentialsRequestDataOrNull should return a non-null value for ImportCredentials`() {
-        val importCredentialsRequest = ImportCredentialsRequestData(
+        val importCredentialsRequestData = ImportCredentialsRequestData(
             uri = mockk(),
             requestJson = "",
         )
         assertEquals(
-            importCredentialsRequest,
+            importCredentialsRequestData,
             SpecialCircumstance
                 .CredentialExchangeExport(
-                    data = importCredentialsRequest,
+                    data = importCredentialsRequestData,
                 )
                 .toImportCredentialsRequestDataOrNull(),
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/base/BitwardenComposeTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/base/BitwardenComposeTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.platform.base
 import androidx.compose.runtime.Composable
 import com.bitwarden.cxf.importer.CredentialExchangeImporter
 import com.bitwarden.cxf.manager.CredentialExchangeCompletionManager
+import com.bitwarden.cxf.validator.CredentialExchangeRequestValidator
 import com.bitwarden.ui.platform.base.BaseComposeTest
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.manager.IntentManager
@@ -44,6 +45,7 @@ abstract class BitwardenComposeTest : BaseComposeTest() {
         permissionsManager: PermissionsManager = mockk(),
         credentialExchangeImporter: CredentialExchangeImporter = mockk(),
         credentialExchangeCompletionManager: CredentialExchangeCompletionManager = mockk(),
+        credentialExchangeRequestValidator: CredentialExchangeRequestValidator = mockk(),
         test: @Composable () -> Unit,
     ) {
         setTestContent {
@@ -61,6 +63,7 @@ abstract class BitwardenComposeTest : BaseComposeTest() {
                 permissionsManager = permissionsManager,
                 credentialExchangeImporter = credentialExchangeImporter,
                 credentialExchangeCompletionManager = credentialExchangeCompletionManager,
+                credentialExchangeRequestValidator = credentialExchangeRequestValidator,
             ) {
                 BitwardenTheme(
                     theme = theme,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/SelectAccountScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/SelectAccountScreenTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.performClick
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.cxf.manager.CredentialExchangeCompletionManager
 import com.bitwarden.cxf.manager.model.ExportCredentialsResult
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
+import com.bitwarden.cxf.validator.CredentialExchangeRequestValidator
 import com.bitwarden.ui.platform.components.account.model.AccountSummary
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.model.AccountSelectionListItem
@@ -35,6 +37,9 @@ class SelectAccountScreenTest : BitwardenComposeTest() {
     private val mockEventFlow = bufferedMutableSharedFlow<SelectAccountEvent>()
 
     private val credentialExchangeCompletionManager = mockk<CredentialExchangeCompletionManager>()
+    private val credentialExchangeRequestValidator = mockk<CredentialExchangeRequestValidator> {
+        every { validate(any()) } returns true
+    }
     private val viewModel = mockk<SelectAccountViewModel> {
         every { eventFlow } returns mockEventFlow
         every { stateFlow } returns mockkStateFlow
@@ -45,6 +50,7 @@ class SelectAccountScreenTest : BitwardenComposeTest() {
     fun setUp() {
         setContent(
             credentialExchangeCompletionManager = credentialExchangeCompletionManager,
+            credentialExchangeRequestValidator = credentialExchangeRequestValidator,
         ) {
             SelectAccountScreen(
                 onAccountSelected = { onAccountSelectedCalled = true },
@@ -183,6 +189,10 @@ private val LOCKED_ACCOUNT_SUMMARY = AccountSummary(
     isLoggedIn = true,
     isVaultUnlocked = false,
 )
+private val DEFAULT_IMPORT_REQUEST = ImportCredentialsRequestData(
+    uri = mockk(),
+    requestJson = "mockRequestJson",
+)
 
 private val DEFAULT_STATE = SelectAccountState(
     viewState = SelectAccountState.ViewState.Content(
@@ -203,4 +213,5 @@ private val DEFAULT_STATE = SelectAccountState(
             ),
         ),
     ),
+    importRequest = DEFAULT_IMPORT_REQUEST,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/SelectAccountViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/SelectAccountViewModelTest.kt
@@ -2,25 +2,32 @@ package com.x8bit.bitwarden.ui.vault.feature.exportitems
 
 import app.cash.turbine.test
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.network.model.OrganizationType
 import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.network.model.createMockPolicy
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.Organization
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
+import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
+import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.model.AccountSelectionListItem
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount.SelectAccountAction
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount.SelectAccountEvent
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount.SelectAccountState
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.selectaccount.SelectAccountViewModel
+import io.mockk.Ordering
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -46,15 +53,83 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
             getActivePoliciesFlow(PolicyTypeJson.PERSONAL_OWNERSHIP)
         } returns mutablePersonalOwnershipPolicyFlow
     }
+    private val specialCircumstanceManager = mockk<SpecialCircumstanceManager> {
+        every { specialCircumstance } returns SpecialCircumstance.CredentialExchangeExport(
+            data = DEFAULT_IMPORT_REQUEST,
+        )
+    }
 
     @Test
     fun `initial state should be correct`() = runTest {
         val viewModel = createViewModel()
         assertEquals(
-            SelectAccountState(viewState = SelectAccountState.ViewState.Loading),
+            SelectAccountState(
+                importRequest = DEFAULT_IMPORT_REQUEST,
+                viewState = SelectAccountState.ViewState.Loading,
+            ),
             viewModel.stateFlow.value,
         )
     }
+
+    @Test
+    fun `initial load should emit ValidateImportRequest event before observing selection data`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                assertEquals(
+                    SelectAccountEvent.ValidateImportRequest(
+                        importCredentialsRequestData = DEFAULT_IMPORT_REQUEST,
+                    ),
+                    awaitItem(),
+                )
+
+                verify(exactly = 0) {
+                    authRepository.userStateFlow
+                    policyManager.getActivePoliciesFlow(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                    policyManager.getActivePoliciesFlow(PolicyTypeJson.PERSONAL_OWNERSHIP)
+                }
+            }
+        }
+
+    @Test
+    fun `ValidateImportRequestResultReceive should show Error content when request is invalid`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.trySendAction(
+                SelectAccountAction.ValidateImportRequestResultReceive(
+                    isValid = false,
+                ),
+            )
+
+            assertEquals(
+                SelectAccountState(
+                    importRequest = DEFAULT_IMPORT_REQUEST,
+                    viewState = SelectAccountState.ViewState.Error(
+                        message = BitwardenString
+                            .the_import_request_could_not_be_processed
+                            .asText(),
+                    ),
+                ),
+                viewModel.stateFlow.value,
+            )
+        }
+
+    @Test
+    fun `ValidateImportRequestResultReceive should observe selection data when request is valid`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.trySendAction(
+                SelectAccountAction.ValidateImportRequestResultReceive(
+                    isValid = true,
+                ),
+            )
+
+            verify(Ordering.ORDERED) {
+                authRepository.userStateFlow
+                policyManager.getActivePoliciesFlow(PolicyTypeJson.RESTRICT_ITEM_TYPES)
+                policyManager.getActivePoliciesFlow(PolicyTypeJson.PERSONAL_OWNERSHIP)
+            }
+        }
 
     @Test
     fun `state is updated when single account with no organization is emitted`() = runTest {
@@ -77,6 +152,7 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
 
         assertEquals(
             SelectAccountState(
+                importRequest = DEFAULT_IMPORT_REQUEST,
                 viewState = SelectAccountState.ViewState.Content(
                     accountSelectionListItems = persistentListOf(expectedItem),
                 ),
@@ -117,7 +193,10 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
             ),
         )
         assertEquals(
-            SelectAccountState(viewState = SelectAccountState.ViewState.NoItems),
+            SelectAccountState(
+                importRequest = DEFAULT_IMPORT_REQUEST,
+                viewState = SelectAccountState.ViewState.NoItems,
+            ),
             viewModel.stateFlow.value,
         )
     }
@@ -163,6 +242,7 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
             )
             assertEquals(
                 SelectAccountState(
+                    importRequest = DEFAULT_IMPORT_REQUEST,
                     viewState = SelectAccountState.ViewState.Content(
                         accountSelectionListItems = persistentListOf(expectedItem),
                     ),
@@ -175,6 +255,8 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
     fun `when CloseClick action is sent, CancelExport event is emitted`() = runTest {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
+            // Skip the request validation event
+            skipItems(1)
             viewModel.trySendAction(SelectAccountAction.CloseClick)
             assertEquals(SelectAccountEvent.CancelExport, awaitItem())
         }
@@ -185,6 +267,8 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
         runTest {
             val viewModel = createViewModel()
             viewModel.eventFlow.test {
+                // Skip the request validation event
+                skipItems(1)
                 viewModel.trySendAction(
                     SelectAccountAction.AccountClick(
                         DEFAULT_ACCOUNT.userId,
@@ -202,6 +286,7 @@ class SelectAccountViewModelTest : BaseViewModelTest() {
     private fun createViewModel(): SelectAccountViewModel = SelectAccountViewModel(
         authRepository = authRepository,
         policyManager = policyManager,
+        specialCircumstanceManager = specialCircumstanceManager,
     )
 }
 
@@ -228,4 +313,8 @@ private val DEFAULT_ACCOUNT = UserState.Account(
 private val DEFAULT_USER_STATE = UserState(
     activeUserId = "activeUserId",
     accounts = listOf(DEFAULT_ACCOUNT),
+)
+private val DEFAULT_IMPORT_REQUEST = ImportCredentialsRequestData(
+    uri = mockk(),
+    requestJson = "mockRequestJson",
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportScreenTest.kt
@@ -140,7 +140,7 @@ private val DEFAULT_STATE = ReviewExportState(
     viewState = ReviewExportState.ViewState(
         itemTypeCounts = ReviewExportState.ItemTypeCounts(),
     ),
-    importCredentialsRequest = ImportCredentialsRequestData(
+    importCredentialsRequestData = ImportCredentialsRequestData(
         uri = Uri.EMPTY,
         requestJson = "",
     ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModelTest.kt
@@ -366,7 +366,7 @@ private val DEFAULT_REQUEST_DATA = ImportCredentialsRequestData(
     requestJson = "mockRequestJson",
 )
 private val DEFAULT_STATE: ReviewExportState = ReviewExportState(
-    importCredentialsRequest = DEFAULT_REQUEST_DATA,
+    importCredentialsRequestData = DEFAULT_REQUEST_DATA,
     viewState = ReviewExportState.ViewState(
         itemTypeCounts = ReviewExportState.ItemTypeCounts(),
     ),

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/importer/CredentialExchangeImporterImpl.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/importer/CredentialExchangeImporterImpl.kt
@@ -1,7 +1,6 @@
 package com.bitwarden.cxf.importer
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import androidx.credentials.providerevents.ProviderEventsManager
 import androidx.credentials.providerevents.exception.ImportCredentialsCancellationException
 import androidx.credentials.providerevents.exception.ImportCredentialsException
@@ -23,7 +22,6 @@ private const val CXP_FORMAT_VERSION_MINOR = 0
  */
 internal class CredentialExchangeImporterImpl(
     private val activity: Context,
-    @param:VisibleForTesting
     private val providerEventsManager: ProviderEventsManager =
         ProviderEventsManager.create(activity),
 ) : CredentialExchangeImporter {

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/ui/composition/LocalCredentialExchangeRequestValidatorProvider.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/ui/composition/LocalCredentialExchangeRequestValidatorProvider.kt
@@ -1,0 +1,17 @@
+@file:OmitFromCoverage
+
+package com.bitwarden.cxf.ui.composition
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.cxf.validator.CredentialExchangeRequestValidator
+
+/**
+ * Provides access to the Credential Exchange request validator throughout the app.
+ */
+@Suppress("MaxLineLength")
+val LocalCredentialExchangeRequestValidator: ProvidableCompositionLocal<CredentialExchangeRequestValidator> =
+    compositionLocalOf {
+        error("CompositionLocal LocalPermissionsManager not present")
+    }

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/validator/CredentialExchangeRequestValidator.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/validator/CredentialExchangeRequestValidator.kt
@@ -1,0 +1,19 @@
+package com.bitwarden.cxf.validator
+
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
+
+/**
+ * Defines the contract for validating a credential exchange request.
+ *
+ * This interface provides a mechanism to ensure that incoming credential import requests
+ * are legitimate and meet the required security criteria before they are processed.
+ */
+interface CredentialExchangeRequestValidator {
+    /**
+     * Validates the provided [ImportCredentialsRequestData].
+     *
+     * @param importCredentialsRequestData The request data to be validated.
+     * @return `true` if the request is valid, `false` otherwise.
+     */
+    fun validate(importCredentialsRequestData: ImportCredentialsRequestData): Boolean
+}

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/validator/CredentialExchangeRequestValidatorImpl.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/validator/CredentialExchangeRequestValidatorImpl.kt
@@ -1,0 +1,30 @@
+package com.bitwarden.cxf.validator
+
+import android.app.Activity
+import com.bitwarden.cxf.model.ImportCredentialsRequestData
+
+private const val GMS_PACKAGE_NAME = "com.google.android.gms"
+
+/**
+ * Default implementation of [CredentialExchangeRequestValidator].
+ */
+internal class CredentialExchangeRequestValidatorImpl(
+    private val activity: Activity,
+) : CredentialExchangeRequestValidator {
+
+    /**
+     * Validates the incoming [ImportCredentialsRequestData].
+     *
+     * This implementation ensures that the request originates from Google Mobile Services (GMS),
+     * which is the expected caller for credential exchange flows on Android.
+     *
+     * Note that [importCredentialsRequestData] is not currently evaluated. It will be used to
+     * perform additional validation once the implementation is finalized.
+     *
+     * @param importCredentialsRequestData The data associated with the import credentials request.
+     * @return `true` if the calling package is GMS, `false` otherwise.
+     */
+    override fun validate(
+        importCredentialsRequestData: ImportCredentialsRequestData,
+    ): Boolean = activity.callingPackage == GMS_PACKAGE_NAME
+}

--- a/cxf/src/main/kotlin/com/bitwarden/cxf/validator/dsl/CredentialExchangeRequestValidatorBuilder.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/validator/dsl/CredentialExchangeRequestValidatorBuilder.kt
@@ -1,0 +1,49 @@
+@file:OmitFromCoverage
+
+package com.bitwarden.cxf.validator.dsl
+
+import android.app.Activity
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.cxf.validator.CredentialExchangeRequestValidator
+import com.bitwarden.cxf.validator.CredentialExchangeRequestValidatorImpl
+
+/**
+ * A builder class for constructing an instance of [CredentialExchangeRequestValidator].
+ *
+ * This class follows the builder pattern and is designed to be used with the
+ * [credentialExchangeRequestValidator] DSL function. It allows for the configuration of necessary
+ * dependencies required by [CredentialExchangeRequestValidator].
+ *
+ * Example usage:
+ * ```
+ * val requestValidator = credentialExchangeRequestValidator(activity = activity)
+ * ```
+ *
+ * @see credentialExchangeRequestValidator
+ */
+@OmitFromCoverage
+class CredentialExchangeRequestValidatorBuilder internal constructor() {
+    internal fun build(activity: Activity): CredentialExchangeRequestValidator =
+        CredentialExchangeRequestValidatorImpl(activity = activity)
+}
+
+/**
+ * Creates an instance of [CredentialExchangeRequestValidator] using the
+ * [CredentialExchangeRequestValidatorBuilder] DSL.
+ *
+ * This function provides a convenient way to configure and build a
+ * [CredentialExchangeRequestValidator].
+ *
+ * @param activity The [Activity] that is handling the request.
+ * @param config A lambda with a receiver of type [CredentialExchangeRequestValidatorBuilder] to
+ * configure the validator.
+ *
+ * @return A new instance of [CredentialExchangeRequestValidator].
+ * @see CredentialExchangeRequestValidatorBuilder
+ */
+fun credentialExchangeRequestValidator(
+    activity: Activity,
+    config: CredentialExchangeRequestValidatorBuilder.() -> Unit = { },
+): CredentialExchangeRequestValidator = CredentialExchangeRequestValidatorBuilder()
+    .apply(config)
+    .build(activity)

--- a/cxf/src/test/kotlin/com/bitwarden/cxf/validator/CredentialExchangeRequestValidatorTest.kt
+++ b/cxf/src/test/kotlin/com/bitwarden/cxf/validator/CredentialExchangeRequestValidatorTest.kt
@@ -1,0 +1,29 @@
+package com.bitwarden.cxf.validator
+
+import android.app.Activity
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CredentialExchangeRequestValidatorTest {
+
+    private val mockActivity: Activity = mockk {
+        every { callingPackage } returns "mockCallingPackage"
+    }
+    private val credentialExchangeRequestValidator =
+        CredentialExchangeRequestValidatorImpl(mockActivity)
+
+    @Test
+    fun `validateRequest should return false when callingPackage is not GMS`() {
+        every { mockActivity.callingPackage } returns "otherPackage"
+        assertFalse(credentialExchangeRequestValidator.validate(mockk()))
+    }
+
+    @Test
+    fun `validateRequest should return true when callingPackage is GMS`() {
+        every { mockActivity.callingPackage } returns "com.google.android.gms"
+        assertTrue(credentialExchangeRequestValidator.validate(mockk()))
+    }
+}

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1132,4 +1132,5 @@ Do you want to switch to this account?</string>
     <string name="passkeys">Passkeys</string>
     <string name="import_verb">Import</string>
     <string name="why_is_this_step_required">Why is this step required?</string>
+    <string name="the_import_request_could_not_be_processed">The import request could not be processed.</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

PM-26716

## 📔 Objective

This commit introduces validation for incoming credential exchange requests to ensure they originate from a trusted source (Google Mobile Services).

Previously, the app would immediately process any credential import request. This change adds a validation step at the beginning of the flow. If the request is not valid, an error screen is displayed to the user, preventing further processing.

Specific changes:
- Add `CredentialExchangeRequestValidator` to validate incoming import requests by checking the calling package.
- Introduce a `CredentialExchangeRequestValidatorBuilder` and a corresponding DSL for easy instantiation.
- Provide the validator via `LocalCredentialExchangeRequestValidator` CompositionLocal.
- In `SelectAccountViewModel`, validate the request data upon initialization. If validation fails, transition to an error state.
- Add an error state to the `SelectAccountScreen` to handle and display validation failures.
- Update `ReviewExportViewModel` to rename `importCredentialsRequest` to `importCredentialsRequestData` for clarity.
- Add a new string resource for the import request processing error message.

## 📸 Screenshots

<img width="365" alt="image" src="https://github.com/user-attachments/assets/c76b0107-a1bb-42a8-aba2-ef62a0be2e13" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
