### PR TITLE
Add optional buttons to BitwardenEmptyContent

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/model/BitwardenButtonData.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/model/BitwardenButtonData.kt
@@ -1,0 +1,16 @@
+package com.bitwarden.ui.platform.components.button.model
+
+import com.bitwarden.ui.util.Text
+
+/**
+ * Represents the data required to render a button.
+ *
+ * @param label The text to be displayed on the button.
+ * @param onClick A lambda function to be executed when the button is clicked.
+ * @param testTag A optional unique identifier for testing purposes.
+ */
+data class BitwardenButtonData(
+    val label: Text,
+    val onClick: () -> Unit,
+    val testTag: String? = null,
+)

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/content/BitwardenEmptyContent.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/content/BitwardenEmptyContent.kt
@@ -1,3 +1,5 @@
+@file:OmitFromCoverage
+
 package com.bitwarden.ui.platform.components.content
 
 import androidx.compose.foundation.layout.Arrangement
@@ -15,17 +17,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.ui.platform.base.util.nullableTestTag
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
+import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
+import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
 import com.bitwarden.ui.platform.components.icon.BitwardenIcon
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.bitwarden.ui.util.asText
 
 /**
  * A Bitwarden-themed, re-usable empty state.
+ *
+ * @param text The primary text to display.
+ * @param modifier The [Modifier] to be applied to the layout.
+ * @param illustrationData Optional illustration to display above the text.
+ * @param labelTestTag A test tag for the primary text.
+ * @param title Optional title to display above the primary text.
+ * @param titleTestTag A test tag for the title.
+ * @param primaryButton Optional primary button to display.
+ * @param secondaryButton Optional secondary button to display.
  */
+@Suppress("LongMethod")
 @Composable
 fun BitwardenEmptyContent(
     text: String,
@@ -34,6 +51,8 @@ fun BitwardenEmptyContent(
     labelTestTag: String? = null,
     title: String? = null,
     titleTestTag: String? = null,
+    primaryButton: BitwardenButtonData? = null,
+    secondaryButton: BitwardenButtonData? = null,
 ) {
     Column(
         modifier = modifier,
@@ -70,6 +89,40 @@ fun BitwardenEmptyContent(
                 .standardHorizontalMargin()
                 .nullableTestTag(tag = labelTestTag),
         )
+
+        // If either of the optional buttons are present add a spacer between the text and the
+        // buttons.
+        if (primaryButton != null || secondaryButton != null) {
+            Spacer(Modifier.height(12.dp))
+        }
+
+        primaryButton?.let {
+            BitwardenFilledButton(
+                label = it.label(),
+                onClick = it.onClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .nullableTestTag(tag = it.testTag),
+            )
+        }
+
+        // If both buttons are visible add the standard button spacing.
+        if (primaryButton != null && secondaryButton != null) {
+            Spacer(Modifier.height(8.dp))
+        }
+
+        secondaryButton?.let {
+            BitwardenOutlinedButton(
+                label = it.label(),
+                onClick = it.onClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .nullableTestTag(tag = it.testTag),
+            )
+        }
+
         Spacer(modifier = Modifier.navigationBarsPadding())
     }
 }
@@ -84,6 +137,16 @@ private fun BitwardenEmptyContent_preview() {
             text = "There is no content to display",
             labelTestTag = "EmptyContentLabel",
             illustrationData = IconData.Local(BitwardenDrawable.ic_empty_vault),
+            primaryButton = BitwardenButtonData(
+                label = "Primary button".asText(),
+                testTag = "EmptyContentPositiveButton",
+                onClick = { },
+            ),
+            secondaryButton = BitwardenButtonData(
+                label = "Secondary button".asText(),
+                testTag = "EmptyContentNegativeButton",
+                onClick = { },
+            ),
             modifier = Modifier
                 .fillMaxSize()
                 .standardHorizontalMargin(),


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This commit enhances the `BitwardenEmptyContent` composable to support optional primary and secondary action buttons.

A new data class, `BitwardenButtonData`, is introduced to encapsulate the data required for rendering a button, including its label, click action, and test tag.

The `BitwardenEmptyContent` composable has been updated to accept optional `BitwardenButtonData` for a primary (filled) and a secondary (outlined) button. When provided, these buttons are displayed below the main content text. The preview for this component has also been updated to demonstrate the new button functionality.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/67290924-4157-4ba6-8a94-2e0ceefaa5a3" /> | <img width="365" src="https://github.com/user-attachments/assets/ff256c39-9ccb-4ca3-921d-ff9f1464c21b" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
