### PR TITLE
PM-27153: Update copy in Authenticator app

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
@@ -117,7 +117,7 @@ fun UnlockScreen(
             )
             Spacer(modifier = Modifier.height(32.dp))
             BitwardenFilledButton(
-                label = stringResource(id = BitwardenString.use_biometrics_to_unlock),
+                label = stringResource(id = BitwardenString.unlock),
                 onClick = {
                     biometricsManager.promptBiometrics(
                         onSuccess = onBiometricsUnlock,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/biometrics/BiometricsManagerImpl.kt
@@ -90,7 +90,7 @@ class BiometricsManagerImpl(
 
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle(activity.getString(BitwardenString.bitwarden_authenticator))
-            .setDescription(activity.getString(BitwardenString.biometrics_direction))
+            .setDescription(activity.getString(BitwardenString.device_verification))
             .setAllowedAuthenticators(allowedAuthenticators)
             .build()
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -376,6 +376,7 @@ Scanning will happen automatically.</string>
     <string name="download">Download</string>
     <string name="login_expired">Your login session has expired.</string>
     <string name="biometrics_direction">Biometric verification</string>
+    <string name="device_verification">Device verification</string>
     <string name="biometrics_failed">Biometrics Failed</string>
     <string name="biometrics_decoding_failure">Log in with your Master Password or PIN then re-enable biometric login in Settings.</string>
     <string name="use_biometrics_to_unlock">Use biometrics to unlock</string>
@@ -1049,7 +1050,7 @@ Do you want to switch to this account?</string>
     <string name="learn_more_link"><annotation link="learnMore">Learn more</annotation></string>
     <string name="shared_codes_error">Unable to sync codes from the Bitwarden app. Make sure both apps are up-to-date. You can still access your existing codes in the Bitwarden app.</string>
     <string name="sync_with_the_bitwarden_app">Sync with the Bitwarden app</string>
-    <string name="sync_with_bitwarden_action_card_message">In order to view all of your verification codes, you’ll need to allow for syncing on all of your accounts.</string>
+    <string name="sync_with_bitwarden_action_card_message">Allow Authenticator app syncing in settings to view all of your verification codes here.</string>
     <string name="take_me_to_app_settings">Take me to the app settings</string>
     <string name="something_went_wrong">Something went wrong</string>
     <string name="please_try_again">Please try again</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27153](https://bitwarden.atlassian.net/browse/PM-27153)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/3ab19a74-8fcd-4588-92f2-e527d31c07a2" width="300" /> | <img src="https://github.com/user-attachments/assets/19379523-d734-4cd0-942a-fee376523a9d" width="300" /> |
| <img src="https://github.com/user-attachments/assets/e15c8929-2f97-475f-b6c6-7f5afbbeb08c" width="300" /> | <img src="https://github.com/user-attachments/assets/12abecca-da5c-450d-b8a1-0ceaf34feab8" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27153]: https://bitwarden.atlassian.net/browse/PM-27153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ