### PR TITLE
PM-29696: Add action card for lapsed premium subscription

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.base.util.toListItemCardStyle
+import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
@@ -39,6 +40,7 @@ import kotlinx.collections.immutable.toPersistentList
 @Composable
 fun VaultItemListingContent(
     state: VaultItemListingState.ViewState.Content,
+    actionCard: VaultItemListingState.ActionCardState?,
     policyDisablesSend: Boolean,
     showAddTotpBanner: Boolean,
     vaultItemListingHandlers: VaultItemListingHandlers,
@@ -99,14 +101,29 @@ fun VaultItemListingContent(
     LazyColumn(
         modifier = modifier,
     ) {
+        actionCard?.let {
+            item(key = "action_card") {
+                Spacer(modifier = Modifier.height(height = 12.dp))
+                ActionCard(
+                    actionCardState = it,
+                    vaultItemListingHandlers = vaultItemListingHandlers,
+                    modifier = Modifier
+                        .standardHorizontalMargin()
+                        .animateItem(),
+                )
+                Spacer(modifier = Modifier.height(height = 12.dp))
+            }
+        }
+
         if (showAddTotpBanner) {
-            item {
+            item(key = "auth_key_callout") {
                 Spacer(modifier = Modifier.height(height = 12.dp))
                 BitwardenInfoCalloutCard(
                     text = stringResource(
                         id = BitwardenString.add_this_authenticator_key_to_a_login,
                     ),
                     modifier = Modifier
+                        .animateItem()
                         .standardHorizontalMargin()
                         .fillMaxWidth(),
                 )
@@ -114,11 +131,12 @@ fun VaultItemListingContent(
         }
 
         if (policyDisablesSend) {
-            item {
+            item(key = "sends_disabled_callout") {
                 Spacer(modifier = Modifier.height(height = 12.dp))
                 BitwardenInfoCalloutCard(
                     text = stringResource(id = BitwardenString.send_disabled_warning),
                     modifier = Modifier
+                        .animateItem()
                         .standardHorizontalMargin()
                         .fillMaxWidth(),
                 )
@@ -126,12 +144,13 @@ fun VaultItemListingContent(
         }
 
         if (state.displayCollectionList.isNotEmpty()) {
-            item {
+            item(key = "collections_header") {
                 Spacer(modifier = Modifier.height(height = 12.dp))
                 BitwardenListHeaderText(
                     label = stringResource(id = BitwardenString.collections),
                     supportingLabel = state.displayCollectionList.count().toString(),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
@@ -139,7 +158,10 @@ fun VaultItemListingContent(
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
 
-            itemsIndexed(state.displayCollectionList) { index, collection ->
+            itemsIndexed(
+                items = state.displayCollectionList,
+                key = { _, collection -> collection.id },
+            ) { index, collection ->
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_collections),
                     label = collection.name,
@@ -149,6 +171,7 @@ fun VaultItemListingContent(
                         .displayCollectionList
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin(),
                 )
@@ -156,12 +179,13 @@ fun VaultItemListingContent(
         }
 
         if (state.displayFolderList.isNotEmpty()) {
-            item {
+            item(key = "folders_header") {
                 Spacer(modifier = Modifier.height(height = 12.dp))
                 BitwardenListHeaderText(
                     label = stringResource(id = BitwardenString.folders),
                     supportingLabel = state.displayFolderList.count().toString(),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
@@ -169,7 +193,10 @@ fun VaultItemListingContent(
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
 
-            itemsIndexed(state.displayFolderList) { index, folder ->
+            itemsIndexed(
+                items = state.displayFolderList,
+                key = { _, folder -> folder.id },
+            ) { index, folder ->
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_folder),
                     label = folder.name,
@@ -179,6 +206,7 @@ fun VaultItemListingContent(
                         .displayFolderList
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin(),
                 )
@@ -186,19 +214,23 @@ fun VaultItemListingContent(
         }
 
         if (state.displayItemList.isNotEmpty()) {
-            item {
+            item(key = "items_header") {
                 Spacer(modifier = Modifier.height(height = 12.dp))
                 BitwardenListHeaderText(
                     label = stringResource(id = BitwardenString.items),
                     supportingLabel = state.displayItemList.size.toString(),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
                 )
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
-            itemsIndexed(state.displayItemList) { index, it ->
+            itemsIndexed(
+                items = state.displayItemList,
+                key = { _, item -> item.id },
+            ) { index, it ->
                 BitwardenListItem(
                     startIcon = it.iconData,
                     startIconTestTag = it.iconTestTag,
@@ -260,15 +292,38 @@ fun VaultItemListingContent(
                         .displayItemList
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin(),
                 )
             }
         }
 
-        item {
+        item(key = "bottom_padding") {
             Spacer(modifier = Modifier.height(88.dp))
             Spacer(modifier = Modifier.navigationBarsPadding())
+        }
+    }
+}
+
+@Composable
+private fun ActionCard(
+    actionCardState: VaultItemListingState.ActionCardState,
+    vaultItemListingHandlers: VaultItemListingHandlers,
+    modifier: Modifier = Modifier,
+) {
+    when (actionCardState) {
+        VaultItemListingState.ActionCardState.PremiumSubscription -> {
+            BitwardenActionCard(
+                cardTitle = stringResource(id = BitwardenString.your_premium_subscription_ended),
+                cardSubtitle = stringResource(
+                    id = BitwardenString
+                        .to_regain_access_to_your_archive_restart_your_premium_subscription,
+                ),
+                actionText = stringResource(id = BitwardenString.restart_premium),
+                onActionClick = vaultItemListingHandlers.upgradeToPremiumClick,
+                modifier = modifier,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -508,6 +508,7 @@ private fun VaultItemListingScaffold(
             is VaultItemListingState.ViewState.Content -> {
                 VaultItemListingContent(
                     state = state.viewState,
+                    actionCard = state.actionCard,
                     showAddTotpBanner = state.isTotp,
                     policyDisablesSend = state.policyDisablesSend &&
                         state.itemListingType is VaultItemListingState.ItemListingType.Send,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -2844,6 +2844,34 @@ data class VaultItemListingState(
     val isArchiveEnabled: Boolean,
 ) {
     /**
+     * Indicates what action card to display.
+     */
+    val actionCard: ActionCardState?
+        get() = when (itemListingType) {
+            ItemListingType.Vault.Archive -> {
+                (viewState as? ViewState.Content)?.let {
+                    if (!isPremium && it.displayItemList.isNotEmpty()) {
+                        ActionCardState.PremiumSubscription
+                    } else {
+                        null
+                    }
+                }
+            }
+
+            ItemListingType.Vault.Card,
+            is ItemListingType.Vault.Collection,
+            is ItemListingType.Vault.Folder,
+            ItemListingType.Vault.Identity,
+            ItemListingType.Vault.Login,
+            ItemListingType.Vault.SecureNote,
+            ItemListingType.Vault.SshKey,
+            ItemListingType.Vault.Trash,
+            ItemListingType.Send.SendFile,
+            ItemListingType.Send.SendText,
+                -> null
+        }
+
+    /**
      * Whether or not the add FAB should be shown.
      */
     val hasAddItemFabButton: Boolean
@@ -3058,6 +3086,16 @@ data class VaultItemListingState(
          */
         @Parcelize
         data object ArchiveRequiresPremium : DialogState()
+    }
+
+    /**
+     * Represents the specific action cards that can be displayed on the [VaultItemListingScreen].
+     */
+    sealed class ActionCardState {
+        /**
+         * Indicates that your premium subscription has lapsed.
+         */
+        data object PremiumSubscription : ActionCardState()
     }
 
     /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -198,6 +198,53 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `action cards should be displayed according to state`() {
+        composeTestRule
+            .onNodeWithText(text = "Your Premium subscription ended")
+            .assertDoesNotExist()
+
+        mutableStateFlow.value = DEFAULT_STATE.copy(
+            isPremium = false,
+            itemListingType = VaultItemListingState.ItemListingType.Vault.Archive,
+            viewState = VaultItemListingState.ViewState.Content(
+                displayItemList = listOf(createDisplayItem(number = 1)),
+                displayFolderList = emptyList(),
+                displayCollectionList = emptyList(),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithText(text = "Your Premium subscription ended")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `premium action card restart premium button click should send UpgradeToPremiumClick`() {
+        composeTestRule
+            .onNodeWithText(text = "Your Premium subscription ended")
+            .assertDoesNotExist()
+
+        mutableStateFlow.value = DEFAULT_STATE.copy(
+            isPremium = false,
+            itemListingType = VaultItemListingState.ItemListingType.Vault.Archive,
+            viewState = VaultItemListingState.ViewState.Content(
+                displayItemList = listOf(createDisplayItem(number = 1)),
+                displayFolderList = emptyList(),
+                displayCollectionList = emptyList(),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithText(text = "Restart Premium")
+            .assertIsDisplayed()
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
+        }
+    }
+
+    @Test
     fun `account icon should update according to state`() {
         composeTestRule
             .onNodeWithText("AU")

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1191,4 +1191,7 @@ Do you want to switch to this account?</string>
     <string name="upgrade_to_premium">Upgrade to premium</string>
     <string name="this_item_is_archived">This item is archived.</string>
     <string name="this_item_is_archived_saving_changes_will_restore_it_to_your_vault">This item is archived. Saving changes will restore it to your vault.</string>
+    <string name="your_premium_subscription_ended">Your Premium subscription ended</string>
+    <string name="to_regain_access_to_your_archive_restart_your_premium_subscription">To regain access to your archive, restart your Premium subscription. If you edit details for an archived item before restarting, it’ll be moved back into your vault.</string>
+    <string name="restart_premium">Restart Premium</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29696](https://bitwarden.atlassian.net/browse/PM-29696)

## 📔 Objective

This PR adds an action card to the `VaultItemListingScreen` for archives to indicate to users that they no longer have a premium subscription and archiving is no longer operational.

## 📸 Screenshots

<img width="400" src="https://github.com/user-attachments/assets/e824a7ae-a7cb-460a-a944-88d85f476fdf" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29696]: https://bitwarden.atlassian.net/browse/PM-29696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ