### PR TITLE
[PM-31980] Fix passkeys on some browsers by fixing JSON parsing

### DIFF
--- a/app/src/main/assets/fido2_privileged_community.json
+++ b/app/src/main/assets/fido2_privileged_community.json
@@ -24,7 +24,7 @@
           {
             "build": "release",
             "cert_fingerprint_sha256": "8F:52:6E:1E:53:D6:BD:4D:FB:F4:F4:B9:3C:2A:91:EC:B5:CB:8D:A5:E1:4A:D9:4C:25:70:E1:E3:C7:13:52:7F"
-          },
+          }
         ]
       }
     },


### PR DESCRIPTION
## 🎟️ Tracking

Closes #6463
Closes PM-31597

## 📔 Objective

Fix JSON parsing by removing comma, which caused passkeys to stop working on some browsers.

Regression introduced with #6299 (PM-30260).

Sorry if I shortcut some processes, but the fix is pretty short.

Tested on Fennec. If you close my PR to develop a long-term solution (adding some tests), I don't mind.