### PR TITLE
PM-31924: Remove the 'android.dependency.useConstraints' gradle property

### DIFF
--- a/cxf/build.gradle.kts
+++ b/cxf/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
+    implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.providerevents)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.google.hilt.android)
     ksp(libs.google.hilt.compiler)
     implementation(libs.kotlinx.serialization)
+    implementation(platform(libs.square.okhttp.bom))
     implementation(libs.square.okhttp)
     implementation(libs.timber)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 android.experimental.enableTestFixturesKotlinSupport=true
-android.dependency.useConstraints=true
 android.newDsl=false
 
 kotlin.code.style=official

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     testImplementation(libs.junit.vintage)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockk.mockk)
+    testImplementation(platform(libs.square.okhttp.bom))
     testImplementation(libs.square.okhttp.mockwebserver)
     testImplementation(libs.square.turbine)
 
@@ -71,9 +72,10 @@ dependencies {
     testFixturesImplementation(libs.junit.jupiter)
     testFixturesImplementation(libs.junit.vintage)
     testFixturesImplementation(libs.kotlinx.serialization)
+    testFixturesImplementation(platform(libs.square.okhttp.bom))
     testFixturesImplementation(libs.square.okhttp)
+    testFixturesImplementation(libs.square.okhttp.mockwebserver)
     testFixturesImplementation(platform(libs.square.retrofit.bom))
     testFixturesImplementation(libs.square.retrofit)
     testFixturesImplementation(libs.square.retrofit.kotlinx.serialization)
-    testFixturesImplementation(libs.square.okhttp.mockwebserver)
 }

--- a/ui/src/testFixtures/kotlin/com/bitwarden/ui/platform/base/BaseComposeTest.kt
+++ b/ui/src/testFixtures/kotlin/com/bitwarden/ui/platform/base/BaseComposeTest.kt
@@ -3,6 +3,7 @@ package com.bitwarden.ui.platform.base
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -16,6 +17,7 @@ abstract class BaseComposeTest : BaseRobolectricTest() {
     @OptIn(ExperimentalCoroutinesApi::class)
     protected val dispatcher = UnconfinedTestDispatcher()
 
+    @OptIn(ExperimentalTestApi::class)
     @get:Rule
     val composeTestRule = createComposeRule(effectContext = dispatcher)
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31924](https://bitwarden.atlassian.net/browse/PM-31924)

## 📔 Objective

This PR removes the `android.dependency.useConstraints` property from the `gradle.properties` file. The default value for this is `false` and should improve build times.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31924]: https://bitwarden.atlassian.net/browse/PM-31924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ