### PR TITLE
[PM-29842] Add organization event types for item migration acceptance and rejection

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEvent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEvent.kt
@@ -114,4 +114,24 @@ sealed class OrganizationEvent {
         override val type: OrganizationEventType
             get() = OrganizationEventType.USER_CLIENT_EXPORTED_VAULT
     }
+
+    /**
+     * Tracks when a user's personal ciphers have been migrated to their organization's My Items
+     * folder as required by the organization's personal vault ownership policy.
+     */
+    data object ItemOrganizationAccepted : OrganizationEvent() {
+        override val cipherId: String? = null
+        override val type: OrganizationEventType
+            get() = OrganizationEventType.ORGANIZATION_ITEM_ORGANIZATION_ACCEPTED
+    }
+
+    /**
+     * Tracks when a user chooses to leave an organization instead of migrating their personal
+     * ciphers to their organization's My Items folder.
+     */
+    data object ItemOrganizationDeclined : OrganizationEvent() {
+        override val cipherId: String? = null
+        override val type: OrganizationEventType
+            get() = OrganizationEventType.ORGANIZATION_ITEM_ORGANIZATION_DECLINED
+    }
 }

--- a/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventType.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventType.kt
@@ -126,6 +126,12 @@ enum class OrganizationEventType {
 
     @SerialName("1601")
     ORGANIZATION_PURGED_VAULT,
+
+    @SerialName("1618")
+    ORGANIZATION_ITEM_ORGANIZATION_ACCEPTED,
+
+    @SerialName("1619")
+    ORGANIZATION_ITEM_ORGANIZATION_DECLINED,
 }
 
 @Keep


### PR DESCRIPTION
## 🎟️ Tracking

PM-29842
Relates to https://github.com/bitwarden/server/pull/6721

## 📔 Objective

Introduce new organization event types to track user decisions regarding the migration of personal ciphers to an organization's "My Items" folder, typically triggered by personal vault ownership policies.

Actual event tracking will be implemented in a subsequent PR.

Specific changes:
- Update `OrganizationEventType` in the network layer to include `ORGANIZATION_ITEM_ORGANIZATION_ACCEPTED` (1618) and `ORGANIZATION_ITEM_ORGANIZATION_DECLINED` (1619).
- Add corresponding data objects `ItemOrganizationAccepted` and `ItemOrganizationDeclined` to the `OrganizationEvent` sealed class hierarchy to handle these events within the application logic.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
