### PR TITLE
[PM-26810] Remove loading dialog flicker on vault data updates

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModel.kt
@@ -164,7 +164,7 @@ class ReviewExportViewModel @Inject constructor(
     }
 
     private fun handleVaultDataLoading() {
-        showLoadingDialog()
+        showLoadingDialog(BitwardenString.loading_vault_data.asText())
     }
 
     private fun handleVaultDataLoaded(data: DataState.Loaded<DecryptCipherListResult>) {
@@ -172,7 +172,6 @@ class ReviewExportViewModel @Inject constructor(
     }
 
     private fun handleVaultDataPending(data: DataState.Pending<DecryptCipherListResult>) {
-        showLoadingDialog()
         updateItemTypeCounts(data = data, clearDialog = false)
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModelTest.kt
@@ -294,7 +294,7 @@ class ReviewExportViewModelTest : BaseViewModelTest() {
         }
 
         @Test
-        fun `VaultDataReceive Pending should show loading dialog and update item type counts`() =
+        fun `VaultDataReceive Pending should update item type counts`() =
             runTest {
                 val viewModel = createViewModel()
                 viewModel.trySendAction(
@@ -313,9 +313,6 @@ class ReviewExportViewModelTest : BaseViewModelTest() {
                         itemTypeCounts = DEFAULT_CONTENT_VIEW_STATE.itemTypeCounts.copy(
                             passwordCount = 1,
                         ),
-                    ),
-                    dialog = ReviewExportState.DialogState.Loading(
-                        BitwardenString.loading.asText(),
                     ),
                 )
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1140,4 +1140,5 @@ Do you want to switch to this account?</string>
     <string name="enter_the_6_digit_code_that_was_emailed_to_the_address_below">Enter the 6-digit code that was emailed to the address below</string>
     <string name="lock_app">Lock app</string>
     <string name="use_your_devices_lock_method_to_unlock_the_app">Use your device’s lock method to unlock the app</string>
+    <string name="loading_vault_data">Loading vault data…</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

PM-26810

## 📔 Objective

This commit addresses a UI flicker issue where a loading dialog would briefly appear, or remain visible, when the vault data was being updated in the background during the item export flow.

The `handleVaultDataPending` function in `ReviewExportViewModel` was unnecessarily triggering a generic loading dialog. This function is called when vault data is updating (e.g., after a sync), which caused the dialog to flash on the screen or remain due to race-conditions.

The fix removes the call to `showLoadingDialog` from `handleVaultDataPending`. A more specific loading message, "Loading vault data...", has been added to the `handleVaultDataLoading` function to provide better user feedback when the initial data is being fetched. Additionally, a test case was updated to reflect that the loading dialog is not cleared during the pending state.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
