### PR TITLE
[PM-28352] Add logging to Credential Manager and Origin Manager flows

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/OriginManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/OriginManagerImpl.kt
@@ -57,7 +57,7 @@ class OriginManagerImpl(
                     }
                 },
                 onFailure = {
-                    Timber.e("Failed to validate origin: ${callingAppInfo.packageName}")
+                    Timber.e("Failed to validate origin for calling app")
                     ValidateOriginResult.Error.AssetLinkNotFound
                 },
             )
@@ -107,7 +107,7 @@ class OriginManagerImpl(
             .fold(
                 onSuccess = { it },
                 onFailure = {
-                    Timber.e(it, "Failed to validate privileged app: ${callingAppInfo.packageName}")
+                    Timber.e(it, "Failed to validate calling app is privileged.")
                     ValidateOriginResult.Error.Unknown
                 },
             )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/processor/CredentialProviderProcessorImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/processor/CredentialProviderProcessorImpl.kt
@@ -67,7 +67,7 @@ class CredentialProviderProcessorImpl(
         Timber.d("Create credential request received.")
         val userId = authRepository.activeUserId
         if (userId == null) {
-            Timber.w("No active user. Can't create credential.")
+            Timber.w("No active user. Cannot create credential.")
             callback.onError(CreateCredentialUnknownException("Active user is required."))
             return
         }
@@ -98,7 +98,7 @@ class CredentialProviderProcessorImpl(
         // If the user is not logged in, return an error.
         val userState = authRepository.userStateFlow.value
         if (userState == null) {
-            Timber.w("No active user. Can't get credentials.")
+            Timber.w("No active user. Cannot get credentials.")
             callback.onError(GetCredentialUnknownException("Active user is required."))
             return
         }


### PR DESCRIPTION
## 🎟️ Tracking

PM-28352

## 📔 Objective

Enhance the observability of the Credential Provider implementation by adding `Timber` logs to key lifecycle events and error handling paths. This facilitates better debugging of credential creation, retrieval, and origin validation processes.

Specific changes include:
- Update `OriginManagerImpl` to log the success status of digital asset link validation and error details if validation fails.
- Update `CredentialProviderProcessorImpl` to log entry points for `onBeginCreateCredentialRequest`, `onBeginGetCredentialRequest`, and `onClearCredentialStateRequest`.
- Add specific logs for edge cases such as missing active users, locked vaults, and unknown request types.
- Log success and failure outcomes for credential operations, as well as system-triggered cancellations.
- Minor refactor in `onBeginCreateCredentialRequest` to accommodate the new logging logic within the failure branch.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
