### PR TITLE
[PM-31292] ci: update renovate config to remove gradle group and ignore sdk updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,20 +21,6 @@
       ]
     },
     {
-      "groupName": "gradle minor",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "matchManagers": [
-        "gradle"
-      ],
-      "excludePackageNames": [
-        "com.github.bumptech.glide:compose",
-        "com.bitwarden:sdk-android"
-      ]
-    },
-    {
       "groupName": "kotlin",
       "description": "Kotlin and Compose dependencies that must be updated together to maintain compatibility.",
       "matchManagers": [


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31292](https://bitwarden.atlassian.net/browse/PM-31292)

## 📔 Objective

Update renovate config to:
1. Open individual PRs for all gradle dependencies 
2. Ignore SDK updates - handled by our custom workflow. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31292]: https://bitwarden.atlassian.net/browse/PM-31292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ