### PR TITLE
PM-30708: Add archive item navigation

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
@@ -31,6 +31,7 @@ enum class SearchableItemType {
     SENDS_TEXTS,
     SENDS_FILES,
     VAULT_ALL,
+    VAULT_ARCHIVE,
     VAULT_LOGINS,
     VAULT_CARDS,
     VAULT_IDENTITIES,
@@ -62,6 +63,7 @@ fun SavedStateHandle.toSearchArgs(): SearchArgs {
             SearchableItemType.SENDS_TEXTS -> SearchType.Sends.Texts
             SearchableItemType.SENDS_FILES -> SearchType.Sends.Files
             SearchableItemType.VAULT_ALL -> SearchType.Vault.All
+            SearchableItemType.VAULT_ARCHIVE -> SearchType.Vault.Archive
             SearchableItemType.VAULT_LOGINS -> SearchType.Vault.Logins
             SearchableItemType.VAULT_CARDS -> SearchType.Vault.Cards
             SearchableItemType.VAULT_IDENTITIES -> SearchType.Vault.Identities
@@ -134,6 +136,7 @@ private fun SearchType.toSearchableItemType(): SearchableItemType =
         SearchType.Vault.Trash -> SearchableItemType.VAULT_TRASH
         SearchType.Vault.VerificationCodes -> SearchableItemType.VAULT_VERIFICATION_CODES
         SearchType.Vault.SshKeys -> SearchableItemType.VAULT_SSH_KEYS
+        SearchType.Vault.Archive -> SearchableItemType.VAULT_ARCHIVE
     }
 
 private fun SearchType.toIdOrNull(): String? =
@@ -152,4 +155,5 @@ private fun SearchType.toIdOrNull(): String? =
         SearchType.Vault.Trash -> null
         SearchType.Vault.VerificationCodes -> null
         SearchType.Vault.SshKeys -> null
+        SearchType.Vault.Archive -> null
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -1115,6 +1115,13 @@ sealed class SearchTypeData : Parcelable {
         }
 
         /**
+         * Indicates that we should be searching all archived vault items.
+         */
+        data object Archive : Vault() {
+            override val title: Text get() = BitwardenString.search_archive.asText()
+        }
+
+        /**
          * Indicates that we should be searching only login ciphers.
          */
         data object Logins : Vault() {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/model/SearchType.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/model/SearchType.kt
@@ -39,6 +39,11 @@ sealed class SearchType : Parcelable {
         data object All : Vault()
 
         /**
+         * Indicates that we should be searching all archived vault items.
+         */
+        data object Archive : Vault()
+
+        /**
          * Indicates that we should be searching only login ciphers.
          */
         data object Logins : Vault()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
@@ -58,6 +58,7 @@ fun SearchTypeData.updateWithAdditionalDataIfNecessary(
         SearchTypeData.Sends.Files -> this
         SearchTypeData.Sends.Texts -> this
         SearchTypeData.Vault.All -> this
+        SearchTypeData.Vault.Archive -> this
         SearchTypeData.Vault.Cards -> this
         SearchTypeData.Vault.Identities -> this
         SearchTypeData.Vault.Logins -> this
@@ -108,6 +109,7 @@ private fun CipherListView.filterBySearchType(
 ): Boolean =
     when (searchTypeData) {
         SearchTypeData.Vault.All -> deletedDate == null
+        SearchTypeData.Vault.Archive -> archivedDate != null && deletedDate == null
         is SearchTypeData.Vault.Cards -> type is CipherListViewType.Card && deletedDate == null
         is SearchTypeData.Vault.Collection -> {
             searchTypeData.collectionId in this.collectionIds && deletedDate == null

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeExtensions.kt
@@ -12,6 +12,7 @@ fun SearchType.toSearchTypeData(): SearchTypeData =
         SearchType.Sends.Files -> SearchTypeData.Sends.Files
         SearchType.Sends.Texts -> SearchTypeData.Sends.Texts
         SearchType.Vault.All -> SearchTypeData.Vault.All
+        SearchType.Vault.Archive -> SearchTypeData.Vault.Archive
         SearchType.Vault.Cards -> SearchTypeData.Vault.Cards
         is SearchType.Vault.Collection -> SearchTypeData.Vault.Collection(collectionId)
         is SearchType.Vault.Folder -> SearchTypeData.Vault.Folder(folderId)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
@@ -102,6 +102,7 @@ enum class ItemListingType {
     COLLECTION,
     SEND_FILE,
     SEND_TEXT,
+    ARCHIVE,
 }
 
 /**
@@ -118,6 +119,7 @@ fun SavedStateHandle.toVaultItemListingArgs(): VaultItemListingArgs {
     val route = this.toRoute<VaultItemListingRoute>()
     return VaultItemListingArgs(
         vaultItemListingType = when (route.type) {
+            ItemListingType.ARCHIVE -> VaultItemListingType.Archive
             ItemListingType.LOGIN -> VaultItemListingType.Login
             ItemListingType.CARD -> VaultItemListingType.Card
             ItemListingType.IDENTITY -> VaultItemListingType.Identity
@@ -289,6 +291,7 @@ fun NavController.navigateToSendItemListing(
 
 private fun VaultItemListingType.toItemListingType(): ItemListingType {
     return when (this) {
+        is VaultItemListingType.Archive -> ItemListingType.ARCHIVE
         is VaultItemListingType.Card -> ItemListingType.CARD
         is VaultItemListingType.Collection -> ItemListingType.COLLECTION
         is VaultItemListingType.Folder -> ItemListingType.FOLDER
@@ -306,6 +309,7 @@ private fun VaultItemListingType.toIdOrNull(): String? =
     when (this) {
         is VaultItemListingType.Collection -> collectionId
         is VaultItemListingType.Folder -> folderId
+        is VaultItemListingType.Archive -> null
         is VaultItemListingType.Card -> null
         is VaultItemListingType.Identity -> null
         is VaultItemListingType.Login -> null

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -3104,7 +3104,15 @@ data class VaultItemListingState(
             }
 
             /**
-             * A Secure Trash item listing.
+             * An archive item listing.
+             */
+            data object Archive : Vault() {
+                override val titleText: Text get() = BitwardenString.archive.asText()
+                override val hasFab: Boolean get() = false
+            }
+
+            /**
+             * A Trash item listing.
              */
             data object Trash : Vault() {
                 override val titleText: Text get() = BitwardenString.trash.asText()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -80,6 +80,10 @@ fun CipherListView.determineListingPredicate(
         is VaultItemListingState.ItemListingType.Vault.Trash -> {
             deletedDate != null
         }
+
+        is VaultItemListingState.ItemListingType.Vault.Archive -> {
+            archivedDate != null && deletedDate == null
+        }
     }
 
 /**
@@ -234,6 +238,10 @@ fun VaultData.toViewState(
                     VaultItemListingState.ItemListingType.Vault.SshKey -> {
                         BitwardenString.no_ssh_keys
                     }
+
+                    VaultItemListingState.ItemListingType.Vault.Archive -> {
+                        BitwardenString.no_archives
+                    }
                 }
                     .asText()
             }
@@ -354,6 +362,7 @@ fun VaultItemListingState.ItemListingType.updateWithAdditionalDataIfNecessary(
         is VaultItemListingState.ItemListingType.Send.SendFile -> this
         is VaultItemListingState.ItemListingType.Send.SendText -> this
         is VaultItemListingState.ItemListingType.Vault.SshKey -> this
+        is VaultItemListingState.ItemListingType.Vault.Archive -> this
     }
 
 @Suppress("LongParameterList")

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensions.kt
@@ -10,6 +10,7 @@ import com.x8bit.bitwarden.ui.vault.model.VaultItemCipherType
  */
 fun VaultItemListingState.ItemListingType.toSearchType(): SearchType =
     when (this) {
+        is VaultItemListingState.ItemListingType.Vault.Archive -> SearchType.Vault.Archive
         is VaultItemListingState.ItemListingType.Vault.Card -> SearchType.Vault.Cards
         is VaultItemListingState.ItemListingType.Vault.Folder -> {
             folderId
@@ -51,6 +52,7 @@ fun VaultItemListingState.ItemListingType.Vault.toVaultItemCipherType(): VaultIt
         is VaultItemListingState.ItemListingType.Vault.Login -> VaultItemCipherType.LOGIN
         is VaultItemListingState.ItemListingType.Vault.Collection -> VaultItemCipherType.LOGIN
         is VaultItemListingState.ItemListingType.Vault.Folder -> VaultItemCipherType.LOGIN
+        is VaultItemListingState.ItemListingType.Vault.Archive,
         is VaultItemListingState.ItemListingType.Vault.Trash,
             -> {
             throw IllegalStateException(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingTypeExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingTypeExtensions.kt
@@ -17,6 +17,7 @@ fun VaultItemListingType.toItemListingType(): VaultItemListingState.ItemListingT
         is VaultItemListingType.Login -> VaultItemListingState.ItemListingType.Vault.Login
         is VaultItemListingType.SecureNote -> VaultItemListingState.ItemListingType.Vault.SecureNote
         is VaultItemListingType.SshKey -> VaultItemListingState.ItemListingType.Vault.SshKey
+        is VaultItemListingType.Archive -> VaultItemListingState.ItemListingType.Vault.Archive
         is VaultItemListingType.Trash -> VaultItemListingState.ItemListingType.Vault.Trash
         is VaultItemListingType.Collection -> {
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = collectionId)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/model/VaultItemListingType.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/model/VaultItemListingType.kt
@@ -6,6 +6,11 @@ package com.x8bit.bitwarden.ui.vault.model
 sealed class VaultItemListingType {
 
     /**
+     * An Archive listing.
+     */
+    data object Archive : VaultItemListingType()
+
+    /**
      * A Login listing.
      */
     data object Login : VaultItemListingType()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -1731,6 +1731,7 @@ class SearchViewModelTest : BaseViewModelTest() {
                     SearchTypeData.Sends.Files -> SearchType.Sends.Files
                     SearchTypeData.Sends.Texts -> SearchType.Sends.Texts
                     SearchTypeData.Vault.All -> SearchType.Vault.All
+                    SearchTypeData.Vault.Archive -> SearchType.Vault.Archive
                     SearchTypeData.Vault.Cards -> SearchType.Vault.Cards
                     is SearchTypeData.Vault.Collection -> SearchType.Vault.Collection(
                         collectionId = searchType.collectionId,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
@@ -150,6 +150,19 @@ class SearchTypeDataExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `updateWithAdditionalDataIfNecessary should return the searchTypeData unchanged for Vault Archive`() {
+        val searchTypeData = SearchTypeData.Vault.Archive
+        assertEquals(
+            searchTypeData,
+            searchTypeData.updateWithAdditionalDataIfNecessary(
+                folderList = listOf(),
+                collectionList = emptyList(),
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `updateWithAdditionalDataIfNecessary should return the searchTypeData unchanged for Vault Cards`() {
         val searchTypeData = SearchTypeData.Vault.Cards
         assertEquals(
@@ -304,6 +317,19 @@ class SearchTypeDataExtensionsTest {
             searchTerm = "match",
         )
         assertEquals(listOf(match2), result)
+    }
+
+    @Test
+    fun `CipherViews filterAndOrganize should return list with only archived items`() {
+        val match1 = createMockCipherListView(number = 1, isArchived = true).copy(name = "match1")
+        val match2 = createMockCipherListView(number = 2).copy(name = "match2")
+        val match3 = createMockCipherListView(number = 3, isArchived = true).copy(name = "match3")
+        val ciphers = listOf(match1, match2, match3)
+        val result = ciphers.filterAndOrganize(
+            searchTypeData = SearchTypeData.Vault.Archive,
+            searchTerm = "match",
+        )
+        assertEquals(listOf(match1, match3), result)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeExtensionsTest.kt
@@ -8,32 +8,37 @@ import org.junit.jupiter.api.Test
 class SearchTypeExtensionsTest {
 
     @Test
-    fun `toSearchTypeData should return Sends All then SearchType is Sends All`() {
+    fun `toSearchTypeData should return Sends All when SearchType is Sends All`() {
         assertEquals(SearchTypeData.Sends.All, SearchType.Sends.All.toSearchTypeData())
     }
 
     @Test
-    fun `toSearchTypeData should return Sends Files then SearchType is Sends Files`() {
+    fun `toSearchTypeData should return Sends Files when SearchType is Sends Files`() {
         assertEquals(SearchTypeData.Sends.Files, SearchType.Sends.Files.toSearchTypeData())
     }
 
     @Test
-    fun `toSearchTypeData should return Sends Texts then SearchType is Sends Texts`() {
+    fun `toSearchTypeData should return Sends Texts when SearchType is Sends Texts`() {
         assertEquals(SearchTypeData.Sends.Texts, SearchType.Sends.Texts.toSearchTypeData())
     }
 
     @Test
-    fun `toSearchTypeData should return Vault All then SearchType is Vault All`() {
+    fun `toSearchTypeData should return Vault All when SearchType is Vault All`() {
         assertEquals(SearchTypeData.Vault.All, SearchType.Vault.All.toSearchTypeData())
     }
 
     @Test
-    fun `toSearchTypeData should return Vault Cards then SearchType is Vault Cards`() {
+    fun `toSearchTypeData should return Vault Archive when SearchType is Vault Archive`() {
+        assertEquals(SearchTypeData.Vault.Archive, SearchType.Vault.Archive.toSearchTypeData())
+    }
+
+    @Test
+    fun `toSearchTypeData should return Vault Cards when SearchType is Vault Cards`() {
         assertEquals(SearchTypeData.Vault.Cards, SearchType.Vault.Cards.toSearchTypeData())
     }
 
     @Test
-    fun `toSearchTypeData should return Vault Collection then SearchType is Vault Collection`() {
+    fun `toSearchTypeData should return Vault Collection when SearchType is Vault Collection`() {
         val collectionId = "collectionId"
         assertEquals(
             SearchTypeData.Vault.Collection(collectionId),
@@ -42,7 +47,7 @@ class SearchTypeExtensionsTest {
     }
 
     @Test
-    fun `toSearchTypeData should return Vault Folder then SearchType is Vault Folder`() {
+    fun `toSearchTypeData should return Vault Folder when SearchType is Vault Folder`() {
         val folderId = "folderId"
         assertEquals(
             SearchTypeData.Vault.Folder(folderId),
@@ -51,7 +56,7 @@ class SearchTypeExtensionsTest {
     }
 
     @Test
-    fun `toSearchTypeData should return Vault Identities then SearchType is Vault Identities`() {
+    fun `toSearchTypeData should return Vault Identities when SearchType is Vault Identities`() {
         assertEquals(
             SearchTypeData.Vault.Identities,
             SearchType.Vault.Identities.toSearchTypeData(),
@@ -59,17 +64,17 @@ class SearchTypeExtensionsTest {
     }
 
     @Test
-    fun `toSearchTypeData should return Vault Logins then SearchType is Vault Logins`() {
+    fun `toSearchTypeData should return Vault Logins when SearchType is Vault Logins`() {
         assertEquals(SearchTypeData.Vault.Logins, SearchType.Vault.Logins.toSearchTypeData())
     }
 
     @Test
-    fun `toSearchTypeData should return Vault NoFolder then SearchType is Vault NoFolder`() {
+    fun `toSearchTypeData should return Vault NoFolder when SearchType is Vault NoFolder`() {
         assertEquals(SearchTypeData.Vault.NoFolder, SearchType.Vault.NoFolder.toSearchTypeData())
     }
 
     @Test
-    fun `toSearchTypeData should return Vault SecureNotes then SearchType is Vault SecureNotes`() {
+    fun `toSearchTypeData should return Vault SecureNotes when SearchType is Vault SecureNotes`() {
         assertEquals(
             SearchTypeData.Vault.SecureNotes,
             SearchType.Vault.SecureNotes.toSearchTypeData(),
@@ -77,13 +82,13 @@ class SearchTypeExtensionsTest {
     }
 
     @Test
-    fun `toSearchTypeData should return Vault Trash then SearchType is Vault Trash`() {
+    fun `toSearchTypeData should return Vault Trash when SearchType is Vault Trash`() {
         assertEquals(SearchTypeData.Vault.Trash, SearchType.Vault.Trash.toSearchTypeData())
     }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `toSearchTypeData should return Vault VerificationCodes then SearchType is Vault VerificationCodes`() {
+    fun `toSearchTypeData should return Vault VerificationCodes when SearchType is Vault VerificationCodes`() {
         assertEquals(
             SearchTypeData.Vault.VerificationCodes,
             SearchType.Vault.VerificationCodes.toSearchTypeData(),
@@ -91,7 +96,7 @@ class SearchTypeExtensionsTest {
     }
 
     @Test
-    fun `toSearchTypeData should return Vault SshKeys then SearchType is Vault SshKeys`() {
+    fun `toSearchTypeData should return Vault SshKeys when SearchType is Vault SshKeys`() {
         assertEquals(SearchTypeData.Vault.SshKeys, SearchType.Vault.SshKeys.toSearchTypeData())
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
@@ -67,6 +67,36 @@ class VaultItemListingDataExtensionsTest {
     }
 
     @Test
+    fun `determineListingPredicate should return the correct predicate for archived cipherView`() {
+        val cipherView = createMockCipherListView(
+            number = 1,
+            isArchived = true,
+            type = CipherListViewType.Login(v1 = createMockLoginListView(number = 1)),
+        )
+
+        mapOf(
+            VaultItemListingState.ItemListingType.Vault.Login to true,
+            VaultItemListingState.ItemListingType.Vault.Card to false,
+            VaultItemListingState.ItemListingType.Vault.SecureNote to false,
+            VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to true,
+            VaultItemListingState.ItemListingType.Vault.Trash to false,
+            VaultItemListingState.ItemListingType.Vault.Folder("mockId-1") to true,
+            VaultItemListingState.ItemListingType.Vault.Collection("mockId-1") to true,
+        )
+            .forEach { (type, expected) ->
+                val result = cipherView.determineListingPredicate(
+                    itemListingType = type,
+                )
+                println("Type: $type")
+                assertEquals(
+                    expected,
+                    result,
+                )
+            }
+    }
+
+    @Test
     @Suppress("MaxLineLength")
     fun `determineListingPredicate should return the correct predicate for non trash Login cipherView`() {
         val cipherView = createMockCipherListView(
@@ -80,6 +110,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to false,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to true,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to true,
@@ -109,6 +140,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to true,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to false,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to false,
@@ -138,6 +170,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to true,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to false,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to true,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to true,
@@ -167,6 +200,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to true,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to false,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to false,
@@ -196,6 +230,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to true,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to false,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to true,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to true,
@@ -225,6 +260,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to true,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to false,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to false,
@@ -254,6 +290,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to true,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to false,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to true,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to true,
@@ -283,6 +320,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to true,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to false,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to false,
@@ -313,6 +351,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to false,
             VaultItemListingState.ItemListingType.Vault.SshKey to true,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to true,
@@ -344,6 +383,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to true,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to false,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = null) to true,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to true,
@@ -373,6 +413,7 @@ class VaultItemListingDataExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
             VaultItemListingState.ItemListingType.Vault.Trash to true,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to false,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to false,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensionsTest.kt
@@ -71,6 +71,16 @@ class VaultItemListingStateExtensionsTest {
     }
 
     @Test
+    fun `toSearchType should return Archive when item type is Archive`() {
+        val expected = SearchType.Vault.Archive
+        val itemType = VaultItemListingState.ItemListingType.Vault.Archive
+
+        val result = itemType.toSearchType()
+
+        assertEquals(expected, result)
+    }
+
+    @Test
     fun `toSearchType should return Trash when item type is Trash`() {
         val expected = SearchType.Vault.Trash
         val itemType = VaultItemListingState.ItemListingType.Vault.Trash
@@ -152,6 +162,9 @@ class VaultItemListingStateExtensionsTest {
 
     @Test
     fun `toVaultItemCipherType should throw an exception for unsupported ItemListingTypes`() {
+        assertThrows<IllegalStateException> {
+            VaultItemListingState.ItemListingType.Vault.Archive.toVaultItemCipherType()
+        }
         assertThrows<IllegalStateException> {
             VaultItemListingState.ItemListingType.Vault.Trash.toVaultItemCipherType()
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingTypeExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingTypeExtensionsTest.kt
@@ -12,6 +12,7 @@ class VaultItemListingTypeExtensionsTest {
     fun `toItemListingType should transform a VaultItemListingType into a VaultItemListingState ItemListingType`() {
         val itemListingTypeList = listOf(
             VaultItemListingType.Folder(folderId = "mock"),
+            VaultItemListingType.Archive,
             VaultItemListingType.Trash,
             VaultItemListingType.Collection(collectionId = "collectionId"),
             VaultItemListingType.SshKey,
@@ -28,6 +29,7 @@ class VaultItemListingTypeExtensionsTest {
         assertEquals(
             listOf(
                 VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mock"),
+                VaultItemListingState.ItemListingType.Vault.Archive,
                 VaultItemListingState.ItemListingType.Vault.Trash,
                 VaultItemListingState.ItemListingType.Vault.Collection(
                     collectionId = "collectionId",

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -129,6 +129,7 @@
     <string name="no_text_sends">There are no text Sends in your vault.</string>
     <string name="no_file_sends">There are no file Sends in your vault.</string>
     <string name="no_ssh_keys">There are no SSH keys in your vault.</string>
+    <string name="no_archives">No items in archive.</string>
     <string name="new_text_send">New text Send</string>
     <string name="new_file_send">New file Send</string>
     <string name="no_username">No Username</string>
@@ -1172,4 +1173,6 @@ Do you want to switch to this account?</string>
     <string name="why_am_i_seeing_this">Why am I seeing this?</string>
     <string name="migrating_items_to_x">Migrating items to %s</string>
     <string name="failed_to_migrate_items_to_x">Failed to migrate items to %s</string>
+    <string name="search_archive">Search archive</string>
+    <string name="archive">Archive</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30708](https://bitwarden.atlassian.net/browse/PM-30708)

## 📔 Objective

This PR adds the enumerations for archived item support so we can navigate to the listing and search screens for archived items.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30708]: https://bitwarden.atlassian.net/browse/PM-30708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ