### PR TITLE
[PM-32011] Add cookie callback flow to AuthRepository

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepository.kt
@@ -34,6 +34,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
 import com.x8bit.bitwarden.data.auth.repository.model.VerifiedOrganizationDomainSsoDetailsResult
 import com.x8bit.bitwarden.data.auth.repository.model.VerifyOtpResult
+import com.x8bit.bitwarden.data.auth.repository.util.CookieCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.DuoCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.SsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
@@ -69,6 +70,12 @@ interface AuthRepository :
      * receive updates whenever [setSsoCallbackResult] is called.
      */
     val ssoCallbackResultFlow: Flow<SsoCallbackResult>
+
+    /**
+     * Flow of the current [CookieCallbackResult]. Subscribers should listen to the flow in order
+     * to receive updates whenever [setCookieCallbackResult] is called.
+     */
+    val cookieCallbackResultFlow: Flow<CookieCallbackResult>
 
     /**
      * Flow of the current [YubiKeyResult]. Subscribers should listen to the flow in order to
@@ -341,6 +348,11 @@ interface AuthRepository :
      * Set the value of [ssoCallbackResultFlow].
      */
     fun setSsoCallbackResult(result: SsoCallbackResult)
+
+    /**
+     * Set the value of [cookieCallbackResultFlow].
+     */
+    fun setCookieCallbackResult(result: CookieCallbackResult)
 
     /**
      * Get a [Boolean] indicating whether this is a known device.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -94,6 +94,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
 import com.x8bit.bitwarden.data.auth.repository.model.VerifiedOrganizationDomainSsoDetailsResult
 import com.x8bit.bitwarden.data.auth.repository.model.VerifyOtpResult
 import com.x8bit.bitwarden.data.auth.repository.model.toLoginErrorResult
+import com.x8bit.bitwarden.data.auth.repository.util.CookieCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.DuoCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.SsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
@@ -267,6 +268,10 @@ class AuthRepositoryImpl(
     private val mutableSsoCallbackResultFlow = bufferedMutableSharedFlow<SsoCallbackResult>()
     override val ssoCallbackResultFlow: Flow<SsoCallbackResult> =
         mutableSsoCallbackResultFlow.asSharedFlow()
+
+    private val mutableCookieCallbackResultFlow = bufferedMutableSharedFlow<CookieCallbackResult>()
+    override val cookieCallbackResultFlow: Flow<CookieCallbackResult> =
+        mutableCookieCallbackResultFlow.asSharedFlow()
 
     override var rememberedEmailAddress: String? by authDiskSource::rememberedEmailAddress
 
@@ -1246,6 +1251,10 @@ class AuthRepositoryImpl(
 
     override fun setSsoCallbackResult(result: SsoCallbackResult) {
         mutableSsoCallbackResultFlow.tryEmit(result)
+    }
+
+    override fun setCookieCallbackResult(result: CookieCallbackResult) {
+        mutableCookieCallbackResultFlow.tryEmit(result)
     }
 
     override suspend fun getIsKnownDevice(emailAddress: String): KnownDeviceResult =

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -119,6 +119,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
 import com.x8bit.bitwarden.data.auth.repository.model.VerifiedOrganizationDomainSsoDetailsResult
 import com.x8bit.bitwarden.data.auth.repository.model.VerifyOtpResult
 import com.x8bit.bitwarden.data.auth.repository.model.createMockOrganization
+import com.x8bit.bitwarden.data.auth.repository.util.CookieCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.DuoCallbackTokenResult
 import com.x8bit.bitwarden.data.auth.repository.util.SsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
@@ -6128,6 +6129,19 @@ class AuthRepositoryTest {
             )
             assertEquals(
                 SsoCallbackResult.Success(state = "mockk_state", code = "mockk_code"),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `setCookieCallbackResult should change the value of cookieCallbackResultFlow`() = runTest {
+        repository.cookieCallbackResultFlow.test {
+            repository.setCookieCallbackResult(
+                CookieCallbackResult.Success(cookies = mapOf("test_cookie" to "test_value")),
+            )
+            assertEquals(
+                CookieCallbackResult.Success(cookies = mapOf("test_cookie" to "test_value")),
                 awaitItem(),
             )
         }


### PR DESCRIPTION
## 🎟️ Tracking

PM-32011

## 📔 Objective

Define observable cookie callback result flow in AuthRepo. This will be used to set and listen for callback results for pending cookie acquisition.

AuthRepository Changes:
- Added cookieCallbackResultFlow: Flow<CookieCallbackResult>
- Added setCookieCallbackResult() method
- Follows existing ssoCallbackResultFlow pattern

Implementation:
- Uses bufferedMutableSharedFlow() helper
- Exposes as Flow (not StateFlow - one-time event)
- Non-blocking tryEmit() for setter

Tests:
- Added Turbine flow test
- Verifies flow emission on setCookieCallbackResult()

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
