### PR TITLE
[PM-27816] Not clearing the fingerprint on requests that don't return fingerprint on LoginWithDevice

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModel.kt
@@ -99,13 +99,11 @@ class LoginWithDeviceViewModel @Inject constructor(
     ) {
         when (val result = action.result) {
             is CreateAuthRequestResult.Success -> {
+                updateContent { content ->
+                    content.copy(isResendNotificationLoading = false)
+                }
                 mutableStateFlow.update {
                     it.copy(
-                        viewState = LoginWithDeviceState.ViewState.Content(
-                            loginWithDeviceType = it.loginWithDeviceType,
-                            fingerprintPhrase = "",
-                            isResendNotificationLoading = false,
-                        ),
                         dialogState = null,
                         loginData = LoginWithDeviceState.LoginData(
                             accessCode = result.accessCode,
@@ -133,13 +131,11 @@ class LoginWithDeviceViewModel @Inject constructor(
             }
 
             is CreateAuthRequestResult.Error -> {
+                updateContent { content ->
+                    content.copy(isResendNotificationLoading = false)
+                }
                 mutableStateFlow.update {
                     it.copy(
-                        viewState = LoginWithDeviceState.ViewState.Content(
-                            loginWithDeviceType = it.loginWithDeviceType,
-                            fingerprintPhrase = "",
-                            isResendNotificationLoading = false,
-                        ),
                         dialogState = LoginWithDeviceState.DialogState.Error(
                             title = BitwardenString.an_error_has_occurred.asText(),
                             message = BitwardenString.generic_error_message.asText(),
@@ -153,13 +149,11 @@ class LoginWithDeviceViewModel @Inject constructor(
             CreateAuthRequestResult.Declined -> Unit
 
             CreateAuthRequestResult.Expired -> {
+                updateContent { content ->
+                    content.copy(isResendNotificationLoading = false)
+                }
                 mutableStateFlow.update {
                     it.copy(
-                        viewState = LoginWithDeviceState.ViewState.Content(
-                            loginWithDeviceType = it.loginWithDeviceType,
-                            fingerprintPhrase = "",
-                            isResendNotificationLoading = false,
-                        ),
                         dialogState = LoginWithDeviceState.DialogState.Error(
                             title = null,
                             message = BitwardenString.login_request_has_already_expired.asText(),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceViewModelTest.kt
@@ -191,7 +191,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_STATE.copy(
                         viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                            fingerprintPhrase = "",
+                            fingerprintPhrase = FINGERPRINT,
                         ),
                         loginData = DEFAULT_LOGIN_DATA,
                         dialogState = LoginWithDeviceState.DialogState.Loading(
@@ -203,7 +203,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_STATE.copy(
                         viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                            fingerprintPhrase = "",
+                            fingerprintPhrase = FINGERPRINT,
                         ),
                         dialogState = null,
                         loginData = DEFAULT_LOGIN_DATA,
@@ -261,7 +261,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     initialState.copy(
                         viewState = initialViewState.copy(
-                            fingerprintPhrase = "",
+                            fingerprintPhrase = FINGERPRINT,
                         ),
                         dialogState = LoginWithDeviceState.DialogState.Loading(
                             message = BitwardenString.logging_in.asText(),
@@ -273,7 +273,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     initialState.copy(
                         viewState = initialViewState.copy(
-                            fingerprintPhrase = "",
+                            fingerprintPhrase = FINGERPRINT,
                         ),
                         dialogState = null,
                         loginData = DEFAULT_LOGIN_DATA,
@@ -365,7 +365,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     assertEquals(
                         DEFAULT_STATE.copy(
                             viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                                fingerprintPhrase = "",
+                                fingerprintPhrase = FINGERPRINT,
                             ),
                             loginData = DEFAULT_LOGIN_DATA,
                             dialogState = LoginWithDeviceState.DialogState.Loading(
@@ -377,7 +377,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     assertEquals(
                         DEFAULT_STATE.copy(
                             viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                                fingerprintPhrase = "",
+                                fingerprintPhrase = FINGERPRINT,
                             ),
                             dialogState = LoginWithDeviceState.DialogState.Error(
                                 title = BitwardenString.an_error_has_occurred.asText(),
@@ -431,7 +431,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     assertEquals(
                         DEFAULT_STATE.copy(
                             viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                                fingerprintPhrase = "",
+                                fingerprintPhrase = FINGERPRINT,
                             ),
                             loginData = DEFAULT_LOGIN_DATA,
                             dialogState = LoginWithDeviceState.DialogState.Loading(
@@ -443,7 +443,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     assertEquals(
                         DEFAULT_STATE.copy(
                             viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                                fingerprintPhrase = "",
+                                fingerprintPhrase = FINGERPRINT,
                             ),
                             dialogState = LoginWithDeviceState.DialogState.Error(
                                 title = BitwardenString.an_error_has_occurred.asText(),
@@ -496,7 +496,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     assertEquals(
                         DEFAULT_STATE.copy(
                             viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                                fingerprintPhrase = "",
+                                fingerprintPhrase = FINGERPRINT,
                             ),
                             loginData = DEFAULT_LOGIN_DATA,
                             dialogState = LoginWithDeviceState.DialogState.Loading(
@@ -508,7 +508,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     assertEquals(
                         DEFAULT_STATE.copy(
                             viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                                fingerprintPhrase = "",
+                                fingerprintPhrase = FINGERPRINT,
                             ),
                             dialogState = LoginWithDeviceState.DialogState.Error(
                                 title = BitwardenString.an_error_has_occurred.asText(),
@@ -561,7 +561,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     assertEquals(
                         DEFAULT_STATE.copy(
                             viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                                fingerprintPhrase = "",
+                                fingerprintPhrase = FINGERPRINT,
                             ),
                             loginData = DEFAULT_LOGIN_DATA,
                             dialogState = LoginWithDeviceState.DialogState.Loading(
@@ -573,7 +573,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
                     assertEquals(
                         DEFAULT_STATE.copy(
                             viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                                fingerprintPhrase = "",
+                                fingerprintPhrase = FINGERPRINT,
                             ),
                             dialogState = LoginWithDeviceState.DialogState.Error(
                                 title = BitwardenString.an_error_has_occurred.asText(),
@@ -609,7 +609,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
         assertEquals(
             DEFAULT_STATE.copy(
                 viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                    fingerprintPhrase = "",
+                    fingerprintPhrase = FINGERPRINT,
                     isResendNotificationLoading = false,
                 ),
                 dialogState = LoginWithDeviceState.DialogState.Error(
@@ -660,7 +660,7 @@ class LoginWithDeviceViewModelTest : BaseViewModelTest() {
         assertEquals(
             DEFAULT_STATE.copy(
                 viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
-                    fingerprintPhrase = "",
+                    fingerprintPhrase = FINGERPRINT,
                     isResendNotificationLoading = false,
                 ),
                 dialogState = LoginWithDeviceState.DialogState.Error(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27816

## 📔 Objective

Fingerprint should not be cleared when an error is thrown

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
