### PR TITLE
Fix TopAppBar height for multiline titles

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/appbar/BitwardenTopAppBar.kt
@@ -143,14 +143,12 @@ fun BitwardenTopAppBar(
             scrollBehavior = scrollBehavior,
             navigationIcon = navigationIconContent,
             collapsedHeight = minimumHeight,
-            expandedHeight = 96.dp,
             title = {
-                // The height of the component is controlled and will only allow for 1 extra row,
-                // making adding any arguments for softWrap and minLines superfluous.
                 Text(
                     text = title,
                     style = BitwardenTheme.typography.titleLarge,
                     overflow = TextOverflow.Ellipsis,
+                    maxLines = 2,
                     modifier = Modifier.testTag(tag = "PageTitleLabel"),
                 )
             },


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR addresses a height issues in the `BitwardenTopAppBar` when displaying a title with multiple lines.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/3df0bb0d-7943-48c2-99b8-ff8f4751ad7e" /> | <img width="350" src="https://github.com/user-attachments/assets/95d2725d-9c09-46c2-b7ba-5431c31ff01c" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
