### PR TITLE
[PM-27130] Update alert (Snackbar) color to inverseSurface in dynamic color scheme

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/color/ColorScheme.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/color/ColorScheme.kt
@@ -179,7 +179,7 @@ fun dynamicBitwardenColorScheme(
             primary = materialColorScheme.background,
             secondary = materialColorScheme.surfaceContainer,
             tertiary = materialColorScheme.surfaceContainerHighest,
-            alert = materialColorScheme.error,
+            alert = materialColorScheme.inverseSurface,
             scrim = materialColorScheme.scrim.copy(alpha = 0.4f),
             pressed = materialColorScheme.onSurfaceVariant,
         ),


### PR DESCRIPTION
## 🎟️ Tracking

PM-27130

## 📔 Objective

This commit changes the `alert` color, used by the Snackbar, within the app's color scheme. The color is updated from `materialColorScheme.error` to `materialColorScheme.inverseSurface`.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/85a97a73-1498-45ac-b306-a8cb2f69a3b0" /> | <img width="365" src="https://github.com/user-attachments/assets/359187ed-04dc-4a11-a1ca-d8669cbd67a0" /> |
| <img width="365" src="https://github.com/user-attachments/assets/1055614e-0086-4aa8-829c-7ba3aa0db746" /> |<img width="365" src="https://github.com/user-attachments/assets/b133ea41-5057-469d-abff-7fd62388a5dd" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
