### PR TITLE
PM-26577: Feat: Support multiple schemes for Duo, WebAuthn, and SSO callbacks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -170,6 +170,7 @@
                 <data android:scheme="https" />
                 <data android:host="bitwarden.com" />
                 <data android:host="bitwarden.eu" />
+                <data android:host="bitwarden.pw" />
                 <data android:pathPattern="/duo-callback" />
                 <data android:pathPattern="/sso-callback" />
                 <data android:pathPattern="/webauthn-callback" />

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/EnvironmentUrlDataJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/EnvironmentUrlDataJsonExtensions.kt
@@ -23,23 +23,23 @@ private fun EnvironmentUrlDataJson.authTabData(
     kind: String,
 ): AuthTabData = when (this.environmentRegion) {
     EnvironmentRegion.UNITED_STATES -> {
-        // TODO: PM-26577 Update this to use a "HttpsScheme"
-        AuthTabData.CustomScheme(
-            callbackUrl = "bitwarden://$kind-callback",
+        AuthTabData.HttpsScheme(
+            host = "bitwarden.com",
+            path = "$kind-callback",
         )
     }
 
     EnvironmentRegion.EUROPEAN_UNION -> {
-        // TODO: PM-26577 Update this to use a "HttpsScheme"
-        AuthTabData.CustomScheme(
-            callbackUrl = "bitwarden://$kind-callback",
+        AuthTabData.HttpsScheme(
+            host = "bitwarden.eu",
+            path = "$kind-callback",
         )
     }
 
     EnvironmentRegion.INTERNAL -> {
-        // TODO: PM-26577 Update this to use a "HttpsScheme"
-        AuthTabData.CustomScheme(
-            callbackUrl = "bitwarden://$kind-callback",
+        AuthTabData.HttpsScheme(
+            host = "bitwarden.pw",
+            path = "$kind-callback",
         )
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -7840,7 +7840,7 @@ class AuthRepositoryTest {
             Instant.parse("2023-10-27T12:00:00Z"),
             ZoneOffset.UTC,
         )
-        private const val DEEPLINK_SCHEME = "bitwarden"
+        private const val DEEPLINK_SCHEME = "https"
         private const val UNIQUE_APP_ID = "testUniqueAppId"
         private const val NAME = "Example Name"
         private const val EMAIL = "test@bitwarden.com"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/util/EnvironmentUrlDataJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/util/EnvironmentUrlDataJsonExtensionsTest.kt
@@ -9,25 +9,24 @@ class EnvironmentUrlDataJsonExtensionsTest {
 
     @Test
     fun `duoAuthTabData should return the correct AuthTabData for all environments`() {
-        // TODO: PM-26577 Update these to use a "HttpsScheme"
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://duo-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.com",
+                path = "duo-callback",
             ),
             EnvironmentUrlDataJson.DEFAULT_US.duoAuthTabData,
         )
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://duo-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.eu",
+                path = "duo-callback",
             ),
             EnvironmentUrlDataJson.DEFAULT_EU.duoAuthTabData,
         )
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://duo-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.pw",
+                path = "duo-callback",
             ),
             DEFAULT_INTERNAL_ENVIRONMENT_URL_DATA.duoAuthTabData,
         )
@@ -42,25 +41,24 @@ class EnvironmentUrlDataJsonExtensionsTest {
 
     @Test
     fun `webAuthnAuthTabData should return the correct AuthTabData for all environments`() {
-        // TODO: PM-26577 Update these to use a "HttpsScheme"
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://webauthn-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.com",
+                path = "webauthn-callback",
             ),
             EnvironmentUrlDataJson.DEFAULT_US.webAuthnAuthTabData,
         )
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://webauthn-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.eu",
+                path = "webauthn-callback",
             ),
             EnvironmentUrlDataJson.DEFAULT_EU.webAuthnAuthTabData,
         )
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://webauthn-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.pw",
+                path = "webauthn-callback",
             ),
             DEFAULT_INTERNAL_ENVIRONMENT_URL_DATA.webAuthnAuthTabData,
         )
@@ -75,25 +73,24 @@ class EnvironmentUrlDataJsonExtensionsTest {
 
     @Test
     fun `ssoAuthTabData should return the correct AuthTabData for all environments`() {
-        // TODO: PM-26577 Update these to use a "HttpsScheme"
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://sso-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.com",
+                path = "sso-callback",
             ),
             EnvironmentUrlDataJson.DEFAULT_US.ssoAuthTabData,
         )
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://sso-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.eu",
+                path = "sso-callback",
             ),
             EnvironmentUrlDataJson.DEFAULT_EU.ssoAuthTabData,
         )
         assertEquals(
-            AuthTabData.CustomScheme(
-                callbackUrl = "bitwarden://sso-callback",
-                callbackScheme = "bitwarden",
+            AuthTabData.HttpsScheme(
+                host = "bitwarden.pw",
+                path = "sso-callback",
             ),
             DEFAULT_INTERNAL_ENVIRONMENT_URL_DATA.ssoAuthTabData,
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnViewModelTest.kt
@@ -189,9 +189,9 @@ class EnterpriseSignOnViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     EnterpriseSignOnEvent.NavigateToSsoLogin(
                         uri = ssoUri,
-                        authTabData = AuthTabData.CustomScheme(
-                            callbackUrl = "bitwarden://sso-callback",
-                            callbackScheme = "bitwarden",
+                        authTabData = AuthTabData.HttpsScheme(
+                            host = "bitwarden.com",
+                            path = "sso-callback",
                         ),
                     ),
                     eventFlow.awaitItem(),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -430,9 +430,9 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     TwoFactorLoginEvent.NavigateToDuo(
                         uri = mockkUri,
-                        authTabData = AuthTabData.CustomScheme(
-                            callbackUrl = "bitwarden://duo-callback",
-                            callbackScheme = "bitwarden",
+                        authTabData = AuthTabData.HttpsScheme(
+                            host = "bitwarden.com",
+                            path = "duo-callback",
                         ),
                     ),
                     awaitItem(),
@@ -519,9 +519,9 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     TwoFactorLoginEvent.NavigateToWebAuth(
                         uri = mockkUri,
-                        authTabData = AuthTabData.CustomScheme(
-                            callbackUrl = "bitwarden://webauthn-callback",
-                            callbackScheme = "bitwarden",
+                        authTabData = AuthTabData.HttpsScheme(
+                            host = "bitwarden.com",
+                            path = "webauthn-callback",
                         ),
                     ),
                     awaitItem(),

--- a/data/src/main/kotlin/com/bitwarden/data/repository/util/EnvironmentUrlDataJsonExtensions.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/repository/util/EnvironmentUrlDataJsonExtensions.kt
@@ -41,10 +41,7 @@ val EnvironmentUrlDataJson.appLinksScheme: String
         EnvironmentRegion.UNITED_STATES,
         EnvironmentRegion.EUROPEAN_UNION,
         EnvironmentRegion.INTERNAL,
-            -> {
-            // TODO: PM-26577 Update this to use "https"
-            "bitwarden"
-        }
+            -> "https"
 
         EnvironmentRegion.SELF_HOSTED -> "bitwarden"
     }

--- a/data/src/test/kotlin/com/bitwarden/data/repository/util/EnvironmentUrlsDataJsonExtensionsTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/repository/util/EnvironmentUrlsDataJsonExtensionsTest.kt
@@ -339,8 +339,7 @@ class EnvironmentUrlsDataJsonExtensionsTest {
 
     @Test
     fun `appLinksScheme should return the correct scheme for US environment`() {
-        // TODO: PM-26577 Update this to use "https"
-        val expectedScheme = "bitwarden"
+        val expectedScheme = "https"
 
         assertEquals(
             expectedScheme,
@@ -350,8 +349,7 @@ class EnvironmentUrlsDataJsonExtensionsTest {
 
     @Test
     fun `appLinksScheme should return the correct scheme for EU environment`() {
-        // TODO: PM-26577 Update this to use "https"
-        val expectedScheme = "bitwarden"
+        val expectedScheme = "https"
 
         assertEquals(
             expectedScheme,
@@ -361,8 +359,7 @@ class EnvironmentUrlsDataJsonExtensionsTest {
 
     @Test
     fun `appLinksScheme should return the correct scheme for internal environment`() {
-        // TODO: PM-26577 Update this to use "https"
-        val expectedScheme = "bitwarden"
+        val expectedScheme = "https"
 
         assertEquals(
             expectedScheme,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26577](https://bitwarden.atlassian.net/browse/PM-26577)

## 📔 Objective

This PR updates the Duo and WebAuthn logic to send the appropriate deeplink scheme data.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26577]: https://bitwarden.atlassian.net/browse/PM-26577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ