### PR TITLE
[PM-30258] Remove CalyxOS Chromium from the FIDO2 privileged list

### DIFF
--- a/app/src/main/assets/fido2_privileged_community.json
+++ b/app/src/main/assets/fido2_privileged_community.json
@@ -31,18 +31,6 @@
     {
       "type": "android",
       "info": {
-        "package_name": "org.chromium.chrome",
-        "signatures": [
-          {
-            "build": "release",
-            "cert_fingerprint_sha256": "A8:56:48:50:79:BC:B3:57:BF:BE:69:BA:19:A9:BA:43:CD:0A:D9:AB:22:67:52:C7:80:B6:88:8A:FD:48:21:6B"
-          }
-        ]
-      }
-    },
-    {
-      "type": "android",
-      "info": {
         "package_name": "org.cromite.cromite",
         "signatures": [
           {


### PR DESCRIPTION
CalyxOS is currently on a pause and its Chromium variant is not updating, it is stuck on 137
The signing keys for the project are being rotated, which would include Chromium as well, so it would need to be rotated anyway
Hopefully the package ID is also changed by then