### PR TITLE
PM-30795: Update cipher filtering logic for archive

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/provider/AutofillCipherProviderImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/provider/AutofillCipherProviderImpl.kt
@@ -68,6 +68,8 @@ class AutofillCipherProviderImpl(
                         it.type is CipherListViewType.Card &&
                             // Must not be deleted.
                             it.deletedDate == null &&
+                            // Must not be archived.
+                            it.archivedDate == null &&
                             // Must not require a reprompt.
                             it.reprompt == CipherRepromptType.NONE &&
                             // Must not be restricted by organization.
@@ -106,6 +108,8 @@ class AutofillCipherProviderImpl(
                 it.type is CipherListViewType.Login &&
                     // Must not be deleted.
                     it.deletedDate == null &&
+                    // Must not be archived.
+                    it.archivedDate == null &&
                     // Must not require a reprompt.
                     it.reprompt == CipherRepromptType.NONE
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
@@ -108,26 +108,46 @@ private fun CipherListView.filterBySearchType(
     searchTypeData: SearchTypeData.Vault,
 ): Boolean =
     when (searchTypeData) {
-        SearchTypeData.Vault.All -> deletedDate == null
+        SearchTypeData.Vault.All -> deletedDate == null && archivedDate == null
         SearchTypeData.Vault.Archive -> archivedDate != null && deletedDate == null
-        is SearchTypeData.Vault.Cards -> type is CipherListViewType.Card && deletedDate == null
+        is SearchTypeData.Vault.Cards -> {
+            type is CipherListViewType.Card && deletedDate == null && archivedDate == null
+        }
+
         is SearchTypeData.Vault.Collection -> {
-            searchTypeData.collectionId in this.collectionIds && deletedDate == null
+            searchTypeData.collectionId in this.collectionIds &&
+                deletedDate == null &&
+                archivedDate == null
         }
 
-        is SearchTypeData.Vault.Folder -> folderId == searchTypeData.folderId && deletedDate == null
-        SearchTypeData.Vault.NoFolder -> folderId == null && deletedDate == null
+        is SearchTypeData.Vault.Folder -> {
+            folderId == searchTypeData.folderId && deletedDate == null && archivedDate == null
+        }
+
+        SearchTypeData.Vault.NoFolder -> {
+            folderId == null && deletedDate == null && archivedDate == null
+        }
+
         is SearchTypeData.Vault.Identities -> {
-            type is CipherListViewType.Identity && deletedDate == null
+            type is CipherListViewType.Identity && deletedDate == null && archivedDate == null
         }
 
-        is SearchTypeData.Vault.Logins -> type is CipherListViewType.Login && deletedDate == null
+        is SearchTypeData.Vault.Logins -> {
+            type is CipherListViewType.Login && deletedDate == null && archivedDate == null
+        }
+
         is SearchTypeData.Vault.SecureNotes -> {
-            type is CipherListViewType.SecureNote && deletedDate == null
+            type is CipherListViewType.SecureNote && deletedDate == null && archivedDate == null
         }
 
-        is SearchTypeData.Vault.SshKeys -> type is CipherListViewType.SshKey && deletedDate == null
-        is SearchTypeData.Vault.VerificationCodes -> login?.totp != null && deletedDate == null
+        is SearchTypeData.Vault.SshKeys -> {
+            type is CipherListViewType.SshKey && deletedDate == null && archivedDate == null
+        }
+
+        is SearchTypeData.Vault.VerificationCodes -> {
+            login?.totp != null && deletedDate == null && archivedDate == null
+        }
+
         is SearchTypeData.Vault.Trash -> deletedDate != null
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -50,31 +50,33 @@ fun CipherListView.determineListingPredicate(
 ): Boolean =
     when (itemListingType) {
         is VaultItemListingState.ItemListingType.Vault.Card -> {
-            type is CipherListViewType.Card && deletedDate == null
+            type is CipherListViewType.Card && deletedDate == null && archivedDate == null
         }
 
         is VaultItemListingState.ItemListingType.Vault.Collection -> {
-            itemListingType.collectionId in this.collectionIds && deletedDate == null
+            itemListingType.collectionId in this.collectionIds &&
+                deletedDate == null &&
+                archivedDate == null
         }
 
         is VaultItemListingState.ItemListingType.Vault.Folder -> {
-            folderId == itemListingType.folderId && deletedDate == null
+            folderId == itemListingType.folderId && deletedDate == null && archivedDate == null
         }
 
         is VaultItemListingState.ItemListingType.Vault.Identity -> {
-            type is CipherListViewType.Identity && deletedDate == null
+            type is CipherListViewType.Identity && deletedDate == null && archivedDate == null
         }
 
         is VaultItemListingState.ItemListingType.Vault.Login -> {
-            type is CipherListViewType.Login && deletedDate == null
+            type is CipherListViewType.Login && deletedDate == null && archivedDate == null
         }
 
         is VaultItemListingState.ItemListingType.Vault.SecureNote -> {
-            type is CipherListViewType.SecureNote && deletedDate == null
+            type is CipherListViewType.SecureNote && deletedDate == null && archivedDate == null
         }
 
         is VaultItemListingState.ItemListingType.Vault.SshKey -> {
-            type is CipherListViewType.SshKey && deletedDate == null
+            type is CipherListViewType.SshKey && deletedDate == null && archivedDate == null
         }
 
         is VaultItemListingState.ItemListingType.Vault.Trash -> {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillCipherProviderTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/processor/AutofillCipherProviderTest.kt
@@ -53,6 +53,7 @@ class AutofillCipherProviderTest {
     }
     private val cardCipherListView: CipherListView = mockk {
         every { card } returns cardListView
+        every { archivedDate } returns null
         every { deletedDate } returns null
         every { id } returns CARD_CIPHER_ID
         every { name } returns CARD_NAME
@@ -70,6 +71,7 @@ class AutofillCipherProviderTest {
     }
     private val cardCipherView: CipherView = mockk {
         every { card } returns cardView
+        every { archivedDate } returns null
         every { deletedDate } returns null
         every { id } returns CARD_CIPHER_ID
         every { name } returns CARD_NAME
@@ -81,6 +83,7 @@ class AutofillCipherProviderTest {
         every { totp } returns null
     }
     private val loginCipherListViewWithoutTotp: CipherListView = mockk {
+        every { archivedDate } returns null
         every { deletedDate } returns null
         every { id } returns LOGIN_WITHOUT_TOTP_CIPHER_ID
         every { login } returns loginListViewWithoutTotp
@@ -93,6 +96,7 @@ class AutofillCipherProviderTest {
         every { totp } returns "TOTP-CODE"
     }
     private val loginCipherListViewWithTotp: CipherListView = mockk {
+        every { archivedDate } returns null
         every { deletedDate } returns null
         every { id } returns LOGIN_WITH_TOTP_CIPHER_ID
         every { login } returns loginListViewWithTotp
@@ -106,6 +110,7 @@ class AutofillCipherProviderTest {
         every { totp } returns null
     }
     private val loginCipherViewWithoutTotp: CipherView = mockk {
+        every { archivedDate } returns null
         every { deletedDate } returns null
         every { id } returns LOGIN_WITHOUT_TOTP_CIPHER_ID
         every { login } returns loginViewWithoutTotp
@@ -119,6 +124,7 @@ class AutofillCipherProviderTest {
         every { totp } returns "TOTP-CODE"
     }
     private val loginCipherViewWithTotp: CipherView = mockk {
+        every { archivedDate } returns null
         every { deletedDate } returns null
         every { id } returns LOGIN_WITH_TOTP_CIPHER_ID
         every { login } returns loginViewWithTotp
@@ -266,22 +272,31 @@ class AutofillCipherProviderTest {
     @Test
     fun `getCardAutofillCiphers when unlocked should decrypt then return non-null, non-deleted, non-reprompt, and non-restricted card ciphers`() =
         runTest {
+            val archivedCardCipherView: CipherListView = mockk {
+                every { archivedDate } returns mockk()
+                every { deletedDate } returns null
+                every { type } returns CipherListViewType.Card(cardListView)
+            }
             val deletedCardCipherView: CipherListView = mockk {
+                every { archivedDate } returns null
                 every { deletedDate } returns mockk()
                 every { type } returns CipherListViewType.Card(cardListView)
             }
             val repromptCardCipherView: CipherListView = mockk {
+                every { archivedDate } returns null
                 every { deletedDate } returns null
                 every { reprompt } returns CipherRepromptType.PASSWORD
                 every { type } returns CipherListViewType.Card(cardListView)
             }
             val restrictedCardCipherView: CipherListView = mockk {
+                every { archivedDate } returns null
                 every { deletedDate } returns null
                 every { type } returns CipherListViewType.Card(cardListView)
                 every { reprompt } returns CipherRepromptType.NONE
                 every { organizationId } returns ORGANIZATION_ID_WITH_CARD_TYPE_RESTRICTIONS
             }
             val personalVaultCardCipherView: CipherListView = mockk {
+                every { archivedDate } returns null
                 every { deletedDate } returns null
                 every { type } returns CipherListViewType.Card(cardListView)
                 every { reprompt } returns CipherRepromptType.NONE
@@ -290,6 +305,7 @@ class AutofillCipherProviderTest {
             val decryptCipherListViewsResult = DecryptCipherListResult(
                 successes = listOf(
                     cardCipherListView,
+                    archivedCardCipherView,
                     deletedCardCipherView,
                     repromptCardCipherView,
                     restrictedCardCipherView,
@@ -372,11 +388,18 @@ class AutofillCipherProviderTest {
     @Test
     fun `getLoginAutofillCiphers when unlocked should decrypt then return matched, non-deleted, non-reprompt, login ciphers`() =
         runTest {
+            val archivedLoginCipherView: CipherListView = mockk {
+                every { archivedDate } returns mockk()
+                every { deletedDate } returns null
+                every { type } returns CipherListViewType.Login(v1 = mockk())
+            }
             val deletedLoginCipherView: CipherListView = mockk {
+                every { archivedDate } returns null
                 every { deletedDate } returns mockk()
                 every { type } returns CipherListViewType.Login(v1 = mockk())
             }
             val repromptLoginCipherView: CipherListView = mockk {
+                every { archivedDate } returns null
                 every { deletedDate } returns null
                 every { reprompt } returns CipherRepromptType.PASSWORD
                 every { type } returns CipherListViewType.Login(v1 = mockk())
@@ -385,6 +408,7 @@ class AutofillCipherProviderTest {
                 cardCipherListView,
                 loginCipherListViewWithTotp,
                 loginCipherListViewWithoutTotp,
+                archivedLoginCipherView,
                 deletedLoginCipherView,
                 repromptLoginCipherView,
             )
@@ -508,7 +532,7 @@ class AutofillCipherProviderTest {
             )
 
             verify(exactly = 1) {
-                Timber.Forest.e(
+                Timber.e(
                     t = any(),
                     message = "Failed to decrypt cipher for autofill.",
                 )
@@ -569,7 +593,7 @@ class AutofillCipherProviderTest {
             )
 
             verify(exactly = 1) {
-                Timber.Forest.e("Cipher not found for autofill.")
+                Timber.e("Cipher not found for autofill.")
             }
         }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
@@ -266,6 +266,20 @@ class SearchTypeDataExtensionsTest {
     }
 
     @Test
+    fun `CipherViews filterAndOrganize should exclude archived items from non-archive searches`() {
+        val match1 = createMockCipherListView(number = 1, isArchived = true).copy(name = "match1")
+        val match2 = createMockCipherListView(number = 2).copy(name = "match2")
+        val match3 = createMockCipherListView(number = 3, isArchived = true).copy(name = "match3")
+        val ciphers = listOf(match1, match2, match3)
+
+        val result = ciphers.filterAndOrganize(
+            searchTypeData = SearchTypeData.Vault.Logins,
+            searchTerm = "match",
+        )
+        assertEquals(listOf(match2), result)
+    }
+
+    @Test
     fun `CipherViews filterAndOrganize should return empty list when search term is blank`() {
         val ciphers = listOf(createMockCipherListView(number = 1))
         val result = ciphers.filterAndOrganize(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
@@ -75,20 +75,50 @@ class VaultItemListingDataExtensionsTest {
         )
 
         mapOf(
-            VaultItemListingState.ItemListingType.Vault.Login to true,
+            VaultItemListingState.ItemListingType.Vault.Login to false,
             VaultItemListingState.ItemListingType.Vault.Card to false,
             VaultItemListingState.ItemListingType.Vault.SecureNote to false,
             VaultItemListingState.ItemListingType.Vault.Identity to false,
             VaultItemListingState.ItemListingType.Vault.Archive to true,
             VaultItemListingState.ItemListingType.Vault.Trash to false,
-            VaultItemListingState.ItemListingType.Vault.Folder("mockId-1") to true,
-            VaultItemListingState.ItemListingType.Vault.Collection("mockId-1") to true,
+            VaultItemListingState.ItemListingType.Vault.Folder("mockId-1") to false,
+            VaultItemListingState.ItemListingType.Vault.Collection("mockId-1") to false,
         )
             .forEach { (type, expected) ->
                 val result = cipherView.determineListingPredicate(
                     itemListingType = type,
                 )
-                println("Type: $type")
+                assertEquals(
+                    expected,
+                    result,
+                )
+            }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `determineListingPredicate should return the correct predicate for archived and deleted cipherView`() {
+        val cipherView = createMockCipherListView(
+            number = 1,
+            isArchived = true,
+            isDeleted = true,
+            type = CipherListViewType.Login(v1 = createMockLoginListView(number = 1)),
+        )
+
+        mapOf(
+            VaultItemListingState.ItemListingType.Vault.Login to false,
+            VaultItemListingState.ItemListingType.Vault.Card to false,
+            VaultItemListingState.ItemListingType.Vault.SecureNote to false,
+            VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
+            VaultItemListingState.ItemListingType.Vault.Trash to true,
+            VaultItemListingState.ItemListingType.Vault.Folder("mockId-1") to false,
+            VaultItemListingState.ItemListingType.Vault.Collection("mockId-1") to false,
+        )
+            .forEach { (type, expected) ->
+                val result = cipherView.determineListingPredicate(
+                    itemListingType = type,
+                )
                 assertEquals(
                     expected,
                     result,
@@ -517,6 +547,7 @@ class VaultItemListingDataExtensionsTest {
                 failures = listOf(
                     createMockSdkCipher(number = 5).copy(
                         deletedDate = null,
+                        archivedDate = null,
                         folderId = "mockId-1",
                         favorite = true,
                     ),
@@ -526,6 +557,7 @@ class VaultItemListingDataExtensionsTest {
                     ),
                     createMockSdkCipher(number = 7).copy(
                         deletedDate = null,
+                        archivedDate = null,
                         folderId = "mockId-1",
                     ),
                     createMockSdkCipher(number = 8).copy(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1650,6 +1650,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                                 deletedDate = null,
                             ),
                             createMockSdkCipher(number = 2).copy(
+                                archivedDate = null,
                                 deletedDate = null,
                             ),
                         ),
@@ -1664,7 +1665,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             assertEquals(
                 createMockVaultState(
                     viewState = VaultState.ViewState.Content(
-                        loginItemsCount = 2,
+                        loginItemsCount = 1,
                         cardItemsCount = 0,
                         identityItemsCount = 0,
                         secureNoteItemsCount = 0,
@@ -1676,7 +1677,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = 5,
                         sshKeyItemsCount = 0,
-                        archivedItemsCount = 2,
+                        archivedItemsCount = 1,
                         archiveEnabled = true,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -1708,9 +1709,11 @@ class VaultViewModelTest : BaseViewModelTest() {
                         .copy(
                             failures = listOf(
                                 createMockSdkCipher(number = 1).copy(
+                                    archivedDate = null,
                                     deletedDate = null,
                                 ),
                                 createMockSdkCipher(number = 2).copy(
+                                    archivedDate = null,
                                     deletedDate = null,
                                 ),
                             ),
@@ -1747,7 +1750,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 1,
                         itemTypesCount = 5,
                         sshKeyItemsCount = 0,
-                        archivedItemsCount = 2,
+                        archivedItemsCount = 0,
                         archiveEnabled = true,
                         archiveSubText = null,
                         archiveEndIcon = null,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
@@ -55,11 +55,18 @@ class VaultDataExtensionsTest {
         val mockCipher = createMockSdkCipher(number = 2).copy(
             folderId = null,
             favorite = true,
+            archivedDate = null,
             deletedDate = null,
+        )
+        val mockArchivedCipher = createMockCipherListView(
+            number = 3,
+            folderId = null,
+            isDeleted = false,
+            isArchived = true,
         )
         val vaultData = VaultData(
             decryptCipherListResult = DecryptCipherListResult(
-                successes = listOf(createMockCipherListView(number = 1)),
+                successes = listOf(createMockCipherListView(number = 1), mockArchivedCipher),
                 failures = listOf(mockCipher),
             ),
             collectionViewList = listOf(createMockCollectionView(number = 1)),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30795](https://bitwarden.atlassian.net/browse/PM-30795)

## 📔 Objective

This PR updates the filtering logic to ensure archived items are only only ever displayed in the archive section (or trash when deleted).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30795]: https://bitwarden.atlassian.net/browse/PM-30795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ