### PR TITLE
[PM-29151] Update reusable workflow reference for code review

### DIFF
--- a/.github/workflows/review-code.yml
+++ b/.github/workflows/review-code.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   review:
     name: Review
-    uses: bitwarden/gh-actions/.github/workflows/_review-code.yml@main
+    uses: bitwarden/gh-actions/.github/workflows/_review-code.yml@PM-29151-use-marketplace-absolute-path-in-claude-config
     secrets:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## 🎟️ Tracking

PM-29151

## 📔 Objective

Update the `review-code.yml` workflow to point to a specific feature branch of the reusable `_review-code.yml` workflow instead of `main`.

This change updates the `uses` reference for the `bitwarden/gh-actions/.github/workflows/_review-code.yml` workflow to the `PM-29151-use-marketplace-absolute-path-in-claude-config` branch. This presumably incorporates updates related to using absolute paths for Marketplace actions within the Claude configuration.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
