### PR TITLE
PM-27770: Update error parsing when creating or updating a cipher

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
@@ -91,7 +91,10 @@ class CipherManagerImpl(
             .map { response ->
                 when (response) {
                     is CreateCipherResponseJson.Invalid -> {
-                        CreateCipherResult.Error(errorMessage = response.message, error = null)
+                        CreateCipherResult.Error(
+                            errorMessage = response.firstValidationErrorMessage,
+                            error = null,
+                        )
                     }
 
                     is CreateCipherResponseJson.Success -> {
@@ -131,7 +134,10 @@ class CipherManagerImpl(
             .map { response ->
                 when (response) {
                     is CreateCipherResponseJson.Invalid -> {
-                        CreateCipherResult.Error(errorMessage = response.message, error = null)
+                        CreateCipherResult.Error(
+                            errorMessage = response.firstValidationErrorMessage,
+                            error = null,
+                        )
                     }
 
                     is CreateCipherResponseJson.Success -> {
@@ -301,7 +307,10 @@ class CipherManagerImpl(
             .map { response ->
                 when (response) {
                     is UpdateCipherResponseJson.Invalid -> {
-                        UpdateCipherResult.Error(errorMessage = response.message, error = null)
+                        UpdateCipherResult.Error(
+                            errorMessage = response.firstValidationErrorMessage,
+                            error = null,
+                        )
                     }
 
                     is UpdateCipherResponseJson.Success -> {
@@ -581,9 +590,7 @@ class CipherManagerImpl(
                         .flatMap { response ->
                             when (response) {
                                 is UpdateCipherResponseJson.Invalid -> {
-                                    IllegalStateException(
-                                        response.message,
-                                    )
+                                    IllegalStateException(response.firstValidationErrorMessage)
                                         .asFailure()
                                 }
 

--- a/network/src/main/kotlin/com/bitwarden/network/model/CreateCipherResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/CreateCipherResponseJson.kt
@@ -24,9 +24,9 @@ sealed class CreateCipherResponseJson {
     @Serializable
     data class Invalid(
         @SerialName("message")
-        val message: String?,
+        override val message: String,
 
         @SerialName("validationErrors")
-        val validationErrors: Map<String, List<String>>?,
-    ) : CreateCipherResponseJson()
+        override val validationErrors: Map<String, List<String>>?,
+    ) : CreateCipherResponseJson(), InvalidJsonResponse
 }

--- a/network/src/main/kotlin/com/bitwarden/network/model/UpdateCipherResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/UpdateCipherResponseJson.kt
@@ -25,9 +25,9 @@ sealed class UpdateCipherResponseJson {
     @Serializable
     data class Invalid(
         @SerialName("message")
-        val message: String?,
+        override val message: String,
 
         @SerialName("validationErrors")
-        val validationErrors: Map<String, List<String>>?,
-    ) : UpdateCipherResponseJson()
+        override val validationErrors: Map<String, List<String>>?,
+    ) : UpdateCipherResponseJson(), InvalidJsonResponse
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27770](https://bitwarden.atlassian.net/browse/PM-27770)

## 📔 Objective

This PR updates the error responses to better parse the message displayed to the user.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="300" src="https://github.com/user-attachments/assets/3f096fe9-fa2a-405b-974a-c1740a987962" /> | <img width="300" src="https://github.com/user-attachments/assets/d79aa178-41f1-41a5-bee6-ffdda96ae01b" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27770]: https://bitwarden.atlassian.net/browse/PM-27770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ