### PR TITLE
Add navigation chevron for Import Items button

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -24,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.ui.platform.base.util.EventsEffect
+import com.bitwarden.ui.platform.base.util.mirrorIfRtl
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.badge.NotificationBadge
@@ -37,6 +40,7 @@ import com.bitwarden.ui.platform.components.snackbar.model.rememberBitwardenSnac
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
  * Displays the vault settings screen.
@@ -160,7 +164,18 @@ fun VaultSettingsScreen(
                     .testTag("ImportItemsLinkItemView")
                     .standardHorizontalMargin()
                     .fillMaxWidth(),
-            )
+            ) {
+                if (state.showImportItemsChevron) {
+                    Icon(
+                        painter = rememberVectorPainter(id = BitwardenDrawable.ic_chevron_right),
+                        contentDescription = null,
+                        tint = BitwardenTheme.colorScheme.icon.primary,
+                        modifier = Modifier
+                            .mirrorIfRtl()
+                            .size(size = 16.dp),
+                    )
+                }
+            }
             Spacer(modifier = Modifier.height(height = 16.dp))
             Spacer(modifier = Modifier.navigationBarsPadding())
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreenTest.kt
@@ -29,11 +29,7 @@ class VaultSettingsScreenTest : BitwardenComposeTest() {
     private var onNavigateToExportVaultCalled = false
     private var onNavigateToFoldersCalled = false
     private val mutableEventFlow = bufferedMutableSharedFlow<VaultSettingsEvent>()
-    private val mutableStateFlow = MutableStateFlow(
-        VaultSettingsState(
-            showImportActionCard = false,
-        ),
-    )
+    private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
 
     val viewModel = mockk<VaultSettingsViewModel>(relaxed = true) {
         every { eventFlow } returns mutableEventFlow
@@ -158,3 +154,8 @@ class VaultSettingsScreenTest : BitwardenComposeTest() {
             .assertIsNotDisplayed()
     }
 }
+
+private val DEFAULT_STATE: VaultSettingsState = VaultSettingsState(
+    showImportActionCard = false,
+    showImportItemsChevron = true,
+)


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds a chevron to the `Import Items` button when the `CredentialExchangeProtocolImport` feature flag is enabled.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/884e36d3-195f-49e0-8273-9dffb4fe16ac" width="350" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
