### PR TITLE
🍒 [PM-27902] Logout user after successful master password reset

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -1023,12 +1023,6 @@ class AuthRepositoryImpl(
             }
             .fold(
                 onSuccess = {
-                    // Clear the password reset reason, since it's no longer relevant.
-                    storeUserResetPasswordReason(
-                        userId = activeAccount.profile.userId,
-                        reason = null,
-                    )
-
                     // Update the saved master password hash.
                     authSdkSource
                         .hashPassword(
@@ -1043,6 +1037,10 @@ class AuthRepositoryImpl(
                                 passwordHash = passwordHash,
                             )
                         }
+
+                    // Log out the user after successful password reset.
+                    // This clears all user state including forcePasswordResetReason.
+                    logout(reason = LogoutReason.PasswordReset)
 
                     // Return the success.
                     ResetPasswordResult.Success

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LogoutReason.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/model/LogoutReason.kt
@@ -67,6 +67,11 @@ sealed class LogoutReason {
     data object Notification : LogoutReason()
 
     /**
+     * Indicates that the logout is happening because the user reset their master password.
+     */
+    data object PasswordReset : LogoutReason()
+
+    /**
      * Indicates that the logout is happening because the sync security stamp was invalidated.
      */
     data object SecurityStamp : LogoutReason()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -5073,6 +5073,12 @@ class AuthRepositoryTest {
             userId = USER_ID_1,
             passwordHash = newPasswordHash,
         )
+        verify {
+            userLogoutManager.logout(
+                userId = ACCOUNT_1.profile.userId,
+                reason = LogoutReason.PasswordReset,
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

PM-27902
Cherry-picked from https://github.com/bitwarden/android/pull/6133

## 📔 Objective

Fixes a critical security issue where users remained logged in after updating their master password due to policy requirements. This allowed users to immediately access their vault with the new password without re-authentication, bypassing the security intent of forced password resets.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
