### PR TITLE
[PM-27869] fix/[PM-26241] : draw out keyboard on talkback click

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.test.onSiblings
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeRight
 import androidx.compose.ui.text.AnnotatedString
@@ -973,7 +974,7 @@ class GeneratorScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText("Word separator")
             .performScrollTo()
-            .performTextInput("a")
+            .performTextReplacement("a")
 
         verify {
             viewModel.trySendAction(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -1266,7 +1266,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         verify {
             viewModel.trySendAction(
                 VaultAddEditAction.ItemType.LoginType.UriValueChange(
-                    UriItem(id = "TestId", uri = "TestURI", match = null, checksum = null),
+                    UriItem(id = "TestId", uri = "URITest", match = null, checksum = null),
                 ),
             )
         }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -278,14 +279,16 @@ fun BitwardenTextField(
         val isDropDownExpanded = filteredAutoCompleteList.isNotEmpty() && hasFocused
         ExposedDropdownMenuBox(
             expanded = isDropDownExpanded,
-            onExpandedChange = { hasFocused = false },
+            onExpandedChange = {
+                hasFocused = !hasFocused
+                focusRequester.requestFocus()
+            },
             modifier = modifier.defaultMinSize(minHeight = 60.dp),
         ) {
             Column(
                 modifier = Modifier
                     .onGloballyPositioned { widthPx = it.size.width }
                     .onFocusEvent { focusState -> hasFocused = focusState.hasFocus }
-                    .focusRequester(focusRequester)
                     .cardStyle(
                         cardStyle = cardStyle,
                         paddingTop = 6.dp,
@@ -377,8 +380,14 @@ fun BitwardenTextField(
                         .nullableTestTag(tag = textFieldTestTag)
                         .menuAnchor(type = ExposedDropdownMenuAnchorType.PrimaryEditable)
                         .fillMaxWidth()
+                        .focusRequester(focusRequester)
                         .onFocusChanged { focusState ->
                             focused = focusState.isFocused
+                            if (focused) {
+                                textFieldValueState = textFieldValueState.copy(
+                                    selection = TextRange(textFieldValueState.text.length),
+                                )
+                            }
                         },
                 )
                 supportingContent


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/android/issues/5951

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

* **Fixes Bug:** [PM-26241]
* **The Problem:** The on-screen keyboard failed to appear when TalkBack users selected a text field on the "edit item" screen.
* **The Solution:** This PR ensures that the text field correctly requests and receives focus when activated via TalkBack, which properly triggers the keyboard to display.
* **Impact:** Restores the ability for screen reader users to edit item details, ensuring the feature is accessible.

### Test Updates

* **Context:** The fix for the TalkBack focus behavior revealed that two unit tests were brittle. They were built on an incorrect assumption that text would always be inserted at the **start** of the field.

* **Solution:** This PR also includes a commit to update these tests, making them more robust and aligning them with the new, correct cursor behavior.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

[before.webm](https://github.com/user-attachments/assets/5ca3b6ba-4b4d-4285-9140-47b21c35ec30)


[after.webm](https://github.com/user-attachments/assets/dd7fd4f0-32fa-4b2c-a54e-b399cf10f4c7)



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26241]: https://bitwarden.atlassian.net/browse/PM-26241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ