### PR TITLE
PM-27497: Update Snackbar font when there is no header

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/snackbar/BitwardenSnackbar.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/snackbar/BitwardenSnackbar.kt
@@ -90,7 +90,12 @@ fun BitwardenSnackbar(
                 Text(
                     text = bitwardenSnackbarData.message(),
                     color = BitwardenTheme.colorScheme.text.reversed,
-                    style = BitwardenTheme.typography.bodyMedium,
+                    style = if (bitwardenSnackbarData.messageHeader != null) {
+                        BitwardenTheme.typography.bodyMedium
+                    } else {
+                        // Upgrade the font when it is stand alone.
+                        BitwardenTheme.typography.titleSmall
+                    },
                 )
                 bitwardenSnackbarData.actionLabel?.let {
                     Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27497](https://bitwarden.atlassian.net/browse/PM-27497)

## 📔 Objective

This PR updates the Snackbar font for the message when there is no header present.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e5c4111b-6351-44d0-bbfa-b3e9ce1a0049" width="300" /> | <img src="https://github.com/user-attachments/assets/9115fbed-35c2-4d32-98e6-abe9fde70abc" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27497]: https://bitwarden.atlassian.net/browse/PM-27497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ