### PR TITLE
PM-24277: Add language selector to Authenticator

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -43,6 +43,7 @@ import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.authenticator.ui.platform.composition.LocalBiometricsManager
+import com.bitwarden.authenticator.ui.platform.feature.settings.appearance.model.AppLanguage
 import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
 import com.bitwarden.authenticator.ui.platform.manager.biometrics.BiometricsManager
 import com.bitwarden.authenticator.ui.platform.util.displayLabel
@@ -206,6 +207,9 @@ fun SettingsScreen(
             Spacer(modifier = Modifier.height(16.dp))
             AppearanceSettings(
                 state = state.appearance,
+                onLanguageSelection = remember(viewModel) {
+                    { viewModel.trySendAction(SettingsAction.AppearanceChange.LanguageChange(it)) }
+                },
                 onThemeSelection = remember(viewModel) {
                     {
                         viewModel.trySendAction(SettingsAction.AppearanceChange.ThemeChange(it))
@@ -511,14 +515,32 @@ private fun ScreenCaptureRow(
 @Composable
 private fun ColumnScope.AppearanceSettings(
     state: SettingsState.Appearance,
+    onLanguageSelection: (language: AppLanguage) -> Unit,
     onThemeSelection: (theme: AppTheme) -> Unit,
     onDynamicColorChange: (isEnabled: Boolean) -> Unit,
+    resources: Resources = LocalResources.current,
 ) {
     BitwardenListHeaderText(
         modifier = Modifier
             .standardHorizontalMargin()
             .padding(horizontal = 16.dp),
         label = stringResource(id = BitwardenString.appearance),
+    )
+    Spacer(modifier = Modifier.height(height = 8.dp))
+    BitwardenMultiSelectButton(
+        label = stringResource(id = BitwardenString.language),
+        options = AppLanguage.entries.map { it.text() }.toImmutableList(),
+        selectedOption = state.language.text(),
+        onOptionSelected = { language ->
+            onLanguageSelection(
+                AppLanguage.entries.first { language == it.text.toString(resources) },
+            )
+        },
+        cardStyle = CardStyle.Full,
+        modifier = Modifier
+            .testTag(tag = "LanguageChooser")
+            .standardHorizontalMargin()
+            .fillMaxWidth(),
     )
     Spacer(modifier = Modifier.height(height = 8.dp))
     ThemeSelectionRow(

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -207,6 +208,40 @@ class SettingsScreenTest : AuthenticatorComposeTest() {
             .onAllNodesWithText("Allow screen capture")
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun `on language row click should send display language selector dialog`() {
+        composeTestRule.assertNoDialogExists()
+        composeTestRule
+            .onNodeWithContentDescription(label = "English. Language")
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onAllNodesWithText(text = "Language")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `on language selected should emit LanguageChange event`() {
+        composeTestRule.assertNoDialogExists()
+        composeTestRule
+            .onNodeWithContentDescription(label = "English. Language")
+            .performScrollTo()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(text = "English (United Kingdom)")
+            .performScrollTo()
+            .performClick()
+        composeTestRule.assertNoDialogExists()
+        verify(exactly = 1) {
+            viewModel.trySendAction(
+                action = SettingsAction.AppearanceChange.LanguageChange(
+                    language = AppLanguage.ENGLISH_BRITISH,
+                ),
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24277](https://bitwarden.atlassian.net/browse/PM-24277)

## 📔 Objective

This PR adds the language selector to Authenticator app.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="300" src="https://github.com/user-attachments/assets/70876d51-7910-42ba-afd2-558b983d6e83" /> | <img width="300" src="https://github.com/user-attachments/assets/ba4006a0-436c-4f8c-8792-4af430dd0d91" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24277]: https://bitwarden.atlassian.net/browse/PM-24277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ