### PR TITLE
Remove logging in CredentialExchangeCompletionManager

### DIFF
--- a/cxf/src/main/kotlin/com/bitwarden/cxf/manager/CredentialExchangeCompletionManagerImpl.kt
+++ b/cxf/src/main/kotlin/com/bitwarden/cxf/manager/CredentialExchangeCompletionManagerImpl.kt
@@ -6,7 +6,6 @@ import androidx.credentials.providerevents.IntentHandler
 import androidx.credentials.providerevents.exception.ImportCredentialsException
 import androidx.credentials.providerevents.transfer.ImportCredentialsResponse
 import com.bitwarden.cxf.manager.model.ExportCredentialsResult
-import timber.log.Timber
 import java.time.Clock
 import kotlin.io.encoding.Base64
 
@@ -49,12 +48,10 @@ internal class CredentialExchangeCompletionManagerImpl(
                     }
                 """
                     .trimIndent()
-                Timber.d("completeCredentialExport set headerJson:\n$headerJson")
 
                 val encodedPayload = Base64.UrlSafe
                     .withPadding(Base64.PaddingOption.ABSENT)
                     .encode(headerJson.toByteArray())
-                Timber.d("completeCredentialExport set encodedPayload: $encodedPayload")
 
                 val responseJson = """
                     {
@@ -68,7 +65,6 @@ internal class CredentialExchangeCompletionManagerImpl(
                     }
                 """
                     .trimIndent()
-                Timber.d("completeCredentialExport set responseJson: $responseJson")
 
                 IntentHandler.setImportCredentialsResponse(
                     context = activity,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This commit removes several `Timber.d` logging statements from the `completeCredentialExport` function in `CredentialExchangeCompletionManagerImpl.kt`. The corresponding `timber.log.Timber` import is also removed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
