### PR TITLE
PM-29442: Change 2fa field to not be a password field

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
@@ -41,7 +41,7 @@ import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
-import com.bitwarden.ui.platform.components.field.BitwardenPasswordField
+import com.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
@@ -263,7 +263,7 @@ private fun TwoFactorLoginScreenContent(
 
         Spacer(modifier = Modifier.height(12.dp))
         if (state.shouldShowCodeInput) {
-            BitwardenPasswordField(
+            BitwardenTextField(
                 value = state.codeInput,
                 onValueChange = onCodeInputChange,
                 label = stringResource(id = BitwardenString.verification_code),

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenTextField.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenTextField.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
@@ -101,6 +102,7 @@ import kotlinx.collections.immutable.toImmutableList
  * @param visualTransformation Transforms the visual representation of the input [value].
  * @param keyboardType the preferred type of keyboard input.
  * @param keyboardActions the callbacks of keyboard actions.
+ * @param imeAction the preferred IME action for the keyboard to have.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
  * @param textFieldTestTag The optional test tag associated with the inner text field.
  * @param cardStyle Indicates the type of card style to be applied.
@@ -129,6 +131,7 @@ fun BitwardenTextField(
     shouldAddCustomLineBreaks: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
+    imeAction: ImeAction = ImeAction.Default,
     isError: Boolean = false,
     autoFocus: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
@@ -165,6 +168,7 @@ fun BitwardenTextField(
         shouldAddCustomLineBreaks = shouldAddCustomLineBreaks,
         keyboardType = keyboardType,
         keyboardActions = keyboardActions,
+        imeAction = imeAction,
         isError = isError,
         autoFocus = autoFocus,
         visualTransformation = visualTransformation,
@@ -204,6 +208,7 @@ fun BitwardenTextField(
  * @param visualTransformation Transforms the visual representation of the input [value].
  * @param keyboardType the preferred type of keyboard input.
  * @param keyboardActions the callbacks of keyboard actions.
+ * @param imeAction the preferred IME action for the keyboard to have.
  * @param textToolbarType The type of [TextToolbar] to use on the text field.
  * @param textFieldTestTag The optional test tag associated with the inner text field.
  * @param cardStyle Indicates the type of card style to be applied.
@@ -235,6 +240,7 @@ fun BitwardenTextField(
     shouldAddCustomLineBreaks: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
+    imeAction: ImeAction = ImeAction.Default,
     isError: Boolean = false,
     autoFocus: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
@@ -368,7 +374,10 @@ fun BitwardenTextField(
                     singleLine = singleLine,
                     readOnly = readOnly,
                     textStyle = textStyle,
-                    keyboardOptions = KeyboardOptions.Default.copy(keyboardType = keyboardType),
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        keyboardType = keyboardType,
+                        imeAction = imeAction,
+                    ),
                     keyboardActions = keyboardActions,
                     trailingIcon = actions?.let {
                         {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29442](https://bitwarden.atlassian.net/browse/PM-29442)

## 📔 Objective

This PR changes the text field for the 2fa code from a password field to a regular text field.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/02aad57c-c448-4cf4-bd16-c282e01fccfe" width="300" /> | <img src="https://github.com/user-attachments/assets/1b625d8e-3dfa-44a5-91b2-431b62f2a099" width="300" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29442]: https://bitwarden.atlassian.net/browse/PM-29442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ