### PR TITLE
PM-27705: Enable `filterTouchesWhenObscured` in Authenticator for security

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/MainActivity.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : AppCompatActivity() {
         var shouldShowSplashScreen = true
         installSplashScreen().setKeepOnScreenCondition { shouldShowSplashScreen }
         super.onCreate(savedInstanceState)
-
+        window.decorView.filterTouchesWhenObscured = true
         if (savedInstanceState == null) {
             mainViewModel.trySendAction(
                 MainAction.ReceiveFirstIntent(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27705](https://bitwarden.atlassian.net/browse/PM-27705)

## 📔 Objective

This PR sets the `filterTouchesWhenObscured` flag on the Authenticator Activity for additional security.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27705]: https://bitwarden.atlassian.net/browse/PM-27705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ