### PR TITLE
Exclude Bitwarden Android SDK from Renovate auto-updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,7 +29,8 @@
         "gradle"
       ],
       "excludePackageNames": [
-        "com.github.bumptech.glide:compose"
+        "com.github.bumptech.glide:compose",
+        "com.bitwarden:sdk-android"
       ]
     },
     {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This change updates the Renovate configuration to prevent automatic updates for the `com.bitwarden:sdk-android` package.

The Android SDK is managed and updated as part of a separate, coordinated effort. Excluding it from Renovate's automated dependency updates prevents unintended or out-of-sync versions from being introduced, ensuring stability and alignment with the project's release strategy.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
