### PR TITLE
PM-27755: Create a common LocalQrCodeAnalyzer for both apps

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/composition/LocalManagerProvider.kt
@@ -23,6 +23,9 @@ import com.bitwarden.cxf.ui.composition.LocalCredentialExchangeRequestValidator
 import com.bitwarden.cxf.validator.CredentialExchangeRequestValidator
 import com.bitwarden.cxf.validator.dsl.credentialExchangeRequestValidator
 import com.bitwarden.ui.platform.composition.LocalIntentManager
+import com.bitwarden.ui.platform.composition.LocalQrCodeAnalyzer
+import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzer
+import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzerImpl
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.x8bit.bitwarden.R
 import com.x8bit.bitwarden.data.platform.manager.util.AppResumeStateManager
@@ -80,6 +83,7 @@ fun LocalManagerProvider(
     credentialExchangeRequestValidator: CredentialExchangeRequestValidator =
         credentialExchangeRequestValidator(activity = activity),
     authTabLaunchers: AuthTabLaunchers,
+    qrCodeAnalyzer: QrCodeAnalyzer = QrCodeAnalyzerImpl(),
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
@@ -98,6 +102,7 @@ fun LocalManagerProvider(
         LocalCredentialExchangeCompletionManager provides credentialExchangeCompletionManager,
         LocalCredentialExchangeRequestValidator provides credentialExchangeRequestValidator,
         LocalAuthTabLaunchers provides authTabLaunchers,
+        LocalQrCodeAnalyzer provides qrCodeAnalyzer,
         content = content,
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
@@ -35,8 +35,8 @@ import com.bitwarden.ui.platform.components.camera.CameraPreview
 import com.bitwarden.ui.platform.components.camera.QrCodeSquare
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
+import com.bitwarden.ui.platform.composition.LocalQrCodeAnalyzer
 import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzer
-import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzerImpl
 import com.bitwarden.ui.platform.model.WindowSize
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -55,7 +55,7 @@ fun QrCodeScanScreen(
     onNavigateBack: () -> Unit,
     onNavigateToManualCodeEntryScreen: () -> Unit,
     viewModel: QrCodeScanViewModel = hiltViewModel(),
-    qrCodeAnalyzer: QrCodeAnalyzer = QrCodeAnalyzerImpl(),
+    qrCodeAnalyzer: QrCodeAnalyzer = LocalQrCodeAnalyzer.current,
 ) {
     qrCodeAnalyzer.onQrCodeScanned = remember(viewModel) {
         { viewModel.trySendAction(QrCodeScanAction.QrCodeScanReceive(it)) }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/base/BitwardenComposeTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/base/BitwardenComposeTest.kt
@@ -5,6 +5,7 @@ import com.bitwarden.cxf.importer.CredentialExchangeImporter
 import com.bitwarden.cxf.manager.CredentialExchangeCompletionManager
 import com.bitwarden.cxf.validator.CredentialExchangeRequestValidator
 import com.bitwarden.ui.platform.base.BaseComposeTest
+import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzer
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.theme.BitwardenTheme
@@ -48,6 +49,7 @@ abstract class BitwardenComposeTest : BaseComposeTest() {
         credentialExchangeImporter: CredentialExchangeImporter = mockk(),
         credentialExchangeCompletionManager: CredentialExchangeCompletionManager = mockk(),
         credentialExchangeRequestValidator: CredentialExchangeRequestValidator = mockk(),
+        qrCodeAnalyzer: QrCodeAnalyzer = mockk(),
         test: @Composable () -> Unit,
     ) {
         setTestContent {
@@ -67,6 +69,7 @@ abstract class BitwardenComposeTest : BaseComposeTest() {
                 credentialExchangeImporter = credentialExchangeImporter,
                 credentialExchangeCompletionManager = credentialExchangeCompletionManager,
                 credentialExchangeRequestValidator = credentialExchangeRequestValidator,
+                qrCodeAnalyzer = qrCodeAnalyzer,
             ) {
                 BitwardenTheme(
                     theme = theme,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreenTest.kt
@@ -31,11 +31,12 @@ class QrCodeScanScreenTest : BitwardenComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            qrCodeAnalyzer = qrCodeAnalyzer,
+        ) {
             QrCodeScanScreen(
                 onNavigateBack = { onNavigateBackCalled = true },
                 viewModel = viewModel,
-                qrCodeAnalyzer = qrCodeAnalyzer,
                 onNavigateToManualCodeEntryScreen = {
                     onNavigateToManualCodeEntryScreenCalled = true
                 },

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
@@ -40,8 +40,8 @@ import com.bitwarden.ui.platform.components.camera.CameraPreview
 import com.bitwarden.ui.platform.components.camera.QrCodeSquare
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.ui.platform.composition.LocalQrCodeAnalyzer
 import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzer
-import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzerImpl
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
@@ -57,7 +57,7 @@ import com.bitwarden.ui.platform.theme.color.darkBitwardenColorScheme
 fun QrCodeScanScreen(
     onNavigateBack: () -> Unit,
     viewModel: QrCodeScanViewModel = hiltViewModel(),
-    qrCodeAnalyzer: QrCodeAnalyzer = QrCodeAnalyzerImpl(),
+    qrCodeAnalyzer: QrCodeAnalyzer = LocalQrCodeAnalyzer.current,
     onNavigateToManualCodeEntryScreen: () -> Unit,
 ) {
     qrCodeAnalyzer.onQrCodeScanned = remember(viewModel) {

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/composition/LocalManagerProvider.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/composition/LocalManagerProvider.kt
@@ -19,6 +19,9 @@ import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsMa
 import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManagerImpl
 import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.ui.platform.composition.LocalIntentManager
+import com.bitwarden.ui.platform.composition.LocalQrCodeAnalyzer
+import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzer
+import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzerImpl
 import com.bitwarden.ui.platform.manager.IntentManager
 import java.time.Clock
 
@@ -34,6 +37,7 @@ fun LocalManagerProvider(
     intentManager: IntentManager = IntentManager.create(activity, clock, buildInfoManager),
     exitManager: ExitManager = ExitManagerImpl(activity),
     biometricsManager: BiometricsManager = BiometricsManagerImpl(activity),
+    qrCodeAnalyzer: QrCodeAnalyzer = QrCodeAnalyzerImpl(),
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
@@ -41,6 +45,7 @@ fun LocalManagerProvider(
         LocalIntentManager provides intentManager,
         LocalExitManager provides exitManager,
         LocalBiometricsManager provides biometricsManager,
+        LocalQrCodeAnalyzer provides qrCodeAnalyzer,
         content = content,
     )
 }

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreenTest.kt
@@ -37,10 +37,11 @@ class QrCodeScanScreenTest : AuthenticatorComposeTest() {
 
     @Before
     fun setup() {
-        setContent {
+        setContent(
+            qrCodeAnalyzer = qrCodeAnalyzer,
+        ) {
             QrCodeScanScreen(
                 viewModel = viewModel,
-                qrCodeAnalyzer = qrCodeAnalyzer,
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToManualCodeEntryScreen = {
                     onNavigateToManualCodeEntryScreenCalled = true

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/base/AuthenticatorComposeTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/base/AuthenticatorComposeTest.kt
@@ -6,6 +6,7 @@ import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsMana
 import com.bitwarden.authenticator.ui.platform.manager.exit.ExitManager
 import com.bitwarden.authenticator.ui.platform.manager.permissions.PermissionsManager
 import com.bitwarden.ui.platform.base.BaseComposeTest
+import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzer
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.theme.BitwardenTheme
@@ -28,6 +29,7 @@ abstract class AuthenticatorComposeTest : BaseComposeTest() {
         intentManager: IntentManager = mockk(),
         exitManager: ExitManager = mockk(),
         biometricsManager: BiometricsManager = mockk(),
+        qrCodeAnalyzer: QrCodeAnalyzer = mockk(),
         test: @Composable () -> Unit,
     ) {
         setTestContent {
@@ -37,6 +39,7 @@ abstract class AuthenticatorComposeTest : BaseComposeTest() {
                     intentManager = intentManager,
                     exitManager = exitManager,
                     biometricsManager = biometricsManager,
+                    qrCodeAnalyzer = qrCodeAnalyzer,
                     content = test,
                 )
             }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/composition/LocalProviders.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/composition/LocalProviders.kt
@@ -2,6 +2,7 @@ package com.bitwarden.ui.platform.composition
 
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
+import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzer
 import com.bitwarden.ui.platform.manager.IntentManager
 
 /**
@@ -9,4 +10,11 @@ import com.bitwarden.ui.platform.manager.IntentManager
  */
 val LocalIntentManager: ProvidableCompositionLocal<IntentManager> = compositionLocalOf {
     error("CompositionLocal LocalIntentManager not present")
+}
+
+/**
+ * Provides access to the QR Code Analyzer throughout the app.
+ */
+val LocalQrCodeAnalyzer: ProvidableCompositionLocal<QrCodeAnalyzer> = compositionLocalOf {
+    error("CompositionLocal LocalQrCodeAnalyzer not present")
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27755](https://bitwarden.atlassian.net/browse/PM-27755)

## 📔 Objective

This PR adds a common `LocalQrCodeAnalyzer` to be used across both apps.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27755]: https://bitwarden.atlassian.net/browse/PM-27755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ