### PR TITLE
[PM-31393] Sends: UI/UX inconsistency of the password field

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -217,6 +217,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         addEditSendDestination(
             onNavigateBack = { navController.popBackStack() },
             onNavigateUpToSearchOrRoot = { navController.navigateUpToSearchOrVaultUnlockedRoot() },
+            onNavigateToGeneratorModal = { navController.navigateToGeneratorModal(mode = it) },
         )
         viewSendDestination(
             onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
@@ -37,6 +37,7 @@ import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.animation.AnimateNullableContentVisibility
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedErrorButton
+import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
 import com.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.ui.platform.components.field.BitwardenPasswordField
@@ -367,6 +368,7 @@ private fun AddEditSendOptions(
     addSendHandlers: AddEditSendHandlers,
 ) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
+    var shouldShowDialog by rememberSaveable { mutableStateOf(false) }
     BitwardenExpandingHeader(
         isExpanded = isExpanded,
         onClick = { isExpanded = !isExpanded },
@@ -437,7 +439,47 @@ private fun AddEditSendOptions(
                 modifier = Modifier
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
-            )
+            ) {
+                BitwardenStandardIconButton(
+                    vectorIconRes = BitwardenDrawable.ic_generate,
+                    contentDescription = stringResource(id = BitwardenString.generate_password),
+                    onClick = {
+                        if (state.common.passwordInput.isEmpty()) {
+                            addSendHandlers.onOpenPasswordGeneratorClick()
+                        } else {
+                            shouldShowDialog = true
+                        }
+                    },
+                    modifier = Modifier.testTag(tag = "RegeneratePasswordButton"),
+                )
+                BitwardenStandardIconButton(
+                    vectorIconRes = BitwardenDrawable.ic_copy,
+                    contentDescription = stringResource(id = BitwardenString.copy_password),
+                    isEnabled = state.common.passwordInput.isNotEmpty(),
+                    onClick = {
+                        addSendHandlers.onPasswordCopyClick(state.common.passwordInput)
+                    },
+                    modifier = Modifier.testTag(tag = "CopyPasswordButton"),
+                )
+            }
+            if (shouldShowDialog) {
+                BitwardenTwoButtonDialog(
+                    title = stringResource(id = BitwardenString.password),
+                    message = stringResource(id = BitwardenString.password_override_alert),
+                    confirmButtonText = stringResource(id = BitwardenString.yes),
+                    dismissButtonText = stringResource(id = BitwardenString.no),
+                    onConfirmClick = {
+                        shouldShowDialog = false
+                        addSendHandlers.onOpenPasswordGeneratorClick()
+                    },
+                    onDismissClick = {
+                        shouldShowDialog = false
+                    },
+                    onDismissRequest = {
+                        shouldShowDialog = false
+                    },
+                )
+            }
             Spacer(modifier = Modifier.height(height = 8.dp))
             BitwardenSwitch(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.toRoute
 import com.bitwarden.ui.platform.base.util.composableWithSlideTransitions
+import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.model.AddEditSendType
 import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
 import kotlinx.serialization.Serializable
@@ -57,11 +58,13 @@ fun SavedStateHandle.toAddEditSendArgs(): AddEditSendArgs {
 fun NavGraphBuilder.addEditSendDestination(
     onNavigateBack: () -> Unit,
     onNavigateUpToSearchOrRoot: () -> Unit,
+    onNavigateToGeneratorModal: (GeneratorMode.Modal) -> Unit,
 ) {
     composableWithSlideTransitions<AddEditSendRoute> {
         AddEditSendScreen(
             onNavigateBack = onNavigateBack,
             onNavigateUpToSearchOrRoot = onNavigateUpToSearchOrRoot,
+            onNavigateToGeneratorModal = onNavigateToGeneratorModal,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -38,6 +38,7 @@ import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.ui.platform.composition.LocalPermissionsManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
+import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.handlers.AddEditSendHandlers
 
 /**
@@ -53,6 +54,7 @@ fun AddEditSendScreen(
     permissionsManager: PermissionsManager = LocalPermissionsManager.current,
     onNavigateBack: () -> Unit,
     onNavigateUpToSearchOrRoot: () -> Unit,
+    onNavigateToGeneratorModal: (GeneratorMode.Modal) -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val addSendHandlers = remember(viewModel) { AddEditSendHandlers.create(viewModel) }
@@ -88,6 +90,10 @@ fun AddEditSendScreen(
             }
 
             is AddEditSendEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)
+
+            is AddEditSendEvent.NavigateToGeneratorModal -> {
+                onNavigateToGeneratorModal(event.generatorMode)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/handlers/AddEditSendHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/handlers/AddEditSendHandlers.kt
@@ -22,6 +22,8 @@ data class AddEditSendHandlers(
     val onDeactivateSendToggle: (Boolean) -> Unit,
     val onDeletionDateChange: (ZonedDateTime) -> Unit,
     val onDeleteClick: () -> Unit,
+    val onOpenPasswordGeneratorClick: () -> Unit,
+    val onPasswordCopyClick: (String) -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -59,6 +61,16 @@ data class AddEditSendHandlers(
                     viewModel.trySendAction(AddEditSendAction.DeletionDateChange(it))
                 },
                 onDeleteClick = { viewModel.trySendAction(AddEditSendAction.DeleteClick) },
+                onOpenPasswordGeneratorClick = {
+                    viewModel.trySendAction(AddEditSendAction.OpenPasswordGeneratorClick)
+                },
+                onPasswordCopyClick = {
+                    viewModel.trySendAction(
+                        AddEditSendAction.PasswordCopyClick(
+                            password = it,
+                        ),
+                    )
+                },
             )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/android/issues/6335

## 📔 Objective

Adds the ability to generate and copy passwords under the **Send** tab.

## 📸 Screenshots
![6329903491131838129](https://github.com/user-attachments/assets/664c91a9-c89b-4038-b548-7b32f7a959b0)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
