### PR TITLE
PM-31664: Add new SnackbarRelay type specific for the View Screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -167,7 +167,9 @@ class SearchViewModel @Inject constructor(
         snackbarRelayManager
             .getSnackbarDataFlow(
                 SnackbarRelay.CIPHER_ARCHIVED,
+                SnackbarRelay.CIPHER_ARCHIVED_VIEW,
                 SnackbarRelay.CIPHER_UNARCHIVED,
+                SnackbarRelay.CIPHER_UNARCHIVED_VIEW,
                 SnackbarRelay.CIPHER_DELETED,
                 SnackbarRelay.CIPHER_DELETED_SOFT,
                 SnackbarRelay.CIPHER_RESTORED,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/model/SnackbarRelay.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/model/SnackbarRelay.kt
@@ -10,7 +10,19 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class SnackbarRelay {
     CIPHER_ARCHIVED,
+
+    /**
+     * A separate instance of the [CIPHER_ARCHIVED] relay to avoid the View Cipher screen being
+     * both a producer and consumer of it's own event.
+     */
+    CIPHER_ARCHIVED_VIEW,
     CIPHER_UNARCHIVED,
+
+    /**
+     * A separate instance of the [CIPHER_UNARCHIVED] relay to avoid the View Cipher screen being
+     * both a producer and consumer of it's own event.
+     */
+    CIPHER_UNARCHIVED_VIEW,
     CIPHER_CREATED,
     CIPHER_DELETED,
     CIPHER_DELETED_SOFT,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -1301,7 +1301,7 @@ class VaultItemViewModel @Inject constructor(
                 updateDialogState(dialog = null)
                 snackbarRelayManager.sendSnackbarData(
                     data = BitwardenSnackbarData(BitwardenString.item_moved_to_archived.asText()),
-                    relay = SnackbarRelay.CIPHER_ARCHIVED,
+                    relay = SnackbarRelay.CIPHER_ARCHIVED_VIEW,
                 )
                 sendEvent(VaultItemEvent.NavigateBack)
             }
@@ -1325,7 +1325,7 @@ class VaultItemViewModel @Inject constructor(
                 updateDialogState(dialog = null)
                 snackbarRelayManager.sendSnackbarData(
                     data = BitwardenSnackbarData(BitwardenString.item_moved_to_vault.asText()),
-                    relay = SnackbarRelay.CIPHER_UNARCHIVED,
+                    relay = SnackbarRelay.CIPHER_UNARCHIVED_VIEW,
                 )
                 sendEvent(VaultItemEvent.NavigateBack)
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -227,7 +227,9 @@ class VaultItemListingViewModel @Inject constructor(
         snackbarRelayManager
             .getSnackbarDataFlow(
                 SnackbarRelay.CIPHER_ARCHIVED,
+                SnackbarRelay.CIPHER_ARCHIVED_VIEW,
                 SnackbarRelay.CIPHER_UNARCHIVED,
+                SnackbarRelay.CIPHER_UNARCHIVED_VIEW,
                 SnackbarRelay.CIPHER_CREATED,
                 SnackbarRelay.CIPHER_DELETED,
                 SnackbarRelay.CIPHER_DELETED_SOFT,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -201,6 +201,7 @@ class VaultViewModel @Inject constructor(
                 },
             snackbarRelayManager.getSnackbarDataFlow(
                 SnackbarRelay.CIPHER_ARCHIVED,
+                SnackbarRelay.CIPHER_ARCHIVED_VIEW,
                 SnackbarRelay.CIPHER_CREATED,
                 SnackbarRelay.CIPHER_DELETED,
                 SnackbarRelay.CIPHER_DELETED_SOFT,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -306,7 +306,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                         data = BitwardenSnackbarData(
                             message = BitwardenString.item_moved_to_archived.asText(),
                         ),
-                        relay = SnackbarRelay.CIPHER_ARCHIVED,
+                        relay = SnackbarRelay.CIPHER_ARCHIVED_VIEW,
                     )
                 }
             }
@@ -397,7 +397,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                 verify(exactly = 1) {
                     snackbarRelayManager.sendSnackbarData(
                         data = BitwardenSnackbarData(BitwardenString.item_moved_to_vault.asText()),
-                        relay = SnackbarRelay.CIPHER_UNARCHIVED,
+                        relay = SnackbarRelay.CIPHER_UNARCHIVED_VIEW,
                     )
                 }
             }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31664](https://bitwarden.atlassian.net/browse/PM-31664)

## 📔 Objective

This PR adds two new SnackbarRelay values for the archiving and unarchiving an item from the `VaultItemScreen`. This is required because when the normal relay event is sent, the `VaultItemViewModel` was consuming it right away and the subsequent screens we not getting the event. Providing it its own relay type resolves this issue.


[PM-31664]: https://bitwarden.atlassian.net/browse/PM-31664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ