### PR TITLE
[PM-27816] Navigating back after error on Login With Device

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
@@ -71,6 +71,7 @@ class LoginWithDeviceViewModel @Inject constructor(
 
     private fun handleErrorDialogDismissed() {
         mutableStateFlow.update { it.copy(dialogState = null) }
+        sendEvent(LoginWithDeviceEvent.NavigateBack)
     }
 
     private fun handleResendNotificationClicked() {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
@@ -103,7 +103,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `DismissDialog should clear the dialog state`() {
+    fun `DismissDialog should clear the dialog state and emit NavigateBack`() = runTest {
         val initialState = DEFAULT_STATE.copy(
             dialogState = LoginWithDeviceState.DialogState.Error(
                 title = BitwardenString.an_error_has_occurred.asText(),
@@ -111,8 +111,19 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
             ),
         )
         val viewModel = createViewModel(initialState)
-        viewModel.trySendAction(LoginWithDeviceAction.DismissDialog)
-        assertEquals(initialState.copy(dialogState = null), viewModel.stateFlow.value)
+
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(LoginWithDeviceAction.DismissDialog)
+            assertEquals(
+                LoginWithDeviceEvent.NavigateBack,
+                awaitItem(),
+            )
+        }
+
+        assertEquals(
+            initialState.copy(dialogState = null),
+            viewModel.stateFlow.value,
+        )
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-27816

## 📔 Objective

On Login with Device screen, user is not being redirected to the login screen after an error and screen is not displaying fingerprint.
This aims to fix this by navigating the user back

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
