### PR TITLE
PM-19302: Add support for a typed vault timeout policy

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformation.kt
@@ -123,6 +123,9 @@ sealed class PolicyInformation {
 
         @SerialName("action")
         val action: Action?,
+
+        @SerialName("type")
+        val type: Type?,
     ) : PolicyInformation() {
         /**
          * The action to take when the vault timeout is reached.
@@ -134,6 +137,27 @@ sealed class PolicyInformation {
 
             @SerialName("logOut")
             LOGOUT,
+        }
+
+        /**
+         * The type of vault timeout.
+         */
+        @Serializable
+        enum class Type {
+            @SerialName("never")
+            NEVER,
+
+            @SerialName("onAppRestart")
+            ON_APP_RESTART,
+
+            @SerialName("onSystemLock")
+            ON_SYSTEM_LOCK,
+
+            @SerialName("immediately")
+            IMMEDIATELY,
+
+            @SerialName("custom")
+            CUSTOM,
         }
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformationUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/model/PolicyInformationUtil.kt
@@ -1,5 +1,9 @@
 package com.x8bit.bitwarden.data.auth.repository.model
 
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
 /**
  * Create a mock [PolicyInformation.MasterPassword] with a given parameters.
  */
@@ -22,3 +26,50 @@ fun createMockMasterPasswordPolicy(
         requireSpecial = requireSpecial,
         enforceOnLogin = enforceOnLogin,
     )
+
+/**
+ * Create a mock [PolicyInformation.VaultTimeout] with a given parameters.
+ */
+fun createMockVaultTimeoutPolicy(
+    minutes: Int? = null,
+    action: PolicyInformation.VaultTimeout.Action? = null,
+    type: PolicyInformation.VaultTimeout.Type? = null,
+): PolicyInformation.VaultTimeout =
+    PolicyInformation.VaultTimeout(
+        minutes = minutes,
+        action = action,
+        type = type,
+    )
+
+/**
+ * Create a mock [JsonObject] representing a [PolicyInformation.VaultTimeout].
+ */
+fun createMockVaultTimeoutPolicyJsonObject(
+    vaultTimeout: PolicyInformation.VaultTimeout,
+): JsonObject =
+    buildJsonObject {
+        put(key = "minutes", element = JsonPrimitive(value = vaultTimeout.minutes))
+        put(
+            key = "action",
+            element = JsonPrimitive(
+                value = when (vaultTimeout.action) {
+                    PolicyInformation.VaultTimeout.Action.LOCK -> "lock"
+                    PolicyInformation.VaultTimeout.Action.LOGOUT -> "logOut"
+                    null -> null
+                },
+            ),
+        )
+        put(
+            key = "type",
+            element = JsonPrimitive(
+                value = when (vaultTimeout.type) {
+                    PolicyInformation.VaultTimeout.Type.NEVER -> "never"
+                    PolicyInformation.VaultTimeout.Type.ON_APP_RESTART -> "onAppRestart"
+                    PolicyInformation.VaultTimeout.Type.ON_SYSTEM_LOCK -> "onSystemLock"
+                    PolicyInformation.VaultTimeout.Type.IMMEDIATELY -> "immediately"
+                    PolicyInformation.VaultTimeout.Type.CUSTOM -> "custom"
+                    null -> null
+                },
+            ),
+        )
+    }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/SyncResponseJsonExtensionsTest.kt
@@ -119,6 +119,7 @@ class SyncResponseJsonExtensionsTest {
         val policyInformation = PolicyInformation.VaultTimeout(
             minutes = 10,
             action = PolicyInformation.VaultTimeout.Action.LOCK,
+            type = PolicyInformation.VaultTimeout.Type.CUSTOM,
         )
         val policy = createMockPolicy(
             type = PolicyTypeJson.MAXIMUM_VAULT_TIMEOUT,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -501,6 +501,20 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     }
 
     /**
+     *  Asserts that the stored vault timeout matches the [expected] one.
+     */
+    fun assertVaultTimeoutInMinutes(userId: String, expected: Int?) {
+        assertEquals(expected, storedVaultTimeoutInMinutes[userId])
+    }
+
+    /**
+     *  Asserts that the stored vault timeout action matches the [expected] one.
+     */
+    fun assertVaultTimeoutAction(userId: String, expected: VaultTimeoutAction?) {
+        assertEquals(expected, storedVaultTimeoutActions[userId])
+    }
+
+    /**
      * Asserts that the stored browser autofill dialog reshow time matches the [expected] one.
      */
     fun assertBrowserAutofillDialogReshowTime(expected: Instant?) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity
 
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
@@ -587,12 +588,13 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `session timeout policy warning should update according to state`() {
+    fun `session timeout support text should update according to state`() {
         mutableStateFlow.update {
             it.copy(
                 vaultTimeoutPolicy = VaultTimeoutPolicy(
                     minutes = 100,
                     action = null,
+                    type = PolicyInformation.VaultTimeout.Type.CUSTOM,
                 ),
             )
         }
@@ -607,7 +609,8 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
             it.copy(
                 vaultTimeoutPolicy = VaultTimeoutPolicy(
                     minutes = 100,
-                    action = PolicyInformation.VaultTimeout.Action.LOCK,
+                    action = null,
+                    type = PolicyInformation.VaultTimeout.Type.IMMEDIATELY,
                 ),
             )
         }
@@ -615,6 +618,147 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "This setting is managed by your organization.")
             .performScrollTo()
             .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(
+                vaultTimeoutPolicy = VaultTimeoutPolicy(
+                    minutes = 100,
+                    action = null,
+                    type = PolicyInformation.VaultTimeout.Type.ON_APP_RESTART,
+                ),
+            )
+        }
+        val appRestartText = "Your organization has set the default session timeout " +
+            "to on app restart."
+        composeTestRule
+            .onNodeWithText(text = appRestartText)
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(
+                vaultTimeoutPolicy = VaultTimeoutPolicy(
+                    minutes = 100,
+                    action = null,
+                    type = PolicyInformation.VaultTimeout.Type.NEVER,
+                ),
+            )
+        }
+        val neverText = "Your organization has set the default session timeout to never."
+        composeTestRule
+            .onNodeWithText(text = neverText)
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(
+                vaultTimeoutPolicy = VaultTimeoutPolicy(
+                    minutes = 100,
+                    action = null,
+                    type = PolicyInformation.VaultTimeout.Type.ON_SYSTEM_LOCK,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = appRestartText)
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `session timeout action support text should update according to state`() {
+        mutableStateFlow.update {
+            it.copy(
+                isUnlockWithBiometricsEnabled = false,
+                isUnlockWithPasswordEnabled = false,
+                isUnlockWithPinEnabled = false,
+                vaultTimeoutPolicy = null,
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = "Set up an unlock option to change your vault timeout action.")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(
+                isUnlockWithBiometricsEnabled = false,
+                isUnlockWithPasswordEnabled = false,
+                isUnlockWithPinEnabled = false,
+                vaultTimeoutPolicy = VaultTimeoutPolicy(
+                    minutes = 100,
+                    action = PolicyInformation.VaultTimeout.Action.LOCK,
+                    type = null,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = "This setting is managed by your organization.")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        mutableStateFlow.update {
+            it.copy(
+                isUnlockWithBiometricsEnabled = true,
+                isUnlockWithPasswordEnabled = false,
+                isUnlockWithPinEnabled = false,
+                vaultTimeoutPolicy = VaultTimeoutPolicy(
+                    minutes = 100,
+                    action = PolicyInformation.VaultTimeout.Action.LOCK,
+                    type = null,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(text = "This setting is managed by your organization.")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `session timeout should be enabled on or off according to state`() {
+        composeTestRule
+            .onNodeWithContentDescription(label = "30 minutes. Session timeout")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .assertIsEnabled()
+        mutableStateFlow.update {
+            it.copy(
+                vaultTimeoutPolicy = VaultTimeoutPolicy(
+                    minutes = null,
+                    action = null,
+                    type = PolicyInformation.VaultTimeout.Type.IMMEDIATELY,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithContentDescription(label = "30 minutes. Session timeout")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `session timeout action should be enabled on or off according to state`() {
+        composeTestRule
+            .onNodeWithContentDescription(label = "Lock. Session timeout action")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .assertIsEnabled()
+        mutableStateFlow.update {
+            it.copy(
+                vaultTimeoutPolicy = VaultTimeoutPolicy(
+                    minutes = null,
+                    action = PolicyInformation.VaultTimeout.Action.LOCK,
+                    type = null,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithContentDescription(label = "Lock. Session timeout action")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .assertIsNotEnabled()
     }
 
     @Test
@@ -697,6 +841,7 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
                 vaultTimeoutPolicy = VaultTimeoutPolicy(
                     minutes = 100,
                     action = null,
+                    type = PolicyInformation.VaultTimeout.Type.CUSTOM,
                 ),
             )
         }
@@ -1008,6 +1153,7 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
                 vaultTimeoutPolicy = VaultTimeoutPolicy(
                     minutes = 100,
                     action = null,
+                    type = PolicyInformation.VaultTimeout.Type.CUSTOM,
                 ),
             )
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityViewModelTest.kt
@@ -144,6 +144,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
         val policyInformation = PolicyInformation.VaultTimeout(
             minutes = 10,
             action = PolicyInformation.VaultTimeout.Action.LOCK,
+            type = PolicyInformation.VaultTimeout.Type.CUSTOM,
         )
         mutableActivePolicyFlow.emit(
             listOf(
@@ -161,6 +162,7 @@ class AccountSecurityViewModelTest : BaseViewModelTest() {
                     vaultTimeoutPolicy = VaultTimeoutPolicy(
                         minutes = 10,
                         action = PolicyInformation.VaultTimeout.Action.LOCK,
+                        type = PolicyInformation.VaultTimeout.Type.CUSTOM,
                     ),
                 ),
                 awaitItem(),

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -497,19 +497,19 @@ Scanning will happen automatically.</string>
     <string name="fido2_authenticate_web_authn">Authenticate WebAuthn</string>
     <string name="fido2_return_to_app">Return to app</string>
     <string name="reset_password_auto_enroll_invite_warning">This organization has an enterprise policy that will automatically enroll you in password reset. Enrollment will allow organization administrators to change your master password.</string>
-    <string name="vault_timeout_policy_in_effect_both_plural">Your organization has set the maximum session timeout to %1$d hours and %2$d minutes.</string>
-    <string name="vault_timeout_policy_in_effect_hours_plural">Your organization has set the maximum session timeout to %1$d hours and %2$d minute.</string>
-    <string name="vault_timeout_policy_in_effect_minutes_plural">Your organization has set the maximum session timeout to %1$d hour and %2$d minutes.</string>
-    <string name="vault_timeout_policy_in_effect_no_plural">Your organization has set the maximum session timeout to %1$d hour and %2$d minute.</string>
-    <plurals name="vault_timeout_policy_in_effect_hours">
-        <item quantity="one">Your organization has set the maximum session timeout to %1$d hour.</item>
-        <item quantity="other">Your organization has set the maximum session timeout to %1$d hours.</item>
+    <plurals name="hours_format" comment="Can be injected into a sentence with %1$s and %2$s">
+        <item quantity="one">%1$d hour</item>
+        <item quantity="other">%1$d hours</item>
     </plurals>
-    <plurals name="vault_timeout_policy_in_effect_minutes">
-        <item quantity="one">Your organization has set the maximum session timeout to %1$d minute.</item>
-        <item quantity="other">Your organization has set the maximum session timeout to %1$d minutes.</item>
+    <plurals name="minutes_format" comment="Can be injected into a sentence with %1$s and %2$s">
+        <item quantity="one">%1$d minute</item>
+        <item quantity="other">%1$d minutes</item>
     </plurals>
+    <string name="vault_timeout_policy_in_effect_hours_minutes_format" comment="First value will be the number of hours (2 hours, 1 hour) and second value will be the number of minutes (15 minutes, 1 minute)">Your organization has set the maximum session timeout to %1$s and %2$s.</string>
+    <string name="vault_timeout_policy_in_effect_format" comment="Value will be a number of hours or minutes (15 minutes, or 1 minute)">Your organization has set the maximum session timeout to %1$s.</string>
     <string name="this_setting_is_managed_by_your_organization">This setting is managed by your organization.</string>
+    <string name="your_organization_has_set_the_default_session_timeout_to_never">Your organization has set the default session timeout to never.</string>
+    <string name="your_organization_has_set_the_default_session_timeout_to_on_app_restart">Your organization has set the default session timeout to on app restart.</string>
     <string name="vault_timeout_to_large">Your vault timeout exceeds the restrictions set by your organization.</string>
     <string name="disable_personal_vault_export_policy_in_effect">One or more organization policies prevents your from exporting your individual vault.</string>
     <string name="add_account">Add account</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19302](https://bitwarden.atlassian.net/browse/PM-19302)

## 📔 Objective

This PR adds support for the `type` property on the Vault Timeout Policy.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19302]: https://bitwarden.atlassian.net/browse/PM-19302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ