### PR TITLE
PM-31363: Fix crash caused by a duplicate ID

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingContent.kt
@@ -160,7 +160,7 @@ fun VaultItemListingContent(
 
             itemsIndexed(
                 items = state.displayCollectionList,
-                key = { _, collection -> collection.id },
+                key = { _, collection -> "collection_${collection.id}" },
             ) { index, collection ->
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_collections),
@@ -195,7 +195,7 @@ fun VaultItemListingContent(
 
             itemsIndexed(
                 items = state.displayFolderList,
-                key = { _, folder -> folder.id },
+                key = { _, folder -> "folder_${folder.id}" },
             ) { index, folder ->
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_folder),
@@ -229,7 +229,7 @@ fun VaultItemListingContent(
             }
             itemsIndexed(
                 items = state.displayItemList,
-                key = { _, item -> item.id },
+                key = { _, item -> "item_${item.id}" },
             ) { index, it ->
                 BitwardenListItem(
                     startIcon = it.iconData,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -142,7 +142,7 @@ fun VaultContent(
 
             itemsIndexed(
                 items = state.favoriteItems,
-                key = { _, favorite -> favorite.id },
+                key = { _, favorite -> "favorite_${favorite.id}" },
             ) { index, favoriteItem ->
                 VaultEntryListItem(
                     startIcon = favoriteItem.startIcon,
@@ -307,7 +307,7 @@ fun VaultContent(
 
             itemsIndexed(
                 items = state.folderItems,
-                key = { _, folder -> folder.id ?: "no_folder_group" },
+                key = { _, folder -> "folder_${folder.id}" },
             ) { index, folder ->
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_folder),
@@ -344,7 +344,7 @@ fun VaultContent(
             }
             itemsIndexed(
                 items = state.noFolderItems,
-                key = { _, noFolderItem -> noFolderItem.id },
+                key = { _, noFolderItem -> "no_folder_${noFolderItem.id}" },
             ) { index, noFolderItem ->
                 VaultEntryListItem(
                     startIcon = noFolderItem.startIcon,
@@ -400,7 +400,7 @@ fun VaultContent(
 
             itemsIndexed(
                 items = state.collectionItems,
-                key = { _, collection -> collection.id },
+                key = { _, collection -> "collection_${collection.id}" },
             ) { index, collection ->
                 BitwardenGroupItem(
                     startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_collections),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31363](https://bitwarden.atlassian.net/browse/PM-31363)

## 📔 Objective

This PR fixes a crash on the `VaultScreen` caused by a duplicated item key. This is caused when a favorited item and a no-folder item appear at the same time.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31363]: https://bitwarden.atlassian.net/browse/PM-31363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ