### PR TITLE
[PM-21391] Remove debug credential provider configuration

### DIFF
--- a/app/src/debug/res/xml/provider.xml
+++ b/app/src/debug/res/xml/provider.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<credential-provider>
-    <capabilities>
-        <capability name="android.credentials.TYPE_PASSWORD_CREDENTIAL" />
-        <capability name="androidx.credentials.TYPE_PUBLIC_KEY_CREDENTIAL" />
-    </capabilities>
-</credential-provider>

--- a/app/src/main/res/xml/provider.xml
+++ b/app/src/main/res/xml/provider.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <credential-provider>
     <capabilities>
+        <capability name="android.credentials.TYPE_PASSWORD_CREDENTIAL" />
         <capability name="androidx.credentials.TYPE_PUBLIC_KEY_CREDENTIAL" />
     </capabilities>
 </credential-provider>


### PR DESCRIPTION
## 🎟️ Tracking

PM-21391

## 📔 Objective

This PR consolidates credential provider configuration by removing the debug-specific `provider.xml` and adding password credential support to the main provider configuration.

Previously, the debug build variant had a separate credential provider configuration that declared support for both `TYPE_PASSWORD_CREDENTIAL` and `TYPE_PUBLIC_KEY_CREDENTIAL`. This PR removes that debug-specific file and adds the `TYPE_PASSWORD_CREDENTIAL` capability to the main `provider.xml`, ensuring consistent credential provider capabilities across all build variants.

**Changes:**
- Removed `app/src/debug/res/xml/provider.xml`
- Added `TYPE_PASSWORD_CREDENTIAL` capability to `app/src/main/res/xml/provider.xml`

This enables the Credential Manager to register for password credential creation requests in all build configurations, not just debug builds.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
