### PR TITLE
All tests should assert if a value is displayed

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreenTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -64,11 +63,11 @@ class RemovePasswordScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = errorTitle)
             .assert(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
         composeTestRule
             .onNodeWithText(text = errorMessage)
             .assert(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
 
         val loadingMessage = "Loading message"
         mutableStateFlow.update {
@@ -82,7 +81,7 @@ class RemovePasswordScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = loadingMessage)
             .assert(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
 
         mutableStateFlow.update { it.copy(dialogState = null) }
 
@@ -96,7 +95,7 @@ class RemovePasswordScreenTest : BitwardenComposeTest() {
 
         mutableStateFlow.update { it.copy(description = description.asText()) }
 
-        composeTestRule.onNodeWithText(text = description).isDisplayed()
+        composeTestRule.onNodeWithText(text = description).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordScreenTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -72,7 +71,7 @@ class ResetPasswordScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText("Error message")
             .assert(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test
@@ -87,7 +86,7 @@ class ResetPasswordScreenTest : BitwardenComposeTest() {
             )
         }
 
-        composeTestRule.onNodeWithText("Loading...").isDisplayed()
+        composeTestRule.onNodeWithText("Loading...").assertIsDisplayed()
     }
 
     @Suppress("MaxLineLength")
@@ -104,7 +103,7 @@ class ResetPasswordScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText("Are you sure you want to log out?")
             .assert(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
 
         composeTestRule
             .onNodeWithText("Yes")

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreenTest.kt
@@ -2,9 +2,9 @@ package com.x8bit.bitwarden.ui.auth.feature.setpassword
 
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -57,7 +57,7 @@ class SetPasswordScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText("Error message")
             .assert(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test
@@ -72,7 +72,7 @@ class SetPasswordScreenTest : BitwardenComposeTest() {
             )
         }
 
-        composeTestRule.onNodeWithText("Loading...").isDisplayed()
+        composeTestRule.onNodeWithText("Loading...").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -94,7 +93,7 @@ class TwoFactorLoginScreenTest : BitwardenComposeTest() {
             )
         }
 
-        composeTestRule.onNodeWithText("Error message").isDisplayed()
+        composeTestRule.onNodeWithText("Error message").assertIsDisplayed()
     }
 
     @Test
@@ -157,7 +156,7 @@ class TwoFactorLoginScreenTest : BitwardenComposeTest() {
         val emailDetails =
             "Enter the 6 digit verification code that was emailed to ex***@email.com."
         val authAppDetails = "Enter the 6 digit verification code from your authenticator app."
-        composeTestRule.onNodeWithText(emailDetails).isDisplayed()
+        composeTestRule.onNodeWithText(emailDetails).assertIsDisplayed()
         composeTestRule.onNodeWithText(authAppDetails).assertDoesNotExist()
 
         mutableStateFlow.update {
@@ -165,7 +164,7 @@ class TwoFactorLoginScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule.onNodeWithText(emailDetails).assertDoesNotExist()
-        composeTestRule.onNodeWithText(authAppDetails).isDisplayed()
+        composeTestRule.onNodeWithText(authAppDetails).assertIsDisplayed()
     }
 
     @Test
@@ -178,7 +177,7 @@ class TwoFactorLoginScreenTest : BitwardenComposeTest() {
             )
         }
 
-        composeTestRule.onNodeWithText("Loading...").isDisplayed()
+        composeTestRule.onNodeWithText("Loading...").assertIsDisplayed()
     }
 
     @Test
@@ -264,15 +263,15 @@ class TwoFactorLoginScreenTest : BitwardenComposeTest() {
 
     @Test
     fun `title text should update according to state`() {
-        composeTestRule.onNodeWithText("Email").isDisplayed()
-        composeTestRule.onNodeWithText("Authenticator App").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Email").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Authenticator app").assertDoesNotExist()
 
         mutableStateFlow.update {
             it.copy(authMethod = TwoFactorAuthMethod.AUTHENTICATOR_APP)
         }
 
         composeTestRule.onNodeWithText("Email").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Authenticator App").isDisplayed()
+        composeTestRule.onNodeWithText("Authenticator app").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreenTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasTextExactly
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -1170,7 +1169,7 @@ class AccountSecurityScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText("Your vault timeout exceeds the restrictions set by your organization.")
             .assert(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
 
         composeTestRule
             .onAllNodesWithText(text = "Okay")

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreenTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -85,7 +84,7 @@ class ExportVaultScreenTest : BitwardenComposeTest() {
             )
         }
 
-        composeTestRule.onNodeWithText("Error message").isDisplayed()
+        composeTestRule.onNodeWithText("Error message").assertIsDisplayed()
     }
 
     @Test
@@ -219,7 +218,7 @@ class ExportVaultScreenTest : BitwardenComposeTest() {
             )
         }
 
-        composeTestRule.onNodeWithText("Loading...").isDisplayed()
+        composeTestRule.onNodeWithText("Loading...").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreenTest.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder
 
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -94,7 +94,7 @@ class FlightRecorderScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText(text = "Logging duration")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersScreenTest.kt
@@ -2,7 +2,6 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.folders
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -112,7 +111,7 @@ class FoldersScreenTest : BitwardenComposeTest() {
 
         composeTestRule
             .onNodeWithText("There are no folders to list.")
-            .isNotDisplayed()
+            .assertIsDisplayed()
 
         mutableStateFlow.update { DEFAULT_LOADED_STATE }
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasScrollToNodeAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -167,15 +166,15 @@ class SendScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText(text = "Sync")
             .filterToOne(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
         composeTestRule
             .onAllNodesWithText(text = "Lock")
             .filterToOne(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
         composeTestRule
             .onAllNodesWithText(text = "About Send")
             .filterToOne(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -189,15 +188,15 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText("Remove password")
             .assert(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
         composeTestRule
             .onNodeWithText("Copy link")
             .assert(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
         composeTestRule
             .onNodeWithText("Share link")
             .assert(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/SelectAccountScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/SelectAccountScreenTest.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.exportitems
 
-import androidx.compose.ui.test.isDisplayed
-import androidx.compose.ui.test.isNotDisplayed
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -63,11 +63,11 @@ class SelectAccountScreenTest : BitwardenComposeTest() {
     fun `initial state should be correct`() = runTest {
         composeTestRule
             .onNodeWithText("Select account")
-            .isDisplayed()
+            .assertIsDisplayed()
 
         composeTestRule
             .onNodeWithText(ACTIVE_ACCOUNT_SUMMARY.email)
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test
@@ -143,18 +143,17 @@ class SelectAccountScreenTest : BitwardenComposeTest() {
 
         composeTestRule
             .onNodeWithText("No accounts available")
-            .isDisplayed()
+            .assertIsDisplayed()
 
+        val text = "You don’t have any accounts you can import from. Your organization’s " +
+            "security policy may restrict importing items from Bitwarden to another app."
         composeTestRule
-            .onNodeWithText(
-                text = "You don't have any accounts you can import from.",
-                substring = true,
-            )
-            .isDisplayed()
+            .onNodeWithText(text = text)
+            .assertIsDisplayed()
 
         composeTestRule
             .onNodeWithText("Select an account")
-            .isNotDisplayed()
+            .assertIsNotDisplayed()
     }
 
     @Test
@@ -166,7 +165,7 @@ class SelectAccountScreenTest : BitwardenComposeTest() {
         )
         composeTestRule
             .onNodeWithText("Loading")
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportScreenTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -88,7 +87,7 @@ class ReviewExportScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText("title")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test
@@ -126,7 +125,7 @@ class ReviewExportScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText("message")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/verifypassword/VerifyPasswordScreenTest.kt
@@ -6,10 +6,8 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
@@ -69,15 +67,15 @@ class VerifyPasswordScreenTest : BitwardenComposeTest() {
     fun `initial state should be correct`() = runTest {
         composeTestRule
             .onNodeWithText("Verify your master password")
-            .isDisplayed()
+            .assertIsDisplayed()
 
         composeTestRule
             .onNodeWithText("AU")
-            .isDisplayed()
+            .assertIsDisplayed()
 
         composeTestRule
             .onNodeWithText("active@bitwarden.com")
-            .isDisplayed()
+            .assertIsDisplayed()
 
         composeTestRule
             .onNodeWithText("You vault is locked. Verify your master password to continue.")
@@ -109,21 +107,6 @@ class VerifyPasswordScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText("Resend code")
             .assertIsDisplayed()
-    }
-
-    @Test
-    fun `input should update based on state`() = runTest {
-        composeTestRule
-            .onNodeWithText("Master password")
-            .performTextInput("abc123")
-
-        composeTestRule
-            .onNodeWithTag("PasswordVisibilityToggle")
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText("abc123")
-            .isDisplayed()
     }
 
     @Test
@@ -211,7 +194,7 @@ class VerifyPasswordScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText("title")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test
@@ -244,7 +227,7 @@ class VerifyPasswordScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText("message")
             .filterToOne(hasAnyAncestor(isDialog()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -1312,11 +1311,11 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText(text = "Sync")
             .filterToOne(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
         composeTestRule
             .onAllNodesWithText(text = "Lock")
             .filterToOne(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollToNodeAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onChildren
@@ -2162,7 +2161,7 @@ class VaultScreenTest : BitwardenComposeTest() {
         }
         composeTestRule
             .onNodeWithTextAfterScroll("mockSshKey")
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.isDialog
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -414,12 +413,12 @@ class VerificationCodeScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onAllNodesWithText(text = "Sync")
             .filterToOne(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
 
         composeTestRule
             .onAllNodesWithText(text = "Lock")
             .filterToOne(hasAnyAncestor(isPopup()))
-            .isDisplayed()
+            .assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR cleans up a bunch of tests that were using `isDisplayed()` and `isNotDisplayed()` instead of the `assertisDisplayed()` and `assertIsNotDisplayed()`. This change ensures the tests are properly checking if the item is in fact visible or not.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
