### PR TITLE
[PM-30823] ci: Fix BWA Play Store publishing for rc cherry picks and update upload step names

### DIFF
--- a/.github/workflows/build-authenticator.yml
+++ b/.github/workflows/build-authenticator.yml
@@ -198,7 +198,7 @@ jobs:
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Verify Play Store credentials
-        if: ${{ inputs.publish-to-play-store }}
+        if: ${{ env.PUBLISH_TO_PLAY_STORE }}
         run: |
           bundle exec fastlane run validate_play_store_json_key \
           json_key:"${{ github.workspace }}/secrets/authenticator_play_store-creds.json"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
           --name google-services.json --file ${{ github.workspace }}/app/src/standardBeta/google-services.json --output none
 
       - name: Download Firebase credentials
-        if: ${{ matrix.variant == 'prod' && (inputs.distribute-to-firebase || github.event_name == 'push') }}
+        if: ${{ matrix.variant == 'prod' && env.DISTRIBUTE_TO_FIREBASE }}
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile


### PR DESCRIPTION
## 🎟️ Tracking

PM-30823

## 📔 Objective

Address @mpbw2 findings handling the recent release:

1. Fix - when PRs were merged to release branches builds weren't published to PlayStore.
2. Fix - firebase setup and playstore creds verification steps running when the publishing steps are skipped
3. Refactor - consolidate firebase / playstore publishing flags as environment vars.
4. Clarify "Upload" steps are uploading artifacts to the github run, addressing them being confused with steps that upload to Firebase / PlayStore.
5. Align BWA build workflow defaults with BWPM.

Test Runs:
1. BWPM - https://github.com/bitwarden/android/actions/runs/21007063766
2. BWA - https://github.com/bitwarden/android/actions/runs/21007056374


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
