### PR TITLE
Allow trailing commas in JSON

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/di/CoreModule.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/di/CoreModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
@@ -35,6 +36,10 @@ object CoreModule {
 
         // Respect model default property values.
         coerceInputValues = true
+
+        // Allow trailing commas in JSON objects and arrays.
+        @OptIn(ExperimentalSerializationApi::class)
+        allowTrailingComma = true
     }
 
     @Provides


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR allows us to parse JSON that contain trailing commas in objects and arrays. This error was seen when parsing the `PrivilegedAppAllowListJson`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
