### PR TITLE
PM-28545: Remove the compatibility mode toggle from the Autofill screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/parser/AutofillParserImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/parser/AutofillParserImpl.kt
@@ -93,7 +93,6 @@ class AutofillParserImpl(
         val urlBarWebsite = traversalDataList
             .flatMap { it.urlBarWebsites }
             .firstOrNull()
-            ?.takeIf { settingsRepository.isAutofillWebDomainCompatMode }
 
         // Take only the autofill views from the node that currently has focus.
         // Then remove all the fields that cannot be filled with data.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -111,11 +111,6 @@ interface SettingsDiskSource {
     var browserAutofillDialogReshowTime: Instant?
 
     /**
-     * The current status of whether the web domain compatibility mode is enabled.
-     */
-    var isAutofillWebDomainCompatMode: Boolean?
-
-    /**
      * Clears all the settings data for the given user.
      */
     fun clearData(userId: String)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -50,7 +50,6 @@ private const val RESUME_SCREEN = "resumeScreen"
 private const val FLIGHT_RECORDER_KEY = "flightRecorderData"
 private const val IS_DYNAMIC_COLORS_ENABLED = "isDynamicColorsEnabled"
 private const val BROWSER_AUTOFILL_DIALOG_RESHOW_TIME = "browserAutofillDialogReshowTime"
-private const val AUTOFILL_WEB_DOMAIN_COMPATIBILITY = "autofillWebDomainCompatibility"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -233,12 +232,6 @@ class SettingsDiskSourceImpl(
         get() = getLong(key = BROWSER_AUTOFILL_DIALOG_RESHOW_TIME)?.let { Instant.ofEpochMilli(it) }
         set(value) {
             putLong(key = BROWSER_AUTOFILL_DIALOG_RESHOW_TIME, value = value?.toEpochMilli())
-        }
-
-    override var isAutofillWebDomainCompatMode: Boolean?
-        get() = getBoolean(key = AUTOFILL_WEB_DOMAIN_COMPATIBILITY)
-        set(value) {
-            putBoolean(key = AUTOFILL_WEB_DOMAIN_COMPATIBILITY, value = value)
         }
 
     override fun clearData(userId: String) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -156,11 +156,6 @@ interface SettingsRepository : FlightRecorderManager {
     var isAutofillSavePromptDisabled: Boolean
 
     /**
-     * Whether or not the autofill web domain parsing is enabled.
-     */
-    var isAutofillWebDomainCompatMode: Boolean
-
-    /**
      * A list of blocked autofill URI's for the current user.
      */
     var blockedAutofillUris: List<String>

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -338,12 +338,6 @@ class SettingsRepositoryImpl(
             )
         }
 
-    override var isAutofillWebDomainCompatMode: Boolean
-        get() = settingsDiskSource.isAutofillWebDomainCompatMode ?: false
-        set(value) {
-            settingsDiskSource.isAutofillWebDomainCompatMode = value
-        }
-
     override var blockedAutofillUris: List<String>
         get() = activeUserId
             ?.let { settingsDiskSource.getBlockedAutofillUris(userId = it) }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -32,9 +32,6 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.CustomAccessibilityAction
-import androidx.compose.ui.semantics.customActions
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -135,13 +132,6 @@ fun AutoFillScreen(
 
             AutoFillEvent.NavigateToLearnMore -> {
                 intentManager.launchUri("https://bitwarden.com/help/uri-match-detection/".toUri())
-            }
-
-            AutoFillEvent.NavigateToCompatibilityModeLearnMore -> {
-                intentManager.launchUri(
-                    uri = "https://bitwarden.com/help/auto-fill-android/#compatibility-mode"
-                        .toUri(),
-                )
             }
 
             AutoFillEvent.NavigateToAutofillHelp -> {
@@ -255,20 +245,6 @@ private fun AutoFillScreenContent(
             }
         }
 
-        AnimatedVisibility(visible = state.isAutoFillServicesEnabled) {
-            Column {
-                WebDomainCompatibilityModeRow(
-                    isChecked = state.isWebDomainCompatModeEnabled,
-                    onToggle = autoFillHandlers.onWebDomainCompatModeToggled,
-                    onLearnMoreClick = autoFillHandlers.onWebDomainModeCompatLearnMoreClick,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .standardHorizontalMargin(),
-                )
-                Spacer(modifier = Modifier.height(height = 8.dp))
-            }
-        }
-
         if (state.showPasskeyManagementRow) {
             BitwardenExternalLinkRow(
                 text = stringResource(id = BitwardenString.passkey_management),
@@ -368,76 +344,6 @@ private fun AutoFillScreenContent(
         Spacer(modifier = Modifier.height(height = 16.dp))
         Spacer(modifier = Modifier.navigationBarsPadding())
     }
-}
-
-@Suppress("LongMethod")
-@Composable
-private fun WebDomainCompatibilityModeRow(
-    isChecked: Boolean,
-    onToggle: (isEnabled: Boolean) -> Unit,
-    onLearnMoreClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var showConfirmationDialog by rememberSaveable { mutableStateOf(false) }
-    if (showConfirmationDialog) {
-        BitwardenTwoButtonDialog(
-            title = stringResource(id = BitwardenString.warning),
-            message = stringResource(id = BitwardenString.compatibility_mode_warning),
-            confirmButtonText = stringResource(id = BitwardenString.accept),
-            dismissButtonText = stringResource(id = BitwardenString.cancel),
-            onConfirmClick = {
-                onToggle(true)
-                showConfirmationDialog = false
-            },
-            onDismissClick = { showConfirmationDialog = false },
-            onDismissRequest = { showConfirmationDialog = false },
-        )
-    }
-
-    BitwardenSwitch(
-        label = stringResource(id = BitwardenString.use_compatibility_mode_for_browser_autofill),
-        isChecked = isChecked,
-        onCheckedChange = {
-            if (isChecked) {
-                onToggle(false)
-            } else {
-                showConfirmationDialog = true
-            }
-        },
-        cardStyle = CardStyle.Full,
-        modifier = modifier,
-        supportingContent = {
-            val learnMore = stringResource(id = BitwardenString.learn_more)
-            Text(
-                text = annotatedStringResource(
-                    id = BitwardenString
-                        .use_a_less_secure_autofill_method_compatible_with_more_browsers,
-                    style = spanStyleOf(
-                        textStyle = BitwardenTheme.typography.bodyMedium,
-                        color = BitwardenTheme.colorScheme.text.secondary,
-                    ),
-                    onAnnotationClick = {
-                        when (it) {
-                            "learnMore" -> onLearnMoreClick()
-                        }
-                    },
-                ),
-                style = BitwardenTheme.typography.bodyMedium,
-                color = BitwardenTheme.colorScheme.text.secondary,
-                modifier = Modifier.semantics {
-                    customActions = listOf(
-                        CustomAccessibilityAction(
-                            label = learnMore,
-                            action = {
-                                onLearnMoreClick()
-                                true
-                            },
-                        ),
-                    )
-                },
-            )
-        },
-    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModel.kt
@@ -69,7 +69,6 @@ class AutoFillViewModel @Inject constructor(
                 browserAutofillSettingsOptions = browserThirdPartyAutofillEnabledManager
                     .browserThirdPartyAutofillStatus
                     .toBrowserAutoFillSettingsOptions(),
-                isWebDomainCompatModeEnabled = settingsRepository.isAutofillWebDomainCompatMode,
             )
         },
 ) {
@@ -135,10 +134,6 @@ class AutoFillViewModel @Inject constructor(
         AutoFillAction.PrivilegedAppsClick -> handlePrivilegedAppsClick()
         AutoFillAction.LearnMoreClick -> handleLearnMoreClick()
         AutoFillAction.HelpCardClick -> handleHelpCardClick()
-        is AutoFillAction.WebDomainModeCompatToggle -> handleWebDomainModeCompatToggle(action)
-        AutoFillAction.WebDomainModeCompatLearnMoreClick -> {
-            handleNavigateToCompatibilityModeLearnMore()
-        }
     }
 
     private fun handlePrivilegedAppsClick() {
@@ -151,15 +146,6 @@ class AutoFillViewModel @Inject constructor(
 
     private fun handleHelpCardClick() {
         sendEvent(AutoFillEvent.NavigateToAutofillHelp)
-    }
-
-    private fun handleNavigateToCompatibilityModeLearnMore() {
-        sendEvent(AutoFillEvent.NavigateToCompatibilityModeLearnMore)
-    }
-
-    private fun handleWebDomainModeCompatToggle(action: AutoFillAction.WebDomainModeCompatToggle) {
-        settingsRepository.isAutofillWebDomainCompatMode = action.isEnabled
-        mutableStateFlow.update { it.copy(isWebDomainCompatModeEnabled = action.isEnabled) }
     }
 
     private fun handleInternalAction(action: AutoFillAction.Internal) {
@@ -319,7 +305,6 @@ data class AutoFillState(
     val showBrowserAutofillActionCard: Boolean,
     val activeUserId: String,
     val browserAutofillSettingsOptions: ImmutableList<BrowserAutofillSettingsOption>,
-    val isWebDomainCompatModeEnabled: Boolean,
 ) : Parcelable {
     /**
      * Indicates which call-to-action that should be displayed.
@@ -434,11 +419,6 @@ sealed class AutoFillEvent {
     data object NavigateToLearnMore : AutoFillEvent()
 
     /**
-     * Navigate to the web domain learn more site.
-     */
-    data object NavigateToCompatibilityModeLearnMore : AutoFillEvent()
-
-    /**
      * Navigate to the autofill help page.
      */
     data object NavigateToAutofillHelp : AutoFillEvent()
@@ -547,16 +527,6 @@ sealed class AutoFillAction {
      * User has clicked the help CTA.
      */
     data object HelpCardClick : AutoFillAction()
-
-    /**
-     * User has clicked to learn more about compatibility mode.
-     */
-    data object WebDomainModeCompatLearnMoreClick : AutoFillAction()
-
-    /**
-     * User has changed their compatibility setting.
-     */
-    data class WebDomainModeCompatToggle(val isEnabled: Boolean) : AutoFillAction()
 
     /**
      * Internal actions.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/handlers/AutoFillHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/handlers/AutoFillHandlers.kt
@@ -29,8 +29,6 @@ class AutoFillHandlers(
     val onBlockAutoFillClick: () -> Unit,
     val onLearnMoreClick: () -> Unit,
     val onHelpCardClick: () -> Unit,
-    val onWebDomainCompatModeToggled: (isEnabled: Boolean) -> Unit,
-    val onWebDomainModeCompatLearnMoreClick: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -86,12 +84,6 @@ class AutoFillHandlers(
             onBlockAutoFillClick = { viewModel.trySendAction(AutoFillAction.BlockAutoFillClick) },
             onLearnMoreClick = { viewModel.trySendAction(AutoFillAction.LearnMoreClick) },
             onHelpCardClick = { viewModel.trySendAction(AutoFillAction.HelpCardClick) },
-            onWebDomainCompatModeToggled = {
-                viewModel.trySendAction(AutoFillAction.WebDomainModeCompatToggle(it))
-            },
-            onWebDomainModeCompatLearnMoreClick = {
-                viewModel.trySendAction(AutoFillAction.WebDomainModeCompatLearnMoreClick)
-            },
         )
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -1258,23 +1258,6 @@ class SettingsDiskSourceTest {
     }
 
     @Test
-    fun `isAutofillWebDomainCompatMode should update SharedPreferences`() {
-        val autofillWebDomainCompatKey = "bwPreferencesStorage:autofillWebDomainCompatibility"
-        settingsDiskSource.isAutofillWebDomainCompatMode = true
-        assertTrue(fakeSharedPreferences.getBoolean(autofillWebDomainCompatKey, false))
-    }
-
-    @Test
-    fun `isAutofillWebDomainCompatMode should pull value from shared preferences`() {
-        val autofillWebDomainCompatKey = "bwPreferencesStorage:autofillWebDomainCompatibility"
-        fakeSharedPreferences.edit {
-            putBoolean(autofillWebDomainCompatKey, true)
-        }
-
-        assertTrue(settingsDiskSource.isAutofillWebDomainCompatMode!!)
-    }
-
-    @Test
     fun `storeShowUnlockSettingBadge should update SharedPreferences`() {
         val mockUserId = "mockUserId"
         val showUnlockSettingBadgeKey =

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -89,7 +89,6 @@ class FakeSettingsDiskSource : SettingsDiskSource {
     private var storedFlightRecorderData: FlightRecorderDataSet? = null
     private var storedIsDynamicColorsEnabled: Boolean? = null
     private var storedBrowserAutofillDialogReshowTime: Instant? = null
-    private var storedIsAutofillWebDomainCompatMode: Boolean? = null
 
     private val mutableShowAutoFillSettingBadgeFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
@@ -216,12 +215,6 @@ class FakeSettingsDiskSource : SettingsDiskSource {
         get() = storedBrowserAutofillDialogReshowTime
         set(value) {
             storedBrowserAutofillDialogReshowTime = value
-        }
-
-    override var isAutofillWebDomainCompatMode: Boolean?
-        get() = storedIsAutofillWebDomainCompatMode
-        set(value) {
-            storedIsAutofillWebDomainCompatMode = value
         }
 
     override fun getAccountBiometricIntegrityValidity(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -714,19 +714,6 @@ class SettingsRepositoryTest {
     }
 
     @Test
-    fun `isAutofillWebDomainCompatMode should pull from and update SettingsDiskSource`() {
-        assertFalse(settingsRepository.isAutofillWebDomainCompatMode)
-
-        // Updates to the disk source change the repository value.
-        fakeSettingsDiskSource.isAutofillWebDomainCompatMode = true
-        assertTrue(settingsRepository.isAutofillWebDomainCompatMode)
-
-        // Updates to the repository change the disk source value
-        settingsRepository.isAutofillWebDomainCompatMode = false
-        assertFalse(fakeSettingsDiskSource.isAutofillWebDomainCompatMode!!)
-    }
-
-    @Test
     fun `blockedAutofillUris should pull from and update SettingsDiskSource`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         assertEquals(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreenTest.kt
@@ -18,7 +18,6 @@ import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.manager.util.startSystemAccessibilitySettingsActivity
 import com.bitwarden.ui.platform.manager.util.startSystemAutofillSettingsActivity
 import com.bitwarden.ui.util.assertNoDialogExists
-import com.bitwarden.ui.util.performCustomAccessibilityAction
 import com.x8bit.bitwarden.data.autofill.model.browser.BrowserPackage
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
@@ -867,86 +866,6 @@ class AutoFillScreenTest : BitwardenComposeTest() {
             intentManager.launchUri("https://bitwarden.com/help/uri-match-detection/".toUri())
         }
     }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `on NavigateToCompatibilityModeLearnMore should launch the browser to the autofill help page`() {
-        mutableEventFlow.tryEmit(AutoFillEvent.NavigateToCompatibilityModeLearnMore)
-        verify(exactly = 1) {
-            intentManager.launchUri(
-                uri = "https://bitwarden.com/help/auto-fill-android/#compatibility-mode".toUri(),
-            )
-        }
-    }
-
-    @Test
-    fun `on web domain compatibility mode click should display confirmation dialog`() {
-        mutableStateFlow.update { it.copy(isAutoFillServicesEnabled = true) }
-        composeTestRule.assertNoDialogExists()
-        composeTestRule
-            .onNodeWithText(text = "Use compatibility mode for browser autofill")
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText(text = "Warning")
-            .assert(hasAnyAncestor(isDialog()))
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun `on web domain compatibility mode dialog Cancel click should close dialog`() {
-        mutableStateFlow.update { it.copy(isAutoFillServicesEnabled = true) }
-        composeTestRule.assertNoDialogExists()
-        composeTestRule
-            .onNodeWithText(text = "Use compatibility mode for browser autofill")
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText(text = "Cancel")
-            .assert(hasAnyAncestor(isDialog()))
-            .performClick()
-
-        composeTestRule.assertNoDialogExists()
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `on web domain compatibility mode dialog Accept click should close dialog and send event`() {
-        mutableStateFlow.update { it.copy(isAutoFillServicesEnabled = true) }
-        composeTestRule.assertNoDialogExists()
-        composeTestRule
-            .onNodeWithText(text = "Use compatibility mode for browser autofill")
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule
-            .onNodeWithText(text = "Accept")
-            .assert(hasAnyAncestor(isDialog()))
-            .performClick()
-
-        verify(exactly = 1) {
-            viewModel.trySendAction(AutoFillAction.WebDomainModeCompatToggle(true))
-        }
-        composeTestRule.assertNoDialogExists()
-    }
-
-    @Test
-    fun `on learn more about compatibility mode should send WebDomainModeLearnMoreClick`() {
-        mutableStateFlow.update { it.copy(isAutoFillServicesEnabled = true) }
-        composeTestRule
-            .onNodeWithText(
-                text = "Uses a less secure autofill method compatible with more " +
-                    "browsers.\nLearn more about compatibility mode",
-            )
-            .performScrollTo()
-            .performCustomAccessibilityAction(label = "Learn more")
-
-        verify(exactly = 1) {
-            viewModel.trySendAction(AutoFillAction.WebDomainModeCompatLearnMoreClick)
-        }
-    }
 }
 
 private val DEFAULT_STATE: AutoFillState = AutoFillState(
@@ -962,5 +881,4 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     showBrowserAutofillActionCard = false,
     activeUserId = "activeUserId",
     browserAutofillSettingsOptions = persistentListOf(),
-    isWebDomainCompatModeEnabled = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -67,8 +67,6 @@ class AutoFillViewModelTest : BaseViewModelTest() {
         every { isAccessibilityEnabledStateFlow } returns mutableIsAccessibilityEnabledStateFlow
         every { isAutofillEnabledStateFlow } returns mutableIsAutofillEnabledStateFlow
         every { disableAutofill() } just runs
-        every { isAutofillWebDomainCompatMode = any() } just runs
-        every { isAutofillWebDomainCompatMode } returns false
     }
 
     @BeforeEach
@@ -514,43 +512,6 @@ class AutoFillViewModelTest : BaseViewModelTest() {
             }
         }
 
-    @Suppress("MaxLineLength")
-    @Test
-    fun `when WebDomainModeLearnMoreClick action is handled NavigateToCompatibilityModeLearnMore event is sent`() =
-        runTest {
-            val viewModel = createViewModel()
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(AutoFillAction.WebDomainModeCompatLearnMoreClick)
-                assertEquals(
-                    AutoFillEvent.NavigateToCompatibilityModeLearnMore,
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Test
-    fun `when WebDomainModeToggle action is handled settings repo and state is updated`() {
-        val viewModel = createViewModel()
-
-        viewModel.trySendAction(AutoFillAction.WebDomainModeCompatToggle(isEnabled = true))
-        assertEquals(
-            DEFAULT_STATE.copy(isWebDomainCompatModeEnabled = true),
-            viewModel.stateFlow.value,
-        )
-        verify(exactly = 1) {
-            settingsRepository.isAutofillWebDomainCompatMode = true
-        }
-
-        viewModel.trySendAction(AutoFillAction.WebDomainModeCompatToggle(isEnabled = false))
-        assertEquals(
-            DEFAULT_STATE.copy(isWebDomainCompatModeEnabled = false),
-            viewModel.stateFlow.value,
-        )
-        verify(exactly = 1) {
-            settingsRepository.isAutofillWebDomainCompatMode = false
-        }
-    }
-
     private fun createViewModel(
         state: AutoFillState? = DEFAULT_STATE,
     ): AutoFillViewModel = AutoFillViewModel(
@@ -575,7 +536,6 @@ private val DEFAULT_STATE: AutoFillState = AutoFillState(
     showBrowserAutofillActionCard = false,
     activeUserId = "activeUserId",
     browserAutofillSettingsOptions = persistentListOf(),
-    isWebDomainCompatModeEnabled = false,
 )
 
 private val DEFAULT_BROWSER_AUTOFILL_DATA = BrowserThirdPartyAutoFillData(

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1156,7 +1156,4 @@ Do you want to switch to this account?</string>
     <string name="lock_app">Lock app</string>
     <string name="use_your_devices_lock_method_to_unlock_the_app">Use your device’s lock method to unlock the app</string>
     <string name="loading_vault_data">Loading vault data…</string>
-    <string name="compatibility_mode_warning">Compatibility mode should only be enabled if autofill doesn’t work in your browser. This setting reduces security and could allow malicious sites to capture your passwords. Only enable it if you accept this risk.</string>
-    <string name="use_compatibility_mode_for_browser_autofill">Use compatibility mode for browser autofill</string>
-    <string name="use_a_less_secure_autofill_method_compatible_with_more_browsers">Uses a less secure autofill method compatible with more browsers.\n<annotation link="learnMore">Learn more about compatibility mode</annotation></string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28545](https://bitwarden.atlassian.net/browse/PM-28545)

## 📔 Objective

This PR removes the Autofill compatibility mode toggle from the app. The functionality that it controlled is now on by default.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/765acd83-b621-4b15-a068-e741b48271ac" /> | <img width="350" src="https://github.com/user-attachments/assets/36069390-c18e-422a-a570-c57c6bae2212" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28545]: https://bitwarden.atlassian.net/browse/PM-28545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ