### PR TITLE
PM-32146: Add back 'parent' param to webAuthn url

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/WebAuthUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/WebAuthUtils.kt
@@ -5,9 +5,11 @@ import android.net.Uri
 import androidx.browser.auth.AuthTabIntent
 import androidx.core.net.toUri
 import com.bitwarden.annotation.OmitFromCoverage
+import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import java.net.URLEncoder
 import java.util.Base64
 
 private val BITWARDEN_HOSTS: List<String> = listOf("bitwarden.com", "bitwarden.eu", "bitwarden.pw")
@@ -76,7 +78,7 @@ private fun Uri?.getWebAuthResult(): WebAuthResult =
 @Suppress("LongParameterList")
 fun generateUriForWebAuth(
     baseUrl: String,
-    callbackScheme: String,
+    authTabData: AuthTabData,
     data: JsonObject,
     headerText: String,
     buttonText: String,
@@ -92,12 +94,14 @@ fun generateUriForWebAuth(
     val base64Data = Base64
         .getEncoder()
         .encodeToString(json.toString().toByteArray(Charsets.UTF_8))
+    val parentParam = URLEncoder.encode(authTabData.callbackUrl, "UTF-8")
     val url = baseUrl +
         "/webauthn-mobile-connector.html" +
         "?data=$base64Data" +
+        "&parent=$parentParam" +
         "&client=mobile" +
         "&v=2" +
-        "&deeplinkScheme=$callbackScheme"
+        "&deeplinkScheme=${authTabData.callbackScheme}"
     return url.toUri()
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModel.kt
@@ -240,7 +240,7 @@ class TwoFactorLoginViewModel @Inject constructor(
                     val authTabData = environmentData.webAuthnAuthTabData
                     val uri = generateUriForWebAuth(
                         baseUrl = environmentData.baseWebVaultUrlOrDefault,
-                        callbackScheme = authTabData.callbackScheme,
+                        authTabData = authTabData,
                         data = it,
                         headerText = resourceManager.getString(
                             resId = BitwardenString.fido2_title,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/WebAuthUtilsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/util/WebAuthUtilsTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.auth.repository.util
 
 import android.content.Intent
 import android.net.Uri
+import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.json.JsonObject
@@ -15,7 +16,10 @@ class WebAuthUtilsTest {
         val baseUrl = "https://vault.bitwarden.com"
         val actualUri = generateUriForWebAuth(
             baseUrl = baseUrl,
-            callbackScheme = "https",
+            authTabData = AuthTabData.HttpsScheme(
+                host = "bitwarden.com",
+                path = "webauthn-callback",
+            ),
             data = JsonObject(emptyMap()),
             headerText = "header",
             buttonText = "button",
@@ -26,6 +30,7 @@ class WebAuthUtilsTest {
             "?data=eyJkYXRhIjoie30iLCJoZWFkZXJUZXh0IjoiaGVh" +
             "ZGVyIiwiYnRuVGV4dCI6ImJ1dHRvbiIsImJ0blJldHVybl" +
             "RleHQiOiJyZXR1cm5CdXR0b24iLCJtb2JpbGUiOnRydWV9" +
+            "&parent=https%3A%2F%2Fbitwarden.com%2Fwebauthn-callback" +
             "&client=mobile" +
             "&v=2" +
             "&deeplinkScheme=https"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginViewModelTest.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.data.repository.model.Environment
-import com.bitwarden.data.repository.util.appLinksScheme
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
 import com.bitwarden.network.model.GetTokenResponseJson
 import com.bitwarden.network.model.TwoFactorAuthMethod
@@ -23,6 +22,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.repository.util.generateUriForWebAuth
 import com.x8bit.bitwarden.data.auth.util.YubiKeyResult
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
+import com.x8bit.bitwarden.data.platform.util.webAuthnAuthTabData
 import com.x8bit.bitwarden.ui.platform.manager.resource.ResourceManager
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -504,7 +504,7 @@ class TwoFactorLoginViewModelTest : BaseViewModelTest() {
             every {
                 generateUriForWebAuth(
                     baseUrl = Environment.Us.environmentUrlData.baseWebVaultUrlOrDefault,
-                    callbackScheme = Environment.Us.environmentUrlData.appLinksScheme,
+                    authTabData = Environment.Us.environmentUrlData.webAuthnAuthTabData,
                     data = data,
                     headerText = headerText,
                     buttonText = buttonText,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32146](https://bitwarden.atlassian.net/browse/PM-32146)

## 📔 Objective

This PR adds back the `parent` param to the WebAuthn url launched into a browser. This parameter will not be needed in the future but we still need it today!

[PM-32146]: https://bitwarden.atlassian.net/browse/PM-32146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ