### PR TITLE
Item migration flow has been moved into a graph

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainActivity.kt
@@ -12,9 +12,11 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.auth.AuthTabIntent
+import androidx.compose.foundation.background
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.core.app.ActivityCompat
 import androidx.core.os.LocaleListCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -120,6 +122,8 @@ class MainActivity : AppCompatActivity() {
                     NavHost(
                         navController = navController,
                         startDestination = RootNavigationRoute,
+                        modifier = Modifier
+                            .background(color = BitwardenTheme.colorScheme.background.primary),
                     ) {
                         // Both root navigation and debug menu exist at this top level.
                         // The debug menu can appear on top of the rest of the app without

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -55,7 +55,7 @@ class RootNavViewModel @Inject constructor(
                 vaultMigrationData = vaultMigrationData,
             )
         }
-            .onEach(::handleAction)
+            .onEach(::sendAction)
             .launchIn(viewModelScope)
     }
 
@@ -118,12 +118,7 @@ class RootNavViewModel @Inject constructor(
 
             userState.activeAccount.isVaultUnlocked &&
                 action.vaultMigrationData is VaultMigrationData.MigrationRequired &&
-                shouldShowVaultMigration(specialCircumstance) -> {
-                RootNavState.MigrateToMyItems(
-                    organizationId = action.vaultMigrationData.organizationId,
-                    organizationName = action.vaultMigrationData.organizationName,
-                )
-            }
+                shouldShowVaultMigration(specialCircumstance) -> RootNavState.MigrateToMyItems
 
             userState.activeAccount.isVaultUnlocked -> {
                 when (specialCircumstance) {
@@ -363,13 +358,10 @@ sealed class RootNavState : Parcelable {
     data object VaultLocked : RootNavState()
 
     /**
-     * App should show MigrateToMyItems screen.
+     * App should show MigrateToMyItems graph.
      */
     @Parcelize
-    data class MigrateToMyItems(
-        val organizationId: String,
-        val organizationName: String,
-    ) : RootNavState()
+    data object MigrateToMyItems : RootNavState()
 
     /**
      * App should show vault unlocked nav graph for the given [activeUserId].

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -57,11 +57,8 @@ import com.x8bit.bitwarden.ui.vault.feature.importlogins.navigateToImportLoginsS
 import com.x8bit.bitwarden.ui.vault.feature.item.navigateToVaultItem
 import com.x8bit.bitwarden.ui.vault.feature.item.vaultItemDestination
 import com.x8bit.bitwarden.ui.vault.feature.itemlisting.vaultItemListingDestinationAsRoot
-import com.x8bit.bitwarden.ui.vault.feature.leaveorganization.leaveOrganizationDestination
-import com.x8bit.bitwarden.ui.vault.feature.leaveorganization.navigateToLeaveOrganization
 import com.x8bit.bitwarden.ui.vault.feature.manualcodeentry.navigateToManualCodeEntryScreen
 import com.x8bit.bitwarden.ui.vault.feature.manualcodeentry.vaultManualCodeEntryDestination
-import com.x8bit.bitwarden.ui.vault.feature.migratetomyitems.migrateToMyItemsDestination
 import com.x8bit.bitwarden.ui.vault.feature.movetoorganization.navigateToVaultMoveToOrganization
 import com.x8bit.bitwarden.ui.vault.feature.movetoorganization.vaultMoveToOrganizationDestination
 import com.x8bit.bitwarden.ui.vault.feature.qrcodescan.navigateToQrCodeScanScreen
@@ -264,19 +261,6 @@ fun NavGraphBuilder.vaultUnlockedGraph(
             onNavigateBack = { navController.popBackStack() },
         )
         importLoginsScreenDestination(
-            onNavigateBack = { navController.popBackStack() },
-        )
-
-        migrateToMyItemsDestination(
-            onNavigateToLeaveOrganization = { organizationId, organizationName ->
-                navController.navigateToLeaveOrganization(
-                    organizationId = organizationId,
-                    organizationName = organizationName,
-                )
-            },
-        )
-
-        leaveOrganizationDestination(
             onNavigateBack = { navController.popBackStack() },
         )
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsGraphNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsGraphNavigation.kt
@@ -1,0 +1,51 @@
+@file:OmitFromCoverage
+
+package com.x8bit.bitwarden.ui.vault.feature.migratetomyitems
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.navigation
+import com.bitwarden.annotation.OmitFromCoverage
+import com.x8bit.bitwarden.ui.vault.feature.leaveorganization.leaveOrganizationDestination
+import com.x8bit.bitwarden.ui.vault.feature.leaveorganization.navigateToLeaveOrganization
+import kotlinx.serialization.Serializable
+
+/**
+ * The type-safe route for the migrate to my items graph.
+ */
+@OmitFromCoverage
+@Serializable
+data object MigrateToMyItemsGraphRoute
+
+/**
+ * Navigate to the migrate to my items graph.
+ */
+fun NavController.navigateToMigrateToMyItemsGraph(
+    navOptions: NavOptions? = null,
+) {
+    navigate(route = MigrateToMyItemsGraphRoute, navOptions = navOptions)
+}
+
+/**
+ * Add the migrate to my items graph to the nav graph.
+ */
+fun NavGraphBuilder.migrateToMyItemsGraph(
+    navController: NavController,
+) {
+    navigation<MigrateToMyItemsGraphRoute>(
+        startDestination = MigrateToMyItemsRoute,
+    ) {
+        migrateToMyItemsDestination(
+            onNavigateToLeaveOrganization = { organizationId, organizationName ->
+                navController.navigateToLeaveOrganization(
+                    organizationId = organizationId,
+                    organizationName = organizationName,
+                )
+            },
+        )
+        leaveOrganizationDestination(
+            onNavigateBack = { navController.popBackStack() },
+        )
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsNavigation.kt
@@ -2,69 +2,17 @@
 
 package com.x8bit.bitwarden.ui.vault.feature.migratetomyitems
 
-import androidx.lifecycle.SavedStateHandle
-import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavOptions
-import androidx.navigation.toRoute
+import androidx.navigation.compose.composable
 import com.bitwarden.annotation.OmitFromCoverage
-import com.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 import kotlinx.serialization.Serializable
 
 /**
  * The type-safe route for the migrate to my items screen.
- *
- * @property organizationId The ID of the organization requiring migration.
- * @property organizationName The name of the organization requiring migration.
  */
 @OmitFromCoverage
 @Serializable
-data class MigrateToMyItemsRoute(
-    val organizationId: String,
-    val organizationName: String,
-)
-
-/**
- * Class to retrieve migrate to my items arguments from the [SavedStateHandle].
- *
- * @property organizationId The ID of the organization requiring migration.
- * @property organizationName The name of the organization requiring migration.
- */
-data class MigrateToMyItemsArgs(
-    val organizationId: String,
-    val organizationName: String,
-)
-
-/**
- * Constructs a [MigrateToMyItemsArgs] from the [SavedStateHandle] and internal route data.
- */
-fun SavedStateHandle.toMigrateToMyItemsArgs(): MigrateToMyItemsArgs {
-    val route = this.toRoute<MigrateToMyItemsRoute>()
-    return MigrateToMyItemsArgs(
-        organizationId = route.organizationId,
-        organizationName = route.organizationName,
-    )
-}
-
-/**
- * Navigate to the migrate to my items screen.
- *
- * @param organizationId The ID of the organization requiring migration.
- * @param organizationName The name of the organization requiring migration.
- */
-fun NavController.navigateToMigrateToMyItems(
-    organizationId: String,
-    organizationName: String,
-    navOptions: NavOptions? = null,
-) {
-    this.navigate(
-        route = MigrateToMyItemsRoute(
-            organizationId = organizationId,
-            organizationName = organizationName,
-        ),
-        navOptions = navOptions,
-    )
-}
+data object MigrateToMyItemsRoute
 
 /**
  * Add the migrate to my items screen to the nav graph.
@@ -72,7 +20,7 @@ fun NavController.navigateToMigrateToMyItems(
 fun NavGraphBuilder.migrateToMyItemsDestination(
     onNavigateToLeaveOrganization: (organizationId: String, organizationName: String) -> Unit,
 ) {
-    composableWithSlideTransitions<MigrateToMyItemsRoute> {
+    composable<MigrateToMyItemsRoute> {
         MigrateToMyItemsScreen(
             onNavigateToLeaveOrganization = onNavigateToLeaveOrganization,
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsViewModel.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.vault.manager.VaultMigrationManager
 import com.x8bit.bitwarden.data.vault.manager.VaultSyncManager
+import com.x8bit.bitwarden.data.vault.manager.model.VaultMigrationData
 import com.x8bit.bitwarden.data.vault.repository.model.MigratePersonalVaultResult
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -43,10 +44,12 @@ class MigrateToMyItemsViewModel @Inject constructor(
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
 ) : BaseViewModel<MigrateToMyItemsState, MigrateToMyItemsEvent, MigrateToMyItemsAction>(
     initialState = savedStateHandle[KEY_STATE] ?: run {
-        val args = savedStateHandle.toMigrateToMyItemsArgs()
+        // This must be true or we would have never navigated here.
+        val migrationData = (vaultMigrationManager.vaultMigrationDataStateFlow.value
+            as VaultMigrationData.MigrationRequired)
         MigrateToMyItemsState(
-            organizationId = args.organizationId,
-            organizationName = args.organizationName,
+            organizationId = migrationData.organizationId,
+            organizationName = migrationData.organizationName,
             dialog = null,
         )
     },

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -1586,7 +1586,6 @@ class RootNavViewModelTest : BaseViewModelTest() {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `when vaultMigrationDataStateFlow emits true the nav state should be MigrateToMyItems`() {
         mutableVaultMigrationDataStateFlow.value = MOCK_VAULT_MIGRATION_DATA
@@ -1594,10 +1593,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
 
         assertEquals(
-            RootNavState.MigrateToMyItems(
-                organizationId = "mockOrganizationId-1",
-                organizationName = "organizationName",
-            ),
+            RootNavState.MigrateToMyItems,
             viewModel.stateFlow.value,
         )
     }
@@ -1676,28 +1672,22 @@ class RootNavViewModelTest : BaseViewModelTest() {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `when migration required with ShareNewSend shortcut should show migration screen`() {
-        specialCircumstanceManager.specialCircumstance =
-            SpecialCircumstance.ShareNewSend(
-                data = mockk<ShareData.TextSend>(),
-                shouldFinishWhenComplete = true,
-            )
+        specialCircumstanceManager.specialCircumstance = SpecialCircumstance.ShareNewSend(
+            data = mockk<ShareData.TextSend>(),
+            shouldFinishWhenComplete = true,
+        )
         mutableVaultMigrationDataStateFlow.value = MOCK_VAULT_MIGRATION_DATA
         mutableUserStateFlow.tryEmit(MOCK_VAULT_UNLOCKED_USER_STATE)
         val viewModel = createViewModel()
 
         assertEquals(
-            RootNavState.MigrateToMyItems(
-                organizationId = "mockOrganizationId-1",
-                organizationName = "organizationName",
-            ),
+            RootNavState.MigrateToMyItems,
             viewModel.stateFlow.value,
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `when migration required with VaultShortcut should show migration screen`() {
         specialCircumstanceManager.specialCircumstance = SpecialCircumstance.VaultShortcut
@@ -1706,10 +1696,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
 
         assertEquals(
-            RootNavState.MigrateToMyItems(
-                organizationId = "mockOrganizationId-1",
-                organizationName = "organizationName",
-            ),
+            RootNavState.MigrateToMyItems,
             viewModel.stateFlow.value,
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR moves the `migrateToMyItemsDestination` and the `leaveOrganizationDestination` into it's own navigation graph in order to ensure that state-based navigation does not re-navigate the user to the wrong location.

## 📸 Screenshots

This video displays the animations but not the actual functionality.

<video src="https://github.com/user-attachments/assets/e30013de-11e5-4207-817e-22b7921b809d" width="400" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
