### PR TITLE
PM-27263: Add enum for Vault Timeout Policy actions

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformation.kt
@@ -122,6 +122,18 @@ sealed class PolicyInformation {
         val minutes: Int?,
 
         @SerialName("action")
-        val action: String?,
-    ) : PolicyInformation()
+        val action: Action?,
+    ) : PolicyInformation() {
+        /**
+         * The action to take when the vault timeout is reached.
+         */
+        @Serializable
+        enum class Action {
+            @SerialName("lock")
+            LOCK,
+
+            @SerialName("logOut")
+            LOGOUT,
+        }
+    }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -647,10 +647,9 @@ class SettingsRepositoryImpl(
             }
         }
         vaultUnlockPolicy.action?.let {
-            vaultTimeoutAction = if (it == "lock") {
-                VaultTimeoutAction.LOCK
-            } else {
-                VaultTimeoutAction.LOGOUT
+            vaultTimeoutAction = when (it) {
+                PolicyInformation.VaultTimeout.Action.LOCK -> VaultTimeoutAction.LOCK
+                PolicyInformation.VaultTimeout.Action.LOGOUT -> VaultTimeoutAction.LOGOUT
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -61,6 +61,7 @@ import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.ui.platform.components.toggle.BitwardenUnlockWithBiometricsSwitch
@@ -473,25 +474,25 @@ private fun AccountSecurityDialogs(
 @Composable
 private fun SessionTimeoutPolicyRow(
     vaultTimeoutPolicyMinutes: Int?,
-    vaultTimeoutPolicyAction: String?,
+    vaultTimeoutPolicyAction: PolicyInformation.VaultTimeout.Action?,
     modifier: Modifier = Modifier,
 ) {
     // Show the policy warning if applicable.
-    if (vaultTimeoutPolicyMinutes != null || !vaultTimeoutPolicyAction.isNullOrBlank()) {
+    if (vaultTimeoutPolicyMinutes != null || vaultTimeoutPolicyAction != null) {
         // Calculate the hours and minutes to show in the policy label.
         val hours = vaultTimeoutPolicyMinutes?.floorDiv(MINUTES_PER_HOUR)
         val minutes = vaultTimeoutPolicyMinutes?.mod(MINUTES_PER_HOUR)
 
         // Get the localized version of the action.
-        val action = if (vaultTimeoutPolicyAction == "lock") {
-            BitwardenString.lock.asText()
-        } else {
-            BitwardenString.log_out.asText()
+        val action = when (vaultTimeoutPolicyAction) {
+            PolicyInformation.VaultTimeout.Action.LOCK -> BitwardenString.lock.asText()
+            PolicyInformation.VaultTimeout.Action.LOGOUT -> BitwardenString.log_out.asText()
+            null -> BitwardenString.log_out.asText()
         }
 
         val policyText = if (hours == null || minutes == null) {
             BitwardenString.vault_timeout_action_policy_in_effect.asText(action)
-        } else if (vaultTimeoutPolicyAction.isNullOrBlank()) {
+        } else if (vaultTimeoutPolicyAction == null) {
             BitwardenString.vault_timeout_policy_in_effect.asText(hours, minutes)
         } else {
             BitwardenString.vault_timeout_policy_with_action_in_effect.asText(
@@ -629,7 +630,7 @@ private fun SessionCustomTimeoutRow(
 @Composable
 private fun SessionTimeoutActionRow(
     isEnabled: Boolean,
-    vaultTimeoutPolicyAction: String?,
+    vaultTimeoutPolicyAction: PolicyInformation.VaultTimeout.Action?,
     selectedVaultTimeoutAction: VaultTimeoutAction,
     onVaultTimeoutActionSelect: (VaultTimeoutAction) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -519,7 +519,7 @@ data class AccountSecurityState(
     val vaultTimeout: VaultTimeout,
     val vaultTimeoutAction: VaultTimeoutAction,
     val vaultTimeoutPolicyMinutes: Int?,
-    val vaultTimeoutPolicyAction: String?,
+    val vaultTimeoutPolicyAction: PolicyInformation.VaultTimeout.Action?,
     val shouldShowUnlockActionCard: Boolean,
     val removeUnlockWithPinPolicyEnabled: Boolean,
 ) : Parcelable {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensionsTest.kt
@@ -118,7 +118,7 @@ class SyncResponseJsonExtensionsTest {
     fun `policyInformation converts the VaultTimeout Json data to policy information`() {
         val policyInformation = PolicyInformation.VaultTimeout(
             minutes = 10,
-            action = "lock",
+            action = PolicyInformation.VaultTimeout.Action.LOCK,
         )
         val policy = createMockPolicy(
             type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -23,6 +23,7 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.assertNoDialogExists
+import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeout
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
@@ -602,7 +603,7 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
         mutableStateFlow.update {
             it.copy(
                 vaultTimeoutPolicyMinutes = 100,
-                vaultTimeoutPolicyAction = "lock",
+                vaultTimeoutPolicyAction = PolicyInformation.VaultTimeout.Action.LOCK,
             )
         }
         val bothText = "Your organization policies are affecting your vault timeout. " +

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -143,7 +143,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
 
         val policyInformation = PolicyInformation.VaultTimeout(
             minutes = 10,
-            action = "lock",
+            action = PolicyInformation.VaultTimeout.Action.LOCK,
         )
         mutableActivePolicyFlow.emit(
             listOf(
@@ -159,7 +159,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
             assertEquals(
                 DEFAULT_STATE.copy(
                     vaultTimeoutPolicyMinutes = 10,
-                    vaultTimeoutPolicyAction = "lock",
+                    vaultTimeoutPolicyAction = PolicyInformation.VaultTimeout.Action.LOCK,
                 ),
                 awaitItem(),
             )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27263](https://bitwarden.atlassian.net/browse/PM-27263)

## 📔 Objective

This PR adds a little bit of type-safety to the Vault Timeout Policy by adding an enum to represent the action values.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27263]: https://bitwarden.atlassian.net/browse/PM-27263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ