### PR TITLE
Remove intialization of NetworkConnectionManager from application class

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/BitwardenApplication.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/BitwardenApplication.kt
@@ -6,7 +6,6 @@ import com.x8bit.bitwarden.data.auth.manager.AuthRequestNotificationManager
 import com.x8bit.bitwarden.data.platform.manager.LogsManager
 import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConfigManager
-import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
 import com.x8bit.bitwarden.data.platform.manager.restriction.RestrictionManager
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import dagger.hilt.android.HiltAndroidApp
@@ -23,9 +22,6 @@ class BitwardenApplication : Application() {
     // other callers.
     @Inject
     lateinit var logsManager: LogsManager
-
-    @Inject
-    lateinit var networkConnectionManager: NetworkConnectionManager
 
     @Inject
     lateinit var networkConfigManager: NetworkConfigManager


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the `NetworkConnectionManager` from the `BitwardenApplication` in order to resolve an odd issue where initializing the manager so early was causing the `activeNetwork` to be null 100% of the time. This issue would occur whenever the Autofill framework initialized the app, under normal circumstances where the app is launched by the user, this issue would not occur.

The original reason for the manager to be initialized so early was for logging purposes, so it is not required to be there for core functionality and is okay to remove.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
