### PR TITLE
[PM-32251] Decouple SDK token repository from network module

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/di/PlatformManagerModule.kt
@@ -372,12 +372,12 @@ object PlatformManagerModule {
         vaultDiskSource: VaultDiskSource,
         cookieDiskSource: CookieDiskSource,
         configDiskSource: ConfigDiskSource,
-        bitwardenServiceClient: BitwardenServiceClient,
+        authDiskSource: AuthDiskSource,
     ): SdkRepositoryFactory = SdkRepositoryFactoryImpl(
         vaultDiskSource = vaultDiskSource,
         cookieDiskSource = cookieDiskSource,
         configDiskSource = configDiskSource,
-        bitwardenServiceClient = bitwardenServiceClient,
+        authDiskSource = authDiskSource,
     )
 
     @Provides

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryImpl.kt
@@ -2,9 +2,9 @@ package com.x8bit.bitwarden.data.platform.manager.sdk
 
 import com.bitwarden.core.ClientManagedTokens
 import com.bitwarden.data.datasource.disk.ConfigDiskSource
-import com.bitwarden.network.BitwardenServiceClient
 import com.bitwarden.sdk.CipherRepository
 import com.bitwarden.sdk.ServerCommunicationConfigRepository
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.CookieDiskSource
 import com.x8bit.bitwarden.data.platform.manager.sdk.repository.SdkCipherRepository
 import com.x8bit.bitwarden.data.platform.manager.sdk.repository.SdkTokenRepository
@@ -18,7 +18,7 @@ class SdkRepositoryFactoryImpl(
     private val vaultDiskSource: VaultDiskSource,
     private val cookieDiskSource: CookieDiskSource,
     private val configDiskSource: ConfigDiskSource,
-    private val bitwardenServiceClient: BitwardenServiceClient,
+    private val authDiskSource: AuthDiskSource,
 ) : SdkRepositoryFactory {
     override fun getCipherRepository(
         userId: String,
@@ -33,7 +33,7 @@ class SdkRepositoryFactoryImpl(
     ): ClientManagedTokens =
         SdkTokenRepository(
             userId = userId,
-            tokenProvider = bitwardenServiceClient.tokenProvider,
+            authDiskSource = authDiskSource,
         )
 
     override fun getServerCommunicationConfigRepository(): ServerCommunicationConfigRepository =

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkTokenRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkTokenRepository.kt
@@ -1,15 +1,20 @@
 package com.x8bit.bitwarden.data.platform.manager.sdk.repository
 
 import com.bitwarden.core.ClientManagedTokens
-import com.bitwarden.network.provider.TokenProvider
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 
 /**
  * A user-scoped implementation of a Bitwarden SDK [ClientManagedTokens].
+ *
+ * Note: This intentionally provides the raw stored token without proactive expiration checks
+ * or refresh logic. The SDK handles automatic token refresh internally.
  */
 class SdkTokenRepository(
     private val userId: String?,
-    private val tokenProvider: TokenProvider,
+    private val authDiskSource: AuthDiskSource,
 ) : ClientManagedTokens {
     override suspend fun getAccessToken(): String? =
-        userId?.let { tokenProvider.getAccessToken(userId = it) }
+        userId?.let {
+            authDiskSource.getAccountTokens(userId = it)?.accessToken
+        }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryTests.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryTests.kt
@@ -1,10 +1,9 @@
 package com.x8bit.bitwarden.data.platform.manager.sdk
 
 import com.bitwarden.data.datasource.disk.ConfigDiskSource
-import com.bitwarden.network.BitwardenServiceClient
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.CookieDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
-import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
@@ -14,15 +13,13 @@ class SdkRepositoryFactoryTests {
     private val vaultDiskSource: VaultDiskSource = mockk()
     private val cookieDiskSource: CookieDiskSource = mockk()
     private val configDiskSource: ConfigDiskSource = mockk()
-    private val bitwardenServiceClient: BitwardenServiceClient = mockk {
-        every { tokenProvider } returns mockk()
-    }
+    private val authDiskSource: AuthDiskSource = mockk()
 
     private val sdkRepoFactory: SdkRepositoryFactory = SdkRepositoryFactoryImpl(
         vaultDiskSource = vaultDiskSource,
         cookieDiskSource = cookieDiskSource,
         configDiskSource = configDiskSource,
-        bitwardenServiceClient = bitwardenServiceClient,
+        authDiskSource = authDiskSource,
     )
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32251

## 📔 Objective

Decouple the SDK bridge layer from the `:network` module by replacing `BitwardenServiceClient.tokenProvider` with direct `AuthDiskSource` access in `SdkTokenRepository`.

Previously, `SdkRepositoryFactoryImpl` depended on `BitwardenServiceClient` solely to extract its `tokenProvider`. This created an unnecessary coupling between the SDK bridge and the entire `:network` module for a single method call. Since access tokens ultimately come from `AuthDiskSource` (encrypted disk storage), we can bypass `:network` entirely.

**Changes:**
- `SdkTokenRepository` now takes `AuthDiskSource` directly and reads `getAccountTokens(userId)?.accessToken`
- `SdkRepositoryFactoryImpl` constructor parameter changed from `BitwardenServiceClient` to `AuthDiskSource`
- `PlatformManagerModule` Hilt wiring updated accordingly
- Tests updated to mock `AuthDiskSource` instead of `TokenProvider`/`BitwardenServiceClient`