### PR TITLE
Add Push chevron to Block autofill button

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -53,6 +53,7 @@ import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.model.TooltipData
 import com.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow
+import com.bitwarden.ui.platform.components.row.BitwardenPushRow
 import com.bitwarden.ui.platform.components.row.BitwardenTextRow
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
@@ -327,11 +328,11 @@ private fun AutoFillScreenContent(
                 .fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(8.dp))
-        BitwardenTextRow(
+        BitwardenPushRow(
             text = stringResource(id = BitwardenString.block_auto_fill),
-            description = BitwardenString
-                .auto_fill_will_not_be_offered_for_these_ur_is
-                .toAnnotatedString(),
+            description = stringResource(
+                id = BitwardenString.auto_fill_will_not_be_offered_for_these_ur_is,
+            ),
             onClick = autoFillHandlers.onBlockAutoFillClick,
             cardStyle = CardStyle.Full,
             modifier = Modifier

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/row/BitwardenPushRow.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/row/BitwardenPushRow.kt
@@ -32,6 +32,7 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  * @param onClick The callback when the row is clicked.
  * @param cardStyle The [CardStyle] to be applied to this row.
  * @param modifier The modifier for this composable.
+ * @param description The optional displayable description text.
  * @param leadingIcon An optional leading icon.
  * @param notificationCount The optional notification count to be displayed.
  */
@@ -41,6 +42,7 @@ fun BitwardenPushRow(
     onClick: () -> Unit,
     cardStyle: CardStyle,
     modifier: Modifier = Modifier,
+    description: String? = null,
     leadingIcon: IconData? = null,
     notificationCount: Int = 0,
 ) {
@@ -73,12 +75,22 @@ fun BitwardenPushRow(
                 )
                 Spacer(modifier = Modifier.width(width = 12.dp))
             }
-            Text(
-                text = text,
-                style = BitwardenTheme.typography.bodyLarge,
-                color = BitwardenTheme.colorScheme.text.primary,
-                modifier = Modifier.fillMaxWidth(),
-            )
+            Column {
+                Text(
+                    text = text,
+                    style = BitwardenTheme.typography.bodyLarge,
+                    color = BitwardenTheme.colorScheme.text.primary,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                description?.let {
+                    Text(
+                        text = it,
+                        style = BitwardenTheme.typography.bodyMedium,
+                        color = BitwardenTheme.colorScheme.text.secondary,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
         }
         TrailingContent(notificationCount = notificationCount)
     }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes a design inconsistency where the `Block autofill` button performs a push action but does not have the chevron indicator.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/32657967-6438-427a-9a8e-d857c80a86b2" width="300" /> | <img src="https://github.com/user-attachments/assets/c269988e-5869-4a2a-89d3-9e43ab1733c4" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
