### PR TITLE
Fix statusbar color when display is turned off

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StatusBarsAppearanceAffect.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StatusBarsAppearanceAffect.kt
@@ -3,13 +3,13 @@ package com.bitwarden.ui.platform.base.util
 import android.app.Activity
 import android.view.View
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.Lifecycle
 
 /**
  * Sets the appearance of the StatusBars to the [isLightStatusBars] value and clears the value once
- * disposed.
+ * lifecycle is stopped.
  */
 @Composable
 fun StatusBarsAppearanceAffect(
@@ -18,13 +18,24 @@ fun StatusBarsAppearanceAffect(
 ) {
     if (view.isInEditMode) return
     val activity = view.context as Activity
-    DisposableEffect(Unit) {
-        val insetsController = WindowCompat.getInsetsController(activity.window, view)
-        val originalStatusBarValue = insetsController.isAppearanceLightStatusBars
-        insetsController.isAppearanceLightStatusBars = isLightStatusBars
+    val insetsController = WindowCompat.getInsetsController(activity.window, view)
+    val originalStatusBarValue = insetsController.isAppearanceLightStatusBars
+    LifecycleEventEffect { _, event ->
+        when (event) {
+            Lifecycle.Event.ON_START -> {
+                insetsController.isAppearanceLightStatusBars = isLightStatusBars
+            }
 
-        onDispose {
-            insetsController.isAppearanceLightStatusBars = originalStatusBarValue
+            Lifecycle.Event.ON_STOP -> {
+                insetsController.isAppearanceLightStatusBars = originalStatusBarValue
+            }
+
+            Lifecycle.Event.ON_CREATE,
+            Lifecycle.Event.ON_RESUME,
+            Lifecycle.Event.ON_PAUSE,
+            Lifecycle.Event.ON_DESTROY,
+            Lifecycle.Event.ON_ANY,
+                -> Unit
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR ensures the statusbar content color is correct after turning the display on and off.

## 📸 Screenshots

| Bewfore | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/08e40428-7725-42e8-b49a-9d1c11d89154" width="300" /> | <video src="https://github.com/user-attachments/assets/fd5f7c6e-b397-4009-a4f0-88fd8cc2b919" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
