### PR TITLE
🍒 [PM-31446] fix:Append assetlinks.json path to DAL URLs

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManagerImpl.kt
@@ -50,6 +50,8 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import timber.log.Timber
 
+private const val DAL_ROUTE = ".well-known/assetlinks.json"
+
 /**
  * Primary implementation of [BitwardenCredentialManager].
  */
@@ -123,7 +125,7 @@ class BitwardenCredentialManagerImpl(
                         .getSignatureFingerprintAsHexString()
                         .orEmpty(),
                     host = hostUrl,
-                    assetLinkUrl = hostUrl,
+                    assetLinkUrl = hostUrl.toDigitalAssetLinkUrl(),
                 ),
             )
         }
@@ -316,7 +318,7 @@ class BitwardenCredentialManagerImpl(
                 packageName = callingAppInfo.packageName,
                 sha256CertFingerprint = signatureFingerprint,
                 host = host,
-                assetLinkUrl = host,
+                assetLinkUrl = host.toDigitalAssetLinkUrl(),
             ),
         )
 
@@ -428,6 +430,13 @@ class BitwardenCredentialManagerImpl(
             ?.relyingParty
             ?.id
             ?.prefixHttpsIfNecessaryOrNull()
+
+    private fun String.toDigitalAssetLinkUrl(): String =
+        when {
+            this.endsWith(DAL_ROUTE) -> this
+            this.endsWith("/") -> "$this$DAL_ROUTE"
+            else -> "$this/$DAL_ROUTE"
+        }
 }
 
 private const val MAX_AUTHENTICATION_ATTEMPTS = 5

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/manager/BitwardenCredentialManagerTest.kt
@@ -681,7 +681,8 @@ class BitwardenCredentialManagerTest {
                         DEFAULT_PACKAGE_NAME,
                         DEFAULT_CERT_FINGERPRINT,
                         "https://${mockAssertionOptions.relyingPartyId!!}",
-                        "https://${mockAssertionOptions.relyingPartyId}",
+                        @Suppress("MaxLineLength")
+                        "https://${mockAssertionOptions.relyingPartyId}/.well-known/assetlinks.json",
                     ),
                 ),
                 requestCaptureSlot.captured.origin,
@@ -1499,7 +1500,7 @@ private val DEFAULT_ANDROID_ORIGIN = Origin.Android(
         packageName = DEFAULT_PACKAGE_NAME,
         sha256CertFingerprint = DEFAULT_CERT_FINGERPRINT,
         host = "https://$DEFAULT_HOST",
-        assetLinkUrl = "https://$DEFAULT_HOST",
+        assetLinkUrl = "https://$DEFAULT_HOST/.well-known/assetlinks.json",
     ),
 )
 private val DEFAULT_WEB_ORIGIN = Origin.Web("bitwarden.com")


### PR DESCRIPTION
## 🎟️ Tracking

PM-31446
Relates to https://github.com/bitwarden/sdk-internal/pull/606

## 📔 Objective

Cherry-picked from https://github.com/bitwarden/android/pull/6447

Ensures that the Digital Asset Link (DAL) URL passed to the `Origin` constructor always correctly points to the `assetlinks.json` file as required by the latest SDK version.

A private helper function `toDigitalAssetLinkUrl()` has been introduced to consistently append `/.well-known/assetlinks.json` to the host URL. This logic is now used in both the `createCredential` and `getCredential` flows when constructing the `Origin.App` object.

This change fixes a subtle bug where the DAL verification might fail if the host URL did not explicitly point to the `assetlinks.json` file.

Specific changes:
- Added a `DAL_ROUTE` constant for `.well-known/assetlinks.json`.
- Implemented the `toDigitalAssetLinkUrl()` extension function to append the DAL route to a given host string, handling cases with and without trailing slashes.
- Updated calls in `createCredential` and `getCredential` to use this new helper function for constructing the `assetLinkUrl`.
- Adjusted unit tests in `BitwardenCredentialManagerTest` to reflect the corrected, fully-formed `assetLinkUrl`.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
