### PR TITLE
[PM-30663] Unlock with PIN doesn’t appear as enabled after enabling ‘Require master password on app restart’

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/datasource/disk/AuthDiskSource.kt
@@ -72,6 +72,12 @@ interface AuthDiskSource : AppIdProvider {
     fun getShouldUseKeyConnectorFlow(userId: String): Flow<Boolean?>
 
     /**
+     * Retrieves the state indicating whether the in-memory PIN-protected user key envelope
+     * is present as a flow.
+     */
+    fun getIsInMemoryPinEnvelopePresentFlowMap(userId: String): Flow<Boolean>
+
+    /**
      * Stores the boolean indicating that the user should use a key connector.
      */
     fun storeShouldUseKeyConnector(userId: String, shouldUseKeyConnector: Boolean?)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -292,12 +292,16 @@ class SettingsRepositoryImpl(
     override val isUnlockWithPinEnabledFlow: Flow<Boolean>
         get() = activeUserId
             ?.let { userId ->
-                authDiskSource
-                    .getPinProtectedUserKeyFlow(userId)
-                    .combine(
+                    combine(
+                        authDiskSource.getPinProtectedUserKeyFlow(userId),
                         authDiskSource.getPinProtectedUserKeyEnvelopeFlow(userId),
-                    ) { pinProtectedUserKey, pinProtectedUserKeyEnvelope ->
-                        pinProtectedUserKey != null || pinProtectedUserKeyEnvelope != null
+                        authDiskSource.getIsInMemoryPinEnvelopePresentFlowMap(userId),
+                    ) {
+                            pinProtectedUserKey, pinProtectedUserKeyEnvelope,
+                            isInMemoryPinEnvelopePresent,
+                        ->
+                        pinProtectedUserKey != null ||
+                            pinProtectedUserKeyEnvelope != null || isInMemoryPinEnvelopePresent
                     }
             }
             ?: flowOf(false)


### PR DESCRIPTION


## 🎟️ Tracking

https://github.com/bitwarden/android/issues/6306

## 📔 Objective

Fix unlock with PIN doesn’t appear as enabled after enabling ‘Require master password on app restart’

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
