### PR TITLE
PM-31043: Add unarchive button to overflow menus

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchContent.kt
@@ -75,6 +75,7 @@ fun SearchContent(
         is ListingItemOverflowAction.VaultAction.LaunchClick,
         is ListingItemOverflowAction.VaultAction.ViewClick,
         is ListingItemOverflowAction.VaultAction.ArchiveClick,
+        is ListingItemOverflowAction.VaultAction.UnarchiveClick,
         null,
             -> Unit
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
@@ -78,6 +78,7 @@ fun VaultItemListingContent(
         is ListingItemOverflowAction.VaultAction.ViewClick,
         is ListingItemOverflowAction.VaultAction.CopyTotpClick,
         is ListingItemOverflowAction.VaultAction.ArchiveClick,
+        is ListingItemOverflowAction.VaultAction.UnarchiveClick,
         null,
             -> Unit
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
@@ -192,5 +192,14 @@ sealed class ListingItemOverflowAction : Parcelable {
             override val title: Text get() = BitwardenString.archive_verb.asText()
             override val requiresPasswordReprompt: Boolean get() = false
         }
+
+        /**
+         * Click on the unarchive overflow option.
+         */
+        @Parcelize
+        data class UnarchiveClick(val cipherId: String) : VaultAction() {
+            override val title: Text get() = BitwardenString.unarchive.asText()
+            override val requiresPasswordReprompt: Boolean get() = false
+        }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensions.kt
@@ -15,7 +15,7 @@ import kotlinx.collections.immutable.toImmutableList
 /**
  * Creates the list of overflow actions to be displayed for a [CipherView].
  */
-@Suppress("LongMethod")
+@Suppress("CyclomaticComplexMethod", "LongMethod")
 fun CipherListView.toOverflowActions(
     hasMasterPassword: Boolean,
     isPremiumUser: Boolean,
@@ -90,6 +90,10 @@ fun CipherListView.toOverflowActions(
                 ListingItemOverflowAction.VaultAction.ArchiveClick(cipherId = cipherId)
                     .takeIf {
                         this.archivedDate == null && deletedDate == null && isArchiveEnabled
+                    },
+                ListingItemOverflowAction.VaultAction.UnarchiveClick(cipherId = cipherId)
+                    .takeIf {
+                        this.archivedDate != null && deletedDate == null && isArchiveEnabled
                     },
             )
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -60,6 +60,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.ArchiveCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteSendResult
 import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.RemovePasswordSendResult
+import com.x8bit.bitwarden.data.vault.repository.model.UnarchiveCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.UpdateCipherResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
@@ -390,6 +391,64 @@ class SearchViewModelTest : BaseViewModelTest() {
                 dialogState = SearchState.DialogState.Error(
                     title = BitwardenString.an_error_has_occurred.asText(),
                     message = BitwardenString.unable_to_archive_selected_item.asText(),
+                    throwable = error,
+                ),
+            ),
+            viewModel.stateFlow.value,
+        )
+    }
+
+    @Test
+    fun `UnarchiveClick with UnarchiveCipherResult Success should emit a ShowSnackbar event`() =
+        runTest {
+            val cipherView = createMockCipherView(number = 1, clock = clock)
+
+            val viewModel = createViewModel(initialState = null)
+
+            coEvery {
+                vaultRepository.unarchiveCipher(cipherId = "mockId-1", cipherView = cipherView)
+            } returns UnarchiveCipherResult.Success
+
+            viewModel.trySendAction(
+                SearchAction.OverflowOptionClick(
+                    overflowAction = ListingItemOverflowAction.VaultAction.UnarchiveClick(
+                        cipherId = "mockId-1",
+                    ),
+                ),
+            )
+
+            viewModel.eventFlow.test {
+                assertEquals(
+                    SearchEvent.ShowSnackbar(BitwardenString.item_unarchived.asText()),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `UnarchiveClick with UnarchiveCipherResult Failure should show generic error`() = runTest {
+        val cipherView = createMockCipherView(number = 1, clock = clock)
+
+        val viewModel = createViewModel(initialState = null)
+
+        val error = Throwable("Oh dang.")
+        coEvery {
+            vaultRepository.unarchiveCipher(cipherId = "mockId-1", cipherView = cipherView)
+        } returns UnarchiveCipherResult.Error(error = error)
+
+        viewModel.trySendAction(
+            SearchAction.OverflowOptionClick(
+                overflowAction = ListingItemOverflowAction.VaultAction.UnarchiveClick(
+                    cipherId = "mockId-1",
+                ),
+            ),
+        )
+
+        assertEquals(
+            DEFAULT_STATE.copy(
+                dialogState = SearchState.DialogState.Error(
+                    title = BitwardenString.an_error_has_occurred.asText(),
+                    message = BitwardenString.unable_to_unarchive_selected_item.asText(),
                     throwable = error,
                 ),
             ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensionsTest.kt
@@ -425,6 +425,33 @@ class CipherListViewExtensionsTest {
         )
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `toOverflowActions should return Unarchive action when cipher is archived and not deleted`() {
+        val loginListView = createMockLoginListView(
+            number = 1,
+            username = "",
+            uris = emptyList(),
+            totp = null,
+        )
+        val cipher = createMockCipherListView(
+            number = 1,
+            id = id,
+            isArchived = true,
+            isDeleted = false,
+            edit = true,
+            type = CipherListViewType.Login(loginListView),
+        )
+
+        val result = cipher.toOverflowActions(
+            hasMasterPassword = true,
+            isPremiumUser = false,
+            isArchiveEnabled = true,
+        )
+
+        assertTrue(result.contains(ListingItemOverflowAction.VaultAction.UnarchiveClick(id)))
+    }
+
     @Test
     fun `toOverflowActions should not return Archive action when Archive is disabled`() {
         val loginListView = createMockLoginListView(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31043](https://bitwarden.atlassian.net/browse/PM-31043)

## 📔 Objective

This PR adds the unarchive button to the overflow menu for list items on the listing screen, vault screen, and search screen.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31043]: https://bitwarden.atlassian.net/browse/PM-31043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ