### PR TITLE
PM-31926: Add Autofill reminder for Vivaldi browser

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerImpl.kt
@@ -30,6 +30,8 @@ class AutofillActivityManagerImpl(
             braveStableStatusData = browserThirdPartyAutofillManager.stableBraveAutofillStatus,
             chromeStableStatusData = browserThirdPartyAutofillManager.stableChromeAutofillStatus,
             chromeBetaChannelStatusData = browserThirdPartyAutofillManager.betaChromeAutofillStatus,
+            vivaldiStableChannelStatusData = browserThirdPartyAutofillManager
+                .stableVivaldiAutofillStatus,
         )
 
     init {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillEnabledManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillEnabledManagerImpl.kt
@@ -39,4 +39,8 @@ private val DEFAULT_STATUS = BrowserThirdPartyAutofillStatus(
         isAvailable = false,
         isThirdPartyEnabled = false,
     ),
+    vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+        isAvailable = false,
+        isThirdPartyEnabled = false,
+    ),
 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManager.kt
@@ -22,4 +22,9 @@ interface BrowserThirdPartyAutofillManager {
      * The data representing the status of the beta Chrome version
      */
     val betaChromeAutofillStatus: BrowserThirdPartyAutoFillData
+
+    /**
+     * The data representing the status of the Vivaldi version
+     */
+    val stableVivaldiAutofillStatus: BrowserThirdPartyAutoFillData
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManagerImpl.kt
@@ -27,6 +27,8 @@ class BrowserThirdPartyAutofillManagerImpl(
         get() = getThirdPartyAutoFillStatusForChannel(BrowserPackage.CHROME_STABLE)
     override val betaChromeAutofillStatus: BrowserThirdPartyAutoFillData
         get() = getThirdPartyAutoFillStatusForChannel(BrowserPackage.CHROME_BETA)
+    override val stableVivaldiAutofillStatus: BrowserThirdPartyAutoFillData
+        get() = getThirdPartyAutoFillStatusForChannel(BrowserPackage.VIVALDI_STABLE)
 
     private fun getThirdPartyAutoFillStatusForChannel(
         releaseChannel: BrowserPackage,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserPackage.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserPackage.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.autofill.model.browser
 private const val BRAVE_CHANNEL_PACKAGE = "com.brave.browser"
 private const val CHROME_BETA_CHANNEL_PACKAGE = "com.chrome.beta"
 private const val CHROME_RELEASE_CHANNEL_PACKAGE = "com.android.chrome"
+private const val VIVALDI_RELEASE_CHANNEL_PACKAGE = "com.vivaldi.browser"
 
 /**
  * Enumerated values of each browser that supports third party autofill checks.
@@ -13,4 +14,5 @@ enum class BrowserPackage(val packageName: String) {
     BRAVE_RELEASE(BRAVE_CHANNEL_PACKAGE),
     CHROME_STABLE(CHROME_RELEASE_CHANNEL_PACKAGE),
     CHROME_BETA(CHROME_BETA_CHANNEL_PACKAGE),
+    VIVALDI_STABLE(VIVALDI_RELEASE_CHANNEL_PACKAGE),
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserThirdPartyAutoFillData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/model/browser/BrowserThirdPartyAutoFillData.kt
@@ -17,6 +17,7 @@ data class BrowserThirdPartyAutofillStatus(
     val braveStableStatusData: BrowserThirdPartyAutoFillData,
     val chromeStableStatusData: BrowserThirdPartyAutoFillData,
     val chromeBetaChannelStatusData: BrowserThirdPartyAutoFillData,
+    val vivaldiStableChannelStatusData: BrowserThirdPartyAutoFillData,
 ) {
     /**
      * The total number of available browsers.
@@ -24,7 +25,8 @@ data class BrowserThirdPartyAutofillStatus(
     val availableCount: Int
         get() = (if (braveStableStatusData.isAvailable) 1 else 0) +
             (if (chromeStableStatusData.isAvailable) 1 else 0) +
-            (if (chromeBetaChannelStatusData.isAvailable) 1 else 0)
+            (if (chromeBetaChannelStatusData.isAvailable) 1 else 0) +
+            (if (vivaldiStableChannelStatusData.isAvailable) 1 else 0)
 
     /**
      * Whether any of the available browsers have third party autofill disabled.
@@ -32,5 +34,6 @@ data class BrowserThirdPartyAutofillStatus(
     val isAnyIsAvailableAndDisabled: Boolean
         get() = braveStableStatusData.isAvailableButDisabled ||
             chromeStableStatusData.isAvailableButDisabled ||
-            chromeBetaChannelStatusData.isAvailableButDisabled
+            chromeBetaChannelStatusData.isAvailableButDisabled ||
+            vivaldiStableChannelStatusData.isAvailableButDisabled
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/model/BrowserAutofillSettingsOption.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/model/BrowserAutofillSettingsOption.kt
@@ -55,4 +55,17 @@ sealed class BrowserAutofillSettingsOption(val isEnabled: Boolean) : Parcelable 
         override val optionText: Text
             get() = BitwardenString.use_chrome_beta_autofill_integration.asText()
     }
+
+    /**
+     * Represents the stable Vivaldi release channel.
+     */
+    @Parcelize
+    data class VivaldiStable(
+        val enabled: Boolean,
+    ) : BrowserAutofillSettingsOption(isEnabled = enabled) {
+        override val browserPackage: BrowserPackage
+            get() = BrowserPackage.VIVALDI_STABLE
+        override val optionText: Text
+            get() = BitwardenString.use_vivaldi_autofill_integration.asText()
+    }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/util/BrowserThirdPartyAutofillStatusExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/util/BrowserThirdPartyAutofillStatusExtensions.kt
@@ -17,4 +17,7 @@ fun BrowserThirdPartyAutofillStatus.toBrowserAutoFillSettingsOptions(): Immutabl
             .takeIf { this.chromeStableStatusData.isAvailable },
         BrowserAutofillSettingsOption.ChromeBeta(chromeBetaChannelStatusData.isThirdPartyEnabled)
             .takeIf { this.chromeBetaChannelStatusData.isAvailable },
+        BrowserAutofillSettingsOption
+            .VivaldiStable(vivaldiStableChannelStatusData.isThirdPartyEnabled)
+            .takeIf { this.vivaldiStableChannelStatusData.isAvailable },
     )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerTest.kt
@@ -44,6 +44,7 @@ class AutofillActivityManagerTest {
         every { stableBraveAutofillStatus } returns DEFAULT_BROWSER_AUTOFILL_DATA
         every { stableChromeAutofillStatus } returns DEFAULT_BROWSER_AUTOFILL_DATA
         every { betaChromeAutofillStatus } returns DEFAULT_BROWSER_AUTOFILL_DATA
+        every { stableVivaldiAutofillStatus } returns DEFAULT_BROWSER_AUTOFILL_DATA
     }
 
     private val browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager =
@@ -119,4 +120,5 @@ private val DEFAULT_EXPECTED_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
     braveStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeBetaChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
+    vivaldiStableChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserAutofillDialogManagerTest.kt
@@ -76,6 +76,10 @@ class BrowserAutofillDialogManagerTest {
                 isAvailable = false,
                 isThirdPartyEnabled = false,
             ),
+            vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
+                isThirdPartyEnabled = false,
+            ),
         )
         every { autofillEnabledManager.isAutofillEnabled } returns true
         every {
@@ -104,6 +108,10 @@ class BrowserAutofillDialogManagerTest {
             chromeBetaChannelStatusData = BrowserThirdPartyAutoFillData(
                 isAvailable = true,
                 isThirdPartyEnabled = true,
+            ),
+            vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
+                isThirdPartyEnabled = false,
             ),
         )
         every { autofillEnabledManager.isAutofillEnabled } returns true
@@ -135,6 +143,10 @@ class BrowserAutofillDialogManagerTest {
             ),
             chromeBetaChannelStatusData = BrowserThirdPartyAutoFillData(
                 isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+            vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
                 isThirdPartyEnabled = false,
             ),
         )
@@ -169,6 +181,10 @@ class BrowserAutofillDialogManagerTest {
                 isAvailable = true,
                 isThirdPartyEnabled = false,
             ),
+            vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
+                isThirdPartyEnabled = false,
+            ),
         )
         every { autofillEnabledManager.isAutofillEnabled } returns true
         every {
@@ -200,6 +216,10 @@ class BrowserAutofillDialogManagerTest {
             ),
             chromeBetaChannelStatusData = BrowserThirdPartyAutoFillData(
                 isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
+            vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
                 isThirdPartyEnabled = false,
             ),
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillEnabledManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillEnabledManagerTest.kt
@@ -60,4 +60,5 @@ private val DEFAULT_EXPECTED_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
     braveStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeBetaChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
+    vivaldiStableChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FirstTimeActionManagerTest.kt
@@ -466,4 +466,5 @@ private val DEFAULT_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
     braveStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeBetaChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
+    vivaldiStableChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillViewModelTest.kt
@@ -70,6 +70,7 @@ class SetupBrowserAutofillViewModelTest {
                         BrowserAutofillSettingsOption.BraveStable(enabled = true),
                         BrowserAutofillSettingsOption.ChromeStable(enabled = false),
                         BrowserAutofillSettingsOption.ChromeBeta(enabled = false),
+                        BrowserAutofillSettingsOption.VivaldiStable(enabled = false),
                     ),
                 ),
                 awaitItem(),
@@ -85,6 +86,7 @@ class SetupBrowserAutofillViewModelTest {
                     browserAutofillSettingsOptions = persistentListOf(
                         BrowserAutofillSettingsOption.ChromeStable(enabled = false),
                         BrowserAutofillSettingsOption.ChromeBeta(enabled = false),
+                        BrowserAutofillSettingsOption.VivaldiStable(enabled = false),
                     ),
                 ),
                 awaitItem(),
@@ -233,6 +235,10 @@ private val DEFAULT_BROWSER_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
         isAvailable = true,
         isThirdPartyEnabled = false,
     ),
+    vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+        isAvailable = true,
+        isThirdPartyEnabled = false,
+    ),
 )
 
 private val DEFAULT_STATE = SetupBrowserAutofillState(
@@ -242,5 +248,6 @@ private val DEFAULT_STATE = SetupBrowserAutofillState(
         BrowserAutofillSettingsOption.BraveStable(enabled = false),
         BrowserAutofillSettingsOption.ChromeStable(enabled = false),
         BrowserAutofillSettingsOption.ChromeBeta(enabled = false),
+        BrowserAutofillSettingsOption.VivaldiStable(enabled = false),
     ),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillViewModelTest.kt
@@ -547,4 +547,5 @@ private val DEFAULT_AUTOFILL_STATUS = BrowserThirdPartyAutofillStatus(
     braveStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeStableStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
     chromeBetaChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
+    vivaldiStableChannelStatusData = DEFAULT_BROWSER_AUTOFILL_DATA,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/util/BrowserThirdPartyAutofillStatusExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/browser/util/BrowserThirdPartyAutofillStatusExtensionsTest.kt
@@ -24,6 +24,10 @@ class BrowserThirdPartyAutofillStatusExtensionsTest {
                 isAvailable = false,
                 isThirdPartyEnabled = false,
             ),
+            vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = false,
+                isThirdPartyEnabled = false,
+            ),
         )
 
         val result = browserThirdPartyAutofillStatus.toBrowserAutoFillSettingsOptions()
@@ -47,6 +51,10 @@ class BrowserThirdPartyAutofillStatusExtensionsTest {
                 isAvailable = true,
                 isThirdPartyEnabled = false,
             ),
+            vivaldiStableChannelStatusData = BrowserThirdPartyAutoFillData(
+                isAvailable = true,
+                isThirdPartyEnabled = false,
+            ),
         )
 
         val result = browserThirdPartyAutofillStatus.toBrowserAutoFillSettingsOptions()
@@ -56,6 +64,7 @@ class BrowserThirdPartyAutofillStatusExtensionsTest {
                 BrowserAutofillSettingsOption.BraveStable(enabled = false),
                 BrowserAutofillSettingsOption.ChromeStable(enabled = true),
                 BrowserAutofillSettingsOption.ChromeBeta(enabled = false),
+                BrowserAutofillSettingsOption.VivaldiStable(enabled = false),
             ),
             result,
         )

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -936,6 +936,7 @@ Do you want to switch to this account?</string>
     <string name="use_brave_autofill_integration">Use Brave autofill integration</string>
     <string name="use_chrome_autofill_integration">Use Chrome autofill integration</string>
     <string name="use_chrome_beta_autofill_integration">Use Chrome Beta autofill integration</string>
+    <string name="use_vivaldi_autofill_integration">Use Vivaldi autofill integration</string>
     <string name="improves_login_filling_for_supported_websites_on_selected_browsers">Improves login filling for supported websites on selected browsers. Once enabled, you’ll be directed to browser settings to enable third-party autofill.</string>
     <string name="show_more">Show more</string>
     <string name="no_folder">No folder</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31926](https://bitwarden.atlassian.net/browse/PM-31926)

## 📔 Objective

This PR adds the `User Vivaldi autofill integration` switch to remind users of browser specific autofill integrations.

This is identical to the UI we provide for Chrome and Brave already.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31926]: https://bitwarden.atlassian.net/browse/PM-31926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ