### PR TITLE
PM-28492: Replace Authenticator Toasts with Snackbars

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -785,7 +785,7 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `FileChose should emit ShowToast`() = runTest {
+    fun `FileChose should update the state accordingly`() = runTest {
         val initialState = DEFAULT_STATE.copy(
             viewState = DEFAULT_VIEW_STATE.copy(
                 selectedType = AddEditSendState.ViewState.Content.SendType.File(
@@ -824,7 +824,7 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `ChooseFileClick should emit ShowToast`() = runTest {
+    fun `ChooseFileClick should emit ShowChooserSheet`() = runTest {
         val arePermissionsGranted = true
         val viewModel = createViewModel()
         viewModel.eventFlow.test {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -598,7 +598,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `ConfirmDeleteClick with DeleteCipherResult Success should emit ShowToast and NavigateBack`() =
+    fun `ConfirmDeleteClick with DeleteCipherResult Success should emit send snackbar event and NavigateBack`() =
         runTest {
             val cipherListView = createMockCipherListView(number = 1)
             val cipherView = createMockCipherView(number = 1)
@@ -1326,7 +1326,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `in add mode, createCipherInOrganization success should ShowToast and NavigateBack`() =
+    @Suppress("MaxLineLength")
+    fun `in add mode, createCipherInOrganization success should send snackbar event and NavigateBack`() =
         runTest {
             val stateWithName = createVaultAddItemState(
                 commonContentViewState = createCommonContentViewState(
@@ -1656,39 +1657,41 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `in edit mode, updateCipher success should ShowToast and NavigateBack`() = runTest {
-        val cipherView = createMockCipherListView(1)
-        val stateWithName = createVaultAddItemState(
-            vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID),
-            commonContentViewState = createCommonContentViewState(
-                name = "mockName-1",
-            ),
-        )
-
-        mutableVaultDataFlow.value = DataState.Loaded(createVaultData(cipherListView = cipherView))
-
-        val viewModel = createAddVaultItemViewModel(
-            createSavedStateHandleWithState(
-                state = stateWithName,
-                vaultAddEditType = VaultAddEditType.AddItem,
-                vaultItemCipherType = VaultItemCipherType.LOGIN,
-            ),
-        )
-
-        coEvery {
-            vaultRepository.updateCipher(any(), any())
-        } returns UpdateCipherResult.Success
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
-            assertEquals(VaultAddEditEvent.NavigateBack, awaitItem())
-        }
-        verify(exactly = 1) {
-            snackbarRelayManager.sendSnackbarData(
-                data = BitwardenSnackbarData(BitwardenString.item_updated.asText()),
-                relay = SnackbarRelay.CIPHER_UPDATED,
+    fun `in edit mode, updateCipher success should send snackbar event and NavigateBack`() =
+        runTest {
+            val cipherView = createMockCipherListView(1)
+            val stateWithName = createVaultAddItemState(
+                vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID),
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                ),
             )
+
+            mutableVaultDataFlow.value =
+                DataState.Loaded(createVaultData(cipherListView = cipherView))
+
+            val viewModel = createAddVaultItemViewModel(
+                createSavedStateHandleWithState(
+                    state = stateWithName,
+                    vaultAddEditType = VaultAddEditType.AddItem,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
+                ),
+            )
+
+            coEvery {
+                vaultRepository.updateCipher(any(), any())
+            } returns UpdateCipherResult.Success
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
+                assertEquals(VaultAddEditEvent.NavigateBack, awaitItem())
+            }
+            verify(exactly = 1) {
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.item_updated.asText()),
+                    relay = SnackbarRelay.CIPHER_UPDATED,
+                )
+            }
         }
-    }
 
     @Test
     fun `in add mode, SaveClick with no network connection error should show error dialog`() =

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
@@ -403,7 +403,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `ChooseFileClick should emit ShowToast`() = runTest {
+    fun `ChooseFileClick should emit ShowChooserSheet`() = runTest {
         val viewModel = createViewModel()
         viewModel.eventFlow.test {
             viewModel.trySendAction(AttachmentsAction.ChooseFileClick)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanViewModelTest.kt
@@ -62,7 +62,7 @@ class QrCodeScanViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `ManualEntryTextClick should emit ShowToast`() = runTest {
+    fun `ManualEntryTextClick should emit NavigateToManualCodeEntry`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.eventFlow.test {

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
@@ -1,6 +1,5 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.edititem
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,8 +17,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
@@ -67,24 +64,9 @@ fun EditItemScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
-    val context = LocalContext.current
-    val resources = LocalResources.current
-
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
-            EditItemEvent.NavigateBack -> {
-                onNavigateBack()
-            }
-
-            is EditItemEvent.ShowToast -> {
-                Toast
-                    .makeText(
-                        context,
-                        event.message(resources),
-                        Toast.LENGTH_LONG,
-                    )
-                    .show()
-            }
+            EditItemEvent.NavigateBack -> onNavigateBack()
         }
     }
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemViewModel.kt
@@ -13,10 +13,13 @@ import com.bitwarden.authenticator.data.authenticator.repository.model.CreateIte
 import com.bitwarden.authenticator.ui.authenticator.feature.edititem.EditItemState.Companion.MAX_ALLOWED_CODE_DIGITS
 import com.bitwarden.authenticator.ui.authenticator.feature.edititem.EditItemState.Companion.MIN_ALLOWED_CODE_DIGITS
 import com.bitwarden.authenticator.ui.authenticator.feature.edititem.model.EditItemData
+import com.bitwarden.authenticator.ui.platform.model.SnackbarRelay
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.takeUntilLoaded
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.isBase32
+import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
+import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -39,6 +42,7 @@ private const val KEY_STATE = "state"
 @HiltViewModel
 class EditItemViewModel @Inject constructor(
     private val authenticatorRepository: AuthenticatorRepository,
+    private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<EditItemState, EditItemEvent, EditItemAction>(
     initialState = savedStateHandle[KEY_STATE] ?: EditItemState(
@@ -233,7 +237,10 @@ class EditItemViewModel @Inject constructor(
             }
 
             CreateItemResult.Success -> {
-                sendEvent(EditItemEvent.ShowToast(BitwardenString.item_saved.asText()))
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(message = BitwardenString.item_saved.asText()),
+                    relay = SnackbarRelay.ITEM_SAVED,
+                )
                 sendEvent(EditItemEvent.NavigateBack)
             }
         }
@@ -446,11 +453,6 @@ sealed class EditItemEvent {
      * Navigates back.
      */
     data object NavigateBack : EditItemEvent()
-
-    /**
-     * Show a toast with the given [message].
-     */
-    data class ShowToast(val message: Text) : EditItemEvent()
 }
 
 /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -1,7 +1,6 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.itemlisting
 
 import android.Manifest
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -30,8 +29,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -96,8 +93,6 @@ fun ItemListingScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
-    val context = LocalContext.current
-    val resources = LocalResources.current
     val launcher = permissionsManager.getLauncher { isGranted ->
         if (isGranted) {
             viewModel.trySendAction(ItemListingAction.ScanQrCodeClick)
@@ -112,8 +107,8 @@ fun ItemListingScreen(
             is ItemListingEvent.NavigateToSearch -> onNavigateToSearch()
             is ItemListingEvent.NavigateToQrCodeScanner -> onNavigateToQrCodeScanner()
             is ItemListingEvent.NavigateToManualAddItem -> onNavigateToManualKeyEntry()
-            is ItemListingEvent.ShowToast -> {
-                Toast.makeText(context, event.message(resources), Toast.LENGTH_LONG).show()
+            is ItemListingEvent.ShowSnackbar -> {
+                snackbarHostState.showSnackbar(snackbarData = event.data)
             }
 
             is ItemListingEvent.NavigateToEditItem -> onNavigateToEditItemScreen(event.id)
@@ -133,10 +128,6 @@ fun ItemListingScreen(
 
             ItemListingEvent.NavigateToBitwardenSettings -> {
                 intentManager.startBitwardenAccountSettings()
-            }
-
-            is ItemListingEvent.ShowSnackbar -> {
-                snackbarHostState.showSnackbar(snackbarData = event.data)
             }
         }
     }
@@ -429,7 +420,7 @@ private fun ItemListingContent(
 
         when (state.sharedItems) {
             is SharedCodesDisplayState.Codes -> {
-                state.sharedItems.sections.forEachIndexed { index, section ->
+                state.sharedItems.sections.forEachIndexed { _, section ->
                     item(key = "sharedSection_${section.id}") {
                         AuthenticatorExpandingHeader(
                             label = section.label(),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -1,7 +1,6 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.manualcodeentry
 
 import android.Manifest
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,7 +22,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -75,18 +73,10 @@ fun ManualCodeEntryScreen(
         }
     }
 
-    val context = LocalContext.current
-
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             is ManualCodeEntryEvent.NavigateToAppSettings -> {
                 intentManager.startAppSettingsActivity()
-            }
-
-            is ManualCodeEntryEvent.ShowToast -> {
-                Toast
-                    .makeText(context, event.message.invoke(context.resources), Toast.LENGTH_SHORT)
-                    .show()
             }
 
             is ManualCodeEntryEvent.NavigateToQrCodeScreen -> {

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModel.kt
@@ -11,9 +11,12 @@ import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVer
 import com.bitwarden.authenticator.data.authenticator.repository.util.isSyncWithBitwardenEnabled
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
+import com.bitwarden.authenticator.ui.platform.model.SnackbarRelay
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.util.isBase32
+import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
+import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -36,6 +39,7 @@ class ManualCodeEntryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val authenticatorRepository: AuthenticatorRepository,
     private val authenticatorBridgeManager: AuthenticatorBridgeManager,
+    private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     settingsRepository: SettingsRepository,
 ) : BaseViewModel<ManualCodeEntryState, ManualCodeEntryEvent, ManualCodeEntryAction>(
     initialState = savedStateHandle[KEY_STATE]
@@ -157,14 +161,11 @@ class ManualCodeEntryViewModel @Inject constructor(
                     favorite = false,
                 ),
             )
-            sendEvent(
-                event = ManualCodeEntryEvent.ShowToast(
-                    message = BitwardenString.verification_code_added.asText(),
-                ),
+            snackbarRelayManager.sendSnackbarData(
+                data = BitwardenSnackbarData(BitwardenString.verification_code_added.asText()),
+                relay = SnackbarRelay.ITEM_ADDED,
             )
-            sendEvent(
-                event = ManualCodeEntryEvent.NavigateBack,
-            )
+            sendEvent(event = ManualCodeEntryEvent.NavigateBack)
         }
     }
 
@@ -283,11 +284,6 @@ sealed class ManualCodeEntryEvent {
      * Navigate to the app settings.
      */
     data object NavigateToAppSettings : ManualCodeEntryEvent()
-
-    /**
-     * Show a toast with the given [message].
-     */
-    data class ShowToast(val message: Text) : ManualCodeEntryEvent()
 }
 
 /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -62,6 +62,8 @@ import com.bitwarden.ui.platform.components.row.BitwardenExternalLinkRow
 import com.bitwarden.ui.platform.components.row.BitwardenPushRow
 import com.bitwarden.ui.platform.components.row.BitwardenTextRow
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
+import com.bitwarden.ui.platform.components.snackbar.model.rememberBitwardenSnackbarHostState
 import com.bitwarden.ui.platform.components.toggle.BitwardenSwitch
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.composition.LocalIntentManager
@@ -91,7 +93,7 @@ fun SettingsScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-
+    val snackbarState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             SettingsEvent.NavigateToTutorial -> onNavigateToTutorial()
@@ -116,7 +118,6 @@ fun SettingsScreen(
             }
 
             SettingsEvent.NavigateToBitwardenApp -> {
-
                 intentManager.startActivity(
                     Intent(
                         Intent.ACTION_VIEW,
@@ -132,6 +133,8 @@ fun SettingsScreen(
                     "https://play.google.com/store/apps/details?id=com.x8bit.bitwarden".toUri(),
                 )
             }
+
+            is SettingsEvent.ShowSnackbar -> snackbarState.showSnackbar(event.data)
         }
     }
 
@@ -154,6 +157,7 @@ fun SettingsScreen(
                 scrollBehavior = scrollBehavior,
             )
         },
+        snackbarHost = { BitwardenSnackbarHost(bitwardenHostState = snackbarState) },
     ) {
         Column(
             modifier = Modifier

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
@@ -1,7 +1,6 @@
 package com.bitwarden.authenticator.ui.platform.feature.settings.export
 
 import android.net.Uri
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,7 +19,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -40,6 +38,9 @@ import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
+import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
+import com.bitwarden.ui.platform.components.snackbar.model.rememberBitwardenSnackbarHostState
 import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
@@ -58,7 +59,6 @@ fun ExportScreen(
     onNavigateBack: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     val exportLocationReceive: (Uri) -> Unit = remember {
         {
             viewModel.trySendAction(ExportAction.ExportLocationReceive(it))
@@ -69,12 +69,12 @@ fun ExportScreen(
             exportLocationReceive.invoke(it.uri)
         }
     }
-
+    val snackbarState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             ExportEvent.NavigateBack -> onNavigateBack()
-            is ExportEvent.ShowToast -> {
-                Toast.makeText(context, event.message(context.resources), Toast.LENGTH_SHORT).show()
+            is ExportEvent.ShowSnackBar -> {
+                snackbarState.showSnackbar(BitwardenSnackbarData(message = event.message))
             }
 
             is ExportEvent.NavigateToSelectExportDestination -> {
@@ -148,6 +148,7 @@ fun ExportScreen(
                 },
             )
         },
+        snackbarHost = { BitwardenSnackbarHost(snackbarState) },
     ) {
         ExportScreenContent(
             modifier = Modifier.fillMaxSize(),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportViewModel.kt
@@ -129,7 +129,7 @@ class ExportViewModel @Inject constructor(
 
             is ExportDataResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(ExportEvent.ShowToast(BitwardenString.export_success.asText()))
+                sendEvent(ExportEvent.ShowSnackBar(BitwardenString.export_success.asText()))
             }
         }
     }
@@ -175,9 +175,9 @@ sealed class ExportEvent {
     data object NavigateBack : ExportEvent()
 
     /**
-     * Display a toast with the provided [message].
+     * Display a Snackbar with the provided [message].
      */
-    data class ShowToast(val message: Text) : ExportEvent()
+    data class ShowSnackBar(val message: Text) : ExportEvent()
 
     /**
      * Navigate to the select export destination screen.

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
@@ -1,6 +1,5 @@
 package com.bitwarden.authenticator.ui.platform.feature.settings.importing
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,7 +16,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -67,7 +65,6 @@ fun ImportingScreen(
         }
     }
 
-    val context = LocalContext.current
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             ImportEvent.NavigateBack -> onNavigateBack()
@@ -78,12 +75,6 @@ fun ImportingScreen(
                         mimeType = event.importFileFormat.mimeType,
                     ),
                 )
-            }
-
-            is ImportEvent.ShowToast -> {
-                Toast
-                    .makeText(context, event.message(context.resources), Toast.LENGTH_SHORT)
-                    .show()
             }
         }
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingViewModel.kt
@@ -5,7 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.authenticator.data.authenticator.repository.AuthenticatorRepository
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportDataResult
 import com.bitwarden.authenticator.data.platform.manager.imports.model.ImportFileFormat
+import com.bitwarden.authenticator.ui.platform.model.SnackbarRelay
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
+import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.bitwarden.ui.platform.model.FileData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
@@ -22,10 +25,10 @@ import javax.inject.Inject
 @HiltViewModel
 class ImportingViewModel @Inject constructor(
     private val authenticatorRepository: AuthenticatorRepository,
-) :
-    BaseViewModel<ImportState, ImportEvent, ImportAction>(
-        initialState = ImportState(importFileFormat = ImportFileFormat.BITWARDEN_JSON),
-    ) {
+    private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
+) : BaseViewModel<ImportState, ImportEvent, ImportAction>(
+    initialState = ImportState(importFileFormat = ImportFileFormat.BITWARDEN_JSON),
+) {
 
     override fun handleAction(action: ImportAction) {
         when (action) {
@@ -110,10 +113,9 @@ class ImportingViewModel @Inject constructor(
 
             ImportDataResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(
-                    ImportEvent.ShowToast(
-                        message = BitwardenString.import_success.asText(),
-                    ),
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(message = BitwardenString.import_success.asText()),
+                    relay = SnackbarRelay.IMPORT_SUCCESS,
                 )
                 sendEvent(ImportEvent.NavigateBack)
             }
@@ -162,11 +164,6 @@ sealed class ImportEvent {
      * Navigate back to the previous screen.
      */
     data object NavigateBack : ImportEvent()
-
-    /**
-     * Show a Toast with the given [message].
-     */
-    data class ShowToast(val message: Text) : ImportEvent()
 
     /**
      * Navigate to the select import file screen.

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/di/PlatformUiManagerModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/di/PlatformUiManagerModule.kt
@@ -1,0 +1,26 @@
+package com.bitwarden.authenticator.ui.platform.manager.di
+
+import com.bitwarden.authenticator.ui.platform.model.SnackbarRelay
+import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
+import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
+import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManagerImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Provides UI-based managers in the platform package.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+class PlatformUiManagerModule {
+    @Provides
+    @Singleton
+    fun provideSnackbarRelayManager(
+        dispatcherManager: DispatcherManager,
+    ): SnackbarRelayManager<SnackbarRelay> = SnackbarRelayManagerImpl(
+        dispatcherManager = dispatcherManager,
+    )
+}

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/model/SnackbarRelay.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/model/SnackbarRelay.kt
@@ -1,0 +1,15 @@
+package com.bitwarden.authenticator.ui.platform.model
+
+import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a relay key to be mapped to an instance of [BitwardenSnackbarData] being sent
+ * between producers and consumers of the data.
+ */
+@Serializable
+enum class SnackbarRelay {
+    IMPORT_SUCCESS,
+    ITEM_ADDED,
+    ITEM_SAVED,
+}

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreenTest.kt
@@ -82,7 +82,7 @@ class ManualCodeEntryScreenTest : AuthenticatorComposeTest() {
     }
 
     @Test
-    fun `on Close click should emit `() {
+    fun `on Close click should emit CloseClick`() {
         composeTestRule
             .onNodeWithContentDescription(label = "Close")
             .performClick()

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryViewModelTest.kt
@@ -9,15 +9,20 @@ import com.bitwarden.authenticator.data.authenticator.repository.model.CreateIte
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticator.ui.platform.feature.settings.data.model.DefaultSaveOption
+import com.bitwarden.authenticator.ui.platform.model.SnackbarRelay
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
+import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,6 +43,9 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
         every { defaultSaveOption } returns DefaultSaveOption.NONE
     }
     private val mockAuthenticatorBridgeManager = mockk<AuthenticatorBridgeManager>()
+    private val snackbarRelayManager = mockk<SnackbarRelayManager<SnackbarRelay>> {
+        every { sendSnackbarData(data = any(), relay = SnackbarRelay.ITEM_ADDED) } just runs
+    }
 
     @BeforeEach
     fun setUp() {
@@ -191,12 +199,14 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
             }
             viewModel.eventFlow.test {
                 assertEquals(
-                    ManualCodeEntryEvent.ShowToast(BitwardenString.verification_code_added.asText()),
-                    awaitItem(),
-                )
-                assertEquals(
                     ManualCodeEntryEvent.NavigateBack,
                     awaitItem(),
+                )
+            }
+            verify(exactly = 1) {
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.verification_code_added.asText()),
+                    relay = SnackbarRelay.ITEM_ADDED,
                 )
             }
         }
@@ -434,6 +444,7 @@ class ManualCodeEntryViewModelTest : BaseViewModelTest() {
             authenticatorRepository = mockAuthenticatorRepository,
             authenticatorBridgeManager = mockAuthenticatorBridgeManager,
             settingsRepository = mockSettingRepository,
+            snackbarRelayManager = snackbarRelayManager,
         )
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28492](https://bitwarden.atlassian.net/browse/PM-28492)

## 📔 Objective

This PR replaces all the toasts in the Authenticator app with Snackbars.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/77999ab7-566b-4ce7-8154-e82c6be117b8" width="400" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28492]: https://bitwarden.atlassian.net/browse/PM-28492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ