### PR TITLE
PM-32354: Filter out archived items from CXP

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModel.kt
@@ -94,7 +94,7 @@ class ReviewExportViewModel @Inject constructor(
                                 .value
                                 .data
                                 ?.successes
-                                ?.filter { it.deletedDate == null }
+                                ?.filter { it.deletedDate == null && it.archivedDate == null }
                                 .filterRestrictedItemsIfNecessary(),
                         )
                         .fold(
@@ -241,7 +241,7 @@ class ReviewExportViewModel @Inject constructor(
         var secureNoteItemCount = 0
         this@toItemTypeCounts
             ?.successes
-            ?.filter { it.deletedDate == null }
+            ?.filter { it.deletedDate == null && it.archivedDate == null }
             .orEmpty()
             .forEach {
                 when {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportViewModelTest.kt
@@ -120,6 +120,10 @@ class ReviewExportViewModelTest : BaseViewModelTest() {
                     number = 1,
                     isDeleted = true,
                 )
+                val mockArchivedCipherListView = createMockCipherListView(
+                    number = 1,
+                    isArchived = true,
+                )
                 decryptCipherListResultFlow.tryEmit(
                     DataState.Loaded(
                         createMockDecryptCipherListResult(
@@ -128,6 +132,7 @@ class ReviewExportViewModelTest : BaseViewModelTest() {
                                 mockActiveLoginCipherListView,
                                 mockActiveCardCipherListView,
                                 mockDeletedCipherListView,
+                                mockArchivedCipherListView,
                             ),
                         ),
                     ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32354](https://bitwarden.atlassian.net/browse/PM-32354)

## 📔 Objective

This PR filters out archived items when using CXP to export your vault. Filte exports still include archived items by design.


[PM-32354]: https://bitwarden.atlassian.net/browse/PM-32354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ