### PR TITLE
[PM-27516] [PM 27157] Custom text field edit multiline fix

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomField.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditCustomField.kt
@@ -222,7 +222,7 @@ private fun CustomFieldTextField(
         label = label,
         value = value,
         onValueChange = onValueChanged,
-        singleLine = true,
+        singleLine = false,
         textFieldTestTag = "CustomFieldValue",
         actions = {
             BitwardenStandardIconButton(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/android/issues/6050

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fixes the display of multi-line custom text fields when editing a login item.

Previously, only the first line of a multi-line field was visible, requiring users to scroll horizontally to view and edit the full content. This PR ensures the entire text field content is displayed vertically in edit mode, making it easier to read and modify.

## 📸 Screenshots
<img width="400" height="800" alt="mutliline-fix-ss" src="https://github.com/user-attachments/assets/0e0628d2-1e9c-42dc-9195-04bed7ef30bb" />


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
