### PR TITLE
[PM-29014] Update BitwardenPasswordField semantics to support accessibility for visible passwords

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -240,7 +240,7 @@ fun BitwardenPasswordField(
                         // setting. When visible, the password will always be spoken aloud
                         // regardless of the user's configuration.
                         contentDescription = textFieldValue.text
-                            .takeUnless { !showPassword }
+                            .takeIf { showPassword }
                             .orEmpty()
                         isSensitiveData = true
                     }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -36,6 +36,9 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isSensitiveData
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -228,6 +231,19 @@ fun BitwardenPasswordField(
                     )
                 },
                 modifier = Modifier
+                    .semantics {
+                        // Content description must be set to the field value in order for Talkback
+                        // to speak the password aloud when it is visible because we apply a custom
+                        // VisualTransformation to the text, which prevents Talkback from reading
+                        // the value as it normally would.
+                        // NOTE: This overrides the default behavior of Talkback's "Speak Passwords"
+                        // setting. When visible, the password will always be spoken aloud
+                        // regardless of the user's configuration.
+                        contentDescription = textFieldValue.text
+                            .takeUnless { !showPassword }
+                            .orEmpty()
+                        isSensitiveData = true
+                    }
                     .nullableTestTag(tag = passwordFieldTestTag)
                     .fillMaxWidth()
                     .onFocusChanged { focusState -> focused = focusState.isFocused },


### PR DESCRIPTION
## 🎟️ Tracking

PM-29014
Relates to #6212 

## 📔 Objective

Improve accessibility support in `BitwardenPasswordField` by ensuring Talkback can read the password aloud when the user chooses to make it visible, while explicitly marking the content as sensitive data.

Behavioral changes:
*   When the "show password" toggle is active, Talkback will now read the actual password text instead of silence or obfuscated characters. This behavior occurs regardless of the system-wide "Speak Passwords" setting due to the custom visual transformation usage.
*   The field is semantically marked as containing sensitive data.

Specific changes:
*   Apply a `semantics` modifier to the internal `TextField` in `BitwardenPasswordField`.
*   Set `contentDescription` to the actual text value only when `showPassword` is true; otherwise, it defaults to an empty string.
*   Set the `isSensitiveData` semantic property to `true`.

## 📸 Screenshots

<img width="365" src="https://github.com/user-attachments/assets/3246a5db-b1a6-4821-ae5f-47b857ff3427" />

<img width="365" src="https://github.com/user-attachments/assets/b0b19cfe-f271-49b8-a6a6-0fb50c0de340" />

---

<img width="365" src="https://github.com/user-attachments/assets/bcc29eb2-d5f2-44f3-a88b-5aa34565866a" />

<img width="365" src="https://github.com/user-attachments/assets/7313e83f-e1a9-42fe-9955-0a6188cb4e39" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
