### PR TITLE
[PM-28041] Remove SDK Update PR changelog list size limit

### DIFF
--- a/scripts/get-repo-changelog.sh
+++ b/scripts/get-repo-changelog.sh
@@ -17,7 +17,7 @@ CURRENT_REF="$2"
 NEW_REF="$3"
 
 CHANGELOG=$(gh api "repos/$REPO/compare/$CURRENT_REF...$NEW_REF" \
-    --jq '.commits[] | "- \(.commit.message | split("\n")[0])"' | head -20)
+    --jq '.commits[] | "- \(.commit.message | split("\n")[0])"')
 
 if [ -z "$CHANGELOG" ]; then
     echo "No changes found between $CURRENT_REF and $NEW_REF"


### PR DESCRIPTION
## 🎟️ Tracking

PM-28041

## 📔 Objective

The script used to create SDK Update PRs limited the changelog list to the last 20 PRs. We're removing this limitation now.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
