### PR TITLE
[PM-26750] Allow underscores in Block Autofill URI patterns

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/util/StringExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/util/StringExtensions.kt
@@ -44,6 +44,6 @@ fun String.validateUri(existingUris: List<String>): Text? {
  * Checks if the string matches a specific URI pattern.
  */
 fun String.isValidPattern(): Boolean {
-    val pattern = "^(https?|androidapp)://([A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*)(/.*)?$".toRegex()
+    val pattern = "^(https?|androidapp)://([A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+)*)(/.*)?$".toRegex()
     return matches(pattern)
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/util/StringExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/util/StringExtensionsTest.kt
@@ -54,7 +54,9 @@ class StringExtensionsTest {
             "https://a",
             "http://a.com",
             "https://subdomain.example.com",
+            "https://example.com/path_with_underscores",
             "androidapp://com.example.app",
+            "androidapp://com.example.app/path_with_underscores",
         )
 
         val invalidUris = listOf(


### PR DESCRIPTION
## 🎟️ Tracking
PM-26750
fixes #5997

## 📔 Objective

This commit updates the regular expression used for validating URIs in the Block Autofill feature to correctly handle underscores.

The previous regex did not account for underscores in the domain name or path, causing valid URIs to be incorrectly flagged as invalid. This has been fixed by adding the underscore character (`_`) to the character set in the validation pattern.

Additionally, new test cases have been added to `StringExtensionsTest.kt` to verify that URIs containing underscores are now correctly identified as valid patterns.

## 📸 Screenshots

https://github.com/user-attachments/assets/4ad029b8-4b8a-4d09-9687-388296509849

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
