### PR TITLE
PM-31603: Add toast when resetpassword succeeds

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/di/AuthRepositoryModule.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.data.auth.repository.di
 
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
+import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.data.datasource.disk.ConfigDiskSource
 import com.bitwarden.network.service.AccountsService
 import com.bitwarden.network.service.DevicesService
@@ -71,6 +72,7 @@ object AuthRepositoryModule {
         logsManager: LogsManager,
         userStateManager: UserStateManager,
         kdfManager: KdfManager,
+        toastManager: ToastManager,
     ): AuthRepository = AuthRepositoryImpl(
         clock = clock,
         accountsService = accountsService,
@@ -97,6 +99,7 @@ object AuthRepositoryModule {
         logsManager = logsManager,
         userStateManager = userStateManager,
         kdfManager = kdfManager,
+        toastManager = toastManager,
     )
 
     @Provides

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1198,4 +1198,5 @@ Do you want to switch to this account?</string>
     <string name="to_regain_access_to_your_archive_restart_your_premium_subscription">To regain access to your archive, restart your Premium subscription. If you edit details for an archived item before restarting, it’ll be moved back into your vault.</string>
     <string name="restart_premium">Restart Premium</string>
     <string name="items_transferred">Items transferred</string>
+    <string name="updated_master_password">Updated master password</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31603](https://bitwarden.atlassian.net/browse/PM-31603)

## 📔 Objective

This PR adds a toast indicating to users that their password was successfully updated.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/a8b37816-bcf2-4968-9552-1f16153afe08" width="350" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31603]: https://bitwarden.atlassian.net/browse/PM-31603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ