### PR TITLE
PM-32252: Update View Item date information layout

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
@@ -305,23 +305,8 @@ fun VaultItemCardContent(
             }
         }
 
-        item(key = "created") {
-            Spacer(modifier = Modifier.height(height = 16.dp))
-            Text(
-                text = commonState.created(),
-                style = BitwardenTheme.typography.bodySmall,
-                color = BitwardenTheme.colorScheme.text.secondary,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin()
-                    .padding(horizontal = 12.dp)
-                    .animateItem()
-                    .testTag("CardItemCreated"),
-            )
-        }
-
         item(key = "lastUpdated") {
-            Spacer(modifier = Modifier.height(height = 4.dp))
+            Spacer(modifier = Modifier.height(height = 16.dp))
             Text(
                 text = commonState.lastUpdated(),
                 style = BitwardenTheme.typography.bodySmall,
@@ -332,6 +317,21 @@ fun VaultItemCardContent(
                     .padding(horizontal = 12.dp)
                     .animateItem()
                     .testTag("CardItemLastUpdated"),
+            )
+        }
+
+        item(key = "created") {
+            Spacer(modifier = Modifier.height(height = 4.dp))
+            Text(
+                text = commonState.created(),
+                style = BitwardenTheme.typography.bodySmall,
+                color = BitwardenTheme.colorScheme.text.secondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .padding(horizontal = 12.dp)
+                    .animateItem()
+                    .testTag("CardItemCreated"),
             )
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
@@ -357,23 +357,8 @@ fun VaultItemIdentityContent(
             }
         }
 
-        item(key = "created") {
-            Spacer(modifier = Modifier.height(height = 16.dp))
-            Text(
-                text = commonState.created(),
-                style = BitwardenTheme.typography.bodySmall,
-                color = BitwardenTheme.colorScheme.text.secondary,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin()
-                    .padding(horizontal = 12.dp)
-                    .animateItem()
-                    .testTag("IdentityItemCreated"),
-            )
-        }
-
         item(key = "lastUpdated") {
-            Spacer(modifier = Modifier.height(height = 4.dp))
+            Spacer(modifier = Modifier.height(height = 16.dp))
             Text(
                 text = commonState.lastUpdated(),
                 style = BitwardenTheme.typography.bodySmall,
@@ -384,6 +369,21 @@ fun VaultItemIdentityContent(
                     .padding(horizontal = 12.dp)
                     .animateItem()
                     .testTag("IdentityItemLastUpdated"),
+            )
+        }
+
+        item(key = "created") {
+            Spacer(modifier = Modifier.height(height = 4.dp))
+            Text(
+                text = commonState.created(),
+                style = BitwardenTheme.typography.bodySmall,
+                color = BitwardenTheme.colorScheme.text.secondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .padding(horizontal = 12.dp)
+                    .animateItem()
+                    .testTag("IdentityItemCreated"),
             )
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
@@ -270,23 +270,8 @@ fun VaultItemLoginContent(
             }
         }
 
-        item(key = "created") {
-            Spacer(modifier = Modifier.height(height = 16.dp))
-            Text(
-                text = commonState.created(),
-                style = BitwardenTheme.typography.bodySmall,
-                color = BitwardenTheme.colorScheme.text.secondary,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin()
-                    .padding(horizontal = 12.dp)
-                    .animateItem()
-                    .testTag("LoginItemCreated"),
-            )
-        }
-
         item(key = "lastUpdated") {
-            Spacer(modifier = Modifier.height(height = 4.dp))
+            Spacer(modifier = Modifier.height(height = 16.dp))
             Text(
                 text = commonState.lastUpdated(),
                 style = BitwardenTheme.typography.bodySmall,
@@ -297,6 +282,21 @@ fun VaultItemLoginContent(
                     .padding(horizontal = 12.dp)
                     .animateItem()
                     .testTag("LoginItemLastUpdated"),
+            )
+        }
+
+        item(key = "created") {
+            Spacer(modifier = Modifier.height(height = 4.dp))
+            Text(
+                text = commonState.created(),
+                style = BitwardenTheme.typography.bodySmall,
+                color = BitwardenTheme.colorScheme.text.secondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .padding(horizontal = 12.dp)
+                    .animateItem()
+                    .testTag("LoginItemCreated"),
             )
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSecureNoteContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSecureNoteContent.kt
@@ -153,23 +153,8 @@ fun VaultItemSecureNoteContent(
             }
         }
 
-        item(key = "created") {
-            Spacer(modifier = Modifier.height(height = 16.dp))
-            Text(
-                text = commonState.created(),
-                style = BitwardenTheme.typography.bodySmall,
-                color = BitwardenTheme.colorScheme.text.secondary,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin()
-                    .padding(horizontal = 12.dp)
-                    .animateItem()
-                    .testTag("SecureNoteItemCreated"),
-            )
-        }
-
         item(key = "lastUpdated") {
-            Spacer(modifier = Modifier.height(height = 4.dp))
+            Spacer(modifier = Modifier.height(height = 16.dp))
             Text(
                 text = commonState.lastUpdated(),
                 style = BitwardenTheme.typography.bodySmall,
@@ -180,6 +165,21 @@ fun VaultItemSecureNoteContent(
                     .padding(horizontal = 12.dp)
                     .animateItem()
                     .testTag("SecureNoteItemLastUpdated"),
+            )
+        }
+
+        item(key = "created") {
+            Spacer(modifier = Modifier.height(height = 4.dp))
+            Text(
+                text = commonState.created(),
+                style = BitwardenTheme.typography.bodySmall,
+                color = BitwardenTheme.colorScheme.text.secondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .padding(horizontal = 12.dp)
+                    .animateItem()
+                    .testTag("SecureNoteItemCreated"),
             )
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSshKeyContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSshKeyContent.kt
@@ -238,23 +238,8 @@ fun VaultItemSshKeyContent(
             }
         }
 
-        item(key = "created") {
-            Spacer(modifier = Modifier.height(height = 16.dp))
-            Text(
-                text = commonState.created(),
-                style = BitwardenTheme.typography.bodySmall,
-                color = BitwardenTheme.colorScheme.text.secondary,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .standardHorizontalMargin()
-                    .padding(horizontal = 12.dp)
-                    .animateItem()
-                    .testTag("SshKeyItemCreated"),
-            )
-        }
-
         item(key = "lastUpdated") {
-            Spacer(modifier = Modifier.height(height = 4.dp))
+            Spacer(modifier = Modifier.height(height = 16.dp))
             Text(
                 text = commonState.lastUpdated(),
                 style = BitwardenTheme.typography.bodySmall,
@@ -265,6 +250,21 @@ fun VaultItemSshKeyContent(
                     .padding(horizontal = 12.dp)
                     .animateItem()
                     .testTag("SshKeyItemLastUpdated"),
+            )
+        }
+
+        item(key = "created") {
+            Spacer(modifier = Modifier.height(height = 4.dp))
+            Text(
+                text = commonState.created(),
+                style = BitwardenTheme.typography.bodySmall,
+                color = BitwardenTheme.colorScheme.text.secondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .padding(horizontal = 12.dp)
+                    .animateItem()
+                    .testTag("SshKeyItemCreated"),
             )
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/util/CipherViewExtensions.kt
@@ -140,7 +140,7 @@ fun CipherView.toViewState(
                             timeStyle = FormatStyle.SHORT,
                             clock = clock,
                         )
-                        ?.let { BitwardenString.password_last_updated.asText(it) },
+                        ?.let { BitwardenString.password_updated.asText(it) },
                     isPremiumUser = isPremiumUser,
                     canViewTotpCode = isPremiumUser || this.organizationUseTotp,
                     totpCodeItemData = totpCodeItemData,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -2558,7 +2558,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
     fun `in login state, password updated should be displayed according to state`() {
         mutableStateFlow.update { it.copy(viewState = DEFAULT_LOGIN_VIEW_STATE) }
         composeTestRule
-            .onNodeWithTextAfterScroll(text = "Password last updated: Apr 14, 1983 3:56 PM")
+            .onNodeWithTextAfterScroll(text = "Password updated: Apr 14, 1983 3:56 PM")
             .assertIsDisplayed()
 
         mutableStateFlow.update { currentState ->
@@ -2566,7 +2566,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule.assertScrollableNodeDoesNotExist(
-            text = "Password last updated: Apr 14, 1983 3:56 PM",
+            text = "Password updated: Apr 14, 1983 3:56 PM",
         )
     }
     //endregion login
@@ -3382,7 +3382,7 @@ private val DEFAULT_LOGIN: VaultItemState.ViewState.Content.ItemType.Login =
                 isLaunchable = true,
             ),
         ),
-        passwordRevisionDate = BitwardenString.password_last_updated.asText("Apr 14, 1983 3:56 PM"),
+        passwordRevisionDate = BitwardenString.password_updated.asText("Apr 14, 1983 3:56 PM"),
         isPremiumUser = true,
         totpCodeItemData = TotpCodeItemData(
             periodSeconds = 30,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -2837,7 +2837,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
                     ),
                 ),
                 passwordRevisionDate = BitwardenString
-                    .password_last_updated
+                    .password_updated
                     .asText("12/31/69 06:16 PM"),
                 isPremiumUser = true,
                 totpCodeItemData = TotpCodeItemData(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/util/VaultItemTestUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/util/VaultItemTestUtil.kt
@@ -276,7 +276,7 @@ fun createLoginContent(isEmpty: Boolean): VaultItemState.ViewState.Content.ItemT
                 ),
             )
         },
-        passwordRevisionDate = BitwardenString.password_last_updated
+        passwordRevisionDate = BitwardenString.password_updated
             .asText("Jan 1, 1970, 12:16\u202FAM")
             .takeUnless { isEmpty },
         isPremiumUser = true,

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -303,7 +303,7 @@ Scanning will happen automatically.</string>
     <string name="organization">Organization</string>
     <string name="try_again">Try again</string>
     <string name="created">Created: %1$s</string>
-    <string name="password_last_updated">Password last updated: %1$s</string>
+    <string name="password_updated">Password updated: %1$s</string>
     <string name="last_edited">Last edited: %1$s</string>
     <string name="invalid_email">Invalid email address.</string>
     <string name="cards">Cards</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32252](https://bitwarden.atlassian.net/browse/PM-32252)

## 📔 Objective

This PR updates the order in which we display the date information on the View Item Screen. Additionally, the `Password last updated` has been changed to `Password updated`.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/cde8865b-38a3-4f06-9ac0-30fef7eba996" /> | <img width="350" src="https://github.com/user-attachments/assets/afe7e28e-d441-4112-8c44-70180604a1ee" /> |


[PM-32252]: https://bitwarden.atlassian.net/browse/PM-32252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ