### PR TITLE
PM-31927: Pre-emptively patch Brave browser Autofill bug

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/parser/AutofillParserImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/parser/AutofillParserImpl.kt
@@ -33,14 +33,21 @@ private val BLOCK_LISTED_URIS: List<String> = listOf(
  * A map of package ids and the known associated id entry for their url bar.
  */
 private val URL_BARS: Map<String, String> = mapOf(
+    // Edge Browser Variants
     "com.microsoft.emmx" to "url_bar",
     "com.microsoft.emmx.beta" to "url_bar",
     "com.microsoft.emmx.canary" to "url_bar",
     "com.microsoft.emmx.dev" to "url_bar",
+    // Samsung Internet Browser Variants
     "com.sec.android.app.sbrowser" to "location_bar_edit_text",
     "com.sec.android.app.sbrowser.beta" to "location_bar_edit_text",
+    // Opera Browser Variants
     "com.opera.browser" to "url_bar",
     "com.opera.browser.beta" to "url_bar",
+    // Brave Browser Variants
+    "com.brave.browser" to "url_bar",
+    "com.brave.browser_beta" to "url_bar",
+    "com.brave.browser_nightly" to "url_bar",
 )
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31927](https://bitwarden.atlassian.net/browse/PM-31927)

## 📔 Objective

This PR patches a bug in the Brave browser where the domain data is incorrectly applied to the url bar instead of the actual field. This issue currently exists in the beta but we are applying this patch for the prod version as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31927]: https://bitwarden.atlassian.net/browse/PM-31927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ