### PR TITLE
[PM-26804] Clear password input after verification in `VerifyPasswordViewModel`

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModelTest.kt
@@ -312,21 +312,26 @@ class VerifyPasswordViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `ValidatePasswordResultReceive should send PasswordVerified event when result is Success and isValid is true`() =
+    fun `ValidatePasswordResultReceive should send PasswordVerified event and clear input when result is Success and isValid is true`() =
         runTest {
-            createViewModel().also { viewModel ->
-                viewModel.trySendAction(
-                    VerifyPasswordAction.Internal.ValidatePasswordResultReceive(
-                        ValidatePasswordResult.Success(isValid = true),
-                    ),
-                )
-                viewModel.eventFlow.test {
-                    assertEquals(
-                        VerifyPasswordEvent.PasswordVerified(DEFAULT_USER_ID),
-                        awaitItem(),
+            createViewModel(state = DEFAULT_STATE.copy(input = "mockInput"))
+                .also { viewModel ->
+                    viewModel.trySendAction(
+                        VerifyPasswordAction.Internal.ValidatePasswordResultReceive(
+                            ValidatePasswordResult.Success(isValid = true),
+                        ),
                     )
+                    assertEquals(
+                        DEFAULT_STATE.copy(input = ""),
+                        viewModel.stateFlow.value,
+                    )
+                    viewModel.eventFlow.test {
+                        assertEquals(
+                            VerifyPasswordEvent.PasswordVerified(DEFAULT_USER_ID),
+                            awaitItem(),
+                        )
+                    }
                 }
-            }
         }
 
     @Suppress("MaxLineLength")
@@ -372,21 +377,26 @@ class VerifyPasswordViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `UnlockVaultResultReceive should send PasswordVerified event when vault unlock result is Success`() =
+    fun `UnlockVaultResultReceive should send PasswordVerified event and clear inputs when vault unlock result is Success`() =
         runTest {
-            createViewModel().also { viewModel ->
-                viewModel.trySendAction(
-                    VerifyPasswordAction.Internal.UnlockVaultResultReceive(
-                        VaultUnlockResult.Success,
-                    ),
-                )
-                viewModel.eventFlow.test {
-                    assertEquals(
-                        VerifyPasswordEvent.PasswordVerified(DEFAULT_USER_ID),
-                        awaitItem(),
+            createViewModel(state = DEFAULT_STATE.copy(input = "mockInput"))
+                .also { viewModel ->
+                    viewModel.trySendAction(
+                        VerifyPasswordAction.Internal.UnlockVaultResultReceive(
+                            VaultUnlockResult.Success,
+                        ),
                     )
+                    assertEquals(
+                        DEFAULT_STATE.copy(input = ""),
+                        viewModel.stateFlow.value,
+                    )
+                    viewModel.eventFlow.test {
+                        assertEquals(
+                            VerifyPasswordEvent.PasswordVerified(DEFAULT_USER_ID),
+                            awaitItem(),
+                        )
+                    }
                 }
-            }
         }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

PM-26804

## 📔 Objective

This commit addresses a security concern where the password input in the `VerifyPasswordViewModel` was not being cleared after successful verification.

To resolve this, the password input field is now cleared from the view model's state upon successful password validation or vault unlock. The `input` field in `VerifyPasswordState` is also annotated with `@IgnoredOnParcel` to prevent it from being saved to the instance state, further enhancing security.

Additionally, the `onCleared()` method is overridden to explicitly clear the password input, as a temporary workaround for a suspected OS-level memory leak. Corresponding unit tests have been updated to verify that the input is cleared after successful verification.

## 📸 Screenshots


<video src="https://github.com/user-attachments/assets/15fb5ae0-8774-447b-9c50-18acd8e40736"  width="365"/>

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
