### PR TITLE
[PM-26718] Move Credential Exchange intent filter to main manifest

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -20,18 +20,6 @@
                 <data android:host="*.bitwarden.pw" />
                 <data android:pathPattern="/redirect-connector.*" />
             </intent-filter>
-
-            <!-- Handle Credential Exchange transfer requests -->
-            <intent-filter
-                android:autoVerify="true"
-                tools:ignore="AppLinkUrlError">
-                <action android:name="androidx.identitycredentials.action.IMPORT_CREDENTIALS" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:mimeType="application/octet-stream"
-                    android:scheme="content"
-                    tools:ignore="AppLinkUriRelativeFilterGroupError" />
-            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,6 +105,17 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="bitwarden" />
             </intent-filter>
+            <!-- Handle Credential Exchange transfer requests -->
+            <intent-filter
+                android:autoVerify="true"
+                tools:ignore="AppLinkUrlError">
+                <action android:name="androidx.identitycredentials.action.IMPORT_CREDENTIALS" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:mimeType="application/octet-stream"
+                    android:scheme="content"
+                    tools:ignore="AppLinkUriRelativeFilterGroupError" />
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
## 🎟️ Tracking

PM-26718

## 📔 Objective

This commit moves the intent filter for handling Credential Exchange transfer requests from the debug manifest to the main `AndroidManifest.xml`.

The intent filter for the `androidx.identitycredentials.action.IMPORT_CREDENTIALS` action was previously only included in debug builds. This change moves it to the main manifest, making the credential import functionality available in all build variants, including release builds.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
