### PR TITLE
[VULN-362] Move Compose tooling dependency to debugImplementation

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -67,7 +67,6 @@ dependencies {
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.credentials)
@@ -79,7 +78,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.zxing.zxing.core)
 
-    // For now we are restricted to running Compose tests for debug builds only
+    // For now, we are restricted to running Compose tests for debug builds only
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)
 


### PR DESCRIPTION
## 🎟️ Tracking

VULN-362
PM-30462

## 📔 Objective

Optimize the build configuration by ensuring development-only tools are not included in release builds.

Behavioral Changes:
The Android Compose UI tooling library will now only be available in debug builds, preventing it from bloating release artifacts.

Specific Changes:
- `ui/build.gradle.kts`: Changed the dependency scope of `androidx.compose.ui.tooling` from `implementation` to `debugImplementation`.
- `ui/build.gradle.kts`: Fixed a minor grammatical error in a comment ("For now we" -> "For now, we").

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
