### PR TITLE
PM-31162: Update copy on the snackbar for archive feature

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -683,7 +683,7 @@ class SearchViewModel @Inject constructor(
 
             ArchiveCipherResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(SearchEvent.ShowSnackbar(BitwardenString.item_archived.asText()))
+                sendEvent(SearchEvent.ShowSnackbar(BitwardenString.item_moved_to_archived.asText()))
             }
         }
     }
@@ -704,7 +704,7 @@ class SearchViewModel @Inject constructor(
 
             UnarchiveCipherResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
-                sendEvent(SearchEvent.ShowSnackbar(BitwardenString.item_unarchived.asText()))
+                sendEvent(SearchEvent.ShowSnackbar(BitwardenString.item_moved_to_vault.asText()))
             }
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -1818,7 +1818,7 @@ class VaultAddEditViewModel @Inject constructor(
             ArchiveCipherResult.Success -> {
                 clearDialogState()
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.item_archived.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.item_moved_to_archived.asText()),
                     relay = SnackbarRelay.CIPHER_ARCHIVED,
                 )
                 sendEvent(VaultAddEditEvent.NavigateBack)
@@ -1842,7 +1842,7 @@ class VaultAddEditViewModel @Inject constructor(
             UnarchiveCipherResult.Success -> {
                 clearDialogState()
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.item_unarchived.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.item_moved_to_vault.asText()),
                     relay = SnackbarRelay.CIPHER_UNARCHIVED,
                 )
                 sendEvent(VaultAddEditEvent.NavigateBack)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -1300,7 +1300,7 @@ class VaultItemViewModel @Inject constructor(
             ArchiveCipherResult.Success -> {
                 updateDialogState(dialog = null)
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.item_archived.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.item_moved_to_archived.asText()),
                     relay = SnackbarRelay.CIPHER_ARCHIVED,
                 )
                 sendEvent(VaultItemEvent.NavigateBack)
@@ -1324,7 +1324,7 @@ class VaultItemViewModel @Inject constructor(
             UnarchiveCipherResult.Success -> {
                 updateDialogState(dialog = null)
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.item_unarchived.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.item_moved_to_vault.asText()),
                     relay = SnackbarRelay.CIPHER_UNARCHIVED,
                 )
                 sendEvent(VaultItemEvent.NavigateBack)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1731,7 +1731,9 @@ class VaultItemListingViewModel @Inject constructor(
             ArchiveCipherResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
                 sendEvent(
-                    VaultItemListingEvent.ShowSnackbar(BitwardenString.item_archived.asText()),
+                    VaultItemListingEvent.ShowSnackbar(
+                        message = BitwardenString.item_moved_to_archived.asText(),
+                    ),
                 )
             }
         }
@@ -1756,7 +1758,9 @@ class VaultItemListingViewModel @Inject constructor(
             UnarchiveCipherResult.Success -> {
                 mutableStateFlow.update { it.copy(dialogState = null) }
                 sendEvent(
-                    VaultItemListingEvent.ShowSnackbar(BitwardenString.item_unarchived.asText()),
+                    VaultItemListingEvent.ShowSnackbar(
+                        message = BitwardenString.item_moved_to_vault.asText(),
+                    ),
                 )
             }
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -975,7 +975,7 @@ class VaultViewModel @Inject constructor(
 
             ArchiveCipherResult.Success -> {
                 mutableStateFlow.update { it.copy(dialog = null) }
-                sendEvent(VaultEvent.ShowSnackbar(BitwardenString.item_archived.asText()))
+                sendEvent(VaultEvent.ShowSnackbar(BitwardenString.item_moved_to_archived.asText()))
             }
         }
     }
@@ -996,7 +996,7 @@ class VaultViewModel @Inject constructor(
 
             UnarchiveCipherResult.Success -> {
                 mutableStateFlow.update { it.copy(dialog = null) }
-                sendEvent(VaultEvent.ShowSnackbar(BitwardenString.item_unarchived.asText()))
+                sendEvent(VaultEvent.ShowSnackbar(BitwardenString.item_moved_to_vault.asText()))
             }
         }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -361,7 +361,7 @@ class SearchViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 assertEquals(
-                    SearchEvent.ShowSnackbar(BitwardenString.item_archived.asText()),
+                    SearchEvent.ShowSnackbar(BitwardenString.item_moved_to_archived.asText()),
                     awaitItem(),
                 )
             }
@@ -419,7 +419,7 @@ class SearchViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 assertEquals(
-                    SearchEvent.ShowSnackbar(BitwardenString.item_unarchived.asText()),
+                    SearchEvent.ShowSnackbar(BitwardenString.item_moved_to_vault.asText()),
                     awaitItem(),
                 )
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -2398,7 +2398,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             }
             verify(exactly = 1) {
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.item_archived.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.item_moved_to_archived.asText()),
                     relay = SnackbarRelay.CIPHER_ARCHIVED,
                 )
             }
@@ -2511,7 +2511,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             }
             verify(exactly = 1) {
                 snackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(BitwardenString.item_unarchived.asText()),
+                    data = BitwardenSnackbarData(BitwardenString.item_moved_to_vault.asText()),
                     relay = SnackbarRelay.CIPHER_UNARCHIVED,
                 )
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -303,7 +303,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                 }
                 verify(exactly = 1) {
                     snackbarRelayManager.sendSnackbarData(
-                        data = BitwardenSnackbarData(BitwardenString.item_archived.asText()),
+                        data = BitwardenSnackbarData(
+                            message = BitwardenString.item_moved_to_archived.asText(),
+                        ),
                         relay = SnackbarRelay.CIPHER_ARCHIVED,
                     )
                 }
@@ -394,7 +396,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                 }
                 verify(exactly = 1) {
                     snackbarRelayManager.sendSnackbarData(
-                        data = BitwardenSnackbarData(BitwardenString.item_unarchived.asText()),
+                        data = BitwardenSnackbarData(BitwardenString.item_moved_to_vault.asText()),
                         relay = SnackbarRelay.CIPHER_UNARCHIVED,
                     )
                 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -1116,7 +1116,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 assertEquals(
-                    VaultItemListingEvent.ShowSnackbar(BitwardenString.item_archived.asText()),
+                    VaultItemListingEvent.ShowSnackbar(
+                        message = BitwardenString.item_moved_to_archived.asText(),
+                    ),
                     awaitItem(),
                 )
             }
@@ -1174,7 +1176,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 assertEquals(
-                    VaultItemListingEvent.ShowSnackbar(BitwardenString.item_unarchived.asText()),
+                    VaultItemListingEvent.ShowSnackbar(
+                        message = BitwardenString.item_moved_to_vault.asText(),
+                    ),
                     awaitItem(),
                 )
             }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -645,7 +645,7 @@ class VaultViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 assertEquals(
-                    VaultEvent.ShowSnackbar(BitwardenString.item_archived.asText()),
+                    VaultEvent.ShowSnackbar(BitwardenString.item_moved_to_archived.asText()),
                     awaitItem(),
                 )
             }
@@ -703,7 +703,7 @@ class VaultViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 assertEquals(
-                    VaultEvent.ShowSnackbar(BitwardenString.item_unarchived.asText()),
+                    VaultEvent.ShowSnackbar(BitwardenString.item_moved_to_vault.asText()),
                     awaitItem(),
                 )
             }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1184,8 +1184,8 @@ Do you want to switch to this account?</string>
     <string name="unable_to_unarchive_selected_item">Unable to unarchive selected item.</string>
     <string name="archiving">Archiving</string>
     <string name="unarchiving">Unarchiving</string>
-    <string name="item_archived">Item archived</string>
-    <string name="item_unarchived">Item unarchived</string>
+    <string name="item_moved_to_archived">Item moved to archive</string>
+    <string name="item_moved_to_vault">Item moved to vault</string>
     <string name="archive_unavailable">Archive unavailable</string>
     <string name="archiving_items_is_a_premium_feature">Archiving items is a Premium feature. Your current plan does not include access to this feature.</string>
     <string name="upgrade_to_premium">Upgrade to premium</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31162](https://bitwarden.atlassian.net/browse/PM-31162)

## 📔 Objective

This PR updates the copy on archive and unarchive snackbars.
* `Item archived` --> `Item moved to archive`
* `Item unarchived` --> `Item moved to vault`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31162]: https://bitwarden.atlassian.net/browse/PM-31162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ