### PR TITLE
Minor cleanup of the MigrateToMyItemsScreen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -268,7 +268,6 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         )
 
         migrateToMyItemsDestination(
-            onNavigateToVault = { navController.popBackStack() },
             onNavigateToLeaveOrganization = { organizationId, organizationName ->
                 navController.navigateToLeaveOrganization(
                     organizationId = organizationId,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsNavigation.kt
@@ -70,12 +70,10 @@ fun NavController.navigateToMigrateToMyItems(
  * Add the migrate to my items screen to the nav graph.
  */
 fun NavGraphBuilder.migrateToMyItemsDestination(
-    onNavigateToVault: () -> Unit,
     onNavigateToLeaveOrganization: (organizationId: String, organizationName: String) -> Unit,
 ) {
     composableWithSlideTransitions<MigrateToMyItemsRoute> {
         MigrateToMyItemsScreen(
-            onNavigateToVault = onNavigateToVault,
             onNavigateToLeaveOrganization = onNavigateToLeaveOrganization,
         )
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsScreen.kt
@@ -3,13 +3,19 @@ package com.x8bit.bitwarden.ui.vault.feature.migratetomyitems
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -44,7 +50,6 @@ import com.x8bit.bitwarden.ui.vault.feature.migratetomyitems.handler.rememberMig
  */
 @Composable
 fun MigrateToMyItemsScreen(
-    onNavigateToVault: () -> Unit,
     onNavigateToLeaveOrganization: (organizationId: String, organizationName: String) -> Unit,
     viewModel: MigrateToMyItemsViewModel = hiltViewModel(),
     intentManager: IntentManager = LocalIntentManager.current,
@@ -54,10 +59,10 @@ fun MigrateToMyItemsScreen(
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
-            MigrateToMyItemsEvent.NavigateToVault -> onNavigateToVault()
             is MigrateToMyItemsEvent.NavigateToLeaveOrganization -> {
                 onNavigateToLeaveOrganization(event.organizationId, event.organizationName)
             }
+
             is MigrateToMyItemsEvent.LaunchUri -> intentManager.launchUri(event.uri.toUri())
         }
     }
@@ -68,7 +73,12 @@ fun MigrateToMyItemsScreen(
         onDismissNoNetworkRequest = handlers.onDismissNoNetworkDialog,
     )
 
-    BitwardenScaffold {
+    BitwardenScaffold(
+        contentWindowInsets = ScaffoldDefaults
+            .contentWindowInsets
+            .union(WindowInsets.displayCutout)
+            .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
+    ) {
         MigrateToMyItemsContent(
             state = state,
             onAcceptClick = handlers.onAcceptClick,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsScreenTest.kt
@@ -20,7 +20,6 @@ import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertTrue
 
 class MigrateToMyItemsScreenTest : BitwardenComposeTest() {
-    private var onNavigateToVaultCalled = false
     private var onNavigateToLeaveOrganizationCalled = false
 
     private val intentManager: IntentManager = mockk {
@@ -47,7 +46,6 @@ class MigrateToMyItemsScreenTest : BitwardenComposeTest() {
         setContent(intentManager = intentManager) {
             MigrateToMyItemsScreen(
                 viewModel = viewModel,
-                onNavigateToVault = { onNavigateToVaultCalled = true },
                 onNavigateToLeaveOrganization = { _, _ ->
                     onNavigateToLeaveOrganizationCalled = true
                 },
@@ -99,12 +97,6 @@ class MigrateToMyItemsScreenTest : BitwardenComposeTest() {
         verify {
             viewModel.trySendAction(MigrateToMyItemsAction.HelpLinkClicked)
         }
-    }
-
-    @Test
-    fun `NavigateToVault event should trigger navigation callback`() {
-        mutableEventFlow.tryEmit(MigrateToMyItemsEvent.NavigateToVault)
-        assertTrue(onNavigateToVaultCalled)
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR addresses some minor issues and unnecessary code in the Item Migration logic.
* Added appropriate insets to handle the fact that there is no TopAppBar on the screen
* Remove the unnecessary navigation that is actually controlled by state based navigation.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="400" src="https://github.com/user-attachments/assets/8ff609dc-957a-4cd3-bd0c-1624fa0d21cf" /> | <img width="400" src="https://github.com/user-attachments/assets/024f3899-9723-43ad-b700-9429e9da025d" /> 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
