### PR TITLE
PM-31888: Update the ZonedDateTimeSerializer to be more lenient when deserializing

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/data/serializer/ZonedDateTimeSerializer.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/serializer/ZonedDateTimeSerializer.kt
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter
  */
 class ZonedDateTimeSerializer : KSerializer<ZonedDateTime> {
     private val dateTimeFormatterDeserialization = DateTimeFormatter
-        .ofPattern("yyyy-MM-dd'T'HH:mm:ss[.][:][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]X")
+        .ofPattern("yyyy-MM-dd'T'HH:mm:ss[.][:][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]XXX")
 
     private val dateTimeFormatterSerialization =
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31888](https://bitwarden.atlassian.net/browse/PM-31888)

## 📔 Objective

A deserialization error occurred because a ciphers password history had a date using this format: `2025-03-19T10:34:50.025+00:00`

This change makes our deserialization strategy more lenient with the timezone information style.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31888]: https://bitwarden.atlassian.net/browse/PM-31888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ