### PR TITLE
PM-29806: Move FlightRecorderWriter to the data module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -1,7 +1,7 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk
 
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -5,8 +5,8 @@ import androidx.core.content.edit
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.decodeFromStringOrNull
 import com.bitwarden.data.datasource.disk.BaseDiskSource
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -12,7 +12,7 @@ import com.bitwarden.core.data.manager.toast.ToastManagerImpl
 import com.bitwarden.cxf.registry.CredentialExchangeRegistry
 import com.bitwarden.cxf.registry.dsl.credentialExchangeRegistry
 import com.bitwarden.data.manager.NativeLibraryManager
-import com.bitwarden.data.manager.file.FileManager
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderWriter
 import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.network.BitwardenServiceClient
 import com.bitwarden.network.service.EventService
@@ -66,8 +66,6 @@ import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderManager
 import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderManagerImpl
-import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderWriter
-import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderWriterImpl
 import com.x8bit.bitwarden.data.platform.manager.garbage.GarbageCollectionManager
 import com.x8bit.bitwarden.data.platform.manager.garbage.GarbageCollectionManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConfigManager
@@ -108,18 +106,6 @@ object PlatformManagerModule {
     fun provideAppStateManager(
         application: Application,
     ): AppStateManager = AppStateManagerImpl(application = application)
-
-    @Provides
-    @Singleton
-    fun provideFlightRecorderWriter(
-        clock: Clock,
-        fileManager: FileManager,
-        dispatcherManager: DispatcherManager,
-    ): FlightRecorderWriter = FlightRecorderWriterImpl(
-        clock = clock,
-        fileManager = fileManager,
-        dispatcherManager = dispatcherManager,
-    )
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManager.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.platform.manager.flightrecorder
 
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 import kotlinx.coroutines.flow.StateFlow
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerImpl.kt
@@ -7,8 +7,9 @@ import android.content.IntentFilter
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.util.concurrentMapOf
 import com.bitwarden.core.data.util.toFormattedPattern
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderWriter
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.manager.BuildInfoManager
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
 import com.bitwarden.ui.platform.base.BaseViewModel
@@ -11,7 +12,6 @@ import com.bitwarden.ui.platform.manager.util.deviceData
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/util/FlightRecorderDataSetExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/util/FlightRecorderDataSetExtensions.kt
@@ -2,10 +2,10 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.about.util
 
 import com.bitwarden.core.data.util.toFormattedDateStyle
 import com.bitwarden.core.data.util.toFormattedTimeStyle
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import java.time.Clock
 import java.time.Instant
 import java.time.format.FormatStyle

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsViewModel.kt
@@ -4,13 +4,13 @@ import android.os.Parcelable
 import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.manager.file.FileManager
 import com.bitwarden.data.manager.model.ZipFileResult
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.util.toViewState
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/util/FlightRecorderDataSetExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/util/FlightRecorderDataSetExtensions.kt
@@ -3,10 +3,10 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recorded
 import com.bitwarden.core.data.util.toFormattedDateStyle
 import com.bitwarden.core.data.util.toFormattedPattern
 import com.bitwarden.core.data.util.toFormattedTimeStyle
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.util.fileOf
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
 import com.x8bit.bitwarden.ui.platform.util.formatBytes

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/BitwardenBuildInfoManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/manager/BitwardenBuildInfoManagerImpl.kt
@@ -12,6 +12,8 @@ class BitwardenBuildInfoManagerImpl : BuildInfoManager {
     override val applicationId: String
         get() = BuildConfig.APPLICATION_ID
 
+    override val applicationName: String get() = "Password Manager"
+
     override val isFdroid: Boolean
         get() = BuildConfig.FLAVOR == "fdroid"
 
@@ -39,4 +41,6 @@ class BitwardenBuildInfoManagerImpl : BuildInfoManager {
             "release" -> "prod"
             else -> BuildConfig.BUILD_TYPE
         }
+
+    override val buildAndFlavor: String get() = "${BuildConfig.BUILD_TYPE}/${BuildConfig.FLAVOR}"
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.util.persistentListOfNotNull
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.ui.platform.base.BackgroundEvent
@@ -30,7 +31,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.UpdateKdfMinimumsResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserAutofillDialogManager
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.CredentialExchangeRegistryManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/FlightRecorderDataSetExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/FlightRecorderDataSetExtensions.kt
@@ -2,10 +2,10 @@ package com.x8bit.bitwarden.ui.vault.feature.vault.util
 
 import com.bitwarden.core.data.util.toFormattedDateStyle
 import com.bitwarden.core.data.util.toFormattedTimeStyle
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import java.time.Clock
 import java.time.Instant
 import java.time.format.FormatStyle

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -5,8 +5,8 @@ import app.cash.turbine.test
 import com.bitwarden.core.data.util.decodeFromStringOrNull
 import com.bitwarden.core.di.CoreModule
 import com.bitwarden.data.datasource.disk.base.FakeSharedPreferences
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -2,9 +2,9 @@ package com.x8bit.bitwarden.data.platform.datasource.disk.util
 
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.decodeFromStringOrNull
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.platform.repository.model.VaultTimeoutAction

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/flightrecorder/FlightRecorderManagerTest.kt
@@ -6,7 +6,8 @@ import android.content.Context
 import app.cash.turbine.test
 import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.core.data.util.asSuccess
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderWriter
 import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
 import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 import io.mockk.coEvery

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModelTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.about
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.core.data.manager.BuildInfoManager
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.datasource.disk.model.ServerConfig
 import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
@@ -10,7 +11,6 @@ import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.manager.util.deviceData
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/util/FlightRecorderDataSetExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/util/FlightRecorderDataSetExtensionsTest.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.about.util
 
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsViewModelTest.kt
@@ -3,12 +3,12 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recorded
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.manager.file.FileManager
 import com.bitwarden.data.manager.model.ZipFileResult
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsAction
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsEvent

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/util/FlightRecorderDataSetExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/util/FlightRecorderDataSetExtensionsTest.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedlogs.util
 
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.util.fileOf
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.util.toViewState

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.network.model.OrganizationType
@@ -28,7 +29,6 @@ import com.x8bit.bitwarden.data.auth.repository.model.UpdateKdfMinimumsResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserAutofillDialogManager
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import com.x8bit.bitwarden.data.platform.manager.CredentialExchangeRegistryManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/FlightRecorderDataSetExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/FlightRecorderDataSetExtensionsTest.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.ui.vault.feature.vault.util
 
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/AuthenticatorBuildInfoManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/manager/AuthenticatorBuildInfoManagerImpl.kt
@@ -12,6 +12,8 @@ class AuthenticatorBuildInfoManagerImpl : BuildInfoManager {
     override val applicationId: String
         get() = BuildConfig.APPLICATION_ID
 
+    override val applicationName: String get() = "Authenticator"
+
     /**
      * Indicates whether the build is from the F-Droid flavor.
      * This is always false for Authenticator as it does not have an F-Droid compatible flavor.
@@ -44,4 +46,6 @@ class AuthenticatorBuildInfoManagerImpl : BuildInfoManager {
             "release" -> "prod"
             else -> BuildConfig.BUILD_TYPE
         }
+
+    override val buildAndFlavor: String get() = BuildConfig.BUILD_TYPE
 }

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/BuildInfoManager.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/BuildInfoManager.kt
@@ -15,6 +15,11 @@ interface BuildInfoManager {
     val applicationId: String
 
     /**
+     * The human readable name of the running application (untranslated).
+     */
+    val applicationName: String
+
+    /**
      * A boolean property that indicates whether the current build flavor is "fdroid".
      */
     val isFdroid: Boolean
@@ -48,4 +53,9 @@ interface BuildInfoManager {
      * A string representing the build type.
      */
     val buildTypeName: String
+
+    /**
+     * A string representing the raw build and flavor types.
+     */
+    val buildAndFlavor: String
 }

--- a/data/src/main/kotlin/com/bitwarden/data/datasource/disk/model/FlightRecorderDataSet.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/datasource/disk/model/FlightRecorderDataSet.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.datasource.disk.model
+package com.bitwarden.data.datasource.disk.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/data/src/main/kotlin/com/bitwarden/data/manager/di/DataManagerModule.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/di/DataManagerModule.kt
@@ -1,6 +1,7 @@
 package com.bitwarden.data.manager.di
 
 import android.content.Context
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.data.manager.BitwardenPackageManager
 import com.bitwarden.data.manager.BitwardenPackageManagerImpl
@@ -8,12 +9,15 @@ import com.bitwarden.data.manager.NativeLibraryManager
 import com.bitwarden.data.manager.NativeLibraryManagerImpl
 import com.bitwarden.data.manager.file.FileManager
 import com.bitwarden.data.manager.file.FileManagerImpl
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderWriter
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderWriterImpl
 import com.bitwarden.network.service.DownloadService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -39,6 +43,20 @@ object DataManagerModule {
         context = context,
         downloadService = downloadService,
         dispatcherManager = dispatcherManager,
+    )
+
+    @Provides
+    @Singleton
+    fun provideFlightRecorderWriter(
+        clock: Clock,
+        fileManager: FileManager,
+        dispatcherManager: DispatcherManager,
+        buildInfoManager: BuildInfoManager,
+    ): FlightRecorderWriter = FlightRecorderWriterImpl(
+        clock = clock,
+        fileManager = fileManager,
+        dispatcherManager = dispatcherManager,
+        buildInfoManager = buildInfoManager,
     )
 
     @Provides

--- a/data/src/main/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderWriter.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderWriter.kt
@@ -1,6 +1,6 @@
-package com.x8bit.bitwarden.data.platform.manager.flightrecorder
+package com.bitwarden.data.manager.flightrecorder
 
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import java.io.File
 
 /**

--- a/data/src/main/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderWriterImpl.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderWriterImpl.kt
@@ -1,13 +1,13 @@
-package com.x8bit.bitwarden.data.platform.manager.flightrecorder
+package com.bitwarden.data.manager.flightrecorder
 
 import android.os.Build
 import android.util.Log
 import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.util.toFormattedPattern
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.data.manager.file.FileManager
-import com.x8bit.bitwarden.BuildConfig
-import com.x8bit.bitwarden.data.platform.datasource.disk.model.FlightRecorderDataSet
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.BufferedWriter
@@ -25,10 +25,11 @@ private const val LOG_TIME_PATTERN: String = "yyyy-MM-dd HH:mm:ss:SSS"
  * The default implementation of the [FlightRecorderWriter].
  */
 @OmitFromCoverage
-class FlightRecorderWriterImpl(
+internal class FlightRecorderWriterImpl(
     private val clock: Clock,
     private val fileManager: FileManager,
     private val dispatcherManager: DispatcherManager,
+    private val buildInfoManager: BuildInfoManager,
 ) : FlightRecorderWriter {
     override suspend fun deleteLog(data: FlightRecorderDataSet.FlightRecorderData) {
         fileManager.delete(File(File(fileManager.logsDirectory), data.fileName))
@@ -55,19 +56,18 @@ class FlightRecorderWriterImpl(
                 val startTime = Instant
                     .ofEpochMilli(data.startTimeMs)
                     .toFormattedPattern(pattern = LOG_TIME_PATTERN, clock = clock)
-                val appVersion = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
                 val operatingSystem = "${Build.VERSION.RELEASE} (${Build.VERSION.SDK_INT})"
                 // Upon creating the new file, we pre-populate it with basic data
                 BufferedWriter(FileWriter(logFile, true)).use { bw ->
-                    bw.append("Bitwarden Android")
+                    bw.append("Bitwarden Android - ${buildInfoManager.applicationName}")
                     bw.newLine()
                     bw.append("Log Start Time: $startTime")
                     bw.newLine()
                     bw.append("Log Duration: ${data.durationMs.milliseconds}")
                     bw.newLine()
-                    bw.append("App Version: $appVersion")
+                    bw.append("App Version: ${buildInfoManager.versionData}")
                     bw.newLine()
-                    bw.append("Build: ${BuildConfig.BUILD_TYPE}/${BuildConfig.FLAVOR}")
+                    bw.append("Build: ${buildInfoManager.buildAndFlavor}")
                     bw.newLine()
                     bw.append("Operating System: $operatingSystem")
                     bw.newLine()


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29806](https://bitwarden.atlassian.net/browse/PM-29806)

## 📔 Objective

This PR move the `FlightRecorderWriter` to the common `data` module.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29806]: https://bitwarden.atlassian.net/browse/PM-29806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ