### PR TITLE
PM-27271: Update selection button disabled state

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenTextSelectionButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenTextSelectionButton.kt
@@ -33,6 +33,7 @@ import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.base.util.nullableTestTag
 import com.bitwarden.ui.platform.components.divider.BitwardenHorizontalDivider
 import com.bitwarden.ui.platform.components.field.color.bitwardenTextFieldButtonColors
+import com.bitwarden.ui.platform.components.field.color.bitwardenTextFieldColors
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.model.TooltipData
 import com.bitwarden.ui.platform.components.row.BitwardenRowOfActions
@@ -163,7 +164,6 @@ fun BitwardenTextSelectionButton(
                         Icon(
                             painter = rememberVectorPainter(id = BitwardenDrawable.ic_chevron_down),
                             contentDescription = null,
-                            tint = BitwardenTheme.colorScheme.icon.primary,
                             modifier = Modifier.minimumInteractiveComponentSize(),
                         )
                         actions()
@@ -172,7 +172,11 @@ fun BitwardenTextSelectionButton(
             },
             value = selectedOption.orEmpty(),
             onValueChange = {},
-            colors = bitwardenTextFieldButtonColors(),
+            colors = if (enabled) {
+                bitwardenTextFieldButtonColors()
+            } else {
+                bitwardenTextFieldColors()
+            },
             modifier = Modifier
                 .nullableTestTag(tag = textFieldTestTag)
                 .fillMaxWidth(),

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/color/BitwardenTextFieldColors.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/color/BitwardenTextFieldColors.kt
@@ -11,10 +11,7 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  */
 @Composable
 fun bitwardenTextFieldButtonColors(): TextFieldColors = bitwardenTextFieldColors(
-    unfocusedBorderColor = Color.Transparent,
-    focusedBorderColor = Color.Transparent,
     disabledTextColor = BitwardenTheme.colorScheme.text.primary,
-    disabledBorderColor = Color.Transparent,
     disabledLeadingIconColor = BitwardenTheme.colorScheme.icon.primary,
     disabledTrailingIconColor = BitwardenTheme.colorScheme.icon.primary,
     disabledLabelColor = BitwardenTheme.colorScheme.text.secondary,
@@ -27,18 +24,12 @@ fun bitwardenTextFieldButtonColors(): TextFieldColors = bitwardenTextFieldColors
  */
 @Composable
 fun bitwardenTextFieldColors(
-    focusedBorderColor: Color = Color.Transparent,
-    unfocusedBorderColor: Color = Color.Transparent,
-    disabledTextColor: Color = BitwardenTheme.colorScheme.outlineButton.foregroundDisabled,
-    disabledBorderColor: Color = Color.Transparent,
-    disabledLeadingIconColor: Color = BitwardenTheme.colorScheme.outlineButton.foregroundDisabled,
-    disabledTrailingIconColor: Color = BitwardenTheme.colorScheme.outlineButton.foregroundDisabled,
-    disabledLabelColor: Color = BitwardenTheme.colorScheme.outlineButton.foregroundDisabled,
+    disabledTextColor: Color = BitwardenTheme.colorScheme.filledButton.foregroundDisabled,
+    disabledLeadingIconColor: Color = BitwardenTheme.colorScheme.filledButton.foregroundDisabled,
+    disabledTrailingIconColor: Color = BitwardenTheme.colorScheme.filledButton.foregroundDisabled,
+    disabledLabelColor: Color = BitwardenTheme.colorScheme.filledButton.foregroundDisabled,
     disabledPlaceholderColor: Color = BitwardenTheme.colorScheme.text.secondary,
-    disabledSupportingTextColor: Color = BitwardenTheme
-        .colorScheme
-        .outlineButton
-        .foregroundDisabled,
+    disabledSupportingTextColor: Color = BitwardenTheme.colorScheme.filledButton.foregroundDisabled,
 ): TextFieldColors = TextFieldColors(
     focusedTextColor = BitwardenTheme.colorScheme.text.primary,
     unfocusedTextColor = BitwardenTheme.colorScheme.text.primary,
@@ -54,9 +45,9 @@ fun bitwardenTextFieldColors(
         handleColor = BitwardenTheme.colorScheme.stroke.border,
         backgroundColor = BitwardenTheme.colorScheme.stroke.border.copy(alpha = 0.4f),
     ),
-    focusedIndicatorColor = focusedBorderColor,
-    unfocusedIndicatorColor = unfocusedBorderColor,
-    disabledIndicatorColor = disabledBorderColor,
+    focusedIndicatorColor = Color.Transparent,
+    unfocusedIndicatorColor = Color.Transparent,
+    disabledIndicatorColor = Color.Transparent,
     errorIndicatorColor = BitwardenTheme.colorScheme.status.error,
     focusedLeadingIconColor = BitwardenTheme.colorScheme.icon.primary,
     unfocusedLeadingIconColor = BitwardenTheme.colorScheme.icon.primary,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27271](https://bitwarden.atlassian.net/browse/PM-27271)

## 📔 Objective

This PR updates the `BitwardenTextSelectionButton` to support a proper disabled state.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/8742f484-d672-416a-8f89-f5c90628aed9" /> | <img width="350" src="https://github.com/user-attachments/assets/7a7ef971-c2e4-46ab-8813-b0f7e4bd5c6b" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27271]: https://bitwarden.atlassian.net/browse/PM-27271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ