### PR TITLE
Update logic for handling the pin protected user key

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceImpl.kt
@@ -145,9 +145,6 @@ class AuthDiskSourceImpl(
         storeInvalidUnlockAttempts(userId = userId, invalidUnlockAttempts = null)
         storeUserKey(userId = userId, userKey = null)
         storeUserAutoUnlockKey(userId = userId, userAutoUnlockKey = null)
-        storePinProtectedUserKey(userId = userId, pinProtectedUserKey = null)
-        storePinProtectedUserKeyEnvelope(userId = userId, pinProtectedUserKeyEnvelope = null)
-        storeEncryptedPin(userId = userId, encryptedPin = null)
         storePrivateKey(userId = userId, privateKey = null)
         storeAccountKeys(userId = userId, accountKeys = null)
         storeOrganizationKeys(userId = userId, organizationKeys = null)
@@ -163,9 +160,13 @@ class AuthDiskSourceImpl(
         storeShowImportLogins(userId = userId, showImportLogins = null)
         storeLastLockTimestamp(userId = userId, lastLockTimestamp = null)
 
-        // Do not remove the DeviceKey or PendingAuthRequest on logout, these are persisted
-        // indefinitely unless the TDE flow explicitly removes them.
-        // Do not remove OnboardingStatus we want to keep track of this even after logout.
+        // Certain values are never removed as required by the feature requirements:
+        // * EncryptedPin
+        // * PinProtectedUserKey
+        // * PinProtectedUserKeyEnvelope
+        // * DeviceKey
+        // * PendingAuthRequest
+        // * OnboardingStatus
     }
 
     override fun getAuthenticatorSyncUnlockKey(userId: String): String? =

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -77,16 +77,10 @@ class UserLogoutManagerImpl(
         if (isExpired) {
             showToast(message = BitwardenString.login_expired)
         }
-        authDiskSource.storeAccountTokens(
-            userId = userId,
-            accountTokens = null,
-        )
 
         // Save any data that will still need to be retained after otherwise clearing all dat
         val vaultTimeoutInMinutes = settingsDiskSource.getVaultTimeoutInMinutes(userId = userId)
         val vaultTimeoutAction = settingsDiskSource.getVaultTimeoutAction(userId = userId)
-        val pinProtectedUserKeyEnvelope = authDiskSource
-            .getPinProtectedUserKeyEnvelope(userId = userId)
 
         switchUserIfAvailable(
             currentUserId = userId,
@@ -108,10 +102,6 @@ class UserLogoutManagerImpl(
                 vaultTimeoutAction = vaultTimeoutAction,
             )
         }
-        authDiskSource.storePinProtectedUserKeyEnvelope(
-            userId = userId,
-            pinProtectedUserKeyEnvelope = pinProtectedUserKeyEnvelope,
-        )
     }
 
     private fun clearData(userId: String) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/PinProtectedUserKeyManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/PinProtectedUserKeyManager.kt
@@ -1,0 +1,30 @@
+package com.x8bit.bitwarden.data.vault.manager
+
+/**
+ * Manager class to manage the pin-protected user key.
+ */
+interface PinProtectedUserKeyManager {
+    /**
+     * Checks if the given [userId] has an associated encrypted PIN key but not a pin-protected
+     * user key. This indicates a scenario in which a user has requested PIN unlocking but requires
+     * master-password unlocking on app restart. This function may then be called after such an
+     * unlock to derive a pin-protected user key and store it in memory for use for any subsequent
+     * unlocks during this current app session.
+     *
+     * If the user's vault has not yet been unlocked, this call will do nothing.
+     *
+     * @param userId The ID of the user to check.
+     */
+    suspend fun deriveTemporaryPinProtectedUserKeyIfNecessary(userId: String)
+
+    /**
+     * Migrates the PIN-protected user key for the given user if needed.
+     *
+     * If an encrypted PIN exists and no PIN-protected user key envelope is present, enrolls the
+     * PIN with the encrypted PIN and stores the resulting envelope.
+     * Optionally marks the envelope as in-memory only if the PIN-protected user key is not present.
+     *
+     * @param userId The ID of the user for whom to migrate the PIN-protected user key.
+     */
+    suspend fun migratePinProtectedUserKeyIfNeeded(userId: String)
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/PinProtectedUserKeyManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/PinProtectedUserKeyManagerImpl.kt
@@ -1,0 +1,95 @@
+package com.x8bit.bitwarden.data.vault.manager
+
+import com.bitwarden.core.EnrollPinResponse
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
+import timber.log.Timber
+
+/**
+ * The default implementation of the [PinProtectedUserKeyManager].
+ */
+internal class PinProtectedUserKeyManagerImpl(
+    private val authDiskSource: AuthDiskSource,
+    private val vaultSdkSource: VaultSdkSource,
+) : PinProtectedUserKeyManager {
+    override suspend fun deriveTemporaryPinProtectedUserKeyIfNecessary(userId: String) {
+        val encryptedPin = authDiskSource.getEncryptedPin(userId = userId) ?: return
+        if (authDiskSource.getPinProtectedUserKeyEnvelope(userId = userId) != null) return
+
+        this
+            .enrollPinWithEncryptedPin(
+                userId = userId,
+                encryptedPin = encryptedPin,
+                inMemoryOnly = true,
+            )
+            .onSuccess {
+                Timber.d("[Auth] Set PIN-protected user key in memory")
+            }
+    }
+
+    override suspend fun migratePinProtectedUserKeyIfNeeded(userId: String) {
+        val encryptedPin = authDiskSource.getEncryptedPin(userId = userId) ?: return
+        if (authDiskSource.getPinProtectedUserKeyEnvelope(userId = userId) != null) return
+
+        val inMemoryOnly = authDiskSource.getPinProtectedUserKey(userId = userId) == null
+        this
+            .enrollPinWithEncryptedPin(
+                userId = userId,
+                encryptedPin = encryptedPin,
+                inMemoryOnly = inMemoryOnly,
+            )
+            .onSuccess {
+                if (inMemoryOnly) {
+                    Timber.d("[Auth] Set PIN-protected user key in memory")
+                } else {
+                    Timber.d("[Auth] Migrated from legacy PIN to PIN-protected user key envelope")
+                }
+            }
+    }
+
+    private suspend fun enrollPinWithEncryptedPin(
+        userId: String,
+        encryptedPin: String,
+        inMemoryOnly: Boolean,
+    ): Result<EnrollPinResponse> =
+        vaultSdkSource
+            .enrollPinWithEncryptedPin(userId = userId, encryptedPin = encryptedPin)
+            .onSuccess { enrollPinResponse ->
+                storePinData(
+                    userId = userId,
+                    encryptedPin = enrollPinResponse.userKeyEncryptedPin,
+                    pinProtectedUserKeyEnvelope = enrollPinResponse.pinProtectedUserKeyEnvelope,
+                    inMemoryOnly = inMemoryOnly,
+                )
+            }
+            .onFailure {
+                storePinData(
+                    userId = userId,
+                    encryptedPin = null,
+                    pinProtectedUserKeyEnvelope = null,
+                    inMemoryOnly = false,
+                )
+            }
+
+    private fun storePinData(
+        userId: String,
+        encryptedPin: String?,
+        pinProtectedUserKeyEnvelope: String?,
+        inMemoryOnly: Boolean,
+    ) {
+        authDiskSource.storeEncryptedPin(userId = userId, encryptedPin = encryptedPin)
+        authDiskSource.storePinProtectedUserKeyEnvelope(
+            userId = userId,
+            pinProtectedUserKeyEnvelope = pinProtectedUserKeyEnvelope,
+            inMemoryOnly = inMemoryOnly,
+        )
+        // This property is deprecated and we should be migrated to the PinProtectedUserKeyEnvelope.
+        // Because of this, we always clear this value and it should always be cleared at the disk
+        // level, not the in-memory level.
+        authDiskSource.storePinProtectedUserKey(
+            userId = userId,
+            pinProtectedUserKey = null,
+            inMemoryOnly = false,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -91,6 +91,7 @@ class VaultLockManagerImpl(
     private val userLogoutManager: UserLogoutManager,
     private val trustedDeviceManager: TrustedDeviceManager,
     private val kdfManager: KdfManager,
+    private val pinProtectedUserKeyManager: PinProtectedUserKeyManager,
     dispatcherManager: DispatcherManager,
     context: Context,
 ) : VaultLockManager {
@@ -234,7 +235,8 @@ class VaultLockManagerImpl(
                                         trustedDeviceManager
                                             .trustThisDeviceIfNecessary(userId = userId)
                                         updateKdfIfNeeded(initUserCryptoMethod)
-                                        migratePinProtectedUserKeyIfNeeded(userId = userId)
+                                        pinProtectedUserKeyManager
+                                            .migratePinProtectedUserKeyIfNeeded(userId = userId)
                                         setVaultToUnlocked(userId = userId)
                                     } else {
                                         incrementInvalidUnlockCount(userId = userId)
@@ -306,47 +308,6 @@ class VaultLockManagerImpl(
                 onFailure = { setVaultToLocked(userId = userId) },
                 onSuccess = { setVaultToUnlocked(userId = userId) },
             )
-    }
-
-    /**
-     * Migrates the PIN-protected user key for the given user if needed.
-     *
-     * If an encrypted PIN exists and no PIN-protected user key envelope is present,
-     * enrolls the PIN with the encrypted PIN and stores the resulting envelope.
-     * Optionally marks the envelope as in-memory only if the PIN-protected user key is not present.
-     *
-     * @param userId The ID of the user for whom to migrate the PIN-protected user key.
-     */
-    private suspend fun migratePinProtectedUserKeyIfNeeded(
-        userId: String,
-    ) {
-        val encryptedPin = authDiskSource.getEncryptedPin(userId) ?: return
-        if (authDiskSource.getPinProtectedUserKeyEnvelope(userId) != null) return
-
-        val inMemoryOnly = authDiskSource.getPinProtectedUserKey(userId) == null
-
-        vaultSdkSource.enrollPinWithEncryptedPin(userId, encryptedPin)
-            .onSuccess { enrollPinResponse ->
-                authDiskSource.storeEncryptedPin(
-                    userId = userId,
-                    encryptedPin = enrollPinResponse.userKeyEncryptedPin,
-                )
-                authDiskSource.storePinProtectedUserKeyEnvelope(
-                    userId = userId,
-                    pinProtectedUserKeyEnvelope = enrollPinResponse.pinProtectedUserKeyEnvelope,
-                    inMemoryOnly = inMemoryOnly,
-                )
-                authDiskSource.storePinProtectedUserKey(
-                    userId = userId,
-                    pinProtectedUserKey = null,
-                    inMemoryOnly = inMemoryOnly,
-                )
-                if (inMemoryOnly) {
-                    Timber.d("[Auth] Set PIN-protected user key in memory")
-                } else {
-                    Timber.d("[Auth] Migrated from legacy PIN to PIN-protected user key envelope")
-                }
-            }
     }
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
@@ -31,6 +31,8 @@ import com.x8bit.bitwarden.data.vault.manager.FileManager
 import com.x8bit.bitwarden.data.vault.manager.FileManagerImpl
 import com.x8bit.bitwarden.data.vault.manager.FolderManager
 import com.x8bit.bitwarden.data.vault.manager.FolderManagerImpl
+import com.x8bit.bitwarden.data.vault.manager.PinProtectedUserKeyManager
+import com.x8bit.bitwarden.data.vault.manager.PinProtectedUserKeyManagerImpl
 import com.x8bit.bitwarden.data.vault.manager.SendManager
 import com.x8bit.bitwarden.data.vault.manager.SendManagerImpl
 import com.x8bit.bitwarden.data.vault.manager.TotpCodeManager
@@ -146,6 +148,7 @@ object VaultManagerModule {
         dispatcherManager: DispatcherManager,
         trustedDeviceManager: TrustedDeviceManager,
         kdfManager: KdfManager,
+        pinProtectedUserKeyManager: PinProtectedUserKeyManager,
     ): VaultLockManager =
         VaultLockManagerImpl(
             context = context,
@@ -160,6 +163,18 @@ object VaultManagerModule {
             dispatcherManager = dispatcherManager,
             trustedDeviceManager = trustedDeviceManager,
             kdfManager = kdfManager,
+            pinProtectedUserKeyManager = pinProtectedUserKeyManager,
+        )
+
+    @Provides
+    @Singleton
+    fun providePinProtectedUserKeyManager(
+        authDiskSource: AuthDiskSource,
+        vaultSdkSource: VaultSdkSource,
+    ): PinProtectedUserKeyManager =
+        PinProtectedUserKeyManagerImpl(
+            authDiskSource = authDiskSource,
+            vaultSdkSource = vaultSdkSource,
         )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/di/VaultRepositoryModule.kt
@@ -7,6 +7,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.manager.CipherManager
 import com.x8bit.bitwarden.data.vault.manager.CredentialExchangeImportManager
 import com.x8bit.bitwarden.data.vault.manager.FolderManager
+import com.x8bit.bitwarden.data.vault.manager.PinProtectedUserKeyManager
 import com.x8bit.bitwarden.data.vault.manager.SendManager
 import com.x8bit.bitwarden.data.vault.manager.TotpCodeManager
 import com.x8bit.bitwarden.data.vault.manager.VaultLockManager
@@ -40,6 +41,7 @@ object VaultRepositoryModule {
         totpCodeManager: TotpCodeManager,
         vaultSyncManager: VaultSyncManager,
         credentialExchangeImportManager: CredentialExchangeImportManager,
+        pinProtectedUserKeyManager: PinProtectedUserKeyManager,
     ): VaultRepository = VaultRepositoryImpl(
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
@@ -52,5 +54,6 @@ object VaultRepositoryModule {
         totpCodeManager = totpCodeManager,
         vaultSyncManager = vaultSyncManager,
         credentialExchangeImportManager = credentialExchangeImportManager,
+        pinProtectedUserKeyManager = pinProtectedUserKeyManager,
     )
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSourceTest.kt
@@ -267,9 +267,15 @@ class AuthDiskSourceTest {
             userId = userId,
             biometricsKey = "1234-9876-0192",
         )
+        val pinProtectedUserKey = "pinProtectedUserKey"
         authDiskSource.storePinProtectedUserKey(
             userId = userId,
-            pinProtectedUserKey = "pinProtectedUserKey",
+            pinProtectedUserKey = pinProtectedUserKey,
+        )
+        val pinProtectedUserKeyEnvelope = "pinProtectedUserKeyEnvelope"
+        authDiskSource.storePinProtectedUserKeyEnvelope(
+            userId = userId,
+            pinProtectedUserKeyEnvelope = pinProtectedUserKeyEnvelope,
         )
         authDiskSource.storeInvalidUnlockAttempts(
             userId = userId,
@@ -304,7 +310,8 @@ class AuthDiskSourceTest {
                 refreshToken = "refreshToken",
             ),
         )
-        authDiskSource.storeEncryptedPin(userId = userId, encryptedPin = "encryptedPin")
+        val encryptedPin = "encryptedPin"
+        authDiskSource.storeEncryptedPin(userId = userId, encryptedPin = encryptedPin)
         authDiskSource.storeMasterPasswordHash(userId = userId, passwordHash = "passwordHash")
         authDiskSource.storeAuthenticatorSyncUnlockKey(
             userId = userId,
@@ -326,12 +333,16 @@ class AuthDiskSourceTest {
             OnboardingStatus.AUTOFILL_SETUP,
             authDiskSource.getOnboardingStatus(userId = userId),
         )
+        assertEquals(encryptedPin, authDiskSource.getEncryptedPin(userId = userId))
+        assertEquals(pinProtectedUserKey, authDiskSource.getPinProtectedUserKey(userId = userId))
+        assertEquals(
+            pinProtectedUserKeyEnvelope,
+            authDiskSource.getPinProtectedUserKeyEnvelope(userId = userId),
+        )
 
         // These should be cleared
         assertNull(authDiskSource.getUserBiometricInitVector(userId = userId))
         assertNull(authDiskSource.getUserBiometricUnlockKey(userId = userId))
-        assertNull(authDiskSource.getPinProtectedUserKey(userId = userId))
-        assertNull(authDiskSource.getPinProtectedUserKeyEnvelope(userId = userId))
         assertNull(authDiskSource.getInvalidUnlockAttempts(userId = userId))
         assertNull(authDiskSource.getUserKey(userId = userId))
         assertNull(authDiskSource.getUserAutoUnlockKey(userId = userId))
@@ -341,7 +352,6 @@ class AuthDiskSourceTest {
         assertNull(authDiskSource.getOrganizations(userId = userId))
         assertNull(authDiskSource.getPolicies(userId = userId))
         assertNull(authDiskSource.getAccountTokens(userId = userId))
-        assertNull(authDiskSource.getEncryptedPin(userId = userId))
         assertNull(authDiskSource.getMasterPasswordHash(userId = userId))
         assertNull(authDiskSource.getShouldUseKeyConnector(userId = userId))
         assertNull(authDiskSource.getIsTdeLoginComplete(userId = userId))

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/util/FakeAuthDiskSource.kt
@@ -84,8 +84,6 @@ class FakeAuthDiskSource : AuthDiskSource {
         storedPrivateKeys.remove(userId)
         storedTwoFactorTokens.clear()
         storedUserAutoUnlockKeys.remove(userId)
-        storedPinProtectedUserKeys.remove(userId)
-        storedEncryptedPins.remove(userId)
         storedOrganizations.remove(userId)
         storedPolicies.remove(userId)
         storedAccountTokens.remove(userId)
@@ -98,7 +96,6 @@ class FakeAuthDiskSource : AuthDiskSource {
         mutableOrganizationsFlowMap.remove(userId)
         mutablePoliciesFlowMap.remove(userId)
         mutableAccountTokensFlowMap.remove(userId)
-        mutablePinProtectedUserKeyEnvelopesFlowMap.remove(userId)
     }
 
     private fun getMutablePinProtectedUserKeyEnvelopeFlow(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
@@ -33,13 +33,6 @@ import java.time.ZonedDateTime
 @ExtendWith(MainDispatcherExtension::class)
 class UserLogoutManagerTest {
     private val authDiskSource: AuthDiskSource = mockk {
-        every { storeAccountTokens(userId = any(), accountTokens = null) } just runs
-        every {
-            storePinProtectedUserKeyEnvelope(
-                userId = any(),
-                pinProtectedUserKeyEnvelope = any(),
-            )
-        } just runs
         every { userState = any() } just runs
         every { clearData(any()) } just runs
     }
@@ -149,7 +142,6 @@ class UserLogoutManagerTest {
 
         userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
 
-        verify { authDiskSource.storeAccountTokens(userId = userId, accountTokens = null) }
         assertDataCleared(userId = userId)
 
         verify(exactly = 1) {
@@ -169,10 +161,6 @@ class UserLogoutManagerTest {
             settingsDiskSource.storeVaultTimeoutAction(
                 userId = userId,
                 vaultTimeoutAction = vaultTimeoutAction,
-            )
-            authDiskSource.storePinProtectedUserKeyEnvelope(
-                userId = userId,
-                pinProtectedUserKeyEnvelope = pinProtectedUserKey,
             )
         }
     }
@@ -198,7 +186,6 @@ class UserLogoutManagerTest {
         userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
 
         verify(exactly = 1) {
-            authDiskSource.storeAccountTokens(userId = userId, accountTokens = null)
             authDiskSource.userState = UserStateJson(
                 activeUserId = USER_ID_2,
                 accounts = MULTI_USER_STATE.accounts,
@@ -211,10 +198,6 @@ class UserLogoutManagerTest {
             settingsDiskSource.storeVaultTimeoutAction(
                 userId = userId,
                 vaultTimeoutAction = vaultTimeoutAction,
-            )
-            authDiskSource.storePinProtectedUserKeyEnvelope(
-                userId = userId,
-                pinProtectedUserKeyEnvelope = pinProtectedUserKey,
             )
         }
     }
@@ -241,7 +224,6 @@ class UserLogoutManagerTest {
         userLogoutManager.softLogout(userId = userId, reason = LogoutReason.SecurityStamp)
 
         verify(exactly = 1) {
-            authDiskSource.storeAccountTokens(userId = userId, accountTokens = null)
             authDiskSource.userState = UserStateJson(
                 activeUserId = USER_ID_2,
                 accounts = MULTI_USER_STATE.accounts,
@@ -254,10 +236,6 @@ class UserLogoutManagerTest {
             settingsDiskSource.storeVaultTimeoutAction(
                 userId = userId,
                 vaultTimeoutAction = vaultTimeoutAction,
-            )
-            authDiskSource.storePinProtectedUserKeyEnvelope(
-                userId = userId,
-                pinProtectedUserKeyEnvelope = pinProtectedUserKey,
             )
         }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/PinProtectedUserKeyManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/PinProtectedUserKeyManagerTest.kt
@@ -1,0 +1,279 @@
+package com.x8bit.bitwarden.data.vault.manager
+
+import com.bitwarden.core.EnrollPinResponse
+import com.bitwarden.core.data.util.asFailure
+import com.bitwarden.core.data.util.asSuccess
+import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class PinProtectedUserKeyManagerTest {
+
+    private val fakeAuthDiskSource: FakeAuthDiskSource = FakeAuthDiskSource()
+    private val vaultSdkSource: VaultSdkSource = mockk()
+
+    private val pinProtectedUserKeyManager: PinProtectedUserKeyManager =
+        PinProtectedUserKeyManagerImpl(
+            authDiskSource = fakeAuthDiskSource,
+            vaultSdkSource = vaultSdkSource,
+        )
+
+    @Test
+    fun `deriveTemporaryPinProtectedUserKeyIfNecessary without encryptedKey does nothing`() =
+        runTest {
+            fakeAuthDiskSource.storeEncryptedPin(userId = USER_ID, encryptedPin = null)
+
+            pinProtectedUserKeyManager.deriveTemporaryPinProtectedUserKeyIfNecessary(
+                userId = USER_ID,
+            )
+
+            coVerify(exactly = 0) {
+                vaultSdkSource.enrollPinWithEncryptedPin(userId = any(), encryptedPin = any())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deriveTemporaryPinProtectedUserKeyIfNecessary with encrypted key and existing pinProtectedUserKeyEnvelope does nothing`() =
+        runTest {
+            fakeAuthDiskSource.storeEncryptedPin(userId = USER_ID, encryptedPin = "encryptedPin")
+            fakeAuthDiskSource.storePinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = "pinProtectedUserKeyEnvelope",
+            )
+
+            pinProtectedUserKeyManager.deriveTemporaryPinProtectedUserKeyIfNecessary(
+                userId = USER_ID,
+            )
+
+            coVerify(exactly = 0) {
+                vaultSdkSource.enrollPinWithEncryptedPin(userId = any(), encryptedPin = any())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deriveTemporaryPinProtectedUserKeyIfNecessary with enrollment success should store new pin data`() =
+        runTest {
+            val encryptedPin = "encryptedPin"
+            val pinProtectedUserKeyEnvelope = "pinProtectedUserKeyEnvelope"
+            val userKeyEncryptedPin = "userKeyEncryptedPin"
+            val enrollPinResponse = EnrollPinResponse(
+                pinProtectedUserKeyEnvelope = pinProtectedUserKeyEnvelope,
+                userKeyEncryptedPin = userKeyEncryptedPin,
+            )
+            fakeAuthDiskSource.storeEncryptedPin(userId = USER_ID, encryptedPin = encryptedPin)
+            fakeAuthDiskSource.storePinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = null,
+            )
+            coEvery {
+                vaultSdkSource.enrollPinWithEncryptedPin(
+                    userId = USER_ID,
+                    encryptedPin = encryptedPin,
+                )
+            } returns enrollPinResponse.asSuccess()
+
+            pinProtectedUserKeyManager.deriveTemporaryPinProtectedUserKeyIfNecessary(
+                userId = USER_ID,
+            )
+
+            coVerify(exactly = 1) {
+                vaultSdkSource.enrollPinWithEncryptedPin(
+                    userId = USER_ID,
+                    encryptedPin = encryptedPin,
+                )
+            }
+            fakeAuthDiskSource.assertEncryptedPin(
+                userId = USER_ID,
+                encryptedPin = userKeyEncryptedPin,
+            )
+            fakeAuthDiskSource.assertPinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = pinProtectedUserKeyEnvelope,
+                inMemoryOnly = true,
+            )
+            fakeAuthDiskSource.assertPinProtectedUserKey(
+                userId = USER_ID,
+                pinProtectedUserKey = null,
+                inMemoryOnly = false,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `deriveTemporaryPinProtectedUserKeyIfNecessary with enrollment failure should clear all pin data`() =
+        runTest {
+            val encryptedPin = "encryptedPin"
+            val error = Throwable("Fail!")
+            fakeAuthDiskSource.storeEncryptedPin(userId = USER_ID, encryptedPin = encryptedPin)
+            fakeAuthDiskSource.storePinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = null,
+            )
+            coEvery {
+                vaultSdkSource.enrollPinWithEncryptedPin(
+                    userId = USER_ID,
+                    encryptedPin = encryptedPin,
+                )
+            } returns error.asFailure()
+
+            pinProtectedUserKeyManager.deriveTemporaryPinProtectedUserKeyIfNecessary(
+                userId = USER_ID,
+            )
+
+            coVerify(exactly = 1) {
+                vaultSdkSource.enrollPinWithEncryptedPin(
+                    userId = USER_ID,
+                    encryptedPin = encryptedPin,
+                )
+            }
+            fakeAuthDiskSource.assertEncryptedPin(
+                userId = USER_ID,
+                encryptedPin = null,
+            )
+            fakeAuthDiskSource.assertPinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = null,
+                inMemoryOnly = false,
+            )
+            fakeAuthDiskSource.assertPinProtectedUserKey(
+                userId = USER_ID,
+                pinProtectedUserKey = null,
+                inMemoryOnly = false,
+            )
+        }
+
+    @Test
+    fun `migratePinProtectedUserKeyIfNeeded without encryptedKey does nothing`() =
+        runTest {
+            fakeAuthDiskSource.storeEncryptedPin(userId = USER_ID, encryptedPin = null)
+
+            pinProtectedUserKeyManager.migratePinProtectedUserKeyIfNeeded(userId = USER_ID)
+
+            coVerify(exactly = 0) {
+                vaultSdkSource.enrollPinWithEncryptedPin(userId = any(), encryptedPin = any())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `migratePinProtectedUserKeyIfNeeded with encrypted key and existing pinProtectedUserKeyEnvelope does nothing`() =
+        runTest {
+            fakeAuthDiskSource.storeEncryptedPin(userId = USER_ID, encryptedPin = "encryptedPin")
+            fakeAuthDiskSource.storePinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = "pinProtectedUserKeyEnvelope",
+            )
+
+            pinProtectedUserKeyManager.migratePinProtectedUserKeyIfNeeded(userId = USER_ID)
+
+            coVerify(exactly = 0) {
+                vaultSdkSource.enrollPinWithEncryptedPin(userId = any(), encryptedPin = any())
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `migratePinProtectedUserKeyIfNeeded with enrollment success should store new pin data in memory`() =
+        runTest {
+            val encryptedPin = "encryptedPin"
+            val pinProtectedUserKeyEnvelope = "pinProtectedUserKeyEnvelope"
+            val userKeyEncryptedPin = "userKeyEncryptedPin"
+            val enrollPinResponse = EnrollPinResponse(
+                pinProtectedUserKeyEnvelope = pinProtectedUserKeyEnvelope,
+                userKeyEncryptedPin = userKeyEncryptedPin,
+            )
+            fakeAuthDiskSource.storeEncryptedPin(userId = USER_ID, encryptedPin = encryptedPin)
+            fakeAuthDiskSource.storePinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = null,
+            )
+            fakeAuthDiskSource.storePinProtectedUserKey(
+                userId = USER_ID,
+                pinProtectedUserKey = null,
+            )
+            coEvery {
+                vaultSdkSource.enrollPinWithEncryptedPin(
+                    userId = USER_ID,
+                    encryptedPin = encryptedPin,
+                )
+            } returns enrollPinResponse.asSuccess()
+
+            pinProtectedUserKeyManager.migratePinProtectedUserKeyIfNeeded(userId = USER_ID)
+
+            coVerify(exactly = 1) {
+                vaultSdkSource.enrollPinWithEncryptedPin(
+                    userId = USER_ID,
+                    encryptedPin = encryptedPin,
+                )
+            }
+            fakeAuthDiskSource.assertEncryptedPin(
+                userId = USER_ID,
+                encryptedPin = userKeyEncryptedPin,
+            )
+            fakeAuthDiskSource.assertPinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = pinProtectedUserKeyEnvelope,
+                inMemoryOnly = true,
+            )
+            fakeAuthDiskSource.assertPinProtectedUserKey(
+                userId = USER_ID,
+                pinProtectedUserKey = null,
+                inMemoryOnly = false,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `migratePinProtectedUserKeyIfNeeded with enrollment failure should clear all pin data at disk level`() =
+        runTest {
+            val encryptedPin = "encryptedPin"
+            val pinProtectedUserKey = "pinProtectedUserKey"
+            val error = Throwable("Fail!")
+            fakeAuthDiskSource.storeEncryptedPin(userId = USER_ID, encryptedPin = encryptedPin)
+            fakeAuthDiskSource.storePinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = null,
+            )
+            fakeAuthDiskSource.storePinProtectedUserKey(
+                userId = USER_ID,
+                pinProtectedUserKey = pinProtectedUserKey,
+            )
+            coEvery {
+                vaultSdkSource.enrollPinWithEncryptedPin(
+                    userId = USER_ID,
+                    encryptedPin = encryptedPin,
+                )
+            } returns error.asFailure()
+
+            pinProtectedUserKeyManager.migratePinProtectedUserKeyIfNeeded(userId = USER_ID)
+
+            coVerify(exactly = 1) {
+                vaultSdkSource.enrollPinWithEncryptedPin(
+                    userId = USER_ID,
+                    encryptedPin = encryptedPin,
+                )
+            }
+            fakeAuthDiskSource.assertEncryptedPin(
+                userId = USER_ID,
+                encryptedPin = null,
+            )
+            fakeAuthDiskSource.assertPinProtectedUserKeyEnvelope(
+                userId = USER_ID,
+                pinProtectedUserKeyEnvelope = null,
+                inMemoryOnly = false,
+            )
+            fakeAuthDiskSource.assertPinProtectedUserKey(
+                userId = USER_ID,
+                pinProtectedUserKey = null,
+                inMemoryOnly = false,
+            )
+        }
+}
+
+private const val USER_ID: String = "user_id"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28355](https://bitwarden.atlassian.net/browse/PM-28355)

## 📔 Objective

This PR updates the way we handle the pin protected user key and it migration to the pin protected user key envelope.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28355]: https://bitwarden.atlassian.net/browse/PM-28355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ