### PR TITLE
PM-30897: Add archive and unarchive button on Edit Cipher Screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -159,6 +159,8 @@ class SearchViewModel @Inject constructor(
 
         snackbarRelayManager
             .getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_ARCHIVED,
+                SnackbarRelay.CIPHER_UNARCHIVED,
                 SnackbarRelay.CIPHER_DELETED,
                 SnackbarRelay.CIPHER_DELETED_SOFT,
                 SnackbarRelay.CIPHER_RESTORED,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/model/SnackbarRelay.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/model/SnackbarRelay.kt
@@ -9,6 +9,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 enum class SnackbarRelay {
+    CIPHER_ARCHIVED,
+    CIPHER_UNARCHIVED,
     CIPHER_CREATED,
     CIPHER_DELETED,
     CIPHER_DELETED_SOFT,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -5,9 +5,11 @@ import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.provider.CallingAppInfo
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.takeUntilLoaded
+import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
 import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.ui.platform.base.BackgroundEvent
 import com.bitwarden.ui.platform.base.BaseViewModel
@@ -32,6 +34,7 @@ import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManager
 import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.credentials.model.UserVerificationRequirement
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
@@ -44,16 +47,19 @@ import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSaveItemOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toAutofillSelectionDataOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toCreateCredentialRequestOrNull
 import com.x8bit.bitwarden.data.platform.manager.util.toTotpDataOrNull
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.data.tools.generator.repository.GeneratorRepository
 import com.x8bit.bitwarden.data.tools.generator.repository.model.GeneratorResult
 import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.data.vault.repository.model.ArchiveCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.CreateCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.CreateFolderResult
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.TotpCodeResult
+import com.x8bit.bitwarden.data.vault.repository.model.UnarchiveCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.credentials.manager.model.CreateCredentialResult
@@ -113,6 +119,7 @@ private const val KEY_STATE = "state"
 @Suppress("TooManyFunctions", "LargeClass", "LongParameterList", "LongMethod")
 class VaultAddEditViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    featureFlagManager: FeatureFlagManager,
     generatorRepository: GeneratorRepository,
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     private val toastManager: ToastManager,
@@ -128,6 +135,7 @@ class VaultAddEditViewModel @Inject constructor(
     private val organizationEventManager: OrganizationEventManager,
     private val networkConnectionManager: NetworkConnectionManager,
     private val firstTimeActionManager: FirstTimeActionManager,
+    private val environmentRepository: EnvironmentRepository,
 ) : BaseViewModel<VaultAddEditState, VaultAddEditEvent, VaultAddEditAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
@@ -169,6 +177,7 @@ class VaultAddEditViewModel @Inject constructor(
             }
 
             VaultAddEditState(
+                isArchiveEnabled = featureFlagManager.getFeatureFlag(FlagKey.ArchiveItems),
                 vaultAddEditType = vaultAddEditType,
                 cipherType = vaultCipherType,
                 viewState = when (vaultAddEditType) {
@@ -205,6 +214,7 @@ class VaultAddEditViewModel @Inject constructor(
                 shouldShowCoachMarkTour = false,
                 shouldClearSpecialCircumstance = autofillSelectionData == null,
                 defaultUriMatchType = settingsRepository.defaultUriMatchType,
+                hasPremium = authRepository.userStateFlow.value?.activeAccount?.isPremium == true,
             )
         },
 ) {
@@ -263,6 +273,12 @@ class VaultAddEditViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
+        featureFlagManager
+            .getFeatureFlagFlow(FlagKey.ArchiveItems)
+            .map { VaultAddEditAction.Internal.ArchiveItemsFlagUpdateReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
         snackbarRelayManager
             .getSnackbarDataFlow(SnackbarRelay.CIPHER_MOVED_TO_ORGANIZATION)
             .map { VaultAddEditAction.Internal.SnackbarDataReceived(it) }
@@ -303,6 +319,9 @@ class VaultAddEditViewModel @Inject constructor(
             is VaultAddEditAction.Common.AttachmentsClick -> handleAttachmentsClick()
             is VaultAddEditAction.Common.MoveToOrganizationClick -> handleMoveToOrganizationClick()
             is VaultAddEditAction.Common.CollectionsClick -> handleCollectionsClick()
+            is VaultAddEditAction.Common.ArchiveClick -> handleArchiveClick()
+            is VaultAddEditAction.Common.UnarchiveClick -> handleUnarchiveClick()
+            VaultAddEditAction.Common.UpgradeToPremiumClick -> handleUpgradeToPremiumClick()
             is VaultAddEditAction.Common.ConfirmDeleteClick -> handleConfirmDeleteClick()
             is VaultAddEditAction.Common.CloseClick -> handleCloseClick()
             is VaultAddEditAction.Common.DismissDialog -> handleDismissDialog()
@@ -544,6 +563,73 @@ class VaultAddEditViewModel @Inject constructor(
 
     private fun handleCollectionsClick() {
         onEdit { sendEvent(VaultAddEditEvent.NavigateToCollections(it.vaultItemId)) }
+    }
+
+    private fun handleArchiveClick() {
+        if (!state.hasPremium) {
+            mutableStateFlow.update {
+                it.copy(dialog = VaultAddEditState.DialogState.ArchiveRequiresPremium)
+            }
+            return
+        }
+        onEdit {
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = VaultAddEditState.DialogState.Loading(
+                        label = BitwardenString.archiving.asText(),
+                    ),
+                )
+            }
+        }
+        onContent { content ->
+            content.common.originalCipher?.id?.let {
+                viewModelScope.launch {
+                    trySendAction(
+                        VaultAddEditAction.Internal.ArchiveCipherReceive(
+                            result = vaultRepository.archiveCipher(
+                                cipherId = it,
+                                cipherView = content.common.originalCipher,
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun handleUnarchiveClick() {
+        onEdit {
+            mutableStateFlow.update {
+                it.copy(
+                    dialog = VaultAddEditState.DialogState.Loading(
+                        label = BitwardenString.unarchiving.asText(),
+                    ),
+                )
+            }
+        }
+        onContent { content ->
+            content.common.originalCipher?.id?.let {
+                viewModelScope.launch {
+                    trySendAction(
+                        VaultAddEditAction.Internal.UnarchiveCipherReceive(
+                            result = vaultRepository.unarchiveCipher(
+                                cipherId = it,
+                                cipherView = content.common.originalCipher,
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun handleUpgradeToPremiumClick() {
+        val baseUrl = environmentRepository.environment.environmentUrlData.baseWebVaultUrlOrDefault
+        sendEvent(
+            VaultAddEditEvent.NavigateToPremium(
+                uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium",
+            ),
+        )
     }
 
     private fun handleConfirmDeleteClick() {
@@ -1543,6 +1629,18 @@ class VaultAddEditViewModel @Inject constructor(
                 handleUpdateCipherResultReceive(action)
             }
 
+            is VaultAddEditAction.Internal.ArchiveCipherReceive -> {
+                handleArchiveCipherReceive(action)
+            }
+
+            is VaultAddEditAction.Internal.UnarchiveCipherReceive -> {
+                handleUnarchiveCipherReceive(action)
+            }
+
+            is VaultAddEditAction.Internal.ArchiveItemsFlagUpdateReceive -> {
+                handleArchiveItemsFlagUpdateReceive(action)
+            }
+
             is VaultAddEditAction.Internal.DeleteCipherReceive -> handleDeleteCipherReceive(action)
             is VaultAddEditAction.Internal.TotpCodeReceive -> handleVaultTotpCodeReceive(action)
             is VaultAddEditAction.Internal.VaultDataReceive -> handleVaultDataReceive(action)
@@ -1702,6 +1800,60 @@ class VaultAddEditViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun handleArchiveCipherReceive(
+        action: VaultAddEditAction.Internal.ArchiveCipherReceive,
+    ) {
+        when (val result = action.result) {
+            is ArchiveCipherResult.Error -> {
+                showDialog(
+                    dialogState = VaultAddEditState.DialogState.Generic(
+                        message = BitwardenString.unable_to_archive_selected_item.asText(),
+                        error = result.error,
+                    ),
+                )
+            }
+
+            ArchiveCipherResult.Success -> {
+                clearDialogState()
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.item_archived.asText()),
+                    relay = SnackbarRelay.CIPHER_ARCHIVED,
+                )
+                sendEvent(VaultAddEditEvent.NavigateBack)
+            }
+        }
+    }
+
+    private fun handleUnarchiveCipherReceive(
+        action: VaultAddEditAction.Internal.UnarchiveCipherReceive,
+    ) {
+        when (val result = action.result) {
+            is UnarchiveCipherResult.Error -> {
+                showDialog(
+                    dialogState = VaultAddEditState.DialogState.Generic(
+                        message = BitwardenString.unable_to_unarchive_selected_item.asText(),
+                        error = result.error,
+                    ),
+                )
+            }
+
+            UnarchiveCipherResult.Success -> {
+                clearDialogState()
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.item_unarchived.asText()),
+                    relay = SnackbarRelay.CIPHER_UNARCHIVED,
+                )
+                sendEvent(VaultAddEditEvent.NavigateBack)
+            }
+        }
+    }
+
+    private fun handleArchiveItemsFlagUpdateReceive(
+        action: VaultAddEditAction.Internal.ArchiveItemsFlagUpdateReceive,
+    ) {
+        mutableStateFlow.update { it.copy(isArchiveEnabled = action.isEnabled) }
     }
 
     private fun handleDeleteCipherReceive(action: VaultAddEditAction.Internal.DeleteCipherReceive) {
@@ -2242,12 +2394,14 @@ data class VaultAddEditState(
     val bottomSheetState: BottomSheetState?,
     val shouldShowCloseButton: Boolean = true,
     // Internal
+    val hasPremium: Boolean,
     val shouldExitOnSave: Boolean = false,
     val shouldClearSpecialCircumstance: Boolean = true,
     val totpData: TotpData? = null,
     val createCredentialRequest: CreateCredentialRequest? = null,
     val defaultUriMatchType: UriMatchType,
     private val shouldShowCoachMarkTour: Boolean,
+    private val isArchiveEnabled: Boolean,
 ) : Parcelable {
 
     /**
@@ -2291,9 +2445,36 @@ data class VaultAddEditState(
     val isAddItemMode: Boolean get() = vaultAddEditType is VaultAddEditType.AddItem
 
     /**
+     * Helper to determine if the UI should display the content in edit item mode.
+     */
+    val isEditItemMode: Boolean get() = vaultAddEditType is VaultAddEditType.EditItem
+
+    /**
      * Helper to determine if the UI should display the content in clone mode.
      */
     val isCloneMode: Boolean get() = vaultAddEditType is VaultAddEditType.CloneItem
+
+    /**
+     * Helper to determine if the UI should display the archive button.
+     */
+    val displayArchiveButton: Boolean
+        get() = isArchiveEnabled &&
+            isEditItemMode &&
+            (viewState as? ViewState.Content)
+                ?.common
+                ?.originalCipher
+                ?.archivedDate == null
+
+    /**
+     * Helper to determine if the UI should display the unarchive button.
+     */
+    val displayUnarchiveButton: Boolean
+        get() = isArchiveEnabled &&
+            isEditItemMode &&
+            (viewState as? ViewState.Content)
+                ?.common
+                ?.originalCipher
+                ?.archivedDate != null
 
     /**
      * Helper to determine if the UI should allow deletion of this item.
@@ -2735,6 +2916,11 @@ data class VaultAddEditState(
     sealed class DialogState : Parcelable {
 
         /**
+         * Displays a dialog to the user indicating they archiving requires a premium account.
+         */
+        data object ArchiveRequiresPremium : DialogState()
+
+        /**
          * Displays a generic dialog to the user.
          */
         @Parcelize
@@ -2862,6 +3048,13 @@ sealed class VaultAddEditEvent {
     ) : VaultAddEditEvent()
 
     /**
+     * Navigates to the upgrade-to-premium url.
+     */
+    data class NavigateToPremium(
+        val uri: String,
+    ) : VaultAddEditEvent()
+
+    /**
      * Navigates to the collections screen.
      */
     data class NavigateToCollections(
@@ -2968,6 +3161,21 @@ sealed class VaultAddEditAction {
          * The user has clicked the collections overflow option.
          */
         data object CollectionsClick : Common()
+
+        /**
+         * The user has clicked the archive overflow option.
+         */
+        data object ArchiveClick : Common()
+
+        /**
+         * The user has clicked the unarchive overflow option.
+         */
+        data object UnarchiveClick : Common()
+
+        /**
+         * The user has clicked the upgrade to premium dialog.
+         */
+        data object UpgradeToPremiumClick : Common()
 
         /**
          * The user has confirmed to deleted the cipher.
@@ -3536,6 +3744,20 @@ sealed class VaultAddEditAction {
         ) : Internal()
 
         /**
+         * Indicates that the archive cipher result has been received.
+         */
+        data class ArchiveCipherReceive(
+            val result: ArchiveCipherResult,
+        ) : Internal()
+
+        /**
+         * Indicates that the unarchive cipher result has been received.
+         */
+        data class UnarchiveCipherReceive(
+            val result: UnarchiveCipherResult,
+        ) : Internal()
+
+        /**
          * Indicates that the delete cipher result has been received.
          */
         data class DeleteCipherReceive(
@@ -3584,6 +3806,13 @@ sealed class VaultAddEditAction {
          */
         data class AvailableFoldersReceive(
             val folderData: DataState<List<FolderView>>,
+        ) : Internal()
+
+        /**
+         * Indicates that the Archive Items flag has been updated.
+         */
+        data class ArchiveItemsFlagUpdateReceive(
+            val isEnabled: Boolean,
         ) : Internal()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -214,6 +214,8 @@ class VaultItemViewModel @Inject constructor(
 
         snackbarRelayManager
             .getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_ARCHIVED,
+                SnackbarRelay.CIPHER_UNARCHIVED,
                 SnackbarRelay.CIPHER_DELETED_SOFT,
                 SnackbarRelay.CIPHER_MOVED_TO_ORGANIZATION,
                 SnackbarRelay.CIPHER_UPDATED,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -219,6 +219,8 @@ class VaultItemListingViewModel @Inject constructor(
 
         snackbarRelayManager
             .getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_ARCHIVED,
+                SnackbarRelay.CIPHER_UNARCHIVED,
                 SnackbarRelay.CIPHER_CREATED,
                 SnackbarRelay.CIPHER_DELETED,
                 SnackbarRelay.CIPHER_DELETED_SOFT,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -192,6 +192,7 @@ class VaultViewModel @Inject constructor(
                     delay(timeMillis = LOGIN_SUCCESS_SNACKBAR_DELAY)
                 },
             snackbarRelayManager.getSnackbarDataFlow(
+                SnackbarRelay.CIPHER_ARCHIVED,
                 SnackbarRelay.CIPHER_CREATED,
                 SnackbarRelay.CIPHER_DELETED,
                 SnackbarRelay.CIPHER_DELETED_SOFT,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.collections.CollectionView
 import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
+import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
@@ -44,6 +45,7 @@ import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
 import com.x8bit.bitwarden.data.credentials.model.UserVerificationRequirement
 import com.x8bit.bitwarden.data.credentials.model.createMockCreateCredentialRequest
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
@@ -56,6 +58,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.tools.generator.repository.GeneratorRepository
 import com.x8bit.bitwarden.data.tools.generator.repository.util.FakeGeneratorRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createEditCollectionView
@@ -70,10 +73,12 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createViewCollectionV
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createViewExceptPasswordsCollectionView
 import com.x8bit.bitwarden.data.vault.manager.model.GetCipherResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.data.vault.repository.model.ArchiveCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.CreateCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.CreateFolderResult
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.TotpCodeResult
+import com.x8bit.bitwarden.data.vault.repository.model.UnarchiveCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.credentials.manager.model.CreateCredentialResult
@@ -218,6 +223,12 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         every { show(messageId = any(), duration = any()) } just runs
         every { show(message = any(), duration = any()) } just runs
     }
+    private val environmentRepository = FakeEnvironmentRepository()
+    private val mutableArchiveItemsFlow = MutableStateFlow(true)
+    private val featureFlagManager: FeatureFlagManager = mockk {
+        every { getFeatureFlag(FlagKey.ArchiveItems) } answers { mutableArchiveItemsFlow.value }
+        every { getFeatureFlagFlow(FlagKey.ArchiveItems) } returns mutableArchiveItemsFlow
+    }
 
     @BeforeEach
     fun setup() {
@@ -257,6 +268,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             shouldExitOnSave = false,
             shouldShowCoachMarkTour = false,
             defaultUriMatchType = UriMatchTypeModel.EXACT,
+            hasPremium = true,
+            isArchiveEnabled = true,
         )
         val viewModel = createAddVaultItemViewModel(
             savedStateHandle = createSavedStateHandleWithState(
@@ -344,6 +357,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 bottomSheetState = null,
                 shouldShowCoachMarkTour = false,
                 defaultUriMatchType = UriMatchTypeModel.EXACT,
+                hasPremium = true,
+                isArchiveEnabled = true,
             ),
             viewModel.stateFlow.value,
         )
@@ -521,6 +536,22 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         viewModel.eventFlow.test {
             viewModel.trySendAction(VaultAddEditAction.Common.CloseClick)
             assertEquals(VaultAddEditEvent.NavigateBack, awaitItem())
+        }
+    }
+
+    @Test
+    fun `UpgradeToPremiumClick should emit NavigateToPremium`() = runTest {
+        val viewModel = createAddVaultItemViewModel()
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(VaultAddEditAction.Common.UpgradeToPremiumClick)
+            assertEquals(
+                VaultAddEditEvent.NavigateToPremium(
+                    uri = "https://vault.bitwarden.com/#/" +
+                        "settings/subscription/premium" +
+                        "?callToAction=upgradeToPremium",
+                ),
+                awaitItem(),
+            )
         }
     }
 
@@ -2258,6 +2289,291 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             }
         }
 
+    @Test
+    fun `ArchiveClick without premium should show ArchiveRequiresPremium dialog`() = runTest {
+        val cipherListView = createMockCipherListView(number = 1, isArchived = false)
+        val cipherView = createMockCipherView(number = 1, isArchived = false)
+        val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
+        val initState = createVaultAddItemState(
+            vaultAddEditType = vaultAddEditType,
+            commonContentViewState = createCommonContentViewState(originalCipher = cipherView),
+        )
+        mutableVaultDataFlow.value = DataState.Loaded(
+            data = createVaultData(cipherListView = cipherListView),
+        )
+
+        val viewModel = createAddVaultItemViewModel(
+            savedStateHandle = createSavedStateHandleWithState(
+                state = initState,
+                vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
+            ),
+        )
+
+        viewModel.trySendAction(VaultAddEditAction.Common.ArchiveClick)
+
+        assertEquals(
+            createVaultAddItemState(
+                hasPremium = false,
+                vaultAddEditType = vaultAddEditType,
+                dialogState = VaultAddEditState.DialogState.ArchiveRequiresPremium,
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                    originalCipher = createMockCipherView(number = 1),
+                    notes = "mockNotes-1",
+                    customFieldData = listOf(
+                        VaultAddEditState.Custom.HiddenField(
+                            itemId = "testId",
+                            name = "mockName-1",
+                            value = "mockValue-1",
+                        ),
+                    ),
+                ),
+                typeContentViewState = createLoginTypeContentViewState(
+                    username = "mockUsername-1",
+                    password = "mockPassword-1",
+                    uri = listOf(
+                        UriItem(
+                            id = "testId",
+                            uri = "www.mockuri1.com",
+                            match = UriMatchType.HOST,
+                            checksum = "mockUriChecksum-1",
+                        ),
+                    ),
+                    totpCode = "mockTotp-1",
+                    canViewPassword = true,
+                    fido2CredentialCreationDateTime = null,
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `ArchiveClick with ArchiveCipherResult Success should emit send snackbar event and NavigateBack`() =
+        runTest {
+            val cipherListView = createMockCipherListView(number = 1, isArchived = false)
+            val cipherView = createMockCipherView(number = 1, isArchived = false)
+            val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
+            val initState = createVaultAddItemState(
+                vaultAddEditType = vaultAddEditType,
+                commonContentViewState = createCommonContentViewState(originalCipher = cipherView),
+                hasPremium = true,
+            )
+            mutableVaultDataFlow.value = DataState.Loaded(
+                data = createVaultData(cipherListView = cipherListView),
+            )
+            val viewModel = createAddVaultItemViewModel(
+                savedStateHandle = createSavedStateHandleWithState(
+                    state = initState,
+                    vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
+                ),
+            )
+
+            coEvery {
+                vaultRepository.archiveCipher(cipherId = "mockId-1", cipherView = cipherView)
+            } returns ArchiveCipherResult.Success
+
+            viewModel.trySendAction(VaultAddEditAction.Common.ArchiveClick)
+
+            viewModel.eventFlow.test {
+                assertEquals(VaultAddEditEvent.NavigateBack, awaitItem())
+            }
+            verify(exactly = 1) {
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.item_archived.asText()),
+                    relay = SnackbarRelay.CIPHER_ARCHIVED,
+                )
+            }
+        }
+
+    @Test
+    fun `ArchiveClick with ArchiveCipherResult Failure should show generic error`() = runTest {
+        mutableUserStateFlow.update {
+            it?.copy(accounts = it.accounts.map { account -> account.copy(isPremium = true) })
+        }
+        val cipherListView = createMockCipherListView(number = 1, isArchived = false)
+        val cipherView = createMockCipherView(number = 1, isArchived = false)
+        val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
+        val initState = createVaultAddItemState(
+            vaultAddEditType = vaultAddEditType,
+            commonContentViewState = createCommonContentViewState(originalCipher = cipherView),
+            hasPremium = true,
+        )
+        mutableVaultDataFlow.value = DataState.Loaded(
+            data = createVaultData(cipherListView = cipherListView),
+        )
+
+        val viewModel = createAddVaultItemViewModel(
+            savedStateHandle = createSavedStateHandleWithState(
+                state = initState,
+                vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
+            ),
+        )
+
+        val error = Throwable("Oh dang.")
+        coEvery {
+            vaultRepository.archiveCipher(cipherId = "mockId-1", cipherView = cipherView)
+        } returns ArchiveCipherResult.Error(error = error)
+
+        viewModel.trySendAction(VaultAddEditAction.Common.ArchiveClick)
+
+        assertEquals(
+            createVaultAddItemState(
+                hasPremium = true,
+                vaultAddEditType = vaultAddEditType,
+                dialogState = VaultAddEditState.DialogState.Generic(
+                    message = BitwardenString.unable_to_archive_selected_item.asText(),
+                    error = error,
+                ),
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                    originalCipher = createMockCipherView(number = 1),
+                    notes = "mockNotes-1",
+                    customFieldData = listOf(
+                        VaultAddEditState.Custom.HiddenField(
+                            itemId = "testId",
+                            name = "mockName-1",
+                            value = "mockValue-1",
+                        ),
+                    ),
+                ),
+                typeContentViewState = createLoginTypeContentViewState(
+                    username = "mockUsername-1",
+                    password = "mockPassword-1",
+                    uri = listOf(
+                        UriItem(
+                            id = "testId",
+                            uri = "www.mockuri1.com",
+                            match = UriMatchType.HOST,
+                            checksum = "mockUriChecksum-1",
+                        ),
+                    ),
+                    totpCode = "mockTotp-1",
+                    canViewPassword = true,
+                    fido2CredentialCreationDateTime = null,
+                )
+                    .copy(totp = "mockTotp-1"),
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `UnarchiveClick with UnarchiveCipherResult Success should emit send snackbar event and NavigateBack`() =
+        runTest {
+            val cipherListView = createMockCipherListView(number = 1, isArchived = false)
+            val cipherView = createMockCipherView(number = 1, isArchived = false)
+            val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
+            val initState = createVaultAddItemState(
+                vaultAddEditType = vaultAddEditType,
+                commonContentViewState = createCommonContentViewState(originalCipher = cipherView),
+                hasPremium = true,
+            )
+            mutableVaultDataFlow.value = DataState.Loaded(
+                data = createVaultData(cipherListView = cipherListView),
+            )
+            val viewModel = createAddVaultItemViewModel(
+                savedStateHandle = createSavedStateHandleWithState(
+                    state = initState,
+                    vaultAddEditType = vaultAddEditType,
+                    vaultItemCipherType = VaultItemCipherType.LOGIN,
+                ),
+            )
+
+            coEvery {
+                vaultRepository.unarchiveCipher(cipherId = "mockId-1", cipherView = cipherView)
+            } returns UnarchiveCipherResult.Success
+
+            viewModel.trySendAction(VaultAddEditAction.Common.UnarchiveClick)
+
+            viewModel.eventFlow.test {
+                assertEquals(VaultAddEditEvent.NavigateBack, awaitItem())
+            }
+            verify(exactly = 1) {
+                snackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(BitwardenString.item_unarchived.asText()),
+                    relay = SnackbarRelay.CIPHER_UNARCHIVED,
+                )
+            }
+        }
+
+    @Test
+    fun `UnarchiveClick with UnarchiveCipherResult Failure should show generic error`() = runTest {
+        mutableUserStateFlow.update {
+            it?.copy(accounts = it.accounts.map { account -> account.copy(isPremium = true) })
+        }
+        val cipherListView = createMockCipherListView(number = 1, isArchived = false)
+        val cipherView = createMockCipherView(number = 1, isArchived = false)
+        val vaultAddEditType = VaultAddEditType.EditItem(DEFAULT_EDIT_ITEM_ID)
+        val initState = createVaultAddItemState(
+            vaultAddEditType = vaultAddEditType,
+            commonContentViewState = createCommonContentViewState(originalCipher = cipherView),
+            hasPremium = true,
+        )
+        mutableVaultDataFlow.value = DataState.Loaded(
+            data = createVaultData(cipherListView = cipherListView),
+        )
+
+        val viewModel = createAddVaultItemViewModel(
+            savedStateHandle = createSavedStateHandleWithState(
+                state = initState,
+                vaultAddEditType = vaultAddEditType,
+                vaultItemCipherType = VaultItemCipherType.LOGIN,
+            ),
+        )
+
+        val error = Throwable("Oh dang.")
+        coEvery {
+            vaultRepository.unarchiveCipher(cipherId = "mockId-1", cipherView = cipherView)
+        } returns UnarchiveCipherResult.Error(error = error)
+
+        viewModel.trySendAction(VaultAddEditAction.Common.UnarchiveClick)
+
+        assertEquals(
+            createVaultAddItemState(
+                hasPremium = true,
+                vaultAddEditType = vaultAddEditType,
+                dialogState = VaultAddEditState.DialogState.Generic(
+                    message = BitwardenString.unable_to_unarchive_selected_item.asText(),
+                    error = error,
+                ),
+                commonContentViewState = createCommonContentViewState(
+                    name = "mockName-1",
+                    originalCipher = createMockCipherView(number = 1),
+                    notes = "mockNotes-1",
+                    customFieldData = listOf(
+                        VaultAddEditState.Custom.HiddenField(
+                            itemId = "testId",
+                            name = "mockName-1",
+                            value = "mockValue-1",
+                        ),
+                    ),
+                ),
+                typeContentViewState = createLoginTypeContentViewState(
+                    username = "mockUsername-1",
+                    password = "mockPassword-1",
+                    uri = listOf(
+                        UriItem(
+                            id = "testId",
+                            uri = "www.mockuri1.com",
+                            match = UriMatchType.HOST,
+                            checksum = "mockUriChecksum-1",
+                        ),
+                    ),
+                    totpCode = "mockTotp-1",
+                    canViewPassword = true,
+                    fido2CredentialCreationDateTime = null,
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
     @Nested
     inner class VaultAddEditLoginTypeItemActions {
         private lateinit var viewModel: VaultAddEditViewModel
@@ -3265,23 +3581,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 vaultAddEditType = VaultAddEditType.AddItem,
                 vaultItemCipherType = VaultItemCipherType.LOGIN,
             )
-            viewModel = VaultAddEditViewModel(
+            viewModel = createAddVaultItemViewModel(
                 savedStateHandle = secureNotesInitialSavedStateHandle,
-                authRepository = authRepository,
-                clipboardManager = clipboardManager,
-                policyManager = policyManager,
-                vaultRepository = vaultRepository,
-                bitwardenCredentialManager = bitwardenCredentialManager,
-                generatorRepository = generatorRepository,
-                settingsRepository = settingsRepository,
-                snackbarRelayManager = snackbarRelayManager,
-                toastManager = toastManager,
-                specialCircumstanceManager = specialCircumstanceManager,
-                resourceManager = resourceManager,
-                clock = fixedClock,
-                organizationEventManager = organizationEventManager,
-                networkConnectionManager = networkConnectionManager,
-                firstTimeActionManager = firstTimeActionManager,
             )
         }
 
@@ -3974,6 +4275,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                         isIndividualVaultDisabled = true,
                         type = createLoginTypeContentViewState(),
                     ),
+                    hasPremium = true,
                 )
                 assertEquals(expectedState, viewModel.stateFlow.value)
             }
@@ -4562,6 +4864,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         totpData: TotpData? = null,
         shouldClearSpecialCircumstance: Boolean = true,
         createCredentialRequest: CreateCredentialRequest? = null,
+        hasPremium: Boolean = false,
     ): VaultAddEditState =
         VaultAddEditState(
             vaultAddEditType = vaultAddEditType,
@@ -4579,6 +4882,8 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             shouldClearSpecialCircumstance = shouldClearSpecialCircumstance,
             createCredentialRequest = createCredentialRequest,
             defaultUriMatchType = UriMatchTypeModel.EXACT,
+            hasPremium = hasPremium,
+            isArchiveEnabled = true,
         )
 
     @Suppress("LongParameterList")
@@ -4661,6 +4966,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     ): VaultAddEditViewModel =
         VaultAddEditViewModel(
             savedStateHandle = savedStateHandle,
+            featureFlagManager = featureFlagManager,
             authRepository = authRepository,
             clipboardManager = bitwardenClipboardManager,
             policyManager = policyManager,
@@ -4676,6 +4982,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             organizationEventManager = organizationEventManager,
             networkConnectionManager = networkConnectionManager,
             firstTimeActionManager = firstTimeActionManager,
+            environmentRepository = environmentRepository,
         )
 
     private fun createVaultData(

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1176,6 +1176,17 @@ Do you want to switch to this account?</string>
     <string name="failed_to_migrate_items_to_x">Failed to migrate items to %s</string>
     <string name="search_archive">Search archive</string>
     <string name="archive_noun">Archive</string>
+    <string name="archive_verb">Archive</string>
+    <string name="unarchive">Unarchive</string>
     <string name="archived">Archived</string>
     <string name="hidden_items">Hidden items</string>
+    <string name="unable_to_archive_selected_item">Unable to archive selected item.</string>
+    <string name="unable_to_unarchive_selected_item">Unable to unarchive selected item.</string>
+    <string name="archiving">Archiving</string>
+    <string name="unarchiving">Unarchiving</string>
+    <string name="item_archived">Item archived</string>
+    <string name="item_unarchived">Item unarchived</string>
+    <string name="archive_unavailable">Archive unavailable</string>
+    <string name="archiving_items_is_a_premium_feature">Archiving items is a Premium feature. Your current plan does not include access to this feature.</string>
+    <string name="upgrade_to_premium">Upgrade to premium</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30897](https://bitwarden.atlassian.net/browse/PM-30897)

## 📔 Objective

This PR adds the `Archive` and `Unarchive` buttons to the Edit Item Screen including the appropriate flows associated with that button.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30897]: https://bitwarden.atlassian.net/browse/PM-30897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ