### PR TITLE
[PM-28442] Added feature flag for migrate myvault to myitems

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -35,6 +35,7 @@ sealed class FlagKey<out T : Any> {
                 ForceUpdateKdfSettings,
                 CipherKeyEncryption,
                 NoLogoutOnKdfChange,
+                MigrateMyVaultToMyItems,
             )
         }
     }
@@ -86,6 +87,14 @@ sealed class FlagKey<out T : Any> {
      */
     data object NoLogoutOnKdfChange : FlagKey<Boolean>() {
         override val keyName: String = "pm-23995-no-logout-on-kdf-change"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     *  Data object holding the feature flag key for the Migrate My Vault to My Items feature.
+     */
+    data object MigrateMyVaultToMyItems : FlagKey<Boolean>() {
+        override val keyName: String = "pm-20558-migrate-myvault-to-myitems"
         override val defaultValue: Boolean = false
     }
 

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -28,6 +28,10 @@ class FlagKeyTest {
             FlagKey.ForceUpdateKdfSettings.keyName,
             "pm-18021-force-update-kdf-settings",
         )
+        assertEquals(
+            FlagKey.MigrateMyVaultToMyItems.keyName,
+            "pm-20558-migrate-myvault-to-myitems",
+        )
     }
 
     @Test
@@ -39,6 +43,7 @@ class FlagKeyTest {
                 FlagKey.CipherKeyEncryption,
                 FlagKey.BitwardenAuthenticationEnabled,
                 FlagKey.ForceUpdateKdfSettings,
+                FlagKey.MigrateMyVaultToMyItems,
             ).all {
                 !it.defaultValue
             },

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
@@ -29,6 +29,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.CipherKeyEncryption,
     FlagKey.ForceUpdateKdfSettings,
     FlagKey.NoLogoutOnKdfChange,
+    FlagKey.MigrateMyVaultToMyItems,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -78,4 +79,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.BitwardenAuthenticationEnabled -> {
         stringResource(BitwardenString.bitwarden_authentication_enabled)
     }
+    FlagKey.MigrateMyVaultToMyItems -> stringResource(BitwardenString.migrate_my_vault_to_my_items)
 }

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -38,6 +38,7 @@
     <string name="import_format_label_aegis_json">Aegis (.json)</string>
     <string name="force_update_kdf_settings">Force update KDF settings</string>
     <string name="avoid_logout_on_kdf_change">Avoid logout on KDF change</string>
+    <string name="migrate_my_vault_to_my_items">Migrate My Vault to My Items</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28442

## 📔 Objective

Add the feature flag for the Migrate myvault to myitems tasks

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
