### PR TITLE
PM-31656, PM-31658, PM-31659: Address Archive feature bugs

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
@@ -90,8 +90,8 @@ class AuthenticatorBridgeRepositoryImpl(
                 // Vault is unlocked, query vault disk source for totp logins:
                 val totpUris = vaultDiskSource
                     .getTotpCiphers(userId = userId)
-                    // Filter out any deleted ciphers.
-                    .filter { it.deletedDate == null }
+                    // Filter out any deleted and archived ciphers.
+                    .filter { it.deletedDate == null && it.archivedDate == null }
                     .mapNotNull {
                         scopedVaultSdkSource
                             .decryptCipher(userId = userId, cipher = it.toEncryptedSdkCipher())

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
@@ -191,6 +191,10 @@ class CipherManagerImpl(
                     userId = userId,
                     cipher = it.toEncryptedNetworkCipherResponse(),
                 )
+                settingsDiskSource.storeIntroducingArchiveActionCardDismissed(
+                    userId = userId,
+                    isDismissed = true,
+                )
             }
             .fold(
                 onSuccess = { ArchiveCipherResult.Success },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -501,7 +501,7 @@ private fun ActionCard(
                         tint = BitwardenTheme.colorScheme.icon.secondary,
                     )
                 },
-                onActionClick = vaultHandlers.archiveClick,
+                onActionClick = { vaultHandlers.actionCardClick(actionCardState) },
                 onDismissClick = { vaultHandlers.dismissActionCardClick(actionCardState) },
                 modifier = modifier,
             )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/handlers/VaultHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/handlers/VaultHandlers.kt
@@ -52,6 +52,7 @@ data class VaultHandlers(
     val onDismissThirdPartyAutofillDialogClick: () -> Unit,
     val upgradeToPremiumClick: () -> Unit,
     val dismissActionCardClick: (VaultState.ActionCardState) -> Unit,
+    val actionCardClick: (VaultState.ActionCardState) -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -151,6 +152,7 @@ data class VaultHandlers(
                 dismissActionCardClick = {
                     viewModel.trySendAction(VaultAction.DismissActionCardClick(it))
                 },
+                actionCardClick = { viewModel.trySendAction(VaultAction.ActionCardClick(it)) },
             )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
@@ -132,6 +132,9 @@ fun VaultData.toViewState(
             noFolderItems.size < NO_FOLDER_ITEM_THRESHOLD
         val totpItems = activeCipherViews.filter { it.login?.totp != null }
         val cardCount = activeCipherViews.count { it.type is CipherListViewType.Card }
+        val archiveCount = allCipherViews.count {
+            it.archivedDate != null && it.deletedDate == null
+        }
         VaultState.ViewState.Content(
             itemTypesCount = itemTypesCount,
             totpItemsCount = if (isPremium) {
@@ -215,15 +218,13 @@ fun VaultData.toViewState(
                     )
                 },
             trashItemsCount = allCipherViews.count { it.deletedDate != null },
-            archivedItemsCount = allCipherViews
-                .count { it.archivedDate != null && it.deletedDate == null }
-                .takeIf { isPremium },
+            archivedItemsCount = archiveCount.takeIf { isPremium || archiveCount > 0 },
             archiveEnabled = isArchiveEnabled,
-            archiveEndIcon = BitwardenDrawable.ic_locked.takeUnless { isPremium },
+            archiveEndIcon = BitwardenDrawable.ic_locked.takeIf { !isPremium && archiveCount == 0 },
             archiveSubText = BitwardenString
                 .premium_subscription_required
                 .asText()
-                .takeUnless { isPremium },
+                .takeIf { !isPremium && archiveCount == 0 },
             showCardGroup = cardCount != 0 || restrictItemTypesPolicyOrgIds.isEmpty(),
         )
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -492,6 +492,13 @@ class FakeSettingsDiskSource(
     }
 
     /**
+     * Asserts that the stored introducing archive action card dismissed matches the [expected] one.
+     */
+    fun assertIntroducingArchiveActionCardDismissed(userId: String, expected: Boolean?) {
+        assertEquals(expected, storedIntroducingArchiveActionCardDismissed[userId])
+    }
+
+    /**
      * Asserts that the stored last sync time matches the [expected] one.
      */
     fun assertLastSyncTime(userId: String, expected: Instant?) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryTest.kt
@@ -238,7 +238,7 @@ class AuthenticatorBridgeRepositoryTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `getSharedAccounts should unlock and re-lock vault for both users and filter out deleted ciphers`() =
+    fun `getSharedAccounts should unlock and re-lock vault for both users and filter out archived and deleted ciphers`() =
         runTest {
             assertEquals(
                 BOTH_ACCOUNT_SUCCESS,
@@ -499,6 +499,7 @@ private val USER_STATE_JSON = UserStateJson(
 private val USER_1_TOTP_CIPHER = mockk<SyncResponseJson.Cipher> {
     every { login?.totp } returns "encryptedTotp1"
     every { login?.username } returns "username"
+    every { archivedDate } returns null
     every { deletedDate } returns null
     every { name } returns "cipher1"
 }
@@ -506,13 +507,23 @@ private val USER_1_TOTP_CIPHER = mockk<SyncResponseJson.Cipher> {
 private val USER_1_DELETED_TOTP_CIPHER = mockk<SyncResponseJson.Cipher> {
     every { login?.totp } returns "encryptedTotp1Deleted"
     every { login?.username } returns "username"
+    every { archivedDate } returns null
     every { deletedDate } returns ZonedDateTime.parse("2023-10-27T12:00:00Z")
+    every { name } returns "cipher1"
+}
+
+private val USER_1_ARCHIVED_TOTP_CIPHER = mockk<SyncResponseJson.Cipher> {
+    every { login?.totp } returns "encryptedTotp1Deleted"
+    every { login?.username } returns "username"
+    every { archivedDate } returns ZonedDateTime.parse("2023-10-27T12:00:00Z")
+    every { deletedDate } returns null
     every { name } returns "cipher1"
 }
 
 private val USER_2_TOTP_CIPHER = mockk<SyncResponseJson.Cipher> {
     every { login?.totp } returns "encryptedTotp2"
     every { login?.username } returns "username"
+    every { archivedDate } returns null
     every { deletedDate } returns null
     every { name } returns "cipher2"
 }
@@ -553,6 +564,7 @@ private val USER_2_SHARED_ACCOUNT = SharedAccountData.Account(
 private val USER_1_CIPHERS = listOf(
     USER_1_TOTP_CIPHER,
     USER_1_DELETED_TOTP_CIPHER,
+    USER_1_ARCHIVED_TOTP_CIPHER,
 )
 
 private val USER_2_CIPHERS = listOf(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
@@ -744,6 +744,10 @@ class CipherManagerTest {
                 cipher = createMockSdkCipher(number = 1, clock = clock),
             )
             val cipherView = createMockCipherView(number = 1)
+            fakeSettingsDiskSource.storeIntroducingArchiveActionCardDismissed(
+                userId = userId,
+                isDismissed = null,
+            )
             coEvery {
                 vaultSdkSource.encryptCipher(userId = userId, cipherView = cipherView)
             } returns encryptionContext.asSuccess()
@@ -770,6 +774,10 @@ class CipherManagerTest {
                 cipherView = cipherView,
             )
 
+            fakeSettingsDiskSource.assertIntroducingArchiveActionCardDismissed(
+                userId = userId,
+                expected = true,
+            )
             assertEquals(ArchiveCipherResult.Success, result)
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -1527,7 +1527,11 @@ class VaultScreenTest : BitwardenComposeTest() {
             .performClick()
 
         verify(exactly = 1) {
-            viewModel.trySendAction(VaultAction.ArchiveClick)
+            viewModel.trySendAction(
+                VaultAction.ActionCardClick(
+                    actionCard = VaultState.ActionCardState.IntroducingArchive,
+                ),
+            )
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31655](https://bitwarden.atlassian.net/browse/PM-31655)
[PM-31656](https://bitwarden.atlassian.net/browse/PM-31656)
[PM-31658](https://bitwarden.atlassian.net/browse/PM-31658)
[PM-31659](https://bitwarden.atlassian.net/browse/PM-31659)
[PM-31663](https://bitwarden.atlassian.net/browse/PM-31663)

## 📔 Objective

This PR address multiple small bugs associated with the archive feature.

* The Archive row should display a premium required dialog if the user does not have premium but does have ciphers.
* The introducing archive action card should be dismissed if the user clicks the `X`, primary action button or archives a cipher.
* We no long display the premium required content on the Archive list item when the user has archived items without a premium account.
* Archived ciphers should not be displayed in the Authenticator when the Sync feature is enabled.

## 📸 Screenshots



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31655]: https://bitwarden.atlassian.net/browse/PM-31655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-31656]: https://bitwarden.atlassian.net/browse/PM-31656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-31658]: https://bitwarden.atlassian.net/browse/PM-31658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-31659]: https://bitwarden.atlassian.net/browse/PM-31659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-31663]: https://bitwarden.atlassian.net/browse/PM-31663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ