### PR TITLE
Add logging to UI module for Auth Tabs

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     implementation(libs.kotlinx.serialization)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.collections.immutable)
+    implementation(libs.timber)
     implementation(libs.zxing.zxing.core)
 
     // For now we are restricted to running Compose tests for debug builds only

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImpl.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImpl.kt
@@ -32,6 +32,7 @@ import com.bitwarden.ui.platform.manager.util.fileProviderAuthority
 import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.util.getLocalFileData
+import timber.log.Timber
 import java.io.File
 import java.time.Clock
 
@@ -80,9 +81,11 @@ internal class IntentManagerImpl(
     ) {
         val providerPackageName = CustomTabsClient.getPackageName(activity, null).toString()
         if (CustomTabsClient.isAuthTabSupported(activity, providerPackageName)) {
+            Timber.d("Launching uri with AuthTab for $providerPackageName")
             AuthTabIntent.Builder().build().launch(launcher, uri, "bitwarden")
         } else {
             // Fall back to a Custom Tab.
+            Timber.d("Launching uri with CustomTabs fallback for $providerPackageName")
             startCustomTabsActivity(uri = uri)
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds the `Timber` logging library to the `ui` module and add simple lag statements for the Auth Tabs feature.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
