### PR TITLE
Ensure the fab is dismissed when clicking on the lower portion of the content

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/fab/BitwardenExpandableFloatingActionButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/fab/BitwardenExpandableFloatingActionButton.kt
@@ -84,7 +84,9 @@ fun BitwardenExpandableFloatingActionButton(
     Column(
         horizontalAlignment = Alignment.End,
         verticalArrangement = Arrangement.Bottom,
-        modifier = modifier,
+        modifier = modifier.clickable(interactionSource = null, indication = null) {
+            onIsExpandedChange(false)
+        },
     ) {
         AnimatedVisibility(
             visible = isExpanded,
@@ -92,11 +94,7 @@ fun BitwardenExpandableFloatingActionButton(
             modifier = Modifier.weight(weight = 1f),
         ) {
             LazyColumn(
-                modifier = Modifier
-                    .clickable(interactionSource = null, indication = null) {
-                        onIsExpandedChange(false)
-                    }
-                    .fillMaxSize(),
+                modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.End,
                 verticalArrangement = Arrangement.spacedBy(
                     space = 12.dp,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR expands the total area that allows for the expanded FAB to be dismissed. The previous implementation allowed users to click the area under the scrolling content and not dismiss.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
