### PR TITLE
PM-31925: Replace 'android' reference with logic in LibraryExtension

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -50,6 +50,7 @@ configure<LibraryExtension> {
     testFixtures {
         enable = true
     }
+    sourceSets["main"].res.directories.add("src/test/res")
 }
 
 dependencies {
@@ -115,8 +116,4 @@ kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvmTarget.get()))
     }
-}
-
-tasks.withType<Test>().configureEach {
-    android.sourceSets["main"].res.srcDirs("src/test/res")
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31925](https://bitwarden.atlassian.net/browse/PM-31925)

## 📔 Objective

This PR removes the last reference to the deprecated `android` variable.


[PM-31925]: https://bitwarden.atlassian.net/browse/PM-31925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ