### PR TITLE
[PM-30394] PM-29960: Skip biometric prompt on Xiaomi HyperOS

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/util/CredentialEntryBuilderExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/util/CredentialEntryBuilderExtensions.kt
@@ -12,12 +12,11 @@ import javax.crypto.Cipher
 
 /**
  * Sets the biometric prompt data on the [PublicKeyCredentialEntry.Builder] if supported.
- * Note: Xiaomi HyperOS is known to not support biometric prompt.
  */
 fun PublicKeyCredentialEntry.Builder.setBiometricPromptDataIfSupported(
     cipher: Cipher?,
 ): PublicKeyCredentialEntry.Builder =
-    if (isBuildVersionAtLeast(Build.VERSION_CODES.VANILLA_ICE_CREAM) && !isHyperOS() && cipher != null) {
+    if (isBiometricPromptDataSupported() && cipher != null) {
         setBiometricPromptData(
             biometricPromptData = buildPromptDataWithCipher(cipher),
         )
@@ -27,15 +26,23 @@ fun PublicKeyCredentialEntry.Builder.setBiometricPromptDataIfSupported(
 
 /**
  * Sets the biometric prompt data on the [PasswordCredentialEntry.Builder] if supported.
- * Note: Xiaomi HyperOS is known to not support biometric prompt.
  */
 fun PasswordCredentialEntry.Builder.setBiometricPromptDataIfSupported(
     cipher: Cipher?,
 ): PasswordCredentialEntry.Builder =
-    if (isBuildVersionAtLeast(Build.VERSION_CODES.VANILLA_ICE_CREAM) && !isHyperOS() && cipher != null) {
+    if (isBiometricPromptDataSupported() && cipher != null) {
         setBiometricPromptData(
             biometricPromptData = buildPromptDataWithCipher(cipher),
         )
     } else {
         this
     }
+
+/**
+ * Returns whether biometric prompt data is supported on this device.
+ * Note: Xiaomi HyperOS is known to be incompatible.
+ */
+private fun isBiometricPromptDataSupported(): Boolean {
+    return isBuildVersionAtLeast(Build.VERSION_CODES.VANILLA_ICE_CREAM) &&
+        !isHyperOS()
+}

--- a/core/src/main/kotlin/com/bitwarden/core/util/AndroidPropUtils.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/util/AndroidPropUtils.kt
@@ -27,4 +27,3 @@ private fun getSystemProperty(key: String): String? {
         null
     }
 }
-


### PR DESCRIPTION
## 🎟️ Tracking
https://github.com/bitwarden/android/issues/6284

## 📔 Objective

Xiaomi HyperOS changed AOSP's credential manager and broke BiometricPrompt. One way to fix it is to skip biometric prompt handling if Bitwarden is running on Hyper OS. 

See more details here: https://github.com/bitwarden/android/issues/6284#issuecomment-3705618623

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
