### PR TITLE
Correct environment variable names in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,48 +241,48 @@ jobs:
       - name: Generate release Play Store bundle
         if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' }}
         env:
-          UPLOAD-KEYSTORE-PASSWORD: ${{ steps.get-kv-secrets.outputs.UPLOAD-KEYSTORE-PASSWORD }}
+          UPLOAD_KEYSTORE_PASSWORD: ${{ steps.get-kv-secrets.outputs.UPLOAD-KEYSTORE-PASSWORD }}
         run: |
           bundle exec fastlane bundlePlayStoreRelease \
           storeFile:app_upload-keystore.jks \
-          storePassword:$UPLOAD-KEYSTORE-PASSWORD \
+          storePassword:$UPLOAD_KEYSTORE_PASSWORD \
           keyAlias:upload \
-          keyPassword:$UPLOAD-KEYSTORE-PASSWORD
+          keyPassword:$UPLOAD_KEYSTORE_PASSWORD
 
       - name: Generate beta Play Store bundle
         if: ${{ (matrix.variant == 'prod') && (matrix.artifact == 'aab') }}
         env:
-          UPLOAD-BETA-KEYSTORE-PASSWORD: ${{ steps.get-kv-secrets.outputs.UPLOAD-BETA-KEYSTORE-PASSWORD }}
-          UPLOAD-BETA-KEY-PASSWORD: ${{ steps.get-kv-secrets.outputs.UPLOAD-BETA-KEY-PASSWORD }}
+          UPLOAD_BETA_KEYSTORE_PASSWORD: ${{ steps.get-kv-secrets.outputs.UPLOAD-BETA-KEYSTORE-PASSWORD }}
+          UPLOAD_BETA_KEY_PASSWORD: ${{ steps.get-kv-secrets.outputs.UPLOAD-BETA-KEY-PASSWORD }}
         run: |
           bundle exec fastlane bundlePlayStoreBeta \
           storeFile:app_beta_upload-keystore.jks \
-          storePassword:$UPLOAD-BETA-KEYSTORE-PASSWORD \
+          storePassword:$UPLOAD_BETA_KEYSTORE_PASSWORD \
           keyAlias:bitwarden-beta-upload \
-          keyPassword:$UPLOAD-BETA-KEYSTORE-PASSWORD
+          keyPassword:$UPLOAD_BETA_KEY_PASSWORD
 
       - name: Generate release Play Store APK
         if: ${{ (matrix.variant == 'prod') && (matrix.artifact == 'apk') }}
         env:
-          PLAY-KEYSTORE-PASSWORD: ${{ steps.get-kv-secrets.outputs.PLAY-KEYSTORE-PASSWORD }}
+          PLAY_KEYSTORE_PASSWORD: ${{ steps.get-kv-secrets.outputs.PLAY-KEYSTORE-PASSWORD }}
         run: |
           bundle exec fastlane assemblePlayStoreReleaseApk \
           storeFile:app_play-keystore.jks \
-          storePassword:$PLAY-KEYSTORE-PASSWORD \
+          storePassword:$PLAY_KEYSTORE_PASSWORD \
           keyAlias:bitwarden \
-          keyPassword:$PLAY-KEYSTORE-PASSWORD
+          keyPassword:$PLAY_KEYSTORE_PASSWORD
 
       - name: Generate beta Play Store APK
         if: ${{ (matrix.variant == 'prod') && (matrix.artifact == 'apk') }}
         env:
-          PLAY-BETA-KEYSTORE-PASSWORD: ${{ steps.get-kv-secrets.outputs.PLAY-BETA-KEYSTORE-PASSWORD }}
-          PLAY-BETA-KEY-PASSWORD: ${{ steps.get-kv-secrets.outputs.PLAY-BETA-KEY-PASSWORD }}
+          PLAY_BETA_KEYSTORE_PASSWORD: ${{ steps.get-kv-secrets.outputs.PLAY-BETA-KEYSTORE-PASSWORD }}
+          PLAY_BETA_KEY_PASSWORD: ${{ steps.get-kv-secrets.outputs.PLAY-BETA-KEY-PASSWORD }}
         run: |
           bundle exec fastlane assemblePlayStoreBetaApk \
           storeFile:app_beta_play-keystore.jks \
-          storePassword:$PLAY-BETA-KEYSTORE-PASSWORD \
+          storePassword:$PLAY_BETA_KEYSTORE_PASSWORD \
           keyAlias:bitwarden-beta \
-          keyPassword:$PLAY-BETA-KEY-PASSWORD
+          keyPassword:$PLAY_BETA_KEY_PASSWORD
 
       - name: Generate debug Play Store APKs
         if: ${{ (matrix.variant != 'prod') && (matrix.artifact == 'apk') }}
@@ -559,14 +559,14 @@ jobs:
 
       - name: Generate F-Droid Beta Artifacts
         env:
-          FDROID-BETA-KEYSTORE-PASSWORD: ${{ steps.get-kv-secrets.outputs.FDROID-BETA-KEYSTORE-PASSWORD }}
-          FDROID-BETA-KEY-PASSWORD: ${{ steps.get-kv-secrets.outputs.FDROID-BETA-KEY-PASSWORD }}
+          FDROID_BETA_KEYSTORE_PASSWORD: ${{ steps.get-kv-secrets.outputs.FDROID-BETA-KEYSTORE-PASSWORD }}
+          FDROID_BETA_KEY_PASSWORD: ${{ steps.get-kv-secrets.outputs.FDROID-BETA-KEY-PASSWORD }}
         run: |
           bundle exec fastlane assembleFDroidBetaApk \
           storeFile:app_beta_fdroid-keystore.jks \
-          storePassword:$FDROID-BETA-KEYSTORE-PASSWORD \
+          storePassword:$FDROID_BETA_KEYSTORE_PASSWORD \
           keyAlias:bitwarden-beta \
-          keyPassword:$FDROID-BETA-KEY-PASSWORD
+          keyPassword:$FDROID_BETA_KEY_PASSWORD
 
       - name: Upload F-Droid .apk artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This commit fixes issues in the `build.yml` GitHub Actions workflow where environment variable names with hyphens were causing build failures. The hyphens have been replaced with underscores to ensure the variables are correctly referenced in the shell environment.

Specifically, the following changes were made in `.github/workflows/build.yml`:
*   Updated environment variable names in the "Generate release Play Store bundle" step.
*   Corrected variable names for the "Generate beta Play Store bundle" step.
*   Fixed variable names in the "Generate release Play Store APK" step.
*   Updated environment variable names for the "Generate beta Play Store APK" step.
*   Corrected variable names in the "Generate F-Droid Beta Artifacts" step.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
