### PR TITLE
PM-31734: Add archived item filtering for passkeys

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherListViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherListViewExtensions.kt
@@ -7,16 +7,19 @@ import com.bitwarden.vault.CopyableCipherFields
 import com.bitwarden.vault.LoginListView
 
 /**
- * Returns true when the cipher is not deleted and contains at least one FIDO 2 credential.
+ * Returns true when the cipher is not archived, not deleted and contains at least one FIDO 2
+ * credential.
  */
 val CipherListView.isActiveWithFido2Credentials: Boolean
-    get() = deletedDate == null && login?.hasFido2 ?: false
+    get() = archivedDate == null && deletedDate == null && login?.hasFido2 ?: false
 
 /**
- * Returns true when the cipher type is not deleted and contains a copyable password.
+ * Returns true when the cipher type is not archived, not deleted and contains a copyable password.
  */
 val CipherListView.isActiveWithCopyablePassword: Boolean
-    get() = deletedDate == null && copyableFields.contains(CopyableCipherFields.LOGIN_PASSWORD)
+    get() = archivedDate == null &&
+        deletedDate == null &&
+        copyableFields.contains(CopyableCipherFields.LOGIN_PASSWORD)
 
 /**
  * Returns the [LoginListView] if the cipher is of type [CipherListViewType.Login], otherwise null.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensions.kt
@@ -48,13 +48,17 @@ fun CipherView.toAutofillCipherProvider(): AutofillCipherProvider =
     }
 
 /**
- * Returns true when the cipher is not deleted and contains at least one FIDO 2 credential.
+ * Returns true when the cipher is not archived, not deleted and contains at least one FIDO 2
+ * credential.
  */
 val CipherView.isActiveWithFido2Credentials: Boolean
-    get() = deletedDate == null && !(login?.fido2Credentials.isNullOrEmpty())
+    get() = archivedDate == null &&
+        deletedDate == null &&
+        !(login?.fido2Credentials.isNullOrEmpty())
 
 /**
- * Returns true when the cipher is not deleted and contains at least one Password credential.
+ * Returns true when the cipher is not archived, not deleted and contains at least one Password
+ * credential.
  */
 val CipherView.isActiveWithPasswordCredentials: Boolean
-    get() = deletedDate == null && !(login?.password.isNullOrEmpty())
+    get() = archivedDate == null && deletedDate == null && !(login?.password.isNullOrEmpty())

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherListViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherListViewExtensionsTest.kt
@@ -62,7 +62,48 @@ class CipherListViewExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `isActiveWithFido2Credentials should return true when Fido2 credentials are present and cipher is not deleted`() {
+    fun `isActiveWithCopyablePassword should return true when copyable fields contains LOGIN_PASSWORD and cipher is not deleted or archived`() {
+        val cipherListView = createMockCipherListView(
+            number = 1,
+            type = CipherListViewType.Login(v1 = createMockLoginListView(number = 1)),
+        )
+        assertTrue(cipherListView.isActiveWithCopyablePassword)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `isActiveWithCopyablePassword should return false copyable fields does not contain LOGIN_PASSWORD`() {
+        val cipherListView = createMockCipherListView(
+            number = 1,
+            copyableFields = emptyList(),
+            type = CipherListViewType.Login(v1 = createMockLoginListView(number = 1)),
+        )
+        assertFalse(cipherListView.isActiveWithCopyablePassword)
+    }
+
+    @Test
+    fun `isActiveWithCopyablePassword should return false when cipher is archived`() {
+        val cipherListView = createMockCipherListView(
+            number = 1,
+            type = CipherListViewType.Login(v1 = createMockLoginListView(number = 1)),
+            isArchived = true,
+        )
+        assertFalse(cipherListView.isActiveWithCopyablePassword)
+    }
+
+    @Test
+    fun `isActiveWithCopyablePassword should return false when cipher is deleted`() {
+        val cipherListView = createMockCipherListView(
+            number = 1,
+            type = CipherListViewType.Login(v1 = createMockLoginListView(number = 1)),
+            isDeleted = true,
+        )
+        assertFalse(cipherListView.isActiveWithCopyablePassword)
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `isActiveWithFido2Credentials should return true when Fido2 credentials are present and cipher is not deleted or archived`() {
         val cipherListView = createMockCipherListView(
             number = 1,
             type = CipherListViewType.Login(
@@ -86,6 +127,21 @@ class CipherListViewExtensionsTest {
                     hasFido2 = false,
                 ),
             ),
+        )
+        assertFalse(cipherListView.isActiveWithFido2Credentials)
+    }
+
+    @Test
+    fun `isActiveWithFido2Credentials should return false when cipher is archived`() {
+        val cipherListView = createMockCipherListView(
+            number = 1,
+            type = CipherListViewType.Login(
+                createMockLoginListView(
+                    number = 1,
+                    hasFido2 = true,
+                ),
+            ),
+            isArchived = true,
         )
         assertFalse(cipherListView.isActiveWithFido2Credentials)
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/util/CipherViewExtensionsTest.kt
@@ -142,13 +142,20 @@ class CipherViewExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `isActiveWithFido2Credentials should return true when type is login, deleted date is null, and fido2 credentials are not null`() {
+    fun `isActiveWithFido2Credentials should return true when type is login, deleted and archived date is null, and fido2 credentials are not null`() {
         assertTrue(
             createMockCipherView(
                 number = 1,
                 fido2Credentials = createMockSdkFido2CredentialList(number = 1),
             )
                 .isActiveWithFido2Credentials,
+        )
+    }
+
+    @Test
+    fun `isActiveWithFido2Credentials should return false when archive date is not null`() {
+        assertFalse(
+            createMockCipherView(number = 1, isArchived = true).isActiveWithFido2Credentials,
         )
     }
 
@@ -187,13 +194,20 @@ class CipherViewExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `isActiveWithPasswordCredentials should return true when type is login, deleted date is null, and password credentials are not empty`() {
+    fun `isActiveWithPasswordCredentials should return true when type is login, deleted and archived date is null, and password credentials are not empty`() {
         assertTrue(
             createMockCipherView(
                 number = 1,
                 login = createMockLoginView(number = 1),
             )
                 .isActiveWithPasswordCredentials,
+        )
+    }
+
+    @Test
+    fun `isActiveWithPasswordCredentials should return false when archive date is not null`() {
+        assertFalse(
+            createMockCipherView(number = 1, isArchived = true).isActiveWithPasswordCredentials,
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31734](https://bitwarden.atlassian.net/browse/PM-31734)

## 📔 Objective

This PR updates the `CipherView` and `CipherListView` extensions for validating that the cipher is available for use with the credential manager by filtering out any archived cipher.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31734]: https://bitwarden.atlassian.net/browse/PM-31734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ