### PR TITLE
PM-1908: Push notifications for non-active accounts prompt for future sync

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncCipherUpsertData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncCipherUpsertData.kt
@@ -5,12 +5,14 @@ import java.time.ZonedDateTime
 /**
  * Required data for sync cipher upsert operations.
  *
+ * @property userId The user ID associated with this update.
  * @property cipherId The cipher ID.
  * @property revisionDate The cipher's revision date. This is used to determine if the local copy of
  * the cipher is out-of-date.
  * @property isUpdate Whether or not this is an update of an existing cipher.
  */
 data class SyncCipherUpsertData(
+    val userId: String,
     val cipherId: String,
     val revisionDate: ZonedDateTime,
     val organizationId: String?,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncFolderUpsertData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncFolderUpsertData.kt
@@ -5,12 +5,14 @@ import java.time.ZonedDateTime
 /**
  * Required data for sync folder upsert operations.
  *
+ * @property userId The user ID associated with this update.
  * @property folderId The folder ID.
  * @property revisionDate The folder's revision date. This is used to determine if the local copy of
  * the folder is out-of-date.
  * @property isUpdate Whether or not this is an update of an existing folder.
  */
 data class SyncFolderUpsertData(
+    val userId: String,
     val folderId: String,
     val revisionDate: ZonedDateTime,
     val isUpdate: Boolean,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncSendUpsertData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SyncSendUpsertData.kt
@@ -5,12 +5,14 @@ import java.time.ZonedDateTime
 /**
  * Required data for sync send upsert operations.
  *
+ * @property userId The user ID associated with this update.
  * @property sendId The send ID.
  * @property revisionDate The send's revision date. This is used to determine if the local copy of
  * the send is out-of-date.
  * @property isUpdate Whether or not this is an update of an existing send.
  */
 data class SyncSendUpsertData(
+    val userId: String,
     val sendId: String,
     val revisionDate: ZonedDateTime,
     val isUpdate: Boolean,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/FolderManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/FolderManagerImpl.kt
@@ -6,6 +6,7 @@ import com.bitwarden.network.model.UpdateFolderResponseJson
 import com.bitwarden.network.service.FolderService
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.model.SyncFolderDeleteData
@@ -25,8 +26,10 @@ import kotlinx.coroutines.flow.onEach
 /**
  * The default implementation of the [FolderManager].
  */
+@Suppress("LongParameterList")
 class FolderManagerImpl(
     private val authDiskSource: AuthDiskSource,
+    private val settingsDiskSource: SettingsDiskSource,
     private val folderService: FolderService,
     private val vaultDiskSource: VaultDiskSource,
     private val vaultSdkSource: VaultSdkSource,
@@ -148,7 +151,7 @@ class FolderManagerImpl(
      * are met.
      */
     private suspend fun syncFolderIfNecessary(syncFolderUpsertData: SyncFolderUpsertData) {
-        val userId = activeUserId ?: return
+        val userId = syncFolderUpsertData.userId
         val folderId = syncFolderUpsertData.folderId
         val isUpdate = syncFolderUpsertData.isUpdate
         val revisionDate = syncFolderUpsertData.revisionDate
@@ -162,6 +165,12 @@ class FolderManagerImpl(
             localFolder.revisionDate.toEpochSecond() < revisionDate.toEpochSecond()
 
         if (!isValidCreate && !isValidUpdate) return
+        if (activeUserId != userId) {
+            // We cannot update right now since the accounts do not match, so we will
+            // do a full-sync on the next check.
+            settingsDiskSource.storeLastSyncTime(userId = userId, lastSyncTime = null)
+            return
+        }
 
         folderService
             .getFolder(folderId = folderId)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/di/VaultManagerModule.kt
@@ -61,6 +61,7 @@ object VaultManagerModule {
     @Singleton
     fun provideCipherManager(
         ciphersService: CiphersService,
+        settingsDiskSource: SettingsDiskSource,
         vaultDiskSource: VaultDiskSource,
         vaultSdkSource: VaultSdkSource,
         authDiskSource: AuthDiskSource,
@@ -71,6 +72,7 @@ object VaultManagerModule {
         pushManager: PushManager,
     ): CipherManager = CipherManagerImpl(
         fileManager = fileManager,
+        settingsDiskSource = settingsDiskSource,
         authDiskSource = authDiskSource,
         ciphersService = ciphersService,
         vaultDiskSource = vaultDiskSource,
@@ -85,6 +87,7 @@ object VaultManagerModule {
     @Singleton
     fun provideFolderManager(
         folderService: FolderService,
+        settingsDiskSource: SettingsDiskSource,
         vaultDiskSource: VaultDiskSource,
         vaultSdkSource: VaultSdkSource,
         authDiskSource: AuthDiskSource,
@@ -92,6 +95,7 @@ object VaultManagerModule {
         pushManager: PushManager,
     ): FolderManager = FolderManagerImpl(
         authDiskSource = authDiskSource,
+        settingsDiskSource = settingsDiskSource,
         folderService = folderService,
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
@@ -106,6 +110,7 @@ object VaultManagerModule {
         vaultDiskSource: VaultDiskSource,
         vaultSdkSource: VaultSdkSource,
         authDiskSource: AuthDiskSource,
+        settingsDiskSource: SettingsDiskSource,
         fileManager: FileManager,
         reviewPromptManager: ReviewPromptManager,
         pushManager: PushManager,
@@ -113,6 +118,7 @@ object VaultManagerModule {
     ): SendManager = SendManagerImpl(
         fileManager = fileManager,
         authDiskSource = authDiskSource,
+        settingsDiskSource = settingsDiskSource,
         sendsService = sendsService,
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/PushManagerTest.kt
@@ -260,6 +260,7 @@ class PushManagerTest {
                         pushManager.onMessageReceived(SYNC_CIPHER_CREATE_NOTIFICATION_MAP)
                         assertEquals(
                             SyncCipherUpsertData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                                 cipherId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                                 organizationId = "6a41d965-ed95-4eae-98c3-5f1ec609c2c1",
                                 collectionIds = listOf(),
@@ -293,6 +294,7 @@ class PushManagerTest {
                         pushManager.onMessageReceived(SYNC_CIPHER_UPDATE_NOTIFICATION_MAP)
                         assertEquals(
                             SyncCipherUpsertData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                                 cipherId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                                 organizationId = "6a41d965-ed95-4eae-98c3-5f1ec609c2c1",
                                 collectionIds = listOf(),
@@ -311,6 +313,7 @@ class PushManagerTest {
                         pushManager.onMessageReceived(SYNC_FOLDER_CREATE_NOTIFICATION_MAP)
                         assertEquals(
                             SyncFolderUpsertData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                                 folderId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                                 revisionDate = ZonedDateTime.parse("2023-10-27T12:00:00.000Z"),
                                 isUpdate = false,
@@ -342,6 +345,7 @@ class PushManagerTest {
                         pushManager.onMessageReceived(SYNC_FOLDER_UPDATE_NOTIFICATION_MAP)
                         assertEquals(
                             SyncFolderUpsertData(
+                                userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                                 folderId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                                 revisionDate = ZonedDateTime.parse("2023-10-27T12:00:00.000Z"),
                                 isUpdate = true,
@@ -372,6 +376,7 @@ class PushManagerTest {
                     pushManager.onMessageReceived(SYNC_SEND_CREATE_NOTIFICATION_MAP)
                     assertEquals(
                         SyncSendUpsertData(
+                            userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                             sendId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                             revisionDate = ZonedDateTime.parse("2023-10-27T12:00:00.000Z"),
                             isUpdate = false,
@@ -401,6 +406,7 @@ class PushManagerTest {
                     pushManager.onMessageReceived(SYNC_SEND_UPDATE_NOTIFICATION_MAP)
                     assertEquals(
                         SyncSendUpsertData(
+                            userId = "078966a2-93c2-4618-ae2a-0a2394c88d37",
                             sendId = "aab5cdcc-f4a7-4e65-bf6d-5e0eab052321",
                             revisionDate = ZonedDateTime.parse("2023-10-27T12:00:00.000Z"),
                             isUpdate = true,
@@ -437,12 +443,13 @@ class PushManagerTest {
             }
 
             @Test
-            fun `onMessageReceived with sync cipher create does nothing`() = runTest {
-                pushManager.syncCipherUpsertFlow.test {
-                    pushManager.onMessageReceived(SYNC_CIPHER_CREATE_NOTIFICATION_MAP)
-                    expectNoEvents()
+            fun `onMessageReceived with sync cipher create emits to syncCipherUpsertFlow`() =
+                runTest {
+                    pushManager.syncCipherUpsertFlow.test {
+                        pushManager.onMessageReceived(SYNC_CIPHER_CREATE_NOTIFICATION_MAP)
+                        expectNoEvents()
+                    }
                 }
-            }
 
             @Test
             fun `onMessageReceived with sync cipher delete does nothing`() = runTest {
@@ -459,12 +466,13 @@ class PushManagerTest {
             }
 
             @Test
-            fun `onMessageReceived with sync cipher update does nothing`() = runTest {
-                pushManager.syncCipherUpsertFlow.test {
-                    pushManager.onMessageReceived(SYNC_CIPHER_UPDATE_NOTIFICATION_MAP)
-                    expectNoEvents()
+            fun `onMessageReceived with sync cipher update emits to syncCipherUpsertFlow`() =
+                runTest {
+                    pushManager.syncCipherUpsertFlow.test {
+                        pushManager.onMessageReceived(SYNC_CIPHER_UPDATE_NOTIFICATION_MAP)
+                        expectNoEvents()
+                    }
                 }
-            }
 
             @Test
             fun `onMessageReceived with sync folder create does nothing`() = runTest {
@@ -538,62 +546,6 @@ class PushManagerTest {
             fun `onMessageReceived with sync send update does nothing`() = runTest {
                 pushManager.syncSendUpsertFlow.test {
                     pushManager.onMessageReceived(SYNC_SEND_UPDATE_NOTIFICATION_MAP)
-                    expectNoEvents()
-                }
-            }
-        }
-
-        @Nested
-        inner class NullUserState {
-            @BeforeEach
-            fun setUp() {
-                authDiskSource.userState = null
-            }
-
-            @Test
-            fun `onMessageReceived with logout does nothing`() = runTest {
-                pushManager.logoutFlow.test {
-                    pushManager.onMessageReceived(LOGOUT_NOTIFICATION_MAP)
-                    expectNoEvents()
-                }
-            }
-
-            @Test
-            fun `onMessageReceived with logout with kdf reason does nothing`() = runTest {
-                pushManager.logoutFlow.test {
-                    pushManager.onMessageReceived(LOGOUT_KDF_NOTIFICATION_MAP)
-                    expectNoEvents()
-                }
-            }
-
-            @Test
-            fun `onMessageReceived with sync ciphers does nothing`() = runTest {
-                pushManager.fullSyncFlow.test {
-                    pushManager.onMessageReceived(SYNC_CIPHERS_NOTIFICATION_MAP)
-                    expectNoEvents()
-                }
-            }
-
-            @Test
-            fun `onMessageReceived with sync org keys does nothing`() = runTest {
-                pushManager.fullSyncFlow.test {
-                    pushManager.onMessageReceived(SYNC_ORG_KEYS_NOTIFICATION_MAP)
-                    expectNoEvents()
-                }
-            }
-
-            @Test
-            fun `onMessageReceived with sync settings does nothing`() = runTest {
-                pushManager.fullSyncFlow.test {
-                    pushManager.onMessageReceived(SYNC_SETTINGS_NOTIFICATION_MAP)
-                    expectNoEvents()
-                }
-            }
-
-            @Test
-            fun `onMessageReceived with sync vault does nothing`() = runTest {
-                pushManager.fullSyncFlow.test {
-                    pushManager.onMessageReceived(SYNC_VAULT_NOTIFICATION_MAP)
                     expectNoEvents()
                 }
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManagerTest.kt
@@ -20,6 +20,7 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountTokensJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
@@ -64,6 +65,7 @@ class SendManagerTest {
         coEvery { delete(files = anyVararg()) } just runs
     }
     private val fakeAuthDiskSource = FakeAuthDiskSource()
+    private val fakeSettingsDiskSource = FakeSettingsDiskSource()
     private val sendsService = mockk<SendsService>()
     private val vaultDiskSource = mockk<VaultDiskSource>()
     private val vaultSdkSource = mockk<VaultSdkSource>()
@@ -82,6 +84,7 @@ class SendManagerTest {
         vaultDiskSource = vaultDiskSource,
         vaultSdkSource = vaultSdkSource,
         authDiskSource = fakeAuthDiskSource,
+        settingsDiskSource = fakeSettingsDiskSource,
         fileManager = fileManager,
         reviewPromptManager = reviewPromptManager,
         pushManager = pushManager,
@@ -129,6 +132,7 @@ class SendManagerTest {
 
         mutableSyncSendUpsertFlow.tryEmit(
             SyncSendUpsertData(
+                userId = userId,
                 sendId = sendId,
                 revisionDate = ZonedDateTime.now(FIXED_CLOCK),
                 isUpdate = false,
@@ -152,6 +156,7 @@ class SendManagerTest {
 
         mutableSyncSendUpsertFlow.tryEmit(
             SyncSendUpsertData(
+                userId = userId,
                 sendId = sendId,
                 revisionDate = ZonedDateTime.now(FIXED_CLOCK),
                 isUpdate = true,
@@ -182,6 +187,7 @@ class SendManagerTest {
 
         mutableSyncSendUpsertFlow.tryEmit(
             SyncSendUpsertData(
+                userId = userId,
                 sendId = sendId,
                 revisionDate = ZonedDateTime.now(FIXED_CLOCK).minus(5, ChronoUnit.MINUTES),
                 isUpdate = true,
@@ -221,6 +227,7 @@ class SendManagerTest {
 
             mutableSyncSendUpsertFlow.tryEmit(
                 SyncSendUpsertData(
+                    userId = userId,
                     sendId = sendId,
                     revisionDate = ZonedDateTime.now(FIXED_CLOCK),
                     isUpdate = true,
@@ -251,6 +258,7 @@ class SendManagerTest {
 
             mutableSyncSendUpsertFlow.tryEmit(
                 SyncSendUpsertData(
+                    userId = userId,
                     sendId = sendId,
                     revisionDate = ZonedDateTime.now(FIXED_CLOCK),
                     isUpdate = false,
@@ -283,6 +291,7 @@ class SendManagerTest {
 
             mutableSyncSendUpsertFlow.tryEmit(
                 SyncSendUpsertData(
+                    userId = userId,
                     sendId = sendId,
                     revisionDate = ZonedDateTime.now(FIXED_CLOCK),
                     isUpdate = false,
@@ -318,6 +327,7 @@ class SendManagerTest {
 
             mutableSyncSendUpsertFlow.tryEmit(
                 SyncSendUpsertData(
+                    userId = userId,
                     sendId = sendId,
                     revisionDate = ZonedDateTime.now(FIXED_CLOCK),
                     isUpdate = true,
@@ -329,6 +339,42 @@ class SendManagerTest {
                 vaultDiskSource.saveSend(userId = userId, send = send)
             }
         }
+
+    @Test
+    fun `syncSendUpsertFlow with inactive userId should clear the last sync time`() = runTest {
+        val number = 1
+        val userId = "nonActiveUserId"
+        val sendId = "mockId-$number"
+        val lastSyncTime = FIXED_CLOCK.instant()
+
+        fakeSettingsDiskSource.storeLastSyncTime(userId = userId, lastSyncTime = lastSyncTime)
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        val sendView = createMockSend(
+            number = number,
+            revisionDate = ZonedDateTime.now(FIXED_CLOCK).minus(5, ChronoUnit.MINUTES),
+        )
+        coEvery {
+            vaultDiskSource.getSends(userId = userId)
+        } returns MutableStateFlow(listOf(sendView))
+
+        mutableSyncSendUpsertFlow.tryEmit(
+            SyncSendUpsertData(
+                userId = userId,
+                sendId = sendId,
+                revisionDate = ZonedDateTime.now(FIXED_CLOCK),
+                isUpdate = true,
+            ),
+        )
+
+        fakeSettingsDiskSource.assertLastSyncTime(userId = userId, expected = null)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getSends(userId = userId)
+        }
+        coVerify(exactly = 0) {
+            sendsService.getSend(sendId = sendId)
+            vaultDiskSource.saveSend(userId = userId, send = any())
+        }
+    }
 
     @Test
     fun `createSend with no active user should return CreateSendResult Error`() =


### PR DESCRIPTION
## 🎟️ Tracking

[PM-1908](https://bitwarden.atlassian.net/browse/PM-1908)

## 📔 Objective

This PR updates the `PushManager` and associated files to allow push notifications for non-active users to be processed and prompt for a sync in the future to ensure the user's data is up-to-date.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-1908]: https://bitwarden.atlassian.net/browse/PM-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ