### PR TITLE
Move extensions to common module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/util/FlightRecorderDataSetExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/util/FlightRecorderDataSetExtensions.kt
@@ -3,13 +3,13 @@ package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recorded
 import com.bitwarden.core.data.util.toFormattedDateStyle
 import com.bitwarden.core.data.util.toFormattedPattern
 import com.bitwarden.core.data.util.toFormattedTimeStyle
+import com.bitwarden.core.util.fileOf
 import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.platform.util.formatBytes
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.util.fileOf
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
-import com.x8bit.bitwarden.ui.platform.util.formatBytes
 import kotlinx.collections.immutable.toImmutableList
 import java.time.Clock
 import java.time.Instant

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/util/FlightRecorderDataSetExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/util/FlightRecorderDataSetExtensionsTest.kt
@@ -1,12 +1,12 @@
 package com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedlogs.util
 
+import com.bitwarden.core.util.fileOf
 import com.bitwarden.data.datasource.disk.model.FlightRecorderDataSet
 import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.platform.util.formatBytes
 import com.bitwarden.ui.util.asText
-import com.x8bit.bitwarden.data.platform.util.fileOf
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.RecordedLogsState
 import com.x8bit.bitwarden.ui.platform.feature.settings.flightrecorder.recordedLogs.util.toViewState
-import com.x8bit.bitwarden.ui.platform.util.formatBytes
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic

--- a/core/src/main/kotlin/com/bitwarden/core/util/FileExtensions.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/util/FileExtensions.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.data.platform.util
+package com.bitwarden.core.util
 
 import com.bitwarden.annotation.OmitFromCoverage
 import java.io.File

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/util/LongExtensions.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/util/LongExtensions.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.util
+package com.bitwarden.ui.platform.util
 
 private const val BASE_DATA_SIZE: Long = 1024L
 private val DATA_SIZE_UNITS = arrayOf("B", "KB", "MB", "GB", "TB")

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/util/LongExtensionsTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/util/LongExtensionsTest.kt
@@ -1,4 +1,4 @@
-package com.x8bit.bitwarden.ui.platform.util
+package com.bitwarden.ui.platform.util
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR moves a few extension function to the common modules for better reusability.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
