### PR TITLE
[PM-22479] Checking signingCertificateHistory for a valid asset link certificate

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensions.kt
@@ -18,6 +18,24 @@ fun CallingAppInfo.getSignatureFingerprintAsHexString(): String? {
 }
 
 /**
+ * Returns a list of all signing certificate hashes formatted as hex strings from the signing
+ * certificate history. This includes the current signing certificate and any previous ones
+ * (due to key rotation).
+ */
+@OptIn(ExperimentalStdlibApi::class)
+fun CallingAppInfo.getAllSignatureFingerprintsAsHexStrings(): List<String> {
+    if (signingInfo.hasMultipleSigners()) return emptyList()
+
+    val md = MessageDigest.getInstance(SHA_ALGORITHM)
+    return signingInfo.signingCertificateHistory.map { signature ->
+        val hash = md.digest(signature.toByteArray())
+        hash.joinToString(":") { b ->
+            b.toHexString(HexFormat.UpperCase)
+        }
+    }
+}
+
+/**
  * Returns true if this [CallingAppInfo] is present in the privileged app [allowList]. Otherwise,
  * returns false.
  */

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/manager/OriginManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/manager/OriginManagerTest.kt
@@ -38,6 +38,7 @@ class OriginManagerTest {
         every { getOrigin(any()) } returns null
         every { signingInfo } returns mockk {
             every { apkContentsSigners } returns arrayOf(Signature(DEFAULT_APP_SIGNATURE))
+            every { signingCertificateHistory } returns arrayOf(Signature(DEFAULT_APP_SIGNATURE))
             every { hasMultipleSigners() } returns false
         }
     }
@@ -242,11 +243,248 @@ class OriginManagerTest {
                 ),
             )
         }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should check all certificate fingerprints from signing history`() =
+        runTest {
+            val customMessageDigest = mockk<MessageDigest> {
+                every { digest(DEFAULT_APP_SIGNATURE.toByteArray()) } returns DEFAULT_APP_SIGNATURE.toByteArray()
+                every { digest(SECOND_APP_SIGNATURE.toByteArray()) } returns SECOND_APP_SIGNATURE.toByteArray()
+            }
+            every { MessageDigest.getInstance(any()) } returns customMessageDigest
+
+            val mockAppInfoWithHistory = mockk<CallingAppInfo> {
+                every { isOriginPopulated() } returns false
+                every { packageName } returns DEFAULT_PACKAGE_NAME
+                every { signingInfo } returns mockk {
+                    every { hasMultipleSigners() } returns false
+                    every { signingCertificateHistory } returns arrayOf(
+                        mockk { every { toByteArray() } returns DEFAULT_APP_SIGNATURE.toByteArray() },
+                        mockk { every { toByteArray() } returns SECOND_APP_SIGNATURE.toByteArray() },
+                    )
+                }
+            }
+
+            // First call with old signature fails
+            coEvery {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = DEFAULT_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            } returns DEFAULT_ASSET_LINKS_CHECK_RESPONSE.copy(linked = false).asSuccess()
+
+            // Second call with new signature succeeds
+            coEvery {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = SECOND_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            } returns DEFAULT_ASSET_LINKS_CHECK_RESPONSE.asSuccess()
+
+            val result = originManager.validateOrigin(
+                relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                callingAppInfo = mockAppInfoWithHistory,
+            )
+
+            // Verify both fingerprints were checked
+            coVerify(exactly = 1) {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = DEFAULT_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            }
+            coVerify(exactly = 1) {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = SECOND_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            }
+
+            assertEquals(
+                ValidateOriginResult.Success(null),
+                result,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return Success on first matching fingerprint from signing history`() =
+        runTest {
+            val customMessageDigest = mockk<MessageDigest> {
+                every { digest(DEFAULT_APP_SIGNATURE.toByteArray()) } returns DEFAULT_APP_SIGNATURE.toByteArray()
+                every { digest(SECOND_APP_SIGNATURE.toByteArray()) } returns SECOND_APP_SIGNATURE.toByteArray()
+            }
+            every { MessageDigest.getInstance(any()) } returns customMessageDigest
+
+            val mockAppInfoWithHistory = mockk<CallingAppInfo> {
+                every { isOriginPopulated() } returns false
+                every { packageName } returns DEFAULT_PACKAGE_NAME
+                every { signingInfo } returns mockk {
+                    every { hasMultipleSigners() } returns false
+                    every { signingCertificateHistory } returns arrayOf(
+                        mockk { every { toByteArray() } returns DEFAULT_APP_SIGNATURE.toByteArray() },
+                        mockk { every { toByteArray() } returns SECOND_APP_SIGNATURE.toByteArray() },
+                    )
+                }
+            }
+
+            // First call with old signature succeeds
+            coEvery {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = DEFAULT_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            } returns DEFAULT_ASSET_LINKS_CHECK_RESPONSE.asSuccess()
+
+            val result = originManager.validateOrigin(
+                relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                callingAppInfo = mockAppInfoWithHistory,
+            )
+
+            // Verify only the first fingerprint was checked (early return on success)
+            coVerify(exactly = 1) {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = DEFAULT_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            }
+            coVerify(exactly = 0) {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = SECOND_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            }
+
+            assertEquals(
+                ValidateOriginResult.Success(null),
+                result,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return AssetLinkNotFound when no fingerprints match from signing history`() =
+        runTest {
+            val customMessageDigest = mockk<MessageDigest> {
+                every { digest(DEFAULT_APP_SIGNATURE.toByteArray()) } returns DEFAULT_APP_SIGNATURE.toByteArray()
+                every { digest(SECOND_APP_SIGNATURE.toByteArray()) } returns SECOND_APP_SIGNATURE.toByteArray()
+            }
+            every { MessageDigest.getInstance(any()) } returns customMessageDigest
+
+            val mockAppInfoWithHistory = mockk<CallingAppInfo> {
+                every { isOriginPopulated() } returns false
+                every { packageName } returns DEFAULT_PACKAGE_NAME
+                every { signingInfo } returns mockk {
+                    every { hasMultipleSigners() } returns false
+                    every { signingCertificateHistory } returns arrayOf(
+                        mockk { every { toByteArray() } returns DEFAULT_APP_SIGNATURE.toByteArray() },
+                        mockk { every { toByteArray() } returns SECOND_APP_SIGNATURE.toByteArray() },
+                    )
+                }
+            }
+
+            // Both calls fail
+            coEvery {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = DEFAULT_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            } returns RuntimeException().asFailure()
+
+            coEvery {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = SECOND_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            } returns RuntimeException().asFailure()
+
+            val result = originManager.validateOrigin(
+                relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                callingAppInfo = mockAppInfoWithHistory,
+            )
+
+            // Verify both fingerprints were checked
+            coVerify(exactly = 1) {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = DEFAULT_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            }
+            coVerify(exactly = 1) {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    sourceWebSite = HTTPS_DEFAULT_RELYING_PARTY_ID,
+                    targetPackageName = DEFAULT_PACKAGE_NAME,
+                    targetCertificateFingerprint = SECOND_CERT_FINGERPRINT,
+                    relations = DELEGATE_PERMISSION_RELATIONS,
+                )
+            }
+
+            assertEquals(
+                ValidateOriginResult.Error.AssetLinkNotFound,
+                result,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validateOrigin should return PasskeyNotSupportedForApp when app has multiple signers`() =
+        runTest {
+            val mockAppInfoWithMultipleSigners = mockk<CallingAppInfo> {
+                every { isOriginPopulated() } returns false
+                every { packageName } returns DEFAULT_PACKAGE_NAME
+                every { signingInfo } returns mockk {
+                    every { hasMultipleSigners() } returns true
+                }
+            }
+
+            val result = originManager.validateOrigin(
+                relyingPartyId = DEFAULT_RELYING_PARTY_ID,
+                callingAppInfo = mockAppInfoWithMultipleSigners,
+            )
+
+            // Verify no asset link service calls were made
+            coVerify(exactly = 0) {
+                mockDigitalAssetLinkService.checkDigitalAssetLinksRelations(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            }
+
+            assertEquals(
+                ValidateOriginResult.Error.PasskeyNotSupportedForApp,
+                result,
+            )
+        }
 }
 
 private const val DEFAULT_PACKAGE_NAME = "com.x8bit.bitwarden"
 private const val DEFAULT_APP_SIGNATURE = "0987654321ABCDEF"
+private const val SECOND_APP_SIGNATURE = "FEDCBA9876543210"
 private const val DEFAULT_CERT_FINGERPRINT = "30:39:38:37:36:35:34:33:32:31:41:42:43:44:45:46"
+private const val SECOND_CERT_FINGERPRINT = "46:45:44:43:42:41:39:38:37:36:35:34:33:32:31:30"
 private const val DEFAULT_ORIGIN = "bitwarden.com"
 private const val DEFAULT_RELYING_PARTY_ID = "www.bitwarden.com"
 private const val GOOGLE_ALLOW_LIST_FILENAME = "fido2_privileged_google.json"
@@ -295,6 +533,8 @@ private const val FAIL_ALLOW_LIST = """
   ]
 }
 """
+private const val HTTPS_DEFAULT_RELYING_PARTY_ID = "https://$DEFAULT_RELYING_PARTY_ID"
+private val DELEGATE_PERMISSION_RELATIONS = listOf("delegate_permission/common.handle_all_urls")
 private val DEFAULT_ASSET_LINKS_CHECK_RESPONSE =
     DigitalAssetLinkCheckResponseJson(
         linked = true,


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-22479

## 📔 Objective

Added method to return signature from current certificate and past signing certificates from `signingCertificateHistory` when `hasMultipleSigners` returns false. 
Using it to validate AssetLinks as some .well-known might not have the most recent certificate.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
