### PR TITLE
PM-29827: Move FlightRecorderManager to common data module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -1,6 +1,6 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk
 
-import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
+import com.bitwarden.data.datasource.disk.FlightRecorderDiskSource
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
@@ -13,7 +13,7 @@ import java.time.Instant
  * Primary access point for general settings-related disk information.
  */
 @Suppress("TooManyFunctions")
-interface SettingsDiskSource {
+interface SettingsDiskSource : FlightRecorderDiskSource {
 
     /**
      * The currently persisted app language (or `null` if not set).
@@ -94,16 +94,6 @@ interface SettingsDiskSource {
      * Emits updates that track [hasUserLoggedInOrCreatedAccount].
      */
     val hasUserLoggedInOrCreatedAccountFlow: Flow<Boolean?>
-
-    /**
-     * The current status of whether the flight recorder is enabled.
-     */
-    var flightRecorderData: FlightRecorderDataSet?
-
-    /**
-     * Emits updates that track [flightRecorderData].
-     */
-    val flightRecorderDataFlow: Flow<FlightRecorderDataSet?>
 
     /**
      * The time at which the browser autofill dialog is allowed to be shown to the user again.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -12,6 +12,7 @@ import com.bitwarden.core.data.manager.toast.ToastManagerImpl
 import com.bitwarden.cxf.registry.CredentialExchangeRegistry
 import com.bitwarden.cxf.registry.dsl.credentialExchangeRegistry
 import com.bitwarden.data.manager.NativeLibraryManager
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
 import com.bitwarden.data.manager.flightrecorder.FlightRecorderWriter
 import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.network.BitwardenServiceClient
@@ -64,8 +65,6 @@ import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardMan
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManagerImpl
-import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderManager
-import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.garbage.GarbageCollectionManager
 import com.x8bit.bitwarden.data.platform.manager.garbage.GarbageCollectionManagerImpl
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConfigManager
@@ -115,11 +114,11 @@ object PlatformManagerModule {
         dispatcherManager: DispatcherManager,
         settingsDiskSource: SettingsDiskSource,
         flightRecorderWriter: FlightRecorderWriter,
-    ): FlightRecorderManager = FlightRecorderManagerImpl(
+    ): FlightRecorderManager = FlightRecorderManager.create(
         context = context,
         clock = clock,
         dispatcherManager = dispatcherManager,
-        settingsDiskSource = settingsDiskSource,
+        flightRecorderDiskSource = settingsDiskSource,
         flightRecorderWriter = flightRecorderWriter,
     )
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.data.platform.repository
 
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
 import com.x8bit.bitwarden.data.auth.repository.model.UserFingerprintResult
-import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderManager
 import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.platform.repository
 import android.view.autofill.AutofillManager
 import com.bitwarden.authenticatorbridge.util.generateSecretKey
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
 import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
 import com.bitwarden.ui.platform.feature.settings.appearance.model.AppTheme
@@ -16,7 +17,6 @@ import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
-import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderManager
 import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.repository.di
 
 import android.view.autofill.AutofillManager
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
 import com.bitwarden.data.repository.ServerConfigRepository
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
@@ -10,7 +11,6 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.EnvironmentDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
-import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderManager
 import com.x8bit.bitwarden.data.platform.repository.AuthenticatorBridgeRepository
 import com.x8bit.bitwarden.data.platform.repository.AuthenticatorBridgeRepositoryImpl
 import com.x8bit.bitwarden.data.platform.repository.DebugMenuRepository

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
@@ -39,7 +40,6 @@ import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.util.displayText
 import kotlinx.collections.immutable.toImmutableList
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderViewModel.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder
 
 import androidx.lifecycle.SavedStateHandle
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/util/FlightRecorderDurationExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/util/FlightRecorderDurationExtensions.kt
@@ -1,9 +1,9 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.util
 
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 
 /**
  * A helper function to map the [FlightRecorderDuration] to a displayable label.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
+import com.bitwarden.data.manager.flightrecorder.FlightRecorderManager
 import com.bitwarden.network.model.KdfTypeJson
 import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.network.model.SyncResponseJson
@@ -29,7 +30,6 @@ import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManagerImpl
 import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
-import com.x8bit.bitwarden.data.platform.manager.flightrecorder.FlightRecorderManager
 import com.x8bit.bitwarden.data.platform.repository.model.BiometricsKeyResult
 import com.x8bit.bitwarden.data.platform.repository.model.ClearClipboardFrequency
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreenTest.kt
@@ -13,10 +13,10 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.printToLog
 import androidx.core.net.toUri
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.util.assertNoDialogExists
 import com.bitwarden.ui.util.performCustomAccessibilityAction
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 import com.x8bit.bitwarden.ui.platform.base.BitwardenComposeTest
 import io.mockk.every
 import io.mockk.just

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderViewModelTest.kt
@@ -2,9 +2,9 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/util/FlightRecorderDurationTests.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/util/FlightRecorderDurationTests.kt
@@ -1,8 +1,8 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.util
 
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
     testImplementation(libs.square.turbine)
 
     testFixturesImplementation(project(":core"))
+    testFixturesImplementation(platform(libs.junit.bom))
+    testFixturesImplementation(libs.junit.jupiter)
     testFixturesImplementation(libs.kotlinx.coroutines.test)
 }
 

--- a/data/src/main/kotlin/com/bitwarden/data/datasource/disk/FlightRecorderDiskSource.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/datasource/disk/FlightRecorderDiskSource.kt
@@ -1,0 +1,19 @@
+package com.bitwarden.data.datasource.disk
+
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Primary access point for flight recorder related disk information.
+ */
+interface FlightRecorderDiskSource {
+    /**
+     * The current status of whether the flight recorder is enabled.
+     */
+    var flightRecorderData: FlightRecorderDataSet?
+
+    /**
+     * Emits updates that track [flightRecorderData].
+     */
+    val flightRecorderDataFlow: Flow<FlightRecorderDataSet?>
+}

--- a/data/src/main/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderManager.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderManager.kt
@@ -1,8 +1,12 @@
-package com.x8bit.bitwarden.data.platform.manager.flightrecorder
+package com.bitwarden.data.manager.flightrecorder
 
+import android.content.Context
+import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
+import com.bitwarden.data.datasource.disk.FlightRecorderDiskSource
 import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import kotlinx.coroutines.flow.StateFlow
+import java.time.Clock
 
 /**
  * Manager class that handles recording logs for the flight recorder.
@@ -42,4 +46,24 @@ interface FlightRecorderManager {
      * Deletes the raw log files and metadata.
      */
     fun deleteAllLogs()
+
+    @Suppress("UndocumentedPublicClass")
+    companion object {
+        /**
+         * Creates a new instance of the [FlightRecorderManager].
+         */
+        fun create(
+            context: Context,
+            clock: Clock,
+            flightRecorderDiskSource: FlightRecorderDiskSource,
+            flightRecorderWriter: FlightRecorderWriter,
+            dispatcherManager: DispatcherManager,
+        ): FlightRecorderManager = FlightRecorderManagerImpl(
+            context = context,
+            clock = clock,
+            flightRecorderDiskSource = flightRecorderDiskSource,
+            flightRecorderWriter = flightRecorderWriter,
+            dispatcherManager = dispatcherManager,
+        )
+    }
 }

--- a/data/src/main/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderManagerImpl.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderManagerImpl.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.manager.flightrecorder
+package com.bitwarden.data.manager.flightrecorder
 
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -7,10 +7,9 @@ import android.content.IntentFilter
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.util.concurrentMapOf
 import com.bitwarden.core.data.util.toFormattedPattern
+import com.bitwarden.data.datasource.disk.FlightRecorderDiskSource
 import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
-import com.bitwarden.data.manager.flightrecorder.FlightRecorderWriter
-import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -34,7 +33,7 @@ private const val EXPIRATION_DURATION_DAYS: Long = 30
 internal class FlightRecorderManagerImpl(
     private val context: Context,
     private val clock: Clock,
-    private val settingsDiskSource: SettingsDiskSource,
+    private val flightRecorderDiskSource: FlightRecorderDiskSource,
     private val flightRecorderWriter: FlightRecorderWriter,
     dispatcherManager: DispatcherManager,
 ) : FlightRecorderManager {
@@ -45,10 +44,12 @@ internal class FlightRecorderManagerImpl(
     private val flightRecorderTree = FlightRecorderTree()
 
     override val flightRecorderData: FlightRecorderDataSet
-        get() = settingsDiskSource.flightRecorderData ?: FlightRecorderDataSet(data = emptySet())
+        get() = flightRecorderDiskSource
+            .flightRecorderData
+            ?: FlightRecorderDataSet(data = emptySet())
 
     override val flightRecorderDataFlow: StateFlow<FlightRecorderDataSet>
-        get() = settingsDiskSource
+        get() = flightRecorderDiskSource
             .flightRecorderDataFlow
             .map { it ?: FlightRecorderDataSet(data = emptySet()) }
             .stateIn(
@@ -74,7 +75,7 @@ internal class FlightRecorderManagerImpl(
 
     override fun dismissFlightRecorderBanner() {
         val originalData = flightRecorderData
-        settingsDiskSource.flightRecorderData = originalData.copy(
+        flightRecorderDiskSource.flightRecorderData = originalData.copy(
             data = originalData.data.map { it.copy(isBannerDismissed = true) }.toSet(),
         )
     }
@@ -82,7 +83,7 @@ internal class FlightRecorderManagerImpl(
     override fun startFlightRecorder(duration: FlightRecorderDuration) {
         val startTime = clock.instant()
         val originalData = flightRecorderData
-        settingsDiskSource.flightRecorderData = originalData.copy(
+        flightRecorderDiskSource.flightRecorderData = originalData.copy(
             data = originalData
                 .data
                 .mapToInactive(clock = clock)
@@ -107,7 +108,7 @@ internal class FlightRecorderManagerImpl(
 
     override fun endFlightRecorder() {
         val originalData = flightRecorderData
-        settingsDiskSource.flightRecorderData = originalData.copy(
+        flightRecorderDiskSource.flightRecorderData = originalData.copy(
             data = originalData.data.mapToInactive(clock = clock),
         )
     }
@@ -118,7 +119,7 @@ internal class FlightRecorderManagerImpl(
             data = flightRecorderData.data.filterNot { it.isActive }.toSet(),
         )
         // Clear everything but the active log.
-        settingsDiskSource.flightRecorderData = activeLog?.let {
+        flightRecorderDiskSource.flightRecorderData = activeLog?.let {
             FlightRecorderDataSet(data = setOf(it))
         }
         // Clear all logs but the active one.
@@ -128,7 +129,7 @@ internal class FlightRecorderManagerImpl(
     override fun deleteLog(data: FlightRecorderDataSet.FlightRecorderData) {
         if (data.isActive) return
         val originalData = flightRecorderData
-        settingsDiskSource.flightRecorderData = originalData.copy(
+        flightRecorderDiskSource.flightRecorderData = originalData.copy(
             data = originalData.data.filterNot { it == data }.toSet(),
         )
         ioScope.launch { flightRecorderWriter.deleteLog(data = data) }

--- a/data/src/main/kotlin/com/bitwarden/data/manager/model/FlightRecorderDuration.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/model/FlightRecorderDuration.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.repository.model
+package com.bitwarden.data.manager.model
 
 /**
  * The selectable durations allowed for the flight recorder.

--- a/data/src/test/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderManagerTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/manager/flightrecorder/FlightRecorderManagerTest.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.manager.flightrecorder
+package com.bitwarden.data.manager.flightrecorder
 
 import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
@@ -7,9 +7,8 @@ import app.cash.turbine.test
 import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
-import com.bitwarden.data.manager.flightrecorder.FlightRecorderWriter
-import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
-import com.x8bit.bitwarden.data.platform.repository.model.FlightRecorderDuration
+import com.bitwarden.data.datasource.disk.util.FakeFlightRecorderDiskSource
+import com.bitwarden.data.manager.model.FlightRecorderDuration
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -38,7 +37,7 @@ class FlightRecorderManagerTest {
     private val context: Context = mockk {
         every { registerReceiver(capture(broadcastReceiver), any()) } returns null
     }
-    private val fakeSettingsDiskSource = FakeSettingsDiskSource()
+    private val fakeFlightRecorderDiskSource = FakeFlightRecorderDiskSource()
     private val flightRecorderWriter = mockk<FlightRecorderWriter> {
         coEvery { getOrCreateLogFile(data = any()) } returns mockk<File>().asSuccess()
         coEvery { deleteLogs(dataset = any()) } just runs
@@ -58,7 +57,7 @@ class FlightRecorderManagerTest {
     private val flightRecorder = FlightRecorderManagerImpl(
         context = context,
         clock = FIXED_CLOCK,
-        settingsDiskSource = fakeSettingsDiskSource,
+        flightRecorderDiskSource = fakeFlightRecorderDiskSource,
         flightRecorderWriter = flightRecorderWriter,
         dispatcherManager = fakeDispatcherManager,
     )
@@ -76,7 +75,7 @@ class FlightRecorderManagerTest {
 
     @Test
     fun `flightRecorderData should pull from and update SettingsDiskSource`() {
-        fakeSettingsDiskSource.flightRecorderData = null
+        fakeFlightRecorderDiskSource.flightRecorderData = null
         assertEquals(FlightRecorderDataSet(data = emptySet()), flightRecorder.flightRecorderData)
 
         val expected = FlightRecorderDataSet(
@@ -94,13 +93,13 @@ class FlightRecorderManagerTest {
                 ),
             ),
         )
-        fakeSettingsDiskSource.flightRecorderData = expected
+        fakeFlightRecorderDiskSource.flightRecorderData = expected
         assertEquals(expected, flightRecorder.flightRecorderData)
     }
 
     @Test
     fun `flightRecorderDataFlow should react to changes in SettingsDiskSource`() = runTest {
-        fakeSettingsDiskSource.flightRecorderData = null
+        fakeFlightRecorderDiskSource.flightRecorderData = null
         flightRecorder
             .flightRecorderDataFlow
             .test {
@@ -121,7 +120,7 @@ class FlightRecorderManagerTest {
                         ),
                     ),
                 )
-                fakeSettingsDiskSource.flightRecorderData = unexpired
+                fakeFlightRecorderDiskSource.flightRecorderData = unexpired
                 assertEquals(unexpired, awaitItem())
 
                 val expired = FlightRecorderDataSet(
@@ -139,21 +138,21 @@ class FlightRecorderManagerTest {
                         ),
                     ),
                 )
-                fakeSettingsDiskSource.flightRecorderData = expired
+                fakeFlightRecorderDiskSource.flightRecorderData = expired
                 assertEquals(FlightRecorderDataSet(data = emptySet()), awaitItem())
 
-                fakeSettingsDiskSource.flightRecorderData = null
+                fakeFlightRecorderDiskSource.flightRecorderData = null
                 expectNoEvents()
             }
     }
 
     @Test
     fun `startFlightRecorder should properly update SettingsDiskSource`() {
-        fakeSettingsDiskSource.flightRecorderData = null
+        fakeFlightRecorderDiskSource.flightRecorderData = null
 
         flightRecorder.startFlightRecorder(duration = FlightRecorderDuration.ONE_HOUR)
 
-        fakeSettingsDiskSource.assertFlightRecorderData(
+        fakeFlightRecorderDiskSource.assertFlightRecorderData(
             expected = FlightRecorderDataSet(
                 data = setOf(
                     FlightRecorderDataSet.FlightRecorderData(
@@ -196,11 +195,11 @@ class FlightRecorderManagerTest {
                 ),
             ),
         )
-        fakeSettingsDiskSource.flightRecorderData = data
+        fakeFlightRecorderDiskSource.flightRecorderData = data
 
         flightRecorder.dismissFlightRecorderBanner()
 
-        fakeSettingsDiskSource.assertFlightRecorderData(
+        fakeFlightRecorderDiskSource.assertFlightRecorderData(
             expected = FlightRecorderDataSet(
                 data = setOf(
                     FlightRecorderDataSet.FlightRecorderData(
@@ -255,11 +254,11 @@ class FlightRecorderManagerTest {
                 ),
             ),
         )
-        fakeSettingsDiskSource.flightRecorderData = data
+        fakeFlightRecorderDiskSource.flightRecorderData = data
 
         flightRecorder.endFlightRecorder()
 
-        fakeSettingsDiskSource.assertFlightRecorderData(
+        fakeFlightRecorderDiskSource.assertFlightRecorderData(
             expected = FlightRecorderDataSet(
                 data = setOf(
                     FlightRecorderDataSet.FlightRecorderData(
@@ -310,7 +309,7 @@ class FlightRecorderManagerTest {
         val activeDataset = FlightRecorderDataSet(data = setOf(activeData))
         val inactiveDataset = FlightRecorderDataSet(data = setOf(inactiveData))
 
-        fakeSettingsDiskSource.flightRecorderData = FlightRecorderDataSet(
+        fakeFlightRecorderDiskSource.flightRecorderData = FlightRecorderDataSet(
             data = setOf(activeData, inactiveData),
         )
 
@@ -319,7 +318,7 @@ class FlightRecorderManagerTest {
         coVerify(exactly = 1) {
             flightRecorderWriter.deleteLogs(dataset = inactiveDataset)
         }
-        fakeSettingsDiskSource.assertFlightRecorderData(expected = activeDataset)
+        fakeFlightRecorderDiskSource.assertFlightRecorderData(expected = activeDataset)
     }
 
     @Test
@@ -332,14 +331,14 @@ class FlightRecorderManagerTest {
             isActive = true,
         )
         val dataset = FlightRecorderDataSet(data = setOf(data))
-        fakeSettingsDiskSource.flightRecorderData = dataset
+        fakeFlightRecorderDiskSource.flightRecorderData = dataset
 
         flightRecorder.deleteLog(data = data)
 
         coVerify(exactly = 0) {
             flightRecorderWriter.deleteLog(data = data)
         }
-        fakeSettingsDiskSource.assertFlightRecorderData(expected = dataset)
+        fakeFlightRecorderDiskSource.assertFlightRecorderData(expected = dataset)
     }
 
     @Test
@@ -352,14 +351,14 @@ class FlightRecorderManagerTest {
             isActive = false,
             expirationTimeMs = FIXED_CLOCK.instant().plus(1L, ChronoUnit.HOURS).toEpochMilli(),
         )
-        fakeSettingsDiskSource.flightRecorderData = FlightRecorderDataSet(data = setOf(data))
+        fakeFlightRecorderDiskSource.flightRecorderData = FlightRecorderDataSet(data = setOf(data))
 
         flightRecorder.deleteLog(data = data)
 
         coVerify(exactly = 1) {
             flightRecorderWriter.deleteLog(data = data)
         }
-        fakeSettingsDiskSource.assertFlightRecorderData(
+        fakeFlightRecorderDiskSource.assertFlightRecorderData(
             expected = FlightRecorderDataSet(data = emptySet()),
         )
     }

--- a/data/src/testFixtures/kotlin/com/bitwarden/data/datasource/disk/util/FakeFlightRecorderDiskSource.kt
+++ b/data/src/testFixtures/kotlin/com/bitwarden/data/datasource/disk/util/FakeFlightRecorderDiskSource.kt
@@ -1,0 +1,32 @@
+package com.bitwarden.data.datasource.disk.util
+
+import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.data.datasource.disk.FlightRecorderDiskSource
+import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onSubscription
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class FakeFlightRecorderDiskSource : FlightRecorderDiskSource {
+    private val mutableFlightRecorderDataFlow =
+        bufferedMutableSharedFlow<FlightRecorderDataSet?>(replay = 1)
+
+    private var storedFlightRecorderData: FlightRecorderDataSet? = null
+
+    override var flightRecorderData: FlightRecorderDataSet?
+        get() = storedFlightRecorderData
+        set(value) {
+            storedFlightRecorderData = value
+            mutableFlightRecorderDataFlow.tryEmit(value)
+        }
+
+    override val flightRecorderDataFlow: Flow<FlightRecorderDataSet?>
+        get() = mutableFlightRecorderDataFlow.onSubscription { emit(storedFlightRecorderData) }
+
+    /**
+     * Asserts that the stored [FlightRecorderDataSet] matches the [expected] one.
+     */
+    fun assertFlightRecorderData(expected: FlightRecorderDataSet) {
+        assertEquals(expected, storedFlightRecorderData)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29827](https://bitwarden.atlassian.net/browse/PM-29827)

## 📔 Objective

This PR moves the `FlightRecorderManager` to the data module. This includes adding a new `FlightRecorderDiskSource` abstraction.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29827]: https://bitwarden.atlassian.net/browse/PM-29827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ