### PR TITLE
Document best practices for Clock/Time handling

### DIFF
--- a/.claude/skills/reviewing-changes/reference/architectural-patterns.md
+++ b/.claude/skills/reviewing-changes/reference/architectural-patterns.md
@@ -11,6 +11,7 @@ Quick reference for Bitwarden Android architectural patterns during code reviews
 - [Hilt Dependency Injection](#hilt-dependency-injection)
   - [ViewModels](#viewmodels)
   - [Repositories and Managers](#repositories-and-managers)
+  - [Clock/Time Handling](#clocktime-handling)
 - [Module Organization](#module-organization)
 - [Error Handling](#error-handling)
   - [Use Result Types, Not Exceptions](#use-result-types-not-exceptions)
@@ -210,6 +211,43 @@ abstract class DataModule {
 
 ---
 
+### Clock/Time Handling
+
+Time-dependent code must use injected `Clock` rather than direct `Instant.now()` or `DateTime.now()` calls. This follows the same DI principle as other dependencies.
+
+**✅ GOOD - Injected Clock**:
+```kotlin
+// ViewModel with Clock injection
+class MyViewModel @Inject constructor(
+    private val clock: Clock,
+) {
+    fun save() {
+        val timestamp = clock.instant()
+    }
+}
+
+// Extension function with Clock parameter
+fun State.getTimestamp(clock: Clock): Instant =
+    existingTime ?: clock.instant()
+```
+
+**❌ BAD - Static/direct calls**:
+```kotlin
+// Hidden dependency, non-testable
+val timestamp = Instant.now()
+val dateTime = DateTime.now()
+```
+
+**Key Rules**:
+- Inject `Clock` via Hilt constructor (like other dependencies)
+- Pass `Clock` as parameter to extension functions
+- `Clock` is provided via `CoreModule` as singleton
+- Enables deterministic testing with `Clock.fixed(...)`
+
+Reference: `docs/STYLE_AND_BEST_PRACTICES.md#best-practices--time-and-clock-handling`
+
+---
+
 ## Module Organization
 
 ```
@@ -299,6 +337,7 @@ Reference: `docs/ARCHITECTURE.md#error-handling`
 - [ ] Business logic in Repository, not ViewModel?
 - [ ] Using Hilt DI (@HiltViewModel, @Inject constructor)?
 - [ ] Injecting interfaces, not implementations?
+- [ ] Time-dependent code uses injected `Clock` (not `Instant.now()`)?
 - [ ] Correct module placement?
 
 ### Error Handling


### PR DESCRIPTION
## 🎟️ Tracking

Documentation updates

## 📔 Objective

Outline the architectural pattern for handling time-dependent code.

The primary objective is to enforce testability and determinism by using an injected `Clock` instead of static calls to `Instant.now()` or `DateTime.now()`.

Specific changes include:
- A new section "Best Practices : Time and Clock Handling" in `STYLE_AND_BEST_PRACTICES.md`. This guide details the rationale, provides good/bad code examples for ViewModels and utility functions, and shows how to use a fixed clock in tests.
- A corresponding section "Clock/Time Handling" in `architectural-patterns.md` to serve as a quick reference for LLM assisted code reviews.
- An update to the pull request checklist in `architectural-patterns.md` to include a check for the use of injected `Clock`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
