### PR TITLE
PM-32353: Archive and Unarchive buttons should honor MP reprompt

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
@@ -190,7 +190,7 @@ sealed class ListingItemOverflowAction : Parcelable {
         @Parcelize
         data class ArchiveClick(val cipherId: String) : VaultAction() {
             override val title: Text get() = BitwardenString.archive_verb.asText()
-            override val requiresPasswordReprompt: Boolean get() = false
+            override val requiresPasswordReprompt: Boolean get() = true
         }
 
         /**
@@ -199,7 +199,7 @@ sealed class ListingItemOverflowAction : Parcelable {
         @Parcelize
         data class UnarchiveClick(val cipherId: String) : VaultAction() {
             override val title: Text get() = BitwardenString.unarchive.asText()
-            override val requiresPasswordReprompt: Boolean get() = false
+            override val requiresPasswordReprompt: Boolean get() = true
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32353](https://bitwarden.atlassian.net/browse/PM-32353)

## 📔 Objective

This PR updates the Archive and Unarchive overflow menu items to prompt the user for a master password if the MP re-prompt feature is enabled for that specific cipher.


[PM-32353]: https://bitwarden.atlassian.net/browse/PM-32353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ