### PR TITLE
PM-28522: Update the LoginWithDevice ui

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreen.kt
@@ -27,18 +27,18 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
+import com.bitwarden.ui.platform.components.card.BitwardenContentCard
 import com.bitwarden.ui.platform.components.content.BitwardenLoadingContent
+import com.bitwarden.ui.platform.components.content.model.ContentBlockData
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
-import com.bitwarden.ui.platform.components.field.BitwardenTextField
-import com.bitwarden.ui.platform.components.field.model.TextToolbarType
-import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.components.text.BitwardenHyperTextLink
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import kotlinx.collections.immutable.persistentListOf
 
 /**
  * The top level composable for the Login with Device screen.
@@ -156,18 +156,18 @@ private fun LoginWithDeviceScreenContent(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        BitwardenTextField(
-            label = stringResource(id = BitwardenString.fingerprint_phrase),
-            value = state.fingerprintPhrase,
-            textFieldTestTag = "FingerprintPhraseValue",
-            onValueChange = { },
-            readOnly = true,
-            singleLine = false,
-            textToolbarType = TextToolbarType.NONE,
-            textStyle = BitwardenTheme.typography.sensitiveInfoSmall,
-            textColor = BitwardenTheme.colorScheme.text.codePink,
-            cardStyle = CardStyle.Full,
+        BitwardenContentCard(
+            contentItems = persistentListOf(
+                ContentBlockData(
+                    headerText = stringResource(id = BitwardenString.fingerprint_phrase),
+                    subtitleText = state.fingerprintPhrase,
+                ),
+            ),
+            contentHeaderTextStyle = BitwardenTheme.typography.titleMedium,
+            contentSubtitleTextStyle = BitwardenTheme.typography.sensitiveInfoSmall,
+            contentSubtitleColor = BitwardenTheme.colorScheme.text.codePink,
             modifier = Modifier
+                .testTag(tag = "FingerprintPhraseValue")
                 .standardHorizontalMargin()
                 .fillMaxWidth(),
         )

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenContentCard.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenContentCard.kt
@@ -1,15 +1,15 @@
 package com.bitwarden.ui.platform.components.card
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import com.bitwarden.ui.platform.base.util.cardBackground
 import com.bitwarden.ui.platform.components.content.BitwardenContentBlock
 import com.bitwarden.ui.platform.components.content.model.ContentBlockData
+import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import kotlinx.collections.immutable.ImmutableList
 
@@ -20,6 +20,7 @@ import kotlinx.collections.immutable.ImmutableList
  * @param contentItems list of [ContentBlockData] items to display.
  * @param contentHeaderTextStyle the text style to use for the header text of the content.
  * @param contentSubtitleTextStyle the text style to use for the subtitle text of the content.
+ * @param contentSubtitleColor the color that should be applied to subtitle text of the content.
  * @param contentBackgroundColor the background color to use for the content.
  */
 @Composable
@@ -28,13 +29,13 @@ fun BitwardenContentCard(
     modifier: Modifier = Modifier,
     contentHeaderTextStyle: TextStyle = BitwardenTheme.typography.titleSmall,
     contentSubtitleTextStyle: TextStyle = BitwardenTheme.typography.bodyMedium,
+    contentSubtitleColor: Color = BitwardenTheme.colorScheme.text.secondary,
     contentBackgroundColor: Color = BitwardenTheme.colorScheme.background.secondary,
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(shape = BitwardenTheme.shapes.content)
-            .background(color = BitwardenTheme.colorScheme.background.secondary),
+            .cardBackground(cardStyle = CardStyle.Full, color = contentBackgroundColor),
     ) {
         contentItems.forEachIndexed { index, item ->
             BitwardenContentBlock(
@@ -42,6 +43,7 @@ fun BitwardenContentCard(
                 showDivider = index != contentItems.lastIndex,
                 headerTextStyle = contentHeaderTextStyle,
                 subtitleTextStyle = contentSubtitleTextStyle,
+                subtitleColor = contentSubtitleColor,
                 backgroundColor = contentBackgroundColor,
             )
         }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/content/BitwardenContentBlock.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/content/BitwardenContentBlock.kt
@@ -35,6 +35,7 @@ fun BitwardenContentBlock(
     modifier: Modifier = Modifier,
     headerTextStyle: TextStyle = BitwardenTheme.typography.titleSmall,
     subtitleTextStyle: TextStyle = BitwardenTheme.typography.bodyMedium,
+    subtitleColor: Color = BitwardenTheme.colorScheme.text.secondary,
     backgroundColor: Color = BitwardenTheme.colorScheme.background.secondary,
     showDivider: Boolean = true,
 ) {
@@ -44,6 +45,7 @@ fun BitwardenContentBlock(
         headerTextStyle = headerTextStyle,
         subtitleText = data.subtitleText,
         subtitleTextStyle = subtitleTextStyle,
+        subtitleColor = subtitleColor,
         iconVectorResource = data.iconVectorResource,
         backgroundColor = backgroundColor,
         showDivider = showDivider,
@@ -61,6 +63,7 @@ private fun BitwardenContentBlock(
     headerTextStyle: TextStyle = BitwardenTheme.typography.titleSmall,
     subtitleText: AnnotatedString? = null,
     subtitleTextStyle: TextStyle = BitwardenTheme.typography.bodyMedium,
+    subtitleColor: Color = BitwardenTheme.colorScheme.text.secondary,
     showDivider: Boolean = true,
     @DrawableRes iconVectorResource: Int? = null,
     backgroundColor: Color = BitwardenTheme.colorScheme.background.secondary,
@@ -102,7 +105,7 @@ private fun BitwardenContentBlock(
                 Text(
                     text = it,
                     style = subtitleTextStyle,
-                    color = BitwardenTheme.colorScheme.text.secondary,
+                    color = subtitleColor,
                 )
             }
             Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28522](https://bitwarden.atlassian.net/browse/PM-28522)

## 📔 Objective

This PR fixes a minor UI discrepancy in the `LoginWithDeviceScreen`.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/faf7a5df-4558-4e9d-a637-69f8bc47fb3b" width="300" /> | <img src="https://github.com/user-attachments/assets/42b3c856-63a3-4ccc-9e07-9e3a54d3e3d7" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28522]: https://bitwarden.atlassian.net/browse/PM-28522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ