### PR TITLE
[PM-31775] Refactor popUpToCompleteRegistration to use type-safe KClass reference

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/completeregistration/CompleteRegistrationNavigation.kt
@@ -81,5 +81,5 @@ fun NavGraphBuilder.completeRegistrationDestination(
  * Pop up to the complete registration screen.
  */
 fun NavController.popUpToCompleteRegistration() {
-    this.popBackStack(route = CompleteRegistrationRoute, inclusive = false)
+    this.popBackStack(route = CompleteRegistrationRoute::class, inclusive = false)
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-31775

## 📔 Objective

Fixes a crash caused when popping up to the CompleteRegistrationRoute.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
