### PR TITLE
PM-28634: Update Autofill terms to support other languages better

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -261,7 +261,7 @@
             android:name="com.x8bit.bitwarden.AutofillTileService"
             android:exported="true"
             android:icon="@drawable/ic_notification"
-            android:label="@string/autofill_title"
+            android:label="@string/autofill_verb"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             tools:ignore="MissingClass">
             <intent-filter>

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
@@ -219,7 +219,7 @@ private fun AutofillSelectionDialog(
         selectionItems = {
             if (AutofillSelectionOption.AUTOFILL in displayItem.autofillSelectionOptions) {
                 BitwardenBasicDialogRow(
-                    text = stringResource(id = BitwardenString.autofill_title),
+                    text = stringResource(id = BitwardenString.autofill_verb),
                     onClick = {
                         selectionCallback(
                             displayItem,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
@@ -241,7 +241,7 @@ enum class Settings(
         testTag = "AccountSecuritySettingsButton",
     ),
     AUTO_FILL(
-        text = BitwardenString.autofill_title.asText(),
+        text = BitwardenString.autofill_noun.asText(),
         vectorIconRes = BitwardenDrawable.ic_check_mark,
         testTag = "AutofillSettingsButton",
     ),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -158,7 +158,7 @@ fun AutoFillScreen(
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             BitwardenTopAppBar(
-                title = stringResource(id = BitwardenString.autofill_title),
+                title = stringResource(id = BitwardenString.autofill_noun),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
@@ -196,7 +196,7 @@ private fun AutoFillScreenContent(
         )
         Spacer(modifier = Modifier.height(height = 16.dp))
         BitwardenListHeaderText(
-            label = stringResource(id = BitwardenString.autofill_title),
+            label = stringResource(id = BitwardenString.autofill_noun),
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin()

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -165,7 +165,8 @@
     <string name="search_for_a_login_or_add_a_new_login">Search for a login or add a new login</string>
     <string name="disabled">Disabled</string>
     <string name="bitwarden_autofill_service_alert2">The easiest way to add new logins to your vault is from the Bitwarden Autofill Service. Learn more about using the Bitwarden Autofill Service by navigating to the “Settings” screen.</string>
-    <string name="autofill_title">Autofill</string>
+    <string name="autofill_noun">Autofill</string>
+    <string name="autofill_verb">Autofill</string>
     <string name="autofill_or_view">Do you want to autofill or view this item?</string>
     <string name="search">Search</string>
     <string name="learn_org">Learn about organizations</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28634](https://bitwarden.atlassian.net/browse/PM-28634)

## 📔 Objective

This PR breaks the `autofill_title` string into two distinct string `autofill_verb` and `autofill_noun`. This change will be completely transparent in English but will allow other languages to use their appropriate phrasing base on whether it is a verb or a noun.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28634]: https://bitwarden.atlassian.net/browse/PM-28634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ