### PR TITLE
[PM-32200] ci: Add workflow to enforce PR labels

### DIFF
--- a/.github/workflows/sdlc-enforce-labels.yml
+++ b/.github/workflows/sdlc-enforce-labels.yml
@@ -39,10 +39,9 @@ jobs:
         run: |
           if [ "$_PR_ACTION" = "opened" ] || [ "$_PR_ACTION" = "reopened" ]; then
             echo "⏳ Waiting 15s for labeler to run..."
-            echo "PR_LABELS: $_PR_LABELS"
             sleep 15
             _PR_LABELS=$(gh api "repos/$_REPO/pulls/$_PR_NUMBER" --jq '.labels')
-            echo "PR_LABELS: $_PR_LABELS"
+            echo "Labels fetched from PR: $_PR_LABELS"
           fi
           _IGNORE_FOR_RELEASE_LABEL=$(echo "$_PR_LABELS" | jq 'any(.[]; .name == "ignore-for-release")')
           if [ "$_IGNORE_FOR_RELEASE_LABEL" = "true" ]; then


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32200](https://bitwarden.atlassian.net/browse/PM-32200)

## 📔 Objective

Add workflow that enforces PR labeling requirements, by failing a run when:

* PRs have banned labels (hold, needs-qa).
* PRs don't have one Change Type (t:*) label, unless ignore-for-release is used.




[PM-32200]: https://bitwarden.atlassian.net/browse/PM-32200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ