### PR TITLE
Fix plurals issue for Crowdin

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -426,9 +426,12 @@ private fun VaultDialogs(
                 title = stringResource(
                     id = BitwardenString.enable_browser_autofill_to_keep_filling_passwords,
                 ),
-                message = pluralStringResource(
-                    id = BitwardenPlurals.your_browser_recently_updated_how_autofill_works,
-                    count = dialogState.browserCount,
+                message = stringResource(
+                    id = if (dialogState.browserCount > 1) {
+                        BitwardenString.your_browser_recently_updated_how_autofill_works_plural
+                    } else {
+                        BitwardenString.your_browser_recently_updated_how_autofill_works_singular
+                    },
                 ),
                 confirmButtonText = stringResource(id = BitwardenString.go_to_settings),
                 dismissButtonText = stringResource(id = BitwardenString.not_now),

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1111,10 +1111,8 @@ Do you want to switch to this account?</string>
         <item quantity="other">%1$d items have been imported to your vault.</item>
     </plurals>
     <string name="enable_browser_autofill_to_keep_filling_passwords">Enable browser Autofill to keep filling passwords</string>
-    <plurals name="your_browser_recently_updated_how_autofill_works">
-        <item quantity="one">Your browser has recently updated, which has disabled Bitwarden autofill. To continue filling your passwords with Bitwarden, enable browser autofill in autofill settings.</item>
-        <item quantity="other">Your browsers have recently updated, which has disabled Bitwarden autofill. To continue filling your passwords with Bitwarden, enable browser autofill for all installed browsers in autofill settings.</item>
-    </plurals>
+    <string name="your_browser_recently_updated_how_autofill_works_singular">Your browser has recently updated, which has disabled Bitwarden autofill. To continue filling your passwords with Bitwarden, enable browser autofill in autofill settings.</string>
+    <string name="your_browser_recently_updated_how_autofill_works_plural">Your browsers have recently updated, which has disabled Bitwarden autofill. To continue filling your passwords with Bitwarden, enable browser autofill for all installed browsers in autofill settings.</string>
     <string name="not_now">Not now</string>
     <string name="import_from_bitwarden">Import from Bitwarden</string>
     <string name="select_account">Select account</string>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates a plural inside the app that do not actually have number based argument values to be regular strings.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
