### PR TITLE
[PM-26810] Clear password input after successful OTP verification

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModel.kt
@@ -317,7 +317,7 @@ class VerifyPasswordViewModel @Inject constructor(
     ) {
         when (action.result) {
             is VerifyOtpResult.Verified -> {
-                mutableStateFlow.update { it.copy(dialog = null) }
+                mutableStateFlow.update { it.copy(input = "", dialog = null) }
                 sendEvent(
                     VerifyPasswordEvent.PasswordVerified(
                         state.accountSummaryListItem.userId,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordViewModelTest.kt
@@ -236,21 +236,26 @@ class VerifyPasswordViewModelTest : BaseViewModelTest() {
         }
 
         @Test
-        fun `VerifyOtpResultReceive verified should send event`() = runTest {
-            createViewModel().also { viewModel ->
-                viewModel.trySendAction(
-                    VerifyPasswordAction.Internal.VerifyOtpResultReceive(
-                        VerifyOtpResult.Verified,
-                    ),
-                )
-
-                viewModel.eventFlow.test {
-                    assertEquals(
-                        VerifyPasswordEvent.PasswordVerified(DEFAULT_USER_ID),
-                        awaitItem(),
+        fun `VerifyOtpResultReceive verified should send event and clear input`() = runTest {
+            createViewModel(state = DEFAULT_STATE.copy(input = "123"))
+                .also { viewModel ->
+                    viewModel.trySendAction(
+                        VerifyPasswordAction.Internal.VerifyOtpResultReceive(
+                            VerifyOtpResult.Verified,
+                        ),
                     )
+
+                    viewModel.eventFlow.test {
+                        assertEquals(
+                            VerifyPasswordEvent.PasswordVerified(DEFAULT_USER_ID),
+                            awaitItem(),
+                        )
+                    }
+
+                    viewModel.stateFlow.test {
+                        assertEquals(DEFAULT_STATE, awaitItem())
+                    }
                 }
-            }
         }
 
         @Test


### PR DESCRIPTION
## 🎟️ Tracking

PM-26810

## 📔 Objective

This commit addresses an issue where the verification code input field was not cleared after a successful Two-Factor Authentication (2FA) verification during the item export process.

When handling a `VerifyOtpResult.Verified` action, the view model state is now updated to reset the `input` field to an empty string. This ensures the verification code is no longer visible in the input field after the OTP dialog is dismissed and the user proceeds.

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
