### PR TITLE
PM-26575: Add AuthTab support for WebAuthN, Duo, and SSO

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/DuoUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/DuoUtils.kt
@@ -1,6 +1,9 @@
 package com.x8bit.bitwarden.data.auth.repository.util
 
 import android.content.Intent
+import android.net.Uri
+import androidx.browser.auth.AuthTabIntent
+import com.bitwarden.annotation.OmitFromCoverage
 
 private const val DUO_HOST: String = "duo-callback"
 
@@ -16,18 +19,41 @@ private const val DUO_HOST: String = "duo-callback"
  */
 fun Intent.getDuoCallbackTokenResult(): DuoCallbackTokenResult? {
     val localData = data
-    return if (
-        action == Intent.ACTION_VIEW && localData != null && localData.host == DUO_HOST
-    ) {
-        val code = localData.getQueryParameter("code")
-        val state = localData.getQueryParameter("state")
-        if (code != null && state != null) {
-            DuoCallbackTokenResult.Success(token = "$code|$state")
-        } else {
-            DuoCallbackTokenResult.MissingToken
-        }
+    return if (action == Intent.ACTION_VIEW && localData != null && localData.host == DUO_HOST) {
+        localData.getDuoCallbackTokenResult()
     } else {
         null
+    }
+}
+
+/**
+ * Retrieves a [DuoCallbackTokenResult] from an Intent. There are three possible cases.
+ *
+ * - `null`: Intent is not a Duo callback, or data is null.
+ *
+ * - [DuoCallbackTokenResult.MissingToken]: Intent is the Duo callback, but it's missing the code or
+ * state value.
+ *
+ * - [DuoCallbackTokenResult.Success]: Intent is the Duo callback, and it has a token.
+ */
+@OmitFromCoverage
+fun AuthTabIntent.AuthResult.getDuoCallbackTokenResult(): DuoCallbackTokenResult =
+    when (this.resultCode) {
+        AuthTabIntent.RESULT_OK -> this.resultUri.getDuoCallbackTokenResult()
+        AuthTabIntent.RESULT_CANCELED -> DuoCallbackTokenResult.MissingToken
+        AuthTabIntent.RESULT_UNKNOWN_CODE -> DuoCallbackTokenResult.MissingToken
+        AuthTabIntent.RESULT_VERIFICATION_FAILED -> DuoCallbackTokenResult.MissingToken
+        AuthTabIntent.RESULT_VERIFICATION_TIMED_OUT -> DuoCallbackTokenResult.MissingToken
+        else -> DuoCallbackTokenResult.MissingToken
+    }
+
+private fun Uri?.getDuoCallbackTokenResult(): DuoCallbackTokenResult {
+    val code = this?.getQueryParameter("code")
+    val state = this?.getQueryParameter("state")
+    return if (code != null && state != null) {
+        DuoCallbackTokenResult.Success(token = "$code|$state")
+    } else {
+        DuoCallbackTokenResult.MissingToken
     }
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
@@ -41,6 +41,8 @@ import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.R
+import com.x8bit.bitwarden.ui.platform.composition.LocalAuthTabLaunchers
+import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
 
 /**
  * The top level composable for the Enterprise Single Sign On screen.
@@ -52,6 +54,7 @@ fun EnterpriseSignOnScreen(
     onNavigateBack: () -> Unit,
     onNavigateToSetPassword: () -> Unit,
     onNavigateToTwoFactorLogin: (email: String, orgIdentifier: String) -> Unit,
+    authTabLaunchers: AuthTabLaunchers = LocalAuthTabLaunchers.current,
     intentManager: IntentManager = LocalIntentManager.current,
     viewModel: EnterpriseSignOnViewModel = hiltViewModel(),
 ) {
@@ -61,7 +64,7 @@ fun EnterpriseSignOnScreen(
             EnterpriseSignOnEvent.NavigateBack -> onNavigateBack()
 
             is EnterpriseSignOnEvent.NavigateToSsoLogin -> {
-                intentManager.startCustomTabsActivity(event.uri)
+                intentManager.startAuthTab(uri = event.uri, launcher = authTabLaunchers.sso)
             }
 
             is EnterpriseSignOnEvent.NavigateToSetPassword -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
@@ -61,8 +61,10 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.auth.feature.twofactorlogin.util.description
 import com.x8bit.bitwarden.ui.auth.feature.twofactorlogin.util.title
+import com.x8bit.bitwarden.ui.platform.composition.LocalAuthTabLaunchers
 import com.x8bit.bitwarden.ui.platform.composition.LocalNfcManager
 import com.x8bit.bitwarden.ui.platform.manager.nfc.NfcManager
+import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
 import kotlinx.collections.immutable.toPersistentList
 
 /**
@@ -74,6 +76,7 @@ import kotlinx.collections.immutable.toPersistentList
 fun TwoFactorLoginScreen(
     onNavigateBack: () -> Unit,
     viewModel: TwoFactorLoginViewModel = hiltViewModel(),
+    authTabLaunchers: AuthTabLaunchers = LocalAuthTabLaunchers.current,
     intentManager: IntentManager = LocalIntentManager.current,
     nfcManager: NfcManager = LocalNfcManager.current,
 ) {
@@ -105,11 +108,11 @@ fun TwoFactorLoginScreen(
             }
 
             is TwoFactorLoginEvent.NavigateToDuo -> {
-                intentManager.startCustomTabsActivity(uri = event.uri)
+                intentManager.startAuthTab(uri = event.uri, launcher = authTabLaunchers.duo)
             }
 
             is TwoFactorLoginEvent.NavigateToWebAuth -> {
-                intentManager.startCustomTabsActivity(uri = event.uri)
+                intentManager.startAuthTab(uri = event.uri, launcher = authTabLaunchers.webAuthn)
             }
 
             is TwoFactorLoginEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
@@ -43,6 +43,7 @@ import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManagerImpl
 import com.x8bit.bitwarden.ui.platform.manager.review.AppReviewManager
 import com.x8bit.bitwarden.ui.platform.manager.review.AppReviewManagerImpl
+import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
 import com.x8bit.bitwarden.ui.platform.model.FeatureFlagsState
 import java.time.Clock
 
@@ -78,6 +79,7 @@ fun LocalManagerProvider(
         },
     credentialExchangeRequestValidator: CredentialExchangeRequestValidator =
         credentialExchangeRequestValidator(activity = activity),
+    authTabLaunchers: AuthTabLaunchers,
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
@@ -95,6 +97,7 @@ fun LocalManagerProvider(
         LocalCredentialExchangeImporter provides credentialExchangeImporter,
         LocalCredentialExchangeCompletionManager provides credentialExchangeCompletionManager,
         LocalCredentialExchangeRequestValidator provides credentialExchangeRequestValidator,
+        LocalAuthTabLaunchers provides authTabLaunchers,
         content = content,
     )
 }
@@ -125,6 +128,13 @@ val LocalClock: ProvidableCompositionLocal<Clock> = compositionLocalOf { Clock.s
  */
 val LocalExitManager: ProvidableCompositionLocal<ExitManager> = compositionLocalOf {
     error("CompositionLocal ExitManager not present")
+}
+
+/**
+ * Provides access to the Auth Tab launchers throughout the app.
+ */
+val LocalAuthTabLaunchers: ProvidableCompositionLocal<AuthTabLaunchers> = compositionLocalOf {
+    error("CompositionLocal AuthTabLaunchers not present")
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/model/AuthTabLaunchers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/model/AuthTabLaunchers.kt
@@ -1,0 +1,15 @@
+package com.x8bit.bitwarden.ui.platform.model
+
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.compose.runtime.Immutable
+
+/**
+ * Contains all the callbacks for the Auth Tabs.
+ */
+@Immutable
+class AuthTabLaunchers(
+    val duo: ActivityResultLauncher<Intent>,
+    val sso: ActivityResultLauncher<Intent>,
+    val webAuthn: ActivityResultLauncher<Intent>,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/DuoUtilsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/DuoUtilsTest.kt
@@ -1,0 +1,77 @@
+package com.x8bit.bitwarden.data.auth.repository.util
+
+import android.content.Intent
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+
+class DuoUtilsTest {
+
+    @Test
+    fun `getDuoCallbackTokenResult should return null when action is not VIEW`() {
+        val intent = mockk<Intent> {
+            every { data } returns mockk()
+            every { action } returns Intent.ACTION_SEND
+        }
+        val result = intent.getDuoCallbackTokenResult()
+        assertNull(result)
+    }
+
+    @Test
+    fun `getDuoCallbackTokenResult should return null when data is null`() {
+        val intent = mockk<Intent> {
+            every { data } returns null
+            every { action } returns Intent.ACTION_VIEW
+        }
+        val result = intent.getDuoCallbackTokenResult()
+        assertNull(result)
+    }
+
+    @Test
+    fun `getDuoCallbackTokenResult should return null when host is not the duo callback`() {
+        val intent = mockk<Intent> {
+            every { data?.host } returns "wrongHost"
+            every { action } returns Intent.ACTION_VIEW
+        }
+        val result = intent.getDuoCallbackTokenResult()
+        assertNull(result)
+    }
+
+    @Test
+    fun `getDuoCallbackTokenResult should return MissingToken code is null`() {
+        val intent = mockk<Intent> {
+            every { data?.host } returns "duo-callback"
+            every { data?.getQueryParameter("code") } returns null
+            every { data?.getQueryParameter("state") } returns "state"
+            every { action } returns Intent.ACTION_VIEW
+        }
+        val result = intent.getDuoCallbackTokenResult()
+        assertEquals(DuoCallbackTokenResult.MissingToken, result)
+    }
+
+    @Test
+    fun `getDuoCallbackTokenResult should return MissingToken state is null`() {
+        val intent = mockk<Intent> {
+            every { data?.host } returns "duo-callback"
+            every { data?.getQueryParameter("code") } returns "code"
+            every { data?.getQueryParameter("state") } returns null
+            every { action } returns Intent.ACTION_VIEW
+        }
+        val result = intent.getDuoCallbackTokenResult()
+        assertEquals(DuoCallbackTokenResult.MissingToken, result)
+    }
+
+    @Test
+    fun `getDuoCallbackTokenResult should return Success when all data is present`() {
+        val intent = mockk<Intent> {
+            every { data?.host } returns "duo-callback"
+            every { data?.getQueryParameter("code") } returns "code"
+            every { data?.getQueryParameter("state") } returns "state"
+            every { action } returns Intent.ACTION_VIEW
+        }
+        val result = intent.getDuoCallbackTokenResult()
+        assertEquals(DuoCallbackTokenResult.Success(token = "code|state"), result)
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreenTest.kt
@@ -1,6 +1,8 @@
 package com.x8bit.bitwarden.ui.auth.feature.enterprisesignon
 
+import android.content.Intent
 import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -17,6 +19,7 @@ import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.assertNoDialogExists
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
+import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -30,6 +33,7 @@ import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 
 class EnterpriseSignOnScreenTest : BitwardenComposeTest() {
+    private val ssoLauncher: ActivityResultLauncher<Intent> = mockk()
     private var onNavigateBackCalled = false
     private var onNavigateToSetPasswordCalled = false
     private var onNavigateToTwoFactorLoginEmailAndOrgIdentifier: Pair<String, String>? = null
@@ -41,12 +45,17 @@ class EnterpriseSignOnScreenTest : BitwardenComposeTest() {
     }
 
     private val intentManager: IntentManager = mockk {
-        every { startCustomTabsActivity(any()) } just runs
+        every { startAuthTab(uri = any(), launcher = any()) } just runs
     }
 
     @Before
     fun setup() {
         setContent(
+            authTabLaunchers = AuthTabLaunchers(
+                duo = mockk(),
+                sso = ssoLauncher,
+                webAuthn = mockk(),
+            ),
             intentManager = intentManager,
         ) {
             EnterpriseSignOnScreen(
@@ -107,7 +116,7 @@ class EnterpriseSignOnScreenTest : BitwardenComposeTest() {
         val ssoUri = Uri.parse("https://identity.bitwarden.com/sso-test")
         mutableEventFlow.tryEmit(EnterpriseSignOnEvent.NavigateToSsoLogin(ssoUri))
         verify(exactly = 1) {
-            intentManager.startCustomTabsActivity(ssoUri)
+            intentManager.startAuthTab(uri = ssoUri, launcher = ssoLauncher)
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/base/BitwardenComposeTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/base/BitwardenComposeTest.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.ui.platform.manager.keychain.KeyChainManager
 import com.x8bit.bitwarden.ui.platform.manager.nfc.NfcManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
 import com.x8bit.bitwarden.ui.platform.manager.review.AppReviewManager
+import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
 import com.x8bit.bitwarden.ui.platform.model.FeatureFlagsState
 import io.mockk.mockk
 import java.time.Clock
@@ -33,6 +34,7 @@ abstract class BitwardenComposeTest : BaseComposeTest() {
     protected fun setContent(
         theme: AppTheme = AppTheme.DEFAULT,
         featureFlagsState: FeatureFlagsState = FeatureFlagsState,
+        authTabLaunchers: AuthTabLaunchers = mockk(),
         appResumeStateManager: AppResumeStateManager = mockk(),
         appReviewManager: AppReviewManager = mockk(),
         biometricsManager: BiometricsManager = mockk(),
@@ -51,6 +53,7 @@ abstract class BitwardenComposeTest : BaseComposeTest() {
         setTestContent {
             LocalManagerProvider(
                 featureFlagsState = featureFlagsState,
+                authTabLaunchers = authTabLaunchers,
                 appResumeStateManager = appResumeStateManager,
                 appReviewManager = appReviewManager,
                 biometricsManager = biometricsManager,

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManager.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManager.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import com.bitwarden.annotation.OmitFromCoverage
@@ -44,6 +45,14 @@ interface IntentManager {
      * Start an activity to view the given [uri] in an external browser.
      */
     fun launchUri(uri: Uri)
+
+    /**
+     * Start an Auth Tab Activity using the provided [Uri].
+     */
+    fun startAuthTab(
+        uri: Uri,
+        launcher: ActivityResultLauncher<Intent>,
+    )
 
     /**
      * Start an activity using the provided [Intent] and provides a callback, via [onResult], for

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImpl.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImpl.kt
@@ -13,7 +13,10 @@ import android.webkit.MimeTypeMap
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.browser.auth.AuthTabIntent
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.Composable
 import androidx.core.content.ContextCompat
@@ -70,6 +73,19 @@ internal class IntentManagerImpl(
             contract = ActivityResultContracts.StartActivityForResult(),
             onResult = onResult,
         )
+
+    override fun startAuthTab(
+        uri: Uri,
+        launcher: ActivityResultLauncher<Intent>,
+    ) {
+        val providerPackageName = CustomTabsClient.getPackageName(activity, null).toString()
+        if (CustomTabsClient.isAuthTabSupported(activity, providerPackageName)) {
+            AuthTabIntent.Builder().build().launch(launcher, uri, "bitwarden")
+        } else {
+            // Fall back to a Custom Tab.
+            startCustomTabsActivity(uri = uri)
+        }
+    }
 
     override fun startCustomTabsActivity(uri: Uri) {
         CustomTabsIntent


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26575](https://bitwarden.atlassian.net/browse/PM-26575)

## 📔 Objective

This PR adds support for `AuthTabs` when logging in with Duo, WebAuthn, and SSO login flows.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26575]: https://bitwarden.atlassian.net/browse/PM-26575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ