### PR TITLE
Remove the unused showDivider flag from BitwardenGroupItem

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/listitem/BitwardenGroupItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/listitem/BitwardenGroupItem.kt
@@ -23,7 +23,7 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
  * A reusable composable function that displays a group item.
- * The list item consists of a start icon, a label, a supporting label and an optional divider.
+ * The list item consists of a start icon, label, sub-label, supporting label, and an end icon.
  *
  * @param label The main text label to be displayed in the group item.
  * @param supportingLabel The secondary supporting text label to be displayed beside the label.
@@ -33,7 +33,6 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  * @param modifier The [Modifier] to be applied to the [Row] composable that holds the list item.
  * @param subLabel The secondary text label to be displayed in the group item.
  * @param endIcon The [IconData] object used to draw the icon at the end of the group item.
- * @param showDivider Indicates whether the divider should be shown or not.
  */
 @Composable
 fun BitwardenGroupItem(
@@ -45,7 +44,6 @@ fun BitwardenGroupItem(
     modifier: Modifier = Modifier,
     subLabel: String? = null,
     endIcon: IconData.Local? = null,
-    showDivider: Boolean = true,
 ) {
     Row(
         modifier = modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
@@ -146,7 +146,6 @@ fun VaultItemListingContent(
                     label = collection.name,
                     supportingLabel = collection.count.toString(),
                     onClick = { collectionClick(collection.id) },
-                    showDivider = false,
                     cardStyle = state
                         .displayCollectionList
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
@@ -177,7 +176,6 @@ fun VaultItemListingContent(
                     label = folder.name,
                     supportingLabel = folder.count.toString(),
                     onClick = { folderClick(folder.id) },
-                    showDivider = false,
                     cardStyle = state
                         .displayFolderList
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -93,7 +93,6 @@ fun VaultContent(
                     label = stringResource(id = BitwardenString.verification_codes),
                     supportingLabel = state.totpItemsCount.toString(),
                     onClick = vaultHandlers.verificationCodesClick,
-                    showDivider = false,
                     cardStyle = CardStyle.Full,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -176,7 +175,6 @@ fun VaultContent(
                 label = stringResource(id = BitwardenString.type_login),
                 supportingLabel = state.loginItemsCount.toString(),
                 onClick = vaultHandlers.loginGroupClick,
-                showDivider = false,
                 cardStyle = CardStyle.Top(dividerPadding = 56.dp),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -195,7 +193,6 @@ fun VaultContent(
                     label = stringResource(id = BitwardenString.type_card),
                     supportingLabel = state.cardItemsCount.toString(),
                     onClick = vaultHandlers.cardGroupClick,
-                    showDivider = false,
                     cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
                     modifier = Modifier
                         .fillMaxWidth()
@@ -214,7 +211,6 @@ fun VaultContent(
                 label = stringResource(id = BitwardenString.type_identity),
                 supportingLabel = state.identityItemsCount.toString(),
                 onClick = vaultHandlers.identityGroupClick,
-                showDivider = false,
                 cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -232,7 +228,6 @@ fun VaultContent(
                 label = stringResource(id = BitwardenString.type_secure_note),
                 supportingLabel = state.secureNoteItemsCount.toString(),
                 onClick = vaultHandlers.secureNoteGroupClick,
-                showDivider = false,
                 cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -250,7 +245,6 @@ fun VaultContent(
                 label = stringResource(id = BitwardenString.type_ssh_key),
                 supportingLabel = state.sshKeyItemsCount.toString(),
                 onClick = vaultHandlers.sshKeyGroupClick,
-                showDivider = false,
                 cardStyle = CardStyle.Bottom,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -282,7 +276,6 @@ fun VaultContent(
                     label = folder.name(),
                     supportingLabel = folder.itemCount.toString(),
                     onClick = { vaultHandlers.folderClick(folder) },
-                    showDivider = false,
                     cardStyle = state
                         .folderItems
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
@@ -366,7 +359,6 @@ fun VaultContent(
                     label = collection.name,
                     supportingLabel = collection.itemCount.toString(),
                     onClick = { vaultHandlers.collectionClick(collection) },
-                    showDivider = false,
                     cardStyle = state
                         .collectionItems
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
@@ -399,7 +391,6 @@ fun VaultContent(
                 label = stringResource(id = BitwardenString.trash),
                 supportingLabel = state.trashItemsCount.toString(),
                 onClick = vaultHandlers.trashClick,
-                showDivider = false,
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the `BitwardenGroupItem` to remove the `showDivider` flag that did not actually do anything.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
