### PR TITLE
[BWA-179] Added clarification of functionality on Authenticator's ExportScreen

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -23,6 +24,7 @@ import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -45,6 +47,7 @@ import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.platform.theme.BitwardenTheme
 import kotlinx.collections.immutable.toImmutableList
 
 /**
@@ -175,7 +178,34 @@ private fun ExportScreenContent(
             .verticalScroll(rememberScrollState()),
     ) {
         val resources = LocalResources.current
+        Spacer(modifier = Modifier.height(height = 24.dp))
+
+        Text(
+            text = stringResource(id = BitwardenString.included_in_this_export),
+            style = BitwardenTheme.typography.titleMedium,
+            color = BitwardenTheme.colorScheme.text.primary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .standardHorizontalMargin()
+                .fillMaxWidth(),
+        )
+
         Spacer(modifier = Modifier.height(height = 12.dp))
+
+        Text(
+            text = stringResource(
+                id = BitwardenString.only_codes_stored_locally_on_this_device_will_be_exported,
+            ),
+            style = BitwardenTheme.typography.bodyMedium,
+            color = BitwardenTheme.colorScheme.text.primary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .standardHorizontalMargin()
+                .fillMaxWidth(),
+        )
+
+        Spacer(modifier = Modifier.height(height = 24.dp))
+
         BitwardenMultiSelectButton(
             label = stringResource(id = BitwardenString.file_format),
             options = ExportVaultFormat.entries.map { it.displayLabel() }.toImmutableList(),

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -385,7 +385,7 @@ Scanning will happen automatically.</string>
     <string name="send_verification_code_to_email">Send a verification code to your email</string>
     <string name="code_sent">Code sent!</string>
     <string name="confirm_your_identity">Confirm your identity to continue.</string>
-    <string name="export_vault_warning">This export contains your vault data in an unencrypted format. You should not store or send the exported file over unsecure channels (such as email). Delete it immediately after you are done using it.</string>
+    <string name="export_vault_warning">For your security, don’t share or send this file over unsecured channels (like email), and delete it when you’re done.</string>
     <string name="export_vault_file_pw_protect_info">This file export will be password protected and require the file password to decrypt.</string>
     <string name="export_vault_confirmation_title">Confirm vault export</string>
     <string name="warning">Warning</string>
@@ -1041,6 +1041,8 @@ Do you want to switch to this account?</string>
     <string name="export">Export</string>
     <string name="export_confirmation_title">Confirm export</string>
     <string name="export_success">Data exported successfully</string>
+    <string name="included_in_this_export">Included in this export</string>
+    <string name="only_codes_stored_locally_on_this_device_will_be_exported">Only codes stored locally on this device will be exported. Synced codes aren\'t included</string>
     <string name="security">Security</string>
     <string name="too_many_failed_biometric_attempts">Too many failed biometrics attempts.</string>
     <string name="version">Version</string>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-179

## 📔 Objective

Added a new label with extra information on the export screen and updated confirmation dialog copy after pressing to export.

## 📸 Screenshots
<img width="316" height="2424" alt="Screenshot_1763733784" src="https://github.com/user-attachments/assets/d341d3f9-f225-402e-a742-31d5ec0debfe" />
<img width="316" height="2424" alt="Screenshot_1763733776" src="https://github.com/user-attachments/assets/a77ba3df-442c-4fb2-97bb-b8a621361344" />



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
