### PR TITLE
Force LTR text direction for passwords and TOTP codes

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeItem.kt
@@ -24,7 +24,7 @@ import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.bitwarden.ui.platform.util.withForcedLtr
+import com.bitwarden.ui.platform.util.withForcedLtrDirection
 
 /**
  * The verification code item displayed to the user.
@@ -108,7 +108,7 @@ fun VaultVerificationCodeItem(
         if (!hideAuthCode) {
             Text(
                 text = authCode.chunked(3).joinToString(" "),
-                style = BitwardenTheme.typography.sensitiveInfoSmall.withForcedLtr(),
+                style = BitwardenTheme.typography.sensitiveInfoSmall.withForcedLtrDirection(),
                 color = BitwardenTheme.colorScheme.text.primary,
             )
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/VaultVerificationCodeItem.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/VaultVerificationCodeItem.kt
@@ -29,7 +29,7 @@ import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.bitwarden.ui.platform.util.withForcedLtr
+import com.bitwarden.ui.platform.util.withForcedLtrDirection
 
 /**
  * The verification code item displayed to the user.
@@ -156,7 +156,7 @@ fun VaultVerificationCodeItem(
         Text(
             modifier = Modifier.testTag(tag = "AuthCode"),
             text = authCode.chunked(size = 3).joinToString(separator = " "),
-            style = BitwardenTheme.typography.sensitiveInfoSmall.withForcedLtr(),
+            style = BitwardenTheme.typography.sensitiveInfoSmall.withForcedLtrDirection(),
             color = BitwardenTheme.colorScheme.text.primary,
         )
 

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/field/BitwardenPasswordField.kt
@@ -60,7 +60,7 @@ import com.bitwarden.ui.platform.components.util.nonLetterColorVisualTransformat
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.bitwarden.ui.platform.util.withForcedLtr
+import com.bitwarden.ui.platform.util.withForcedLtrDirection
 
 /**
  * Represents a Bitwarden-styled password field that hoists show/hide password state to the caller.
@@ -156,7 +156,7 @@ fun BitwardenPasswordField(
             var focused by remember { mutableStateOf(value = false) }
             TextField(
                 colors = bitwardenTextFieldColors(),
-                textStyle = BitwardenTheme.typography.sensitiveInfoSmall.withForcedLtr(),
+                textStyle = BitwardenTheme.typography.sensitiveInfoSmall.withForcedLtrDirection(),
                 label = label?.let {
                     {
                         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/util/TypographyExtensions.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/util/TypographyExtensions.kt
@@ -31,14 +31,15 @@ import com.bitwarden.annotation.OmitFromCoverage
  */
 @OmitFromCoverage
 @Composable
-fun TextStyle.withForcedLtr(): TextStyle {
-    val layoutDirection = LocalLayoutDirection.current
+fun TextStyle.withForcedLtrDirection(
+    layoutDirection: LayoutDirection = LocalLayoutDirection.current,
+): TextStyle {
     return merge(
         TextStyle(
             textDirection = TextDirection.Ltr,
             textAlign = when (layoutDirection) {
-                LayoutDirection.Rtl -> TextAlign.End
-                LayoutDirection.Ltr -> TextAlign.Start
+                LayoutDirection.Rtl -> TextAlign.Right
+                LayoutDirection.Ltr -> TextAlign.Left
             },
         ),
     )


### PR DESCRIPTION
## 🎟️ Tracking

PM-20026
Relates to #4753

## 📔 Objective

Fixes text direction and alignment issues for passwords and TOTP verification codes in RTL (right-to-left) locales such as Persian and Hebrew. 

When the system locale is set to an RTL language, passwords and TOTP codes were displaying incorrectly—reading right-to-left instead of left-to-right, and aligning to the wrong side of the field. 

This PR introduces a reusable `TextStyle.withForcedLtr()` extension that forces left-to-right text direction while maintaining locale-aware alignment, ensuring alphanumeric credentials display correctly across all locales.

Based on work started by @codokie in #5012

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
