### PR TITLE
[PM-30279] Extract credential provider handling to dedicated activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,15 +85,6 @@
                 <data android:pathPattern="/redirect-connector.*" />
             </intent-filter>
             <intent-filter>
-                <action android:name="com.x8bit.bitwarden.credentials.ACTION_CREATE_PASSKEY" />
-                <action android:name="com.x8bit.bitwarden.credentials.ACTION_GET_PASSKEY" />
-                <action android:name="com.x8bit.bitwarden.credentials.ACTION_CREATE_PASSWORD" />
-                <action android:name="com.x8bit.bitwarden.credentials.ACTION_GET_PASSWORD" />
-                <action android:name="com.x8bit.bitwarden.credentials.ACTION_UNLOCK_ACCOUNT" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -117,6 +108,35 @@
                     android:mimeType="application/octet-stream"
                     android:scheme="content"
                     tools:ignore="AppLinkUriRelativeFilterGroupError" />
+            </intent-filter>
+        </activity>
+
+        <!-- Credential Provider Activity for handling passkey and password credential operations.
+             This activity is NOT exported to protect against external apps attempting to extract
+             vault credentials by sending malicious intents. Only our own PendingIntents can
+             launch this activity.
+
+             This is a transparent trampoline activity that launches MainActivity for credential
+             operations and forwards results back to the Credential Manager framework.
+             Uses Theme.Translucent.NoTitleBar for invisibility while allowing normal lifecycle
+             (Theme.NoDisplay requires finish() before onResume(), incompatible with ActivityResult).
+
+             Note: Unlike AuthCallbackActivity, this does NOT use noHistory="true" because it
+             must remain in the back stack to receive the ActivityResult callback from
+             MainActivity. -->
+        <activity
+            android:name=".CredentialProviderActivity"
+            android:exported="false"
+            android:launchMode="singleTop"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="com.x8bit.bitwarden.credentials.ACTION_CREATE_PASSKEY" />
+                <action android:name="com.x8bit.bitwarden.credentials.ACTION_GET_PASSKEY" />
+                <action android:name="com.x8bit.bitwarden.credentials.ACTION_CREATE_PASSWORD" />
+                <action android:name="com.x8bit.bitwarden.credentials.ACTION_GET_PASSWORD" />
+                <action android:name="com.x8bit.bitwarden.credentials.ACTION_UNLOCK_ACCOUNT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/CredentialProviderActivity.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/CredentialProviderActivity.kt
@@ -1,0 +1,89 @@
+package com.x8bit.bitwarden
+
+import android.app.ComponentCaller
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.ui.platform.util.validate
+import com.x8bit.bitwarden.data.credentials.BitwardenCredentialProviderService
+import dagger.hilt.android.AndroidEntryPoint
+
+/**
+ * Transparent trampoline activity for handling credential provider operations.
+ *
+ * This activity is declared as `exported="false"` in the manifest to ensure only
+ * our own PendingIntents can launch it. This protects against external apps attempting
+ * to extract vault credentials by sending malicious intents via CredentialManager.
+ *
+ * All credential flows (FIDO2 passkeys, password credentials) are routed through this
+ * activity when triggered by the Android CredentialManager framework via our
+ * [BitwardenCredentialProviderService].
+ *
+ * ## Architecture
+ *
+ * This activity does not host any UI itself. It acts as a trampoline that:
+ * 1. Receives the credential intent from the CredentialManager framework
+ * 2. Sets the pending credential request via [CredentialProviderViewModel], which stores
+ *    it in `CredentialProviderRequestManager` for secure relay to [MainViewModel]
+ * 3. Launches [MainActivity] to handle the actual credential UI
+ * 4. Forwards the result back to the CredentialManager framework
+ *
+ * This preserves the single-Activity architecture where all UI is hosted by MainActivity,
+ * while still allowing the CredentialManager framework to receive results properly.
+ */
+@OmitFromCoverage
+@AndroidEntryPoint
+class CredentialProviderActivity : ComponentActivity() {
+
+    private val viewModel: CredentialProviderViewModel by viewModels()
+
+    /**
+     * Launcher for MainActivity that forwards the result back to Credential Manager.
+     */
+    private val mainActivityLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        // Forward result back to Credential Manager framework
+        setResult(result.resultCode, result.data)
+        finish()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        intent = intent.validate()
+        super.onCreate(savedInstanceState)
+
+        if (savedInstanceState == null) {
+            // Process credential intent (sets pending request on CredentialProviderRequestManager)
+            viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent))
+            launchMainActivityForResult()
+        }
+        // On restoration (process death), result comes via mainActivityLauncher callback
+    }
+
+    private fun launchMainActivityForResult() {
+        val mainIntent = Intent(this, MainActivity::class.java).apply {
+            // Pending credential request is retrieved by MainViewModel from
+            // CredentialProviderRequestManager, triggering appropriate navigation.
+            // CredentialProviderCompletionManager handles setResult/finish.
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+        mainActivityLauncher.launch(mainIntent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        val newIntent = intent.validate()
+        super.onNewIntent(newIntent)
+        viewModel.trySendAction(CredentialProviderAction.ReceiveNewIntent(newIntent))
+        launchMainActivityForResult()
+    }
+
+    override fun onNewIntent(intent: Intent, caller: ComponentCaller) {
+        val newIntent = intent.validate()
+        super.onNewIntent(newIntent, caller)
+        viewModel.trySendAction(CredentialProviderAction.ReceiveNewIntent(newIntent))
+        launchMainActivityForResult()
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/CredentialProviderViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/CredentialProviderViewModel.kt
@@ -1,0 +1,110 @@
+package com.x8bit.bitwarden
+
+import android.content.Intent
+import com.bitwarden.ui.platform.base.BaseViewModel
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManager
+import com.x8bit.bitwarden.data.credentials.manager.CredentialProviderRequestManager
+import com.x8bit.bitwarden.data.credentials.manager.model.CredentialProviderRequest
+import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
+import com.x8bit.bitwarden.data.credentials.model.Fido2CredentialAssertionRequest
+import com.x8bit.bitwarden.data.credentials.model.GetCredentialsRequest
+import com.x8bit.bitwarden.data.credentials.model.ProviderGetPasswordCredentialRequest
+import com.x8bit.bitwarden.data.credentials.util.getCreateCredentialRequestOrNull
+import com.x8bit.bitwarden.data.credentials.util.getFido2AssertionRequestOrNull
+import com.x8bit.bitwarden.data.credentials.util.getGetCredentialsRequestOrNull
+import com.x8bit.bitwarden.data.credentials.util.getProviderGetPasswordRequestOrNull
+import com.x8bit.bitwarden.ui.platform.feature.rootnav.RootNavViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+/**
+ * A view model that handles credential provider operations for [CredentialProviderActivity].
+ *
+ * This ViewModel processes credential-related intents and sets the pending credential request
+ * on [CredentialProviderRequestManager] for relay to [MainViewModel]. This ensures credential
+ * data is never passed through intent extras to exported activities, providing security
+ * hardening against malicious intent attacks.
+ *
+ * Since [CredentialProviderActivity] is a transparent trampoline with no UI, this ViewModel only
+ * handles intent processing. All UI state management (theme, feature flags, auth flows) is
+ * handled by [MainActivity].
+ *
+ * @see RootNavViewModel for navigation based on SpecialCircumstance.
+ */
+@HiltViewModel
+class CredentialProviderViewModel @Inject constructor(
+    private val credentialProviderRequestManager: CredentialProviderRequestManager,
+    private val authRepository: AuthRepository,
+    private val bitwardenCredentialManager: BitwardenCredentialManager,
+) : BaseViewModel<Unit, Unit, CredentialProviderAction>(initialState = Unit) {
+
+    override fun handleAction(action: CredentialProviderAction) {
+        when (action) {
+            is CredentialProviderAction.ReceiveFirstIntent -> handleIntent(action.intent)
+            is CredentialProviderAction.ReceiveNewIntent -> handleIntent(action.intent)
+        }
+    }
+
+    private fun handleIntent(intent: Intent) {
+        intent.getCreateCredentialRequestOrNull()?.let { handleCreateCredential(it) }
+            ?: intent.getFido2AssertionRequestOrNull()?.let { handleFido2Assertion(it) }
+            ?: intent.getProviderGetPasswordRequestOrNull()?.let { handlePasswordGet(it) }
+            ?: intent.getGetCredentialsRequestOrNull()?.let { handleGetCredentials(it) }
+    }
+
+    private fun handleCreateCredential(request: CreateCredentialRequest) {
+        bitwardenCredentialManager.isUserVerified = request.isUserPreVerified
+
+        // Switch accounts if the selected user is not the active user
+        if (authRepository.activeUserId != null &&
+            authRepository.activeUserId != request.userId
+        ) {
+            authRepository.switchAccount(request.userId)
+        }
+
+        credentialProviderRequestManager.setPendingCredentialRequest(
+            CredentialProviderRequest.CreateCredential(request),
+        )
+    }
+
+    private fun handleFido2Assertion(request: Fido2CredentialAssertionRequest) {
+        // Set the user's verification status when a new FIDO 2 request is received
+        bitwardenCredentialManager.isUserVerified = request.isUserPreVerified
+
+        credentialProviderRequestManager.setPendingCredentialRequest(
+            CredentialProviderRequest.Fido2Assertion(request),
+        )
+    }
+
+    private fun handlePasswordGet(request: ProviderGetPasswordCredentialRequest) {
+        // Set the user's verification status when a new GetPassword request is received
+        bitwardenCredentialManager.isUserVerified = request.isUserPreVerified
+
+        credentialProviderRequestManager.setPendingCredentialRequest(
+            CredentialProviderRequest.GetPassword(request),
+        )
+    }
+
+    private fun handleGetCredentials(request: GetCredentialsRequest) {
+        credentialProviderRequestManager.setPendingCredentialRequest(
+            CredentialProviderRequest.GetCredentials(request),
+        )
+    }
+}
+
+/**
+ * Models actions for the [CredentialProviderViewModel].
+ */
+sealed class CredentialProviderAction {
+
+    /**
+     * Receive the first intent when the activity is created.
+     */
+    data class ReceiveFirstIntent(val intent: Intent) : CredentialProviderAction()
+
+    /**
+     * Receive a new intent when the activity receives onNewIntent.
+     */
+    data class ReceiveNewIntent(val intent: Intent) : CredentialProviderAction()
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/di/CredentialProviderModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/di/CredentialProviderModule.kt
@@ -14,6 +14,8 @@ import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManager
 import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManagerImpl
 import com.x8bit.bitwarden.data.credentials.manager.CredentialManagerPendingIntentManager
 import com.x8bit.bitwarden.data.credentials.manager.CredentialManagerPendingIntentManagerImpl
+import com.x8bit.bitwarden.data.credentials.manager.CredentialProviderRequestManager
+import com.x8bit.bitwarden.data.credentials.manager.CredentialProviderRequestManagerImpl
 import com.x8bit.bitwarden.data.credentials.manager.OriginManager
 import com.x8bit.bitwarden.data.credentials.manager.OriginManagerImpl
 import com.x8bit.bitwarden.data.credentials.parser.RelyingPartyParser
@@ -145,4 +147,9 @@ object CredentialProviderModule {
     @Singleton
     fun providePasskeyAttestationOptionsSanitizer(): PasskeyAttestationOptionsSanitizer =
         PasskeyAttestationOptionsSanitizerImpl
+
+    @Provides
+    @Singleton
+    fun provideCredentialProviderRequestManager(): CredentialProviderRequestManager =
+        CredentialProviderRequestManagerImpl()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/CredentialManagerPendingIntentManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/CredentialManagerPendingIntentManagerImpl.kt
@@ -23,6 +23,7 @@ class CredentialManagerPendingIntentManagerImpl(
     ): PendingIntent {
         val intent = Intent(CREATE_PASSKEY_ACTION)
             .setPackage(context.packageName)
+            .setClass(context, CREDENTIAL_ACTIVITY_CLASS)
             .putExtra(EXTRA_KEY_USER_ID, userId)
 
         return PendingIntent.getActivity(
@@ -44,6 +45,7 @@ class CredentialManagerPendingIntentManagerImpl(
     ): PendingIntent {
         val intent = Intent(GET_PASSKEY_ACTION)
             .setPackage(context.packageName)
+            .setClass(context, CREDENTIAL_ACTIVITY_CLASS)
             .putExtra(EXTRA_KEY_USER_ID, userId)
             .putExtra(EXTRA_KEY_CREDENTIAL_ID, credentialId)
             .putExtra(EXTRA_KEY_CIPHER_ID, cipherId)
@@ -65,6 +67,7 @@ class CredentialManagerPendingIntentManagerImpl(
     ): PendingIntent {
         val intent = Intent(UNLOCK_ACCOUNT_ACTION)
             .setPackage(context.packageName)
+            .setClass(context, CREDENTIAL_ACTIVITY_CLASS)
             .putExtra(EXTRA_KEY_USER_ID, userId)
 
         return PendingIntent.getActivity(
@@ -83,6 +86,7 @@ class CredentialManagerPendingIntentManagerImpl(
     ): PendingIntent {
         val intent = Intent(CREATE_PASSWORD_ACTION)
             .setPackage(context.packageName)
+            .setClass(context, CREDENTIAL_ACTIVITY_CLASS)
             .putExtra(EXTRA_KEY_USER_ID, userId)
 
         return PendingIntent.getActivity(
@@ -103,6 +107,7 @@ class CredentialManagerPendingIntentManagerImpl(
     ): PendingIntent {
         val intent = Intent(GET_PASSWORD_ACTION)
             .setPackage(context.packageName)
+            .setClass(context, CREDENTIAL_ACTIVITY_CLASS)
             .putExtra(EXTRA_KEY_USER_ID, userId)
             .putExtra(EXTRA_KEY_CIPHER_ID, cipherId)
             .putExtra(EXTRA_KEY_UV_PERFORMED_DURING_UNLOCK, isUserVerified)
@@ -116,6 +121,7 @@ class CredentialManagerPendingIntentManagerImpl(
     }
 }
 
+private val CREDENTIAL_ACTIVITY_CLASS = com.x8bit.bitwarden.CredentialProviderActivity::class.java
 private const val CREATE_PASSKEY_ACTION = "com.x8bit.bitwarden.credentials.ACTION_CREATE_PASSKEY"
 private const val UNLOCK_ACCOUNT_ACTION = "com.x8bit.bitwarden.credentials.ACTION_UNLOCK_ACCOUNT"
 private const val GET_PASSKEY_ACTION = "com.x8bit.bitwarden.credentials.ACTION_GET_PASSKEY"

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/CredentialProviderRequestManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/CredentialProviderRequestManager.kt
@@ -1,0 +1,26 @@
+package com.x8bit.bitwarden.data.credentials.manager
+
+import com.x8bit.bitwarden.CredentialProviderActivity
+import com.x8bit.bitwarden.MainActivity
+import com.x8bit.bitwarden.MainViewModel
+import com.x8bit.bitwarden.data.credentials.manager.model.CredentialProviderRequest
+
+/**
+ * Manages pending credential provider requests, relaying them from [CredentialProviderActivity]
+ * to [MainActivity] via a pull-based pattern.
+ *
+ * This approach ensures credential data is never passed through intent extras to
+ * exported activities. [CredentialProviderActivity] sets the request, then [MainViewModel]
+ * retrieves it once when handling the incoming intent.
+ */
+interface CredentialProviderRequestManager {
+    /**
+     * Set a pending credential request.
+     */
+    fun setPendingCredentialRequest(request: CredentialProviderRequest)
+
+    /**
+     * Get and clear the pending credential request. Returns null if no request is pending.
+     */
+    fun getPendingCredentialRequest(): CredentialProviderRequest?
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/CredentialProviderRequestManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/CredentialProviderRequestManagerImpl.kt
@@ -1,0 +1,25 @@
+package com.x8bit.bitwarden.data.credentials.manager
+
+import com.x8bit.bitwarden.data.credentials.manager.model.CredentialProviderRequest
+import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Singleton
+
+/**
+ * Primary implementation of [CredentialProviderRequestManager].
+ *
+ * Uses an [AtomicReference] for thread-safe get-and-clear semantics, ensuring
+ * the pending request is only processed once.
+ */
+@Singleton
+class CredentialProviderRequestManagerImpl : CredentialProviderRequestManager {
+
+    private val pendingRequest = AtomicReference<CredentialProviderRequest?>(null)
+
+    override fun setPendingCredentialRequest(request: CredentialProviderRequest) {
+        pendingRequest.set(request)
+    }
+
+    override fun getPendingCredentialRequest(): CredentialProviderRequest? {
+        return pendingRequest.getAndSet(null)
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/model/CredentialProviderRequest.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/credentials/manager/model/CredentialProviderRequest.kt
@@ -1,0 +1,39 @@
+package com.x8bit.bitwarden.data.credentials.manager.model
+
+import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
+import com.x8bit.bitwarden.data.credentials.model.Fido2CredentialAssertionRequest
+import com.x8bit.bitwarden.data.credentials.model.GetCredentialsRequest
+import com.x8bit.bitwarden.data.credentials.model.ProviderGetPasswordCredentialRequest
+
+/**
+ * Represents a pending credential provider request to be processed by MainActivity.
+ */
+sealed class CredentialProviderRequest {
+    /**
+     * Request to create a new FIDO2 passkey credential.
+     */
+    data class CreateCredential(
+        val request: CreateCredentialRequest,
+    ) : CredentialProviderRequest()
+
+    /**
+     * Request to assert (authenticate with) an existing FIDO2 passkey.
+     */
+    data class Fido2Assertion(
+        val request: Fido2CredentialAssertionRequest,
+    ) : CredentialProviderRequest()
+
+    /**
+     * Request to retrieve a password credential.
+     */
+    data class GetPassword(
+        val request: ProviderGetPasswordCredentialRequest,
+    ) : CredentialProviderRequest()
+
+    /**
+     * Request to get available credentials (BeginGetCredential flow).
+     */
+    data class GetCredentials(
+        val request: GetCredentialsRequest,
+    ) : CredentialProviderRequest()
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -2133,6 +2133,11 @@ class VaultAddEditViewModel @Inject constructor(
             }
 
             is Fido2RegisterCredentialResult.Success -> {
+                // Reset verification state to ensure the next credential operation requires
+                // fresh user verification. Without this reset, the stale isUserVerified = true
+                // from this registration would cause subsequent login attempts to skip
+                // biometric verification.
+                bitwardenCredentialManager.isUserVerified = false
                 // Use toast here because we are closing the activity.
                 toastManager.show(BitwardenString.item_updated)
                 sendEvent(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -2265,6 +2265,11 @@ class VaultItemListingViewModel @Inject constructor(
             }
 
             is Fido2RegisterCredentialResult.Success -> {
+                // Reset verification state to ensure the next credential operation requires
+                // fresh user verification. Without this reset, the stale isUserVerified = true
+                // from this registration would cause subsequent login attempts to skip
+                // biometric verification.
+                bitwardenCredentialManager.isUserVerified = false
                 // This must be a toast because we are finishing the activity and we want the
                 // user to have time to see the message.
                 toastManager.show(messageId = BitwardenString.item_updated)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/CredentialProviderViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/CredentialProviderViewModelTest.kt
@@ -1,0 +1,353 @@
+package com.x8bit.bitwarden
+
+import android.content.Intent
+import androidx.core.os.bundleOf
+import com.bitwarden.ui.platform.base.BaseViewModelTest
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
+import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManager
+import com.x8bit.bitwarden.data.credentials.manager.CredentialProviderRequestManager
+import com.x8bit.bitwarden.data.credentials.manager.model.CredentialProviderRequest
+import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
+import com.x8bit.bitwarden.data.credentials.model.Fido2CredentialAssertionRequest
+import com.x8bit.bitwarden.data.credentials.model.GetCredentialsRequest
+import com.x8bit.bitwarden.data.credentials.model.ProviderGetPasswordCredentialRequest
+import com.x8bit.bitwarden.data.credentials.model.createMockCreateCredentialRequest
+import com.x8bit.bitwarden.data.credentials.model.createMockFido2CredentialAssertionRequest
+import com.x8bit.bitwarden.data.credentials.model.createMockGetCredentialsRequest
+import com.x8bit.bitwarden.data.credentials.model.createMockProviderGetPasswordCredentialRequest
+import com.x8bit.bitwarden.data.credentials.util.getCreateCredentialRequestOrNull
+import com.x8bit.bitwarden.data.credentials.util.getFido2AssertionRequestOrNull
+import com.x8bit.bitwarden.data.credentials.util.getGetCredentialsRequestOrNull
+import com.x8bit.bitwarden.data.credentials.util.getProviderGetPasswordRequestOrNull
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CredentialProviderViewModelTest : BaseViewModelTest() {
+
+    private val mockAuthRepository = mockk<AuthRepository>(relaxed = true) {
+        every { activeUserId } returns ACTIVE_USER_ID
+        every { switchAccount(any()) } returns SwitchAccountResult.NoChange
+    }
+    private val credentialRequestSlot = slot<CredentialProviderRequest>()
+    private val mockCredentialProviderRequestManager = mockk<CredentialProviderRequestManager> {
+        every { setPendingCredentialRequest(capture(credentialRequestSlot)) } just runs
+    }
+    private val bitwardenCredentialManager = mockk<BitwardenCredentialManager> {
+        every { isUserVerified } returns false
+        every { isUserVerified = any() } just runs
+    }
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(
+            Intent::getFido2AssertionRequestOrNull,
+            Intent::getProviderGetPasswordRequestOrNull,
+            Intent::getCreateCredentialRequestOrNull,
+            Intent::getGetCredentialsRequestOrNull,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(
+            Intent::getFido2AssertionRequestOrNull,
+            Intent::getProviderGetPasswordRequestOrNull,
+            Intent::getCreateCredentialRequestOrNull,
+            Intent::getGetCredentialsRequestOrNull,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with create credential request should set pending request to CreateCredential`() {
+        val viewModel = createViewModel()
+        val createCredentialRequest = createMockCreateCredentialRequest(
+            number = 1,
+            isUserPreVerified = false,
+        )
+        val mockIntent = createMockIntent(
+            mockCreateCredentialRequest = createCredentialRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify { mockCredentialProviderRequestManager.setPendingCredentialRequest(any()) }
+        assertTrue(credentialRequestSlot.captured is CredentialProviderRequest.CreateCredential)
+        assertEquals(
+            createCredentialRequest,
+            (credentialRequestSlot.captured as CredentialProviderRequest.CreateCredential).request,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with create credential request should set user verification based on request`() {
+        val viewModel = createViewModel()
+        val createCredentialRequest = createMockCreateCredentialRequest(
+            number = 1,
+            isUserPreVerified = true,
+        )
+        val mockIntent = createMockIntent(
+            mockCreateCredentialRequest = createCredentialRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify { bitwardenCredentialManager.isUserVerified = true }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with create credential request should switch users if active user is not selected`() {
+        val viewModel = createViewModel()
+        val createCredentialRequest = CreateCredentialRequest(
+            userId = "selectedUserId",
+            isUserPreVerified = false,
+            requestData = bundleOf(),
+        )
+        val mockIntent = createMockIntent(
+            mockCreateCredentialRequest = createCredentialRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify(exactly = 1) {
+            mockAuthRepository.switchAccount("selectedUserId")
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with create credential request should not switch users if active user is selected`() {
+        val viewModel = createViewModel()
+        val createCredentialRequest = CreateCredentialRequest(
+            userId = ACTIVE_USER_ID,
+            isUserPreVerified = false,
+            requestData = bundleOf(),
+        )
+        val mockIntent = createMockIntent(
+            mockCreateCredentialRequest = createCredentialRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify(exactly = 0) { mockAuthRepository.switchAccount(any()) }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with FIDO2 assertion request should set pending request to Fido2Assertion`() {
+        val viewModel = createViewModel()
+        val mockAssertionRequest = createMockFido2CredentialAssertionRequest(number = 1)
+        val mockIntent = createMockIntent(
+            mockFido2CredentialAssertionRequest = mockAssertionRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify { mockCredentialProviderRequestManager.setPendingCredentialRequest(any()) }
+        assertTrue(credentialRequestSlot.captured is CredentialProviderRequest.Fido2Assertion)
+        assertEquals(
+            mockAssertionRequest,
+            (credentialRequestSlot.captured as CredentialProviderRequest.Fido2Assertion).request,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with FIDO2 assertion request should set user verification based on request`() {
+        val viewModel = createViewModel()
+        val mockAssertionRequest = Fido2CredentialAssertionRequest(
+            userId = "mockUserId",
+            cipherId = "mockCipherId",
+            credentialId = "mockCredentialId",
+            isUserPreVerified = true,
+            requestData = bundleOf(),
+        )
+        val mockIntent = createMockIntent(
+            mockFido2CredentialAssertionRequest = mockAssertionRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify { bitwardenCredentialManager.isUserVerified = true }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with password get request should set pending request to GetPassword`() {
+        val viewModel = createViewModel()
+        val mockPasswordGetRequest = createMockProviderGetPasswordCredentialRequest(number = 1)
+        val mockIntent = createMockIntent(
+            mockProviderGetPasswordRequest = mockPasswordGetRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify { mockCredentialProviderRequestManager.setPendingCredentialRequest(any()) }
+        assertTrue(credentialRequestSlot.captured is CredentialProviderRequest.GetPassword)
+        assertEquals(
+            mockPasswordGetRequest,
+            (credentialRequestSlot.captured as CredentialProviderRequest.GetPassword).request,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with password get request should set user verification based on request`() {
+        val viewModel = createViewModel()
+        val mockPasswordGetRequest = ProviderGetPasswordCredentialRequest(
+            userId = "mockUserId",
+            cipherId = "mockCipherId",
+            isUserPreVerified = true,
+            requestData = bundleOf(),
+        )
+        val mockIntent = createMockIntent(
+            mockProviderGetPasswordRequest = mockPasswordGetRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify { bitwardenCredentialManager.isUserVerified = true }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveFirstIntent with get credentials request should set pending request to GetCredentials`() {
+        val viewModel = createViewModel()
+        val mockGetCredentialsRequest = createMockGetCredentialsRequest(number = 1)
+        val mockIntent = createMockIntent(
+            mockGetCredentialsRequest = mockGetCredentialsRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify { mockCredentialProviderRequestManager.setPendingCredentialRequest(any()) }
+        assertTrue(credentialRequestSlot.captured is CredentialProviderRequest.GetCredentials)
+        assertEquals(
+            mockGetCredentialsRequest,
+            (credentialRequestSlot.captured as CredentialProviderRequest.GetCredentials).request,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveNewIntent with create credential request should set pending request to CreateCredential`() {
+        val viewModel = createViewModel()
+        val createCredentialRequest = createMockCreateCredentialRequest(number = 1)
+        val mockIntent = createMockIntent(
+            mockCreateCredentialRequest = createCredentialRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveNewIntent(intent = mockIntent))
+
+        verify { mockCredentialProviderRequestManager.setPendingCredentialRequest(any()) }
+        assertTrue(credentialRequestSlot.captured is CredentialProviderRequest.CreateCredential)
+        assertEquals(
+            createCredentialRequest,
+            (credentialRequestSlot.captured as CredentialProviderRequest.CreateCredential).request,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveNewIntent with FIDO2 assertion request should set pending request to Fido2Assertion`() {
+        val viewModel = createViewModel()
+        val mockAssertionRequest = createMockFido2CredentialAssertionRequest(number = 1)
+        val mockIntent = createMockIntent(
+            mockFido2CredentialAssertionRequest = mockAssertionRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveNewIntent(intent = mockIntent))
+
+        verify { mockCredentialProviderRequestManager.setPendingCredentialRequest(any()) }
+        assertTrue(credentialRequestSlot.captured is CredentialProviderRequest.Fido2Assertion)
+        assertEquals(
+            mockAssertionRequest,
+            (credentialRequestSlot.captured as CredentialProviderRequest.Fido2Assertion).request,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveNewIntent with password get request should set pending request to GetPassword`() {
+        val viewModel = createViewModel()
+        val mockPasswordGetRequest = createMockProviderGetPasswordCredentialRequest(number = 1)
+        val mockIntent = createMockIntent(
+            mockProviderGetPasswordRequest = mockPasswordGetRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveNewIntent(intent = mockIntent))
+
+        verify { mockCredentialProviderRequestManager.setPendingCredentialRequest(any()) }
+        assertTrue(credentialRequestSlot.captured is CredentialProviderRequest.GetPassword)
+        assertEquals(
+            mockPasswordGetRequest,
+            (credentialRequestSlot.captured as CredentialProviderRequest.GetPassword).request,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveNewIntent with get credentials request should set pending request to GetCredentials`() {
+        val viewModel = createViewModel()
+        val mockGetCredentialsRequest = createMockGetCredentialsRequest(number = 1)
+        val mockIntent = createMockIntent(
+            mockGetCredentialsRequest = mockGetCredentialsRequest,
+        )
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveNewIntent(intent = mockIntent))
+
+        verify { mockCredentialProviderRequestManager.setPendingCredentialRequest(any()) }
+        assertTrue(credentialRequestSlot.captured is CredentialProviderRequest.GetCredentials)
+        assertEquals(
+            mockGetCredentialsRequest,
+            (credentialRequestSlot.captured as CredentialProviderRequest.GetCredentials).request,
+        )
+    }
+
+    @Test
+    fun `on ReceiveFirstIntent with no credential data should not set pending request`() {
+        val viewModel = createViewModel()
+        val mockIntent = createMockIntent()
+
+        viewModel.trySendAction(CredentialProviderAction.ReceiveFirstIntent(intent = mockIntent))
+
+        verify(exactly = 0) {
+            mockCredentialProviderRequestManager.setPendingCredentialRequest(any())
+        }
+    }
+
+    private fun createViewModel() = CredentialProviderViewModel(
+        credentialProviderRequestManager = mockCredentialProviderRequestManager,
+        authRepository = mockAuthRepository,
+        bitwardenCredentialManager = bitwardenCredentialManager,
+    )
+
+    @Suppress("LongParameterList")
+    private fun createMockIntent(
+        mockFido2CredentialAssertionRequest: Fido2CredentialAssertionRequest? = null,
+        mockProviderGetPasswordRequest: ProviderGetPasswordCredentialRequest? = null,
+        mockCreateCredentialRequest: CreateCredentialRequest? = null,
+        mockGetCredentialsRequest: GetCredentialsRequest? = null,
+    ): Intent = mockk {
+        every { getFido2AssertionRequestOrNull() } returns mockFido2CredentialAssertionRequest
+        every { getProviderGetPasswordRequestOrNull() } returns mockProviderGetPasswordRequest
+        every { getCreateCredentialRequestOrNull() } returns mockCreateCredentialRequest
+        every { getGetCredentialsRequestOrNull() } returns mockGetCredentialsRequest
+    }
+}
+
+private const val ACTIVE_USER_ID = "activeUserId"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/manager/CredentialProviderRequestManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/manager/CredentialProviderRequestManagerTest.kt
@@ -1,0 +1,108 @@
+package com.x8bit.bitwarden.data.credentials.manager
+
+import com.x8bit.bitwarden.data.credentials.manager.model.CredentialProviderRequest
+import com.x8bit.bitwarden.data.credentials.model.createMockCreateCredentialRequest
+import com.x8bit.bitwarden.data.credentials.model.createMockFido2CredentialAssertionRequest
+import com.x8bit.bitwarden.data.credentials.model.createMockGetCredentialsRequest
+import com.x8bit.bitwarden.data.credentials.model.createMockProviderGetPasswordCredentialRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CredentialProviderRequestManagerTest {
+
+    private lateinit var manager: CredentialProviderRequestManagerImpl
+
+    @BeforeEach
+    fun setup() {
+        manager = CredentialProviderRequestManagerImpl()
+    }
+
+    @Test
+    fun `getPendingCredentialRequest returns null when no request is pending`() {
+        assertNull(manager.getPendingCredentialRequest())
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `setPendingCredentialRequest followed by getPendingCredentialRequest returns the request`() {
+        val createRequest = createMockCreateCredentialRequest(number = 1)
+        val credentialRequest = CredentialProviderRequest.CreateCredential(createRequest)
+
+        manager.setPendingCredentialRequest(credentialRequest)
+        val result = manager.getPendingCredentialRequest()
+
+        assertEquals(credentialRequest, result)
+    }
+
+    @Test
+    fun `getPendingCredentialRequest clears the pending request`() {
+        val createRequest = createMockCreateCredentialRequest(number = 1)
+        val credentialRequest = CredentialProviderRequest.CreateCredential(createRequest)
+
+        manager.setPendingCredentialRequest(credentialRequest)
+        manager.getPendingCredentialRequest()
+        val secondResult = manager.getPendingCredentialRequest()
+
+        assertNull(secondResult)
+    }
+
+    @Test
+    fun `setPendingCredentialRequest overwrites previous request`() {
+        val createRequest = createMockCreateCredentialRequest(number = 1)
+        val assertionRequest = createMockFido2CredentialAssertionRequest(number = 1)
+        val firstCredentialRequest = CredentialProviderRequest.CreateCredential(createRequest)
+        val secondCredentialRequest = CredentialProviderRequest.Fido2Assertion(assertionRequest)
+
+        manager.setPendingCredentialRequest(firstCredentialRequest)
+        manager.setPendingCredentialRequest(secondCredentialRequest)
+        val result = manager.getPendingCredentialRequest()
+
+        assertEquals(secondCredentialRequest, result)
+    }
+
+    @Test
+    fun `supports all CredentialProviderRequest types`() {
+        val createRequest = createMockCreateCredentialRequest(number = 1)
+        val fido2Request = createMockFido2CredentialAssertionRequest(number = 1)
+        val passwordRequest = createMockProviderGetPasswordCredentialRequest(number = 1)
+        val getCredentialsRequest = createMockGetCredentialsRequest(number = 1)
+
+        // Test CreateCredential
+        manager.setPendingCredentialRequest(
+            CredentialProviderRequest.CreateCredential(createRequest),
+        )
+        assertEquals(
+            CredentialProviderRequest.CreateCredential(createRequest),
+            manager.getPendingCredentialRequest(),
+        )
+
+        // Test Fido2Assertion
+        manager.setPendingCredentialRequest(
+            CredentialProviderRequest.Fido2Assertion(fido2Request),
+        )
+        assertEquals(
+            CredentialProviderRequest.Fido2Assertion(fido2Request),
+            manager.getPendingCredentialRequest(),
+        )
+
+        // Test GetPassword
+        manager.setPendingCredentialRequest(
+            CredentialProviderRequest.GetPassword(passwordRequest),
+        )
+        assertEquals(
+            CredentialProviderRequest.GetPassword(passwordRequest),
+            manager.getPendingCredentialRequest(),
+        )
+
+        // Test GetCredentials
+        manager.setPendingCredentialRequest(
+            CredentialProviderRequest.GetCredentials(getCredentialsRequest),
+        )
+        assertEquals(
+            CredentialProviderRequest.GetCredentials(getCredentialsRequest),
+            manager.getPendingCredentialRequest(),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -4844,6 +4844,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 }
                 verify(exactly = 1) {
                     toastManager.show(messageId = BitwardenString.item_updated)
+                    // Verify that isUserVerified is reset to false after successful registration
+                    // to ensure subsequent credential operations require fresh user verification
+                    bitwardenCredentialManager.isUserVerified = false
                 }
             }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -3444,6 +3444,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             }
             verify {
                 toastManager.show(messageId = BitwardenString.item_updated)
+                // Verify that isUserVerified is reset to false after successful registration
+                // to ensure subsequent credential operations require fresh user verification
+                bitwardenCredentialManager.isUserVerified = false
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-30279

## 📔 Objective

This PR extracts credential provider handling into a dedicated `CredentialProviderActivity` to improve security and architecture. The new activity serves as a transparent trampoline that receives credential intents from the Android CredentialManager framework, securely relays them to `MainActivity` via `CredentialProviderRequestManager`, and forwards results back to the framework. This approach hardens against malicious intent attacks by ensuring credential data is never passed through intent extras to exported activities, while preserving the single-Activity architecture where all UI is hosted by MainActivity. 

## 📸 Screenshots

Coming soon!

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
