### PR TITLE
PM-29824: Add bulk share ciphers network layer implementation

### DIFF
--- a/network/src/main/kotlin/com/bitwarden/network/api/CiphersApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/CiphersApi.kt
@@ -2,7 +2,9 @@ package com.bitwarden.network.api
 
 import com.bitwarden.network.model.AttachmentJsonRequest
 import com.bitwarden.network.model.AttachmentJsonResponse
+import com.bitwarden.network.model.BulkShareCiphersJsonRequest
 import com.bitwarden.network.model.CipherJsonRequest
+import com.bitwarden.network.model.CipherMiniResponseJson
 import com.bitwarden.network.model.CreateCipherInOrganizationJsonRequest
 import com.bitwarden.network.model.ImportCiphersJsonRequest
 import com.bitwarden.network.model.NetworkResult
@@ -74,6 +76,14 @@ internal interface CiphersApi {
         @Path("cipherId") cipherId: String,
         @Body body: ShareCipherJsonRequest,
     ): NetworkResult<SyncResponseJson.Cipher>
+
+    /**
+     * Shares multiple ciphers in bulk.
+     */
+    @PUT("ciphers/share")
+    suspend fun bulkShareCiphers(
+        @Body body: BulkShareCiphersJsonRequest,
+    ): NetworkResult<List<CipherMiniResponseJson>>
 
     /**
      * Shares an attachment.

--- a/network/src/main/kotlin/com/bitwarden/network/model/BulkShareCiphersJsonRequest.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/BulkShareCiphersJsonRequest.kt
@@ -1,0 +1,19 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a bulk share ciphers request.
+ *
+ * @property ciphers The list of ciphers to share.
+ * @property collectionIds A list of collection IDs to associate with all ciphers.
+ */
+@Serializable
+data class BulkShareCiphersJsonRequest(
+    @SerialName("Ciphers")
+    val ciphers: List<CipherJsonRequest>,
+
+    @SerialName("CollectionIds")
+    val collectionIds: List<String>,
+)

--- a/network/src/main/kotlin/com/bitwarden/network/model/CipherMiniResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/CipherMiniResponseJson.kt
@@ -1,0 +1,66 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.time.ZonedDateTime
+
+/**
+ * Represents a minimal cipher response from the API, typically returned from bulk operations.
+ * Contains core cipher metadata without detailed type-specific fields.
+ *
+ * @property id The ID of the cipher.
+ * @property organizationId The organization ID (nullable).
+ * @property type The type of cipher.
+ * @property data Serialized cipher data (newer API format).
+ * @property attachments List of attachments (nullable).
+ * @property shouldOrganizationUseTotp If the organization should use TOTP.
+ * @property revisionDate The revision date.
+ * @property creationDate The creation date.
+ * @property deletedDate The deleted date (nullable).
+ * @property reprompt The reprompt type.
+ * @property key The cipher key (nullable).
+ * @property archivedDate The archived date (nullable).
+ */
+@Serializable
+data class CipherMiniResponseJson(
+    @SerialName("id")
+    val id: String,
+
+    @SerialName("organizationId")
+    val organizationId: String?,
+
+    @SerialName("type")
+    val type: CipherTypeJson,
+
+    @SerialName("data")
+    val data: String?,
+
+    @SerialName("attachments")
+    val attachments: List<SyncResponseJson.Cipher.Attachment>?,
+
+    @SerialName("organizationUseTotp")
+    val shouldOrganizationUseTotp: Boolean,
+
+    @SerialName("revisionDate")
+    @Contextual
+    val revisionDate: ZonedDateTime,
+
+    @SerialName("creationDate")
+    @Contextual
+    val creationDate: ZonedDateTime,
+
+    @SerialName("deletedDate")
+    @Contextual
+    val deletedDate: ZonedDateTime?,
+
+    @SerialName("reprompt")
+    val reprompt: CipherRepromptTypeJson,
+
+    @SerialName("key")
+    val key: String?,
+
+    @SerialName("archivedDate")
+    @Contextual
+    val archivedDate: ZonedDateTime?,
+)

--- a/network/src/main/kotlin/com/bitwarden/network/service/CiphersService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/CiphersService.kt
@@ -3,7 +3,9 @@ package com.bitwarden.network.service
 import com.bitwarden.network.model.AttachmentInfo
 import com.bitwarden.network.model.AttachmentJsonRequest
 import com.bitwarden.network.model.AttachmentJsonResponse
+import com.bitwarden.network.model.BulkShareCiphersJsonRequest
 import com.bitwarden.network.model.CipherJsonRequest
+import com.bitwarden.network.model.CipherMiniResponseJson
 import com.bitwarden.network.model.CreateCipherInOrganizationJsonRequest
 import com.bitwarden.network.model.CreateCipherResponseJson
 import com.bitwarden.network.model.ImportCiphersJsonRequest
@@ -62,6 +64,13 @@ interface CiphersService {
         cipherId: String,
         body: ShareCipherJsonRequest,
     ): Result<SyncResponseJson.Cipher>
+
+    /**
+     * Attempt to share multiple ciphers in bulk.
+     */
+    suspend fun bulkShareCiphers(
+        body: BulkShareCiphersJsonRequest,
+    ): Result<List<CipherMiniResponseJson>>
 
     /**
      * Attempt to share an attachment.

--- a/network/src/main/kotlin/com/bitwarden/network/service/CiphersServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/CiphersServiceImpl.kt
@@ -6,7 +6,9 @@ import com.bitwarden.network.api.CiphersApi
 import com.bitwarden.network.model.AttachmentInfo
 import com.bitwarden.network.model.AttachmentJsonRequest
 import com.bitwarden.network.model.AttachmentJsonResponse
+import com.bitwarden.network.model.BulkShareCiphersJsonRequest
 import com.bitwarden.network.model.CipherJsonRequest
+import com.bitwarden.network.model.CipherMiniResponseJson
 import com.bitwarden.network.model.CreateCipherInOrganizationJsonRequest
 import com.bitwarden.network.model.CreateCipherResponseJson
 import com.bitwarden.network.model.FileUploadType
@@ -183,6 +185,13 @@ internal class CiphersServiceImpl(
                 cipherId = cipherId,
                 body = body,
             )
+            .toResult()
+
+    override suspend fun bulkShareCiphers(
+        body: BulkShareCiphersJsonRequest,
+    ): Result<List<CipherMiniResponseJson>> =
+        ciphersApi
+            .bulkShareCiphers(body = body)
             .toResult()
 
     override suspend fun updateCipherCollections(

--- a/network/src/test/kotlin/com/bitwarden/network/model/CipherMiniResponseJsonUtil.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/model/CipherMiniResponseJsonUtil.kt
@@ -1,0 +1,23 @@
+package com.bitwarden.network.model
+
+import java.time.ZonedDateTime
+
+/**
+ * Create a mock [CipherMiniResponseJson] for testing.
+ */
+fun createMockCipherMiniResponse(
+    number: Int,
+): CipherMiniResponseJson = CipherMiniResponseJson(
+    id = "mockId-$number",
+    organizationId = "mockOrgId-$number",
+    type = CipherTypeJson.LOGIN,
+    data = "mockData-$number",
+    attachments = null,
+    shouldOrganizationUseTotp = false,
+    revisionDate = ZonedDateTime.parse("2023-10-27T12:00:00.000Z"),
+    creationDate = ZonedDateTime.parse("2023-10-27T12:00:00.000Z"),
+    deletedDate = null,
+    reprompt = CipherRepromptTypeJson.NONE,
+    key = "mockKey-$number",
+    archivedDate = null,
+)


### PR DESCRIPTION
## 🎟️ Tracking

PM-29824

## 📔 Objective

This PR implements the network layer foundation for bulk sharing multiple personal vault items to an organization in a single API call. The implementation adds the request/response models, API endpoint (`PUT /ciphers/share`), service layer methods, and corresponding unit tests, with full alignment to the [server's bulk share contract](https://github.com/bitwarden/server/blob/919d0be6d2fcd2f94fb2b538d4e738b52faba8f1/src/Api/Vault/Controllers/CiphersController.cs#L1248).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
