### PR TITLE
PM-31735: Add the archivedDate property to the updateCipher API

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
@@ -68,6 +68,7 @@ fun Cipher.toEncryptedNetworkCipher(
         card = card?.toEncryptedNetworkCard(),
         key = key,
         sshKey = sshKey?.toEncryptedNetworkSshKey(),
+        archivedDate = archivedDate?.let { ZonedDateTime.ofInstant(it, ZoneOffset.UTC) },
         encryptedFor = encryptedFor,
     )
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -433,7 +433,10 @@ class VaultAddEditViewModel @Inject constructor(
                     handleCreatePublicKeyCredentialRequest(
                         request = createPublicKeyCredentialRequest,
                         callingAppInfo = this.callingAppInfo,
-                        cipherView = content.toCipherView(clock = clock),
+                        cipherView = content.toCipherView(
+                            clock = clock,
+                            isPremiumUser = state.hasPremium,
+                        ),
                     )
                     return@onContent
                 }
@@ -449,7 +452,10 @@ class VaultAddEditViewModel @Inject constructor(
                 is VaultAddEditType.EditItem -> {
                     val result = vaultRepository.updateCipher(
                         cipherId = vaultAddEditType.vaultItemId,
-                        cipherView = content.toCipherView(clock = clock),
+                        cipherView = content.toCipherView(
+                            clock = clock,
+                            isPremiumUser = state.hasPremium,
+                        ),
                     )
                     sendAction(VaultAddEditAction.Internal.UpdateCipherResultReceive(result))
                 }
@@ -695,7 +701,10 @@ class VaultAddEditViewModel @Inject constructor(
                             handleCreatePublicKeyCredentialRequest(
                                 request = createPublicKeyCredentialRequest,
                                 callingAppInfo = request.callingAppInfo,
-                                cipherView = content.toCipherView(clock = clock),
+                                cipherView = content.toCipherView(
+                                    clock = clock,
+                                    isPremiumUser = state.hasPremium,
+                                ),
                             )
                         }
                     }
@@ -726,7 +735,10 @@ class VaultAddEditViewModel @Inject constructor(
                             handleCreatePublicKeyCredentialRequest(
                                 request = createPublicKeyCredentialRequest,
                                 callingAppInfo = request.callingAppInfo,
-                                cipherView = content.toCipherView(clock = clock),
+                                cipherView = content.toCipherView(
+                                    clock = clock,
+                                    isPremiumUser = state.hasPremium,
+                                ),
                             )
                         }
                     }
@@ -2348,11 +2360,16 @@ class VaultAddEditViewModel @Inject constructor(
             ?.map { it.id }
             ?.let {
                 vaultRepository.createCipherInOrganization(
-                    cipherView = toCipherView(clock = clock),
+                    cipherView = toCipherView(
+                        clock = clock,
+                        isPremiumUser = state.hasPremium,
+                    ),
                     collectionIds = it,
                 )
             }
-            ?: vaultRepository.createCipher(cipherView = toCipherView(clock = clock))
+            ?: vaultRepository.createCipher(
+                cipherView = toCipherView(clock = clock, isPremiumUser = state.hasPremium),
+            )
     }
 
     private fun List<VaultAddEditState.Owner>.toUpdatedOwners(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
@@ -28,7 +28,10 @@ import java.time.Instant
 /**
  * Transforms [VaultAddEditState.ViewState.Content] into [CipherView].
  */
-fun VaultAddEditState.ViewState.Content.toCipherView(clock: Clock): CipherView =
+fun VaultAddEditState.ViewState.Content.toCipherView(
+    clock: Clock,
+    isPremiumUser: Boolean,
+): CipherView =
     CipherView(
         // Pulled from original cipher when editing, otherwise uses defaults
         id = common.originalCipher?.id,
@@ -44,7 +47,7 @@ fun VaultAddEditState.ViewState.Content.toCipherView(clock: Clock): CipherView =
         creationDate = common.originalCipher?.creationDate ?: clock.instant(),
         deletedDate = common.originalCipher?.deletedDate,
         revisionDate = common.originalCipher?.revisionDate ?: clock.instant(),
-        archivedDate = common.originalCipher?.archivedDate,
+        archivedDate = common.originalCipher?.archivedDate?.takeIf { isPremiumUser },
         attachmentDecryptionFailures = common.originalCipher?.attachmentDecryptionFailures,
 
         // Type specific section

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensionsTest.kt
@@ -83,6 +83,7 @@ class VaultSdkCipherExtensionsTest {
             createMockCipherJsonRequest(
                 number = 1,
                 login = createMockLogin(number = 1, uri = null),
+                archivedDate = ZonedDateTime.ofInstant(FIXED_CLOCK.instant(), ZoneOffset.UTC),
             ),
             syncCipher,
         )
@@ -363,6 +364,7 @@ class VaultSdkCipherExtensionsTest {
             createMockCipherJsonRequest(
                 number = 1,
                 login = createMockLogin(number = 1, uri = null),
+                archivedDate = ZonedDateTime.ofInstant(FIXED_CLOCK.instant(), ZoneOffset.UTC),
             ),
             encryptionContext.toEncryptedNetworkCipher(),
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
@@ -60,7 +60,7 @@ class VaultAddItemStateExtensionsTest {
             ),
         )
 
-        val result = loginItemType.toCipherView(clock = FIXED_CLOCK)
+        val result = loginItemType.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             CipherView(
@@ -146,7 +146,7 @@ class VaultAddItemStateExtensionsTest {
             ),
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             @Suppress("MaxLineLength")
@@ -238,7 +238,7 @@ class VaultAddItemStateExtensionsTest {
             type = VaultAddEditState.ViewState.Content.ItemType.SecureNotes,
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             CipherView(
@@ -312,7 +312,7 @@ class VaultAddItemStateExtensionsTest {
             type = VaultAddEditState.ViewState.Content.ItemType.SecureNotes,
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             cipherView.copy(
@@ -369,7 +369,7 @@ class VaultAddItemStateExtensionsTest {
             ),
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             CipherView(
@@ -471,7 +471,7 @@ class VaultAddItemStateExtensionsTest {
             ),
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             @Suppress("MaxLineLength")
@@ -566,7 +566,7 @@ class VaultAddItemStateExtensionsTest {
             ),
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             CipherView(
@@ -644,7 +644,7 @@ class VaultAddItemStateExtensionsTest {
             ),
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             cipherView.copy(
@@ -714,7 +714,7 @@ class VaultAddItemStateExtensionsTest {
             ),
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             CipherView(
@@ -757,6 +757,60 @@ class VaultAddItemStateExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `toCipherView without premium should delete the archive date from the original cipher`() {
+        val cipherView = DEFAULT_BASE_CIPHER_VIEW.copy(
+            notes = null,
+            fields = emptyList(),
+            login = LoginView(
+                username = "mockUsername-1",
+                password = "mockPassword-1",
+                passwordRevisionDate = FIXED_CLOCK.instant(),
+                uris = null,
+                totp = null,
+                autofillOnPageLoad = false,
+                fido2Credentials = createMockSdkFido2CredentialList(1),
+            ),
+            archivedDate = FIXED_CLOCK.instant(),
+        )
+
+        val viewState = VaultAddEditState.ViewState.Content(
+            common = VaultAddEditState.ViewState.Content.Common(
+                originalCipher = cipherView,
+                name = "mockName-1",
+                customFieldData = emptyList(),
+                masterPasswordReprompt = true,
+            ),
+            isIndividualVaultDisabled = false,
+            type = VaultAddEditState.ViewState.Content.ItemType.Login(
+                username = "mockUsername-1",
+                password = "mockPassword-1",
+                totp = null,
+                fido2CredentialCreationDateTime = null,
+            ),
+        )
+
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = false)
+
+        assertEquals(
+            cipherView.copy(
+                name = "mockName-1",
+                login = LoginView(
+                    username = "mockUsername-1",
+                    password = "mockPassword-1",
+                    totp = null,
+                    fido2Credentials = null,
+                    uris = null,
+                    passwordRevisionDate = FIXED_CLOCK.instant(),
+                    autofillOnPageLoad = false,
+                ),
+                archivedDate = null,
+            ),
+            result,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `toLoginView should transform Login ItemType to LoginView deleting fido2Credentials with original cipher`() {
         val cipherView = DEFAULT_BASE_CIPHER_VIEW.copy(
             type = CipherType.LOGIN,
@@ -789,7 +843,7 @@ class VaultAddItemStateExtensionsTest {
             ),
         )
 
-        val result = viewState.toCipherView(clock = FIXED_CLOCK)
+        val result = viewState.toCipherView(clock = FIXED_CLOCK, isPremiumUser = true)
 
         assertEquals(
             cipherView.copy(
@@ -833,7 +887,7 @@ class VaultAddItemStateExtensionsTest {
 
         // We need to pass in a future clock to make sure that when the
         // revision date is updated it is updated to a new time
-        val result = viewState.toCipherView(clock = futureClock)
+        val result = viewState.toCipherView(clock = futureClock, isPremiumUser = true)
 
         assertNotEquals(
             viewState.common.originalCipher?.login?.passwordRevisionDate,
@@ -866,7 +920,7 @@ class VaultAddItemStateExtensionsTest {
 
         // We need to pass in a future clock to make sure that if the
         // revision date were to be updated it would be updated to a new time
-        val result = viewState.toCipherView(clock = futureClock)
+        val result = viewState.toCipherView(clock = futureClock, isPremiumUser = true)
 
         assertEquals(
             viewState.common.originalCipher?.login?.passwordRevisionDate,
@@ -902,7 +956,7 @@ class VaultAddItemStateExtensionsTest {
 
         // We need to pass in a future clock to make sure that if the
         // revision date were to be updated it would be updated to a new time
-        val result = viewState.toCipherView(clock = futureClock)
+        val result = viewState.toCipherView(clock = futureClock, isPremiumUser = true)
 
         assertEquals(
             viewState.common.originalCipher?.login?.passwordRevisionDate,
@@ -978,7 +1032,7 @@ private val DEFAULT_BASE_CIPHER_VIEW: CipherView = CipherView(
     creationDate = FIXED_CLOCK.instant(),
     deletedDate = null,
     revisionDate = FIXED_CLOCK.instant(),
-    archivedDate = null,
+    archivedDate = FIXED_CLOCK.instant(),
     sshKey = null,
     attachmentDecryptionFailures = null,
 )

--- a/network/src/main/kotlin/com/bitwarden/network/model/CipherJsonRequest.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/CipherJsonRequest.kt
@@ -23,6 +23,7 @@ import java.time.ZonedDateTime
  * @property isFavorite If the cipher is a favorite.
  * @property card The card of the cipher.
  * @property key The key of the cipher (nullable).
+ * @property archivedDate The archived date of the cipher (nullable).
  * @property encryptedFor ID of the user who the cipher is encrypted by.
  */
 @Serializable
@@ -78,6 +79,10 @@ data class CipherJsonRequest(
 
     @SerialName("key")
     val key: String?,
+
+    @SerialName("archivedDate")
+    @Contextual
+    val archivedDate: ZonedDateTime?,
 
     @SerialName("encryptedFor")
     val encryptedFor: String?,

--- a/network/src/testFixtures/kotlin/com/bitwarden/network/model/CipherJsonRequestUtil.kt
+++ b/network/src/testFixtures/kotlin/com/bitwarden/network/model/CipherJsonRequestUtil.kt
@@ -29,6 +29,7 @@ fun createMockCipherJsonRequest(
     reprompt: CipherRepromptTypeJson = CipherRepromptTypeJson.NONE,
     lastKnownRevisionDate: ZonedDateTime? = ZonedDateTime.parse("2023-10-27T12:00:00Z"),
     key: String? = "mockKey-$number",
+    archivedDate: ZonedDateTime? = ZonedDateTime.parse("2023-10-27T12:00:00Z"),
     encryptedFor: String? = "mockEncryptedFor-$number",
 ): CipherJsonRequest =
     CipherJsonRequest(
@@ -49,5 +50,6 @@ fun createMockCipherJsonRequest(
         reprompt = reprompt,
         lastKnownRevisionDate = lastKnownRevisionDate,
         key = key,
+        archivedDate = archivedDate,
         encryptedFor = encryptedFor,
     )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31735](https://bitwarden.atlassian.net/browse/PM-31735)

## 📔 Objective

This PR updates the `updateCipher` API to take a `archivedDate`. We pass this new value through to ensure that editing an archived cipher does not unarchive it. If a non-premium user updates an archived cipher, we strip the property in order to unarchive it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31735]: https://bitwarden.atlassian.net/browse/PM-31735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ