### PR TITLE
PM-29693: Add introducing archive action card to vault screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -106,6 +106,24 @@ interface SettingsDiskSource : FlightRecorderDiskSource {
     fun clearData(userId: String)
 
     /**
+     * Retrieves the stored value of whether the introducing archive action card has been dismissed.
+     */
+    fun getIntroducingArchiveActionCardDismissed(userId: String): Boolean?
+
+    /**
+     * Stores whether the introducing archive action card has been dismissed.
+     */
+    fun storeIntroducingArchiveActionCardDismissed(
+        userId: String,
+        isDismissed: Boolean?,
+    )
+
+    /**
+     * Emits updates that track [getIntroducingArchiveActionCardDismissed] for the given [userId].
+     */
+    fun getIntroducingArchiveActionCardDismissedFlow(userId: String): Flow<Boolean?>
+
+    /**
      * Retrieves the biometric integrity validity for the given [userId] and
      * [systemBioIntegrityState].
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -243,6 +243,16 @@ interface SettingsRepository : FlightRecorderManager {
     fun storePullToRefreshEnabled(isPullToRefreshEnabled: Boolean)
 
     /**
+     * Gets updates for whether the introducing archive action card is dismissed.
+     */
+    fun getIntroducingArchiveActionCardDismissedFlow(): StateFlow<Boolean>
+
+    /**
+     * Stores that the introducing archive action card has been dismissed for the active user.
+     */
+    fun dismissIntroducingArchiveActionCard()
+
+    /**
      * Stores the encrypted user key for biometrics, allowing it to be used to unlock the current
      * user's vault.
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -500,6 +500,29 @@ class SettingsRepositoryImpl(
         }
     }
 
+    override fun getIntroducingArchiveActionCardDismissedFlow(): StateFlow<Boolean> {
+        val userId = activeUserId ?: return MutableStateFlow(value = false)
+        return settingsDiskSource
+            .getIntroducingArchiveActionCardDismissedFlow(userId = userId)
+            .map { it ?: false }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = settingsDiskSource
+                    .getIntroducingArchiveActionCardDismissed(userId = userId)
+                    ?: false,
+            )
+    }
+
+    override fun dismissIntroducingArchiveActionCard() {
+        activeUserId?.let {
+            settingsDiskSource.storeIntroducingArchiveActionCardDismissed(
+                userId = it,
+                isDismissed = true,
+            )
+        }
+    }
+
     override suspend fun setupBiometricsKey(cipher: Cipher): BiometricsKeyResult {
         val userId = activeUserId
             ?: return BiometricsKeyResult.Error(error = NoActiveUserException())

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,11 +19,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.base.util.toListItemCardStyle
+import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.ui.platform.components.dialog.BitwardenMasterPasswordDialog
 import com.x8bit.bitwarden.ui.platform.components.listitem.BitwardenGroupItem
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.model.ListingItemOverflowAction
@@ -40,6 +44,7 @@ private const val TRASH_TYPES_COUNT: Int = 1
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 fun VaultContent(
     state: VaultState.ViewState.Content,
+    actionCardState: VaultState.ActionCardState?,
     vaultHandlers: VaultHandlers,
     modifier: Modifier = Modifier,
 ) {
@@ -72,15 +77,31 @@ fun VaultContent(
     LazyColumn(
         modifier = modifier,
     ) {
-        item {
+        item(key = "top_spacer") {
             Spacer(modifier = Modifier.height(height = 12.dp))
         }
+
+        actionCardState?.let {
+            item(key = "action_card") {
+                ActionCard(
+                    actionCardState = it,
+                    vaultHandlers = vaultHandlers,
+                    modifier = Modifier
+                        .animateItem()
+                        .fillMaxWidth()
+                        .standardHorizontalMargin(),
+                )
+                Spacer(modifier = Modifier.height(height = 24.dp))
+            }
+        }
+
         if (state.totpItemsCount > 0) {
-            item {
+            item(key = "totp_header") {
                 BitwardenListHeaderText(
                     label = stringResource(id = BitwardenString.totp),
                     supportingLabel = TOTP_TYPES_COUNT.toString(),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
@@ -88,7 +109,7 @@ fun VaultContent(
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
 
-            item {
+            item(key = "verification_codes_group") {
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_clock),
                     label = stringResource(id = BitwardenString.verification_codes),
@@ -96,6 +117,7 @@ fun VaultContent(
                     onClick = vaultHandlers.verificationCodesClick,
                     cardStyle = CardStyle.Full,
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .testTag("VerificationCodesFilter")
                         .standardHorizontalMargin(),
@@ -105,11 +127,12 @@ fun VaultContent(
         }
 
         if (state.favoriteItems.isNotEmpty()) {
-            item {
+            item(key = "favorites_header") {
                 BitwardenListHeaderText(
                     label = stringResource(id = BitwardenString.favorites),
                     supportingLabel = state.favoriteItems.count().toString(),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
@@ -117,7 +140,10 @@ fun VaultContent(
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
 
-            itemsIndexed(state.favoriteItems) { index, favoriteItem ->
+            itemsIndexed(
+                items = state.favoriteItems,
+                key = { _, favorite -> favorite.id },
+            ) { index, favoriteItem ->
                 VaultEntryListItem(
                     startIcon = favoriteItem.startIcon,
                     startIconTestTag = favoriteItem.startIconTestTag,
@@ -145,21 +171,23 @@ fun VaultContent(
                         .favoriteItems
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .testTag("CipherCell")
                         .standardHorizontalMargin(),
                 )
             }
-            item {
+            item(key = "favorites_spacer") {
                 Spacer(modifier = Modifier.height(height = 16.dp))
             }
         }
 
-        item {
+        item(key = "types_header") {
             BitwardenListHeaderText(
                 label = stringResource(id = BitwardenString.types),
                 supportingLabel = state.itemTypesCount.toString(),
                 modifier = Modifier
+                    .animateItem()
                     .fillMaxWidth()
                     .standardHorizontalMargin()
                     .padding(horizontal = 16.dp),
@@ -167,7 +195,7 @@ fun VaultContent(
             Spacer(modifier = Modifier.height(height = 8.dp))
         }
 
-        item {
+        item(key = "logins_group") {
             BitwardenGroupItem(
                 startIcon = IconData.Local(
                     iconRes = BitwardenDrawable.ic_globe,
@@ -178,6 +206,7 @@ fun VaultContent(
                 onClick = vaultHandlers.loginGroupClick,
                 cardStyle = CardStyle.Top(dividerPadding = 56.dp),
                 modifier = Modifier
+                    .animateItem()
                     .fillMaxWidth()
                     .testTag("LoginFilter")
                     .standardHorizontalMargin(),
@@ -185,7 +214,7 @@ fun VaultContent(
         }
 
         if (state.showCardGroup) {
-            item {
+            item(key = "cards_group") {
                 BitwardenGroupItem(
                     startIcon = IconData.Local(
                         iconRes = BitwardenDrawable.ic_payment_card,
@@ -196,6 +225,7 @@ fun VaultContent(
                     onClick = vaultHandlers.cardGroupClick,
                     cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .testTag("CardFilter")
                         .standardHorizontalMargin(),
@@ -203,7 +233,7 @@ fun VaultContent(
             }
         }
 
-        item {
+        item(key = "identities_group") {
             BitwardenGroupItem(
                 startIcon = IconData.Local(
                     iconRes = BitwardenDrawable.ic_id_card,
@@ -214,13 +244,14 @@ fun VaultContent(
                 onClick = vaultHandlers.identityGroupClick,
                 cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
                 modifier = Modifier
+                    .animateItem()
                     .fillMaxWidth()
                     .testTag("IdentityFilter")
                     .standardHorizontalMargin(),
             )
         }
 
-        item {
+        item(key = "notes_group") {
             BitwardenGroupItem(
                 startIcon = IconData.Local(
                     iconRes = BitwardenDrawable.ic_note,
@@ -231,13 +262,14 @@ fun VaultContent(
                 onClick = vaultHandlers.secureNoteGroupClick,
                 cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
                 modifier = Modifier
+                    .animateItem()
                     .fillMaxWidth()
                     .testTag("SecureNoteFilter")
                     .standardHorizontalMargin(),
             )
         }
 
-        item {
+        item(key = "ssh_keys_group") {
             BitwardenGroupItem(
                 startIcon = IconData.Local(
                     iconRes = BitwardenDrawable.ic_ssh_key,
@@ -248,22 +280,24 @@ fun VaultContent(
                 onClick = vaultHandlers.sshKeyGroupClick,
                 cardStyle = CardStyle.Bottom,
                 modifier = Modifier
+                    .animateItem()
                     .fillMaxWidth()
                     .testTag("SshKeyFilter")
                     .standardHorizontalMargin(),
             )
         }
 
-        item {
+        item(key = "types_spacer") {
             Spacer(modifier = Modifier.height(height = 16.dp))
         }
 
         if (state.folderItems.isNotEmpty()) {
-            item {
+            item(key = "folders_header") {
                 BitwardenListHeaderText(
                     label = stringResource(id = BitwardenString.folders),
                     supportingLabel = state.folderItems.count().toString(),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
@@ -271,7 +305,10 @@ fun VaultContent(
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
 
-            itemsIndexed(state.folderItems) { index, folder ->
+            itemsIndexed(
+                items = state.folderItems,
+                key = { _, folder -> folder.id ?: "no_folder_group" },
+            ) { index, folder ->
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_folder),
                     label = folder.name(),
@@ -281,29 +318,34 @@ fun VaultContent(
                         .folderItems
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .testTag("FolderFilter")
                         .standardHorizontalMargin(),
                 )
             }
-            item {
+            item(key = "folders_spacer") {
                 Spacer(modifier = Modifier.height(height = 16.dp))
             }
         }
 
         if (state.noFolderItems.isNotEmpty()) {
-            item {
+            item(key = "no_folders_header") {
                 BitwardenListHeaderText(
                     label = stringResource(id = BitwardenString.folder_none),
                     supportingLabel = state.noFolderItems.count().toString(),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
                 )
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
-            itemsIndexed(state.noFolderItems) { index, noFolderItem ->
+            itemsIndexed(
+                items = state.noFolderItems,
+                key = { _, noFolderItem -> noFolderItem.id },
+            ) { index, noFolderItem ->
                 VaultEntryListItem(
                     startIcon = noFolderItem.startIcon,
                     startIconTestTag = noFolderItem.startIconTestTag,
@@ -331,22 +373,24 @@ fun VaultContent(
                         .noFolderItems
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .testTag("CipherCell")
                         .standardHorizontalMargin(),
                 )
             }
-            item {
+            item(key = "no_folders_spacer") {
                 Spacer(modifier = Modifier.height(height = 16.dp))
             }
         }
 
         if (state.collectionItems.isNotEmpty()) {
-            item {
+            item(key = "collection_header") {
                 BitwardenListHeaderText(
                     label = stringResource(id = BitwardenString.collections),
                     supportingLabel = state.collectionItems.count().toString(),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .standardHorizontalMargin()
                         .padding(horizontal = 16.dp),
@@ -354,7 +398,10 @@ fun VaultContent(
                 Spacer(modifier = Modifier.height(height = 8.dp))
             }
 
-            itemsIndexed(state.collectionItems) { index, collection ->
+            itemsIndexed(
+                items = state.collectionItems,
+                key = { _, collection -> collection.id },
+            ) { index, collection ->
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_collections),
                     label = collection.name,
@@ -364,17 +411,18 @@ fun VaultContent(
                         .collectionItems
                         .toListItemCardStyle(index = index, dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .testTag("CollectionFilter")
                         .standardHorizontalMargin(),
                 )
             }
-            item {
+            item(key = "collections_spacer") {
                 Spacer(modifier = Modifier.height(height = 16.dp))
             }
         }
 
-        item {
+        item(key = "hidden_items_header") {
             BitwardenListHeaderText(
                 label = stringResource(id = BitwardenString.hidden_items),
                 supportingLabel = if (state.archiveEnabled) {
@@ -383,6 +431,7 @@ fun VaultContent(
                     TRASH_TYPES_COUNT.toString()
                 },
                 modifier = Modifier
+                    .animateItem()
                     .fillMaxWidth()
                     .standardHorizontalMargin()
                     .padding(horizontal = 16.dp),
@@ -391,7 +440,7 @@ fun VaultContent(
         }
 
         if (state.archiveEnabled) {
-            item {
+            item(key = "archive_group") {
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_archive),
                     endIcon = state.archiveEndIcon?.let { IconData.Local(iconRes = it) },
@@ -401,6 +450,7 @@ fun VaultContent(
                     onClick = vaultHandlers.archiveClick,
                     cardStyle = CardStyle.Top(dividerPadding = 56.dp),
                     modifier = Modifier
+                        .animateItem()
                         .fillMaxWidth()
                         .testTag(tag = "ArchiveFilter")
                         .standardHorizontalMargin(),
@@ -408,7 +458,7 @@ fun VaultContent(
             }
         }
 
-        item {
+        item(key = "trash_group") {
             BitwardenGroupItem(
                 startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_trash),
                 label = stringResource(id = BitwardenString.trash),
@@ -416,15 +466,45 @@ fun VaultContent(
                 onClick = vaultHandlers.trashClick,
                 cardStyle = if (state.archiveEnabled) CardStyle.Bottom else CardStyle.Full,
                 modifier = Modifier
+                    .animateItem()
                     .fillMaxWidth()
                     .testTag("TrashFilter")
                     .standardHorizontalMargin(),
             )
         }
 
-        item {
+        item(key = "bottom_padding") {
             Spacer(modifier = Modifier.height(height = 88.dp))
             Spacer(modifier = Modifier.navigationBarsPadding())
+        }
+    }
+}
+
+@Composable
+private fun ActionCard(
+    actionCardState: VaultState.ActionCardState,
+    vaultHandlers: VaultHandlers,
+    modifier: Modifier = Modifier,
+) {
+    when (actionCardState) {
+        VaultState.ActionCardState.IntroducingArchive -> {
+            BitwardenActionCard(
+                cardTitle = stringResource(id = BitwardenString.introducing_archive),
+                cardSubtitle = stringResource(
+                    id = BitwardenString.keep_items_you_dont_need_right_now_safe_but_out_sight,
+                ),
+                actionText = stringResource(id = BitwardenString.go_to_archive),
+                leadingContent = {
+                    Icon(
+                        painter = rememberVectorPainter(id = BitwardenDrawable.ic_archive),
+                        contentDescription = null,
+                        tint = BitwardenTheme.colorScheme.icon.secondary,
+                    )
+                },
+                onActionClick = vaultHandlers.archiveClick,
+                onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) },
+                modifier = modifier,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -326,6 +326,7 @@ private fun VaultScreenScaffold(
             when (val viewState = state.viewState) {
                 is VaultState.ViewState.Content -> VaultContent(
                     state = viewState,
+                    actionCardState = state.actionCard,
                     vaultHandlers = vaultHandlers,
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -144,6 +144,9 @@ class VaultViewModel @Inject constructor(
             restrictItemTypesPolicyOrgIds = emptyList(),
             cipherDecryptionFailureIds = persistentListOf(),
             hasShownDecryptionFailureAlert = false,
+            isIntroducingArchiveActionCardDismissed = settingsRepository
+                .getIntroducingArchiveActionCardDismissedFlow()
+                .value,
         )
     },
 ) {
@@ -215,6 +218,11 @@ class VaultViewModel @Inject constructor(
         settingsRepository
             .flightRecorderDataFlow
             .map { VaultAction.Internal.FlightRecorderDataReceive(data = it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+        settingsRepository
+            .getIntroducingArchiveActionCardDismissedFlow()
+            .map { VaultAction.Internal.IntroducingArchiveActionCardDismissedFlowReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -310,6 +318,7 @@ class VaultViewModel @Inject constructor(
             }
 
             VaultAction.UpgradeToPremiumClick -> handleUpgradeToPremiumClick()
+            is VaultAction.DismissActionCardClick -> handleDismissActionCardClick(action)
         }
     }
 
@@ -357,6 +366,14 @@ class VaultViewModel @Inject constructor(
         val baseUrl = environmentRepository.environment.environmentUrlData.baseWebVaultUrlOrDefault
         val url = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
         sendEvent(VaultEvent.NavigateToUrl(url = url))
+    }
+
+    private fun handleDismissActionCardClick(action: VaultAction.DismissActionCardClick) {
+        when (action.actionCard) {
+            VaultState.ActionCardState.IntroducingArchive -> {
+                settingsRepository.dismissIntroducingArchiveActionCard()
+            }
+        }
     }
 
     private fun handleSelectAddItemType() {
@@ -901,6 +918,9 @@ class VaultViewModel @Inject constructor(
 
             is VaultAction.Internal.ArchiveCipherReceive -> handleArchiveCipherReceive(action)
             is VaultAction.Internal.UnarchiveCipherReceive -> handleUnarchiveCipherReceive(action)
+            is VaultAction.Internal.IntroducingArchiveActionCardDismissedFlowReceive -> {
+                handleIntroducingArchiveActionCardDismissedFlowReceive(action)
+            }
         }
     }
 
@@ -998,6 +1018,14 @@ class VaultViewModel @Inject constructor(
                 mutableStateFlow.update { it.copy(dialog = null) }
                 sendEvent(VaultEvent.ShowSnackbar(BitwardenString.item_unarchived.asText()))
             }
+        }
+    }
+
+    private fun handleIntroducingArchiveActionCardDismissedFlowReceive(
+        action: VaultAction.Internal.IntroducingArchiveActionCardDismissedFlowReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(isIntroducingArchiveActionCardDismissed = action.isDismissed)
         }
     }
 
@@ -1412,7 +1440,18 @@ data class VaultState(
     val cipherDecryptionFailureIds: ImmutableList<String>,
     val hasShownDecryptionFailureAlert: Boolean,
     val restrictItemTypesPolicyOrgIds: List<String>,
+    val isIntroducingArchiveActionCardDismissed: Boolean,
 ) : Parcelable {
+
+    /**
+     * Indicates what action card to display.
+     */
+    val actionCard: ActionCardState?
+        get() = (viewState as? ViewState.Content)?.let {
+            ActionCardState.IntroducingArchive.takeIf {
+                isPremium && !isIntroducingArchiveActionCardDismissed && isArchiveEnabled
+            }
+        }
 
     /**
      * The [Color] of the avatar.
@@ -1723,6 +1762,16 @@ data class VaultState(
                 override val type: VaultItemCipherType get() = VaultItemCipherType.SSH_KEY
             }
         }
+    }
+
+    /**
+     * Represents an action card to be displayed.
+     */
+    sealed class ActionCardState {
+        /**
+         * Indicates that the archive feature is ready for use.
+         */
+        data object IntroducingArchive : ActionCardState()
     }
 
     /**
@@ -2133,6 +2182,13 @@ sealed class VaultAction {
     data object UpgradeToPremiumClick : VaultAction()
 
     /**
+     * User clicked the dismiss button on an action card.
+     */
+    data class DismissActionCardClick(
+        val actionCard: VaultState.ActionCardState,
+    ) : VaultAction()
+
+    /**
      * Models actions that the [VaultViewModel] itself might send.
      */
     sealed class Internal : VaultAction() {
@@ -2254,6 +2310,13 @@ sealed class VaultAction {
          */
         data class UnarchiveCipherReceive(
             val result: UnarchiveCipherResult,
+        ) : Internal()
+
+        /**
+         * Indicates that the archive action card dismissed state has been updated.
+         */
+        data class IntroducingArchiveActionCardDismissedFlowReceive(
+            val isDismissed: Boolean,
         ) : Internal()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/handlers/VaultHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/handlers/VaultHandlers.kt
@@ -51,6 +51,7 @@ data class VaultHandlers(
     val onEnabledThirdPartyAutofillClick: () -> Unit,
     val onDismissThirdPartyAutofillDialogClick: () -> Unit,
     val upgradeToPremiumClick: () -> Unit,
+    val dismissActionCardClick: (VaultState.ActionCardState) -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -146,6 +147,9 @@ data class VaultHandlers(
                 },
                 upgradeToPremiumClick = {
                     viewModel.trySendAction(VaultAction.UpgradeToPremiumClick)
+                },
+                dismissActionCardClick = {
+                    viewModel.trySendAction(VaultAction.DismissActionCardClick(it))
                 },
             )
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -138,6 +138,10 @@ class SettingsDiskSourceTest {
             userId = userId,
             isPullToRefreshEnabled = true,
         )
+        settingsDiskSource.storeIntroducingArchiveActionCardDismissed(
+            userId = userId,
+            isDismissed = true,
+        )
         settingsDiskSource.storeInlineAutofillEnabled(
             userId = userId,
             isInlineAutofillEnabled = true,
@@ -168,6 +172,9 @@ class SettingsDiskSourceTest {
         assertTrue(settingsDiskSource.getShowUnlockSettingBadge(userId = userId) ?: false)
         assertTrue(settingsDiskSource.getShowBrowserAutofillSettingBadge(userId = userId) ?: false)
         assertTrue(settingsDiskSource.getShowAutoFillSettingBadge(userId = userId) ?: false)
+        assertTrue(
+            settingsDiskSource.getIntroducingArchiveActionCardDismissed(userId = userId) ?: false,
+        )
 
         // These should be cleared
         assertNull(settingsDiskSource.getVaultTimeoutInMinutes(userId = userId))
@@ -777,6 +784,44 @@ class SettingsDiskSourceTest {
                 )
                 assertEquals(true, awaitItem())
             }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getIntroducingArchiveActionCardDismissed when values are present should pull from SharedPreferences`() {
+        val introducingArchiveBaseKey = "bwPreferencesStorage:introducingArchiveActionCardDismissed"
+        val mockUserId = "mockUserId"
+        val introducingArchiveKey = "${introducingArchiveBaseKey}_$mockUserId"
+        assertNull(settingsDiskSource.getIntroducingArchiveActionCardDismissed(userId = mockUserId))
+        fakeSharedPreferences.edit { putBoolean(introducingArchiveKey, true) }
+        assertEquals(
+            true,
+            settingsDiskSource.getIntroducingArchiveActionCardDismissed(userId = mockUserId),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getIntroducingArchiveActionCardDismissedFlow should react to changes in storeIntroducingArchiveActionCardDismissed`() =
+        runTest {
+            val mockUserId = "mockUserId"
+            settingsDiskSource
+                .getIntroducingArchiveActionCardDismissedFlow(userId = mockUserId)
+                .test {
+                    // The initial values of the Flow and the property are in sync
+                    assertNull(
+                        settingsDiskSource
+                            .getIntroducingArchiveActionCardDismissed(userId = mockUserId),
+                    )
+                    assertNull(awaitItem())
+
+                    // Updating the disk source updates shared preferences
+                    settingsDiskSource.storeIntroducingArchiveActionCardDismissed(
+                        userId = mockUserId,
+                        isDismissed = true,
+                    )
+                    assertEquals(true, awaitItem())
+                }
         }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -66,6 +66,7 @@ class FakeSettingsDiskSource(
     private val storedDisableAutoTotpCopy = mutableMapOf<String, Boolean?>()
     private val storedDisableAutofillSavePrompt = mutableMapOf<String, Boolean?>()
     private val storedPullToRefreshEnabled = mutableMapOf<String, Boolean?>()
+    private var storedIntroducingArchiveActionCardDismissed = mutableMapOf<String, Boolean?>()
     private val storedInlineAutofillEnabled = mutableMapOf<String, Boolean?>()
     private val storedBlockedAutofillUris = mutableMapOf<String, List<String>?>()
     private var storedIsIconLoadingDisabled: Boolean? = null
@@ -107,6 +108,9 @@ class FakeSettingsDiskSource(
 
     private val mutableVaultRegisteredForExportFlow =
         bufferedMutableSharedFlow<Boolean?>()
+
+    private val mutableIntroducingArchiveActionCardDismissedFlow =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     override var appLanguage: AppLanguage?
         get() = storedAppLanguage
@@ -325,6 +329,18 @@ class FakeSettingsDiskSource(
         getMutablePullToRefreshEnabledFlow(userId = userId).tryEmit(isPullToRefreshEnabled)
     }
 
+    override fun getIntroducingArchiveActionCardDismissed(userId: String): Boolean? =
+        storedIntroducingArchiveActionCardDismissed[userId]
+
+    override fun getIntroducingArchiveActionCardDismissedFlow(userId: String): Flow<Boolean?> =
+        getMutableIntroducingArchiveActionCardDismissedFlow(userId = userId)
+            .onSubscription { emit(getIntroducingArchiveActionCardDismissed(userId = userId)) }
+
+    override fun storeIntroducingArchiveActionCardDismissed(userId: String, isDismissed: Boolean?) {
+        storedIntroducingArchiveActionCardDismissed[userId] = isDismissed
+        getMutableIntroducingArchiveActionCardDismissedFlow(userId = userId).tryEmit(isDismissed)
+    }
+
     override fun getInlineAutofillEnabled(userId: String): Boolean? =
         storedInlineAutofillEnabled[userId]
 
@@ -529,6 +545,13 @@ class FakeSettingsDiskSource(
         userId: String,
     ): MutableSharedFlow<Boolean?> =
         mutablePullToRefreshEnabledFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutableIntroducingArchiveActionCardDismissedFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> =
+        mutableIntroducingArchiveActionCardDismissedFlow.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -856,6 +856,38 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `dismissIntroducingArchiveActionCard should properly update SettingsDiskSource`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        settingsRepository.dismissIntroducingArchiveActionCard()
+        assertEquals(
+            true,
+            fakeSettingsDiskSource.getIntroducingArchiveActionCardDismissed(userId = USER_ID),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getIntroducingArchiveActionCardDismissedFlow should react to changes in SettingsDiskSource`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            settingsRepository
+                .getIntroducingArchiveActionCardDismissedFlow()
+                .test {
+                    assertFalse(awaitItem())
+                    fakeSettingsDiskSource.storeIntroducingArchiveActionCardDismissed(
+                        userId = USER_ID,
+                        isDismissed = true,
+                    )
+                    assertTrue(awaitItem())
+                    fakeSettingsDiskSource.storeIntroducingArchiveActionCardDismissed(
+                        userId = USER_ID,
+                        isDismissed = false,
+                    )
+                    assertFalse(awaitItem())
+                }
+        }
+
+    @Test
     fun `storePullToRefreshEnabled should properly update SettingsDiskSource`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         settingsRepository.storePullToRefreshEnabled(true)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -1499,6 +1499,58 @@ class VaultScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `action cards should be displayed according to state`() {
+        composeTestRule
+            .onNodeWithText(text = "Introducing archive")
+            .assertDoesNotExist()
+
+        mutableStateFlow.value = DEFAULT_STATE.copy(
+            isPremium = true,
+            viewState = DEFAULT_CONTENT_VIEW_STATE,
+        )
+
+        composeTestRule
+            .onNodeWithText(text = "Introducing archive")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `IntroducingArchive action card go to archive button click should send ArchiveClick`() {
+        mutableStateFlow.value = DEFAULT_STATE.copy(
+            isPremium = true,
+            viewState = DEFAULT_CONTENT_VIEW_STATE,
+        )
+
+        composeTestRule
+            .onNodeWithText(text = "Go to archive")
+            .assertIsDisplayed()
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(VaultAction.ArchiveClick)
+        }
+    }
+
+    @Test
+    fun `IntroducingArchive action card dismiss button click should send DismissActionCardClick`() {
+        mutableStateFlow.value = DEFAULT_STATE.copy(
+            isPremium = true,
+            viewState = DEFAULT_CONTENT_VIEW_STATE,
+        )
+
+        composeTestRule
+            .onNodeWithContentDescription(label = "Close")
+            .assertIsDisplayed()
+            .performClick()
+
+        verify(exactly = 1) {
+            viewModel.trySendAction(
+                VaultAction.DismissActionCardClick(VaultState.ActionCardState.IntroducingArchive),
+            )
+        }
+    }
+
+    @Test
     fun `collection data should update according to the state`() {
         val collectionsHeader = "COLLECTIONS (1)"
         val collectionName = "Test Collection"
@@ -2458,6 +2510,7 @@ private val DEFAULT_STATE: VaultState = VaultState(
     hasShownDecryptionFailureAlert = false,
     restrictItemTypesPolicyOrgIds = emptyList(),
     isArchiveEnabled = true,
+    isIntroducingArchiveActionCardDismissed = false,
 )
 
 private val DEFAULT_CONTENT_VIEW_STATE: VaultState.ViewState.Content = VaultState.ViewState.Content(

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1190,5 +1190,8 @@ Do you want to switch to this account?</string>
     <string name="archiving_items_is_a_premium_feature">Archiving items is a Premium feature. Your current plan does not include access to this feature.</string>
     <string name="upgrade_to_premium">Upgrade to premium</string>
     <string name="this_item_is_archived">This item is archived.</string>
+    <string name="introducing_archive">Introducing archive</string>
+    <string name="keep_items_you_dont_need_right_now_safe_but_out_sight">Keep items you don’t need right now safe but out of sight.</string>
+    <string name="go_to_archive">Go to archive</string>
     <string name="this_item_is_archived_saving_changes_will_restore_it_to_your_vault">This item is archived. Saving changes will restore it to your vault.</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29693](https://bitwarden.atlassian.net/browse/PM-29693)

## 📔 Objective

This PR adds and action card to the `VaultScreen` to introduce the Archive feature to users. The card will be displayed if the feature is enabled, the user has premium, and the card has nopt been dismissed previously.

## 📸 Screenshots

<img width="400" src="https://github.com/user-attachments/assets/45f4ab3c-4f3d-47b7-9877-4e89823e5f4b" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29693]: https://bitwarden.atlassian.net/browse/PM-29693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ