### PR TITLE
Fix workflow name and permissions

### DIFF
--- a/.github/workflows/publish-github-release-bwa.yml
+++ b/.github/workflows/publish-github-release-bwa.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: write
   id-token: write
-  actions: read
+  actions: write
 
 jobs:
   publish-release-authenticator:

--- a/.github/workflows/publish-github-release-bwpm.yml
+++ b/.github/workflows/publish-github-release-bwpm.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
-  actions: read
+  actions: write
 
 jobs:
   publish-release-password-manager:


### PR DESCRIPTION
## 🎟️ Tracking

In order to enable/disable the publish github workflow, the workflows need actions:write permissions to avoid this error: https://github.com/bitwarden/android/actions/runs/18560562779

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
