### PR TITLE
[PM-26810] Add OTP support to VerifyPasswordScreen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.verticalScroll
@@ -15,8 +16,10 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -25,14 +28,18 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
+import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarHostState
+import com.bitwarden.ui.platform.components.snackbar.model.rememberBitwardenSnackbarHostState
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.component.AccountSummaryListItem
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.component.ExportItemsScaffold
 import com.x8bit.bitwarden.ui.vault.feature.exportitems.model.AccountSelectionListItem
@@ -47,6 +54,7 @@ fun VerifyPasswordScreen(
     onNavigateBack: () -> Unit,
     onPasswordVerified: (userId: String) -> Unit,
     viewModel: VerifyPasswordViewModel = hiltViewModel(),
+    snackbarHostState: BitwardenSnackbarHostState = rememberBitwardenSnackbarHostState(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -58,6 +66,10 @@ fun VerifyPasswordScreen(
 
             is VerifyPasswordEvent.PasswordVerified -> {
                 onPasswordVerified(event.userId)
+            }
+
+            is VerifyPasswordEvent.ShowSnackbar -> {
+                snackbarHostState.showSnackbar(event.data)
             }
         }
     }
@@ -79,10 +91,9 @@ fun VerifyPasswordScreen(
         VerifyPasswordContent(
             state = state,
             onInputChanged = handler.onInputChanged,
-            onUnlockClick = handler.onUnlockClick,
-            modifier = Modifier
-                .fillMaxSize()
-                .standardHorizontalMargin(),
+            onContinueClick = handler.onContinueClick,
+            onResendCodeClick = handler.onSendCodeClick,
+            modifier = Modifier.fillMaxSize(),
         )
     }
 }
@@ -110,11 +121,13 @@ private fun VerifyPasswordDialogs(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun VerifyPasswordContent(
     state: VerifyPasswordState,
     onInputChanged: (String) -> Unit,
-    onUnlockClick: () -> Unit,
+    onContinueClick: () -> Unit,
+    onResendCodeClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -125,11 +138,25 @@ private fun VerifyPasswordContent(
         Spacer(Modifier.height(24.dp))
 
         Text(
-            text = stringResource(BitwardenString.verify_your_master_password),
+            text = state.title(),
             textAlign = TextAlign.Center,
             style = BitwardenTheme.typography.titleMedium,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
         )
+
+        state.subtext?.let { subtext ->
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = subtext(),
+                textAlign = TextAlign.Center,
+                style = BitwardenTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+        }
 
         Spacer(Modifier.height(16.dp))
 
@@ -137,49 +164,95 @@ private fun VerifyPasswordContent(
             item = state.accountSummaryListItem,
             cardStyle = CardStyle.Full,
             clickable = false,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
         )
 
         Spacer(Modifier.height(16.dp))
 
-        BitwardenPasswordField(
-            label = stringResource(BitwardenString.master_password),
-            value = state.input,
-            onValueChange = onInputChanged,
-            showPasswordTestTag = "PasswordVisibilityToggle",
-            imeAction = ImeAction.Done,
-            keyboardActions = KeyboardActions(
-                onDone = {
-                    if (state.isUnlockButtonEnabled) {
-                        onUnlockClick()
-                    } else {
-                        defaultKeyboardAction(ImeAction.Done)
-                    }
-                },
-            ),
-            supportingText = stringResource(BitwardenString.vault_locked_master_password),
-            passwordFieldTestTag = "MasterPasswordEntry",
-            cardStyle = CardStyle.Full,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        if (state.showResendCodeButton) {
+            BitwardenPasswordField(
+                label = stringResource(id = BitwardenString.verification_code),
+                value = state.input,
+                onValueChange = onInputChanged,
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done,
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        if (state.isContinueButtonEnabled) {
+                            onContinueClick()
+                        } else {
+                            defaultKeyboardAction(ImeAction.Done)
+                        }
+                    },
+                ),
+                autoFocus = true,
+                cardStyle = CardStyle.Full,
+                passwordFieldTestTag = "VerificationCodeEntry",
+                showPasswordTestTag = "VerificationCodeVisibilityToggle",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+        } else {
+            BitwardenPasswordField(
+                label = stringResource(BitwardenString.master_password),
+                value = state.input,
+                onValueChange = onInputChanged,
+                showPasswordTestTag = "PasswordVisibilityToggle",
+                imeAction = ImeAction.Done,
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        if (state.isContinueButtonEnabled) {
+                            onContinueClick()
+                        } else {
+                            defaultKeyboardAction(ImeAction.Done)
+                        }
+                    },
+                ),
+                autoFocus = true,
+                supportingText = stringResource(BitwardenString.vault_locked_master_password),
+                passwordFieldTestTag = "MasterPasswordEntry",
+                cardStyle = CardStyle.Full,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+        }
 
         Spacer(Modifier.height(16.dp))
 
         BitwardenFilledButton(
-            label = stringResource(BitwardenString.unlock),
-            onClick = onUnlockClick,
-            isEnabled = state.isUnlockButtonEnabled,
-            modifier = Modifier.fillMaxWidth(),
+            label = stringResource(BitwardenString.continue_text),
+            onClick = onContinueClick,
+            isEnabled = state.isContinueButtonEnabled,
+            modifier = Modifier
+                .testTag("ContinueImportButton")
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
         )
 
+        if (state.showResendCodeButton) {
+            BitwardenOutlinedButton(
+                label = stringResource(BitwardenString.resend_code),
+                onClick = onResendCodeClick,
+                modifier = Modifier
+                    .testTag("ResendTOTPCodeButton")
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+        }
+
         Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.navigationBarsPadding())
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview(showBackground = true)
 @Composable
-private fun VerifyPasswordContent_Preview() {
+private fun VerifyPasswordContent_MasterPassword_preview() {
     val accountSummaryListItem = AccountSelectionListItem(
         userId = "userId",
         isItemRestricted = false,
@@ -188,14 +261,65 @@ private fun VerifyPasswordContent_Preview() {
         email = "john.doe@example.com",
     )
     val state = VerifyPasswordState(
+        title = BitwardenString.verify_your_master_password.asText(),
+        subtext = null,
         accountSummaryListItem = accountSummaryListItem,
     )
-    VerifyPasswordContent(
-        state = state,
-        onInputChanged = {},
-        onUnlockClick = {},
-        modifier = Modifier
-            .fillMaxSize()
-            .standardHorizontalMargin(),
+    ExportItemsScaffold(
+        navIcon = rememberVectorPainter(
+            BitwardenDrawable.ic_back,
+        ),
+        onNavigationIconClick = {},
+        navigationIconContentDescription = stringResource(BitwardenString.back),
+        scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState()),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        VerifyPasswordContent(
+            state = state,
+            onInputChanged = {},
+            onContinueClick = {},
+            onResendCodeClick = {},
+            modifier = Modifier
+                .fillMaxSize(),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+private fun VerifyPasswordContent_Otp_preview() {
+    val accountSummaryListItem = AccountSelectionListItem(
+        userId = "userId",
+        isItemRestricted = false,
+        avatarColorHex = "#FF0000",
+        initials = "JD",
+        email = "john.doe@example.com",
     )
+    val state = VerifyPasswordState(
+        title = BitwardenString.verify_your_account_email_address.asText(),
+        subtext = BitwardenString
+            .enter_the_6_digit_code_that_was_emailed_to_the_address_below
+            .asText(),
+        accountSummaryListItem = accountSummaryListItem,
+        showResendCodeButton = true,
+    )
+    ExportItemsScaffold(
+        navIcon = rememberVectorPainter(
+            BitwardenDrawable.ic_back,
+        ),
+        onNavigationIconClick = {},
+        navigationIconContentDescription = stringResource(BitwardenString.back),
+        scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState()),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        VerifyPasswordContent(
+            state = state,
+            onInputChanged = {},
+            onContinueClick = {},
+            onResendCodeClick = {},
+            modifier = Modifier
+                .fillMaxSize(),
+        )
+    }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/handlers/VerifyPasswordHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/handlers/VerifyPasswordHandlers.kt
@@ -10,8 +10,9 @@ import com.x8bit.bitwarden.ui.vault.feature.exportitems.verifypassword.VerifyPas
  */
 data class VerifyPasswordHandlers(
     val onNavigateBackClick: () -> Unit,
-    val onUnlockClick: () -> Unit,
+    val onContinueClick: () -> Unit,
     val onInputChanged: (String) -> Unit,
+    val onSendCodeClick: () -> Unit,
     val onDismissDialog: () -> Unit,
 ) {
 
@@ -26,13 +27,16 @@ data class VerifyPasswordHandlers(
                 onNavigateBackClick = {
                     viewModel.trySendAction(VerifyPasswordAction.NavigateBackClick)
                 },
-                onUnlockClick = {
-                    viewModel.trySendAction(VerifyPasswordAction.UnlockClick)
+                onContinueClick = {
+                    viewModel.trySendAction(VerifyPasswordAction.ContinueClick)
                 },
                 onInputChanged = {
                     viewModel.trySendAction(
                         VerifyPasswordAction.PasswordInputChangeReceive(it),
                     )
+                },
+                onSendCodeClick = {
+                    viewModel.trySendAction(VerifyPasswordAction.ResendCodeClick)
                 },
                 onDismissDialog = {
                     viewModel.trySendAction(VerifyPasswordAction.DismissDialog)

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1135,4 +1135,6 @@ Do you want to switch to this account?</string>
     <string name="your_vault_may_be_empty_or_import_some_item_types_isnt_supported">Your vault may be empty, or importing some item types isn’t allowed for your account.</string>
     <string name="no_items_available_to_import">No items available to import</string>
     <string name="select_a_different_account">Select a different account</string>
+    <string name="verify_your_account_email_address">Verify your account email address</string>
+    <string name="enter_the_6_digit_code_that_was_emailed_to_the_address_below">Enter the 6-digit code that was emailed to the address below</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

PM-26810

## 📔 Objective

This commit introduces support for One-Time Passcode (OTP) verification on the "Verify Password" screen, in addition to the existing master password verification. This is primarily for TDE users who do not have a master password set on their account.

The behavioral changes are as follows:
*   If a user does not have a master password, they will be prompted to enter a 6-digit OTP code that is automatically sent to their email address.
*   The UI displays a "Resend code" button for the OTP flow.
*   The primary action button label has been changed from "Unlock" to "Continue" to accommodate both verification flows.

Specific changes include:
*   **ViewModel:**
    *   `VerifyPasswordViewModel` now checks if the active account has a master password.
    *   If no master password exists, it automatically requests an OTP and updates the UI to reflect the OTP verification flow.
    *   New actions (`ResendCodeClick`, `SendOtpCodeResultReceive`, `VerifyOtpResultReceive`) and events (`ShowSnackbar`) have been added to handle the OTP logic.
    *   The `UnlockClick` action has been renamed to `ContinueClick`.
    *   The state has been updated to include a `title`, `subtext`, and `showResendCodeButton` to dynamically adjust the screen content.
*   **UI (Screen & Composables):**
    *   `VerifyPasswordScreen.kt` and its content composable have been updated to conditionally display either the master password field or the OTP code field based on the view model's state.
    *   A "Resend code" button is now shown for the OTP flow.
    *   The main button is now labeled "Continue" and triggers the `ContinueClick` action.
    *   A snackbar is now used to show feedback, for instance when an OTP code has been resent.
*   **Strings:**
    *   New string resources have been added for the OTP verification flow, such as "Verify your account email address".
*   **Tests:**
    *   `VerifyPasswordViewModelTest` and `VerifyPasswordScreenTest` have been extensively updated to cover the new OTP verification logic, state changes, and UI interactions. Existing tests were refactored to align with the new logic.

## 📸 Screenshots

### Master Password verification

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/c1e6a108-a78f-4938-8093-735ce074b7e6" /> |  <img width="365" src="https://github.com/user-attachments/assets/afe29845-47e2-4764-9a2f-d1901155e57e" /> | 


### OTP Verification

| Before | After |
|--------|--------|
| N/A | <img width="365" src="https://github.com/user-attachments/assets/216d5782-04e2-46cf-a2a2-6d1e07dc86ce" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
