### PR TITLE
[PM-31954] Add server communication models to ConfigResponseJson

### DIFF
--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -7710,6 +7710,7 @@ class AuthRepositoryTest {
                     ssoUrl = "mockSsoUrl",
                 ),
                 featureStates = emptyMap(),
+                communication = null,
             ),
         )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
@@ -324,5 +324,6 @@ private val SERVER_CONFIG = ServerConfig(
             "dummy-boolean" to JsonPrimitive(true),
             "flexible-collections-v-1" to JsonPrimitive(false),
         ),
+        communication = null,
     ),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/util/FakeServerConfigRepository.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/util/FakeServerConfigRepository.kt
@@ -54,5 +54,6 @@ private val SERVER_CONFIG = ServerConfig(
             "flexible-collections-v-1" to JsonPrimitive(false),
             "dummy-boolean" to JsonPrimitive(true),
         ),
+        communication = null,
     ),
 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/FeatureFlagManagerTest.kt
@@ -267,5 +267,6 @@ private val SERVER_CONFIG = ServerConfig(
             "dummy-boolean" to JsonPrimitive(true),
             "flexible-collections-v-1" to JsonPrimitive(false),
         ),
+        communication = null,
     ),
 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/repository/util/FakeServerConfigRepository.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/repository/util/FakeServerConfigRepository.kt
@@ -54,5 +54,6 @@ private val SERVER_CONFIG = ServerConfig(
             "flexible-collections-v-1" to JsonPrimitive(false),
             "dummy-boolean" to JsonPrimitive(true),
         ),
+        communication = null,
     ),
 )

--- a/data/src/test/kotlin/com/bitwarden/data/datasource/disk/ConfigDiskSourceTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/datasource/disk/ConfigDiskSourceTest.kt
@@ -111,5 +111,6 @@ private val SERVER_CONFIG = ServerConfig(
             "duo-redirect" to JsonPrimitive(true),
             "flexible-collections-v-1" to JsonPrimitive(false),
         ),
+        communication = null,
     ),
 )

--- a/data/src/test/kotlin/com/bitwarden/data/repository/ServerConfigRepositoryTest.kt
+++ b/data/src/test/kotlin/com/bitwarden/data/repository/ServerConfigRepositoryTest.kt
@@ -166,6 +166,7 @@ private val SERVER_CONFIG = ServerConfig(
             "duo-redirect" to JsonPrimitive(true),
             "flexible-collections-v-1" to JsonPrimitive(false),
         ),
+        communication = null,
     ),
 )
 
@@ -189,4 +190,5 @@ private val CONFIG_RESPONSE_JSON = ConfigResponseJson(
         "duo-redirect" to JsonPrimitive(true),
         "flexible-collections-v-1" to JsonPrimitive(false),
     ),
+    communication = null,
 )

--- a/network/src/main/kotlin/com/bitwarden/network/model/ConfigResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/ConfigResponseJson.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.JsonPrimitive
  * @property server The server information (nullable).
  * @property environment The environment information containing URLs (vault, api, identity, etc.).
  * @property featureStates A map containing various feature states.
+ * @property communication The communication configuration for server bootstrap (nullable).
  */
 @Serializable
 data class ConfigResponseJson(
@@ -33,6 +34,9 @@ data class ConfigResponseJson(
 
     @SerialName("featureStates")
     val featureStates: Map<String, JsonPrimitive>?,
+
+    @SerialName("communication")
+    val communication: CommunicationJson?,
 ) {
     /**
      * Represents a server in the configuration response.
@@ -79,4 +83,38 @@ data class ConfigResponseJson(
         @SerialName("sso")
         val ssoUrl: String?,
     )
+
+    /**
+     * Represents the communication configuration in the configuration response.
+     *
+     * @param bootstrap The bootstrap configuration for server communication (nullable).
+     */
+    @Serializable
+    data class CommunicationJson(
+        @SerialName("bootstrap")
+        val bootstrap: BootstrapJson,
+    ) {
+        /**
+         * Represents the bootstrap configuration for SSO cookie vendor authentication.
+         *
+         * @param type The type of bootstrap configuration (e.g., "ssoCookieVendor").
+         * @param idpLoginUrl The URL of the identity provider login page.
+         * @param cookieName The name of the authentication cookie.
+         * @param cookieDomain The domain for which the cookie is valid.
+         */
+        @Serializable
+        data class BootstrapJson(
+            @SerialName("type")
+            val type: String,
+
+            @SerialName("idpLoginUrl")
+            val idpLoginUrl: String?,
+
+            @SerialName("cookieName")
+            val cookieName: String?,
+
+            @SerialName("cookieDomain")
+            val cookieDomain: String?,
+        )
+    }
 }

--- a/network/src/test/kotlin/com/bitwarden/network/service/ConfigServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/ConfigServiceTest.kt
@@ -42,6 +42,14 @@ private const val CONFIG_RESPONSE_JSON = """
   },
   "featureStates": {
     "feature one": false
+  },
+  "communication": {
+    "bootstrap": {
+      "type": "ssoCookieVendor",
+      "idpLoginUrl": "https://idp.example.com/login",
+      "cookieName": "sso-cookie",
+      "cookieDomain": ".example.com"
+    }
   }
 }
 """
@@ -63,5 +71,13 @@ private val CONFIG_RESPONSE = ConfigResponseJson(
     ),
     featureStates = mapOf(
         "feature one" to JsonPrimitive(false),
+    ),
+    communication = ConfigResponseJson.CommunicationJson(
+        bootstrap = ConfigResponseJson.CommunicationJson.BootstrapJson(
+            type = "ssoCookieVendor",
+            idpLoginUrl = "https://idp.example.com/login",
+            cookieName = "sso-cookie",
+            cookieDomain = ".example.com",
+        ),
     ),
 )


### PR DESCRIPTION
## 🎟️ Tracking

PM-31954
Relates to https://github.com/bitwarden/server/pull/6892

## 📔 Objective

[PM-27124] Add server communication models to ConfigResponseJson

Introduce new data models to the `network` module for handling server communication configuration received in the `/config` endpoint response.

Specifically, adds `CommunicationJson` and its nested `BootstrapJson` class to `ConfigResponseJson` to support server-driven cookie acquisition flows.

### Specific Changes:

-   **`ConfigResponseJson.kt`**
    -   Added a new nullable property `communication: CommunicationJson?` to `ConfigResponseJson`.
    -   Defined the new serializable data class `CommunicationJson`, which contains a nullable `bootstrap: BootstrapJson?` property.
    -   Defined the nested serializable data class `BootstrapJson`, which includes properties for SSO cookie vendor authentication:
        -   `type: String`
        -   `idpLoginUrl: String?`
        -   `cookieName: String?`
        -   `cookieDomain: String?`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27124]: https://bitwarden.atlassian.net/browse/PM-27124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ