### PR TITLE
PM-25632: Ensure that we use lowercase email addresses when creating a fingerprint

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/sdk/AuthSdkSourceImpl.kt
@@ -30,7 +30,7 @@ class AuthSdkSourceImpl(
         getClient()
             .auth()
             .newAuthRequest(
-                email = email,
+                email = email.lowercase(),
             )
     }
 
@@ -42,7 +42,7 @@ class AuthSdkSourceImpl(
             .platform()
             .fingerprint(
                 req = FingerprintRequest(
-                    fingerprintMaterial = email,
+                    fingerprintMaterial = email.lowercase(),
                     publicKey = publicKey,
                 ),
             )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25632](https://bitwarden.atlassian.net/browse/PM-25632)

## 📔 Objective

This PR updates the `AuthSdkSource` to enforce that email addresses that are used to generate a fingerprint are always lowercase. This ensures that the fingerprint phrase matches between the client and the web (which also forces the email to be lowercase).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25632]: https://bitwarden.atlassian.net/browse/PM-25632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ