### PR TITLE
use option to determine if release will be marked latest

### DIFF
--- a/.github/workflows/publish-github-release-bwa.yml
+++ b/.github/workflows/publish-github-release-bwa.yml
@@ -18,6 +18,7 @@ jobs:
       workflow_name: "publish-github-release-bwa.yml"
       credentials_filename: "authenticator_play_store-creds.json"
       project_type: android
+      make_latest: false
       check_release_command: >
         bundle exec fastlane getLatestPlayStoreVersion package_name:com.bitwarden.authenticator track:production
     secrets: inherit

--- a/.github/workflows/publish-github-release-bwpm.yml
+++ b/.github/workflows/publish-github-release-bwpm.yml
@@ -19,6 +19,7 @@ jobs:
       workflow_name: "publish-github-release-bwpm.yml"
       credentials_filename: "play_creds.json"
       project_type: android
+      make_latest: true
       check_release_command: >
         bundle exec fastlane getLatestPlayStoreVersion package_name:com.x8bit.bitwarden track:production
     secrets: inherit


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C08MD8XMK4J/p1762279615949629

## 📔 Objective

Github releases should only be marked "latest" if password manager is being released.  This implements an option sent by the calling workflow rather than text recognition to resolve an ongoing issue.

Related: 
https://github.com/bitwarden/gh-actions/pull/597
https://github.com/bitwarden/ios/pull/2289

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
