### PR TITLE
PM-30892: Fix radio button spacing

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -865,7 +865,9 @@ private fun OwnerSelectionBottomSheetContent(
                     text = option,
                     color = BitwardenTheme.colorScheme.text.primary,
                     style = BitwardenTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(horizontal = 16.dp),
+                    modifier = Modifier
+                        .weight(weight = 1f)
+                        .padding(horizontal = 16.dp),
                 )
                 BitwardenRadioButton(
                     isSelected = selectedOption == option,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30892](https://bitwarden.atlassian.net/browse/PM-30892)

## 📔 Objective

This PR fixes the spacing between the text and the radio button when selecting a organization for a new cipher.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/e1107295-5fd2-42e1-bc22-884afeee20d2" /> | <img width="350" src="https://github.com/user-attachments/assets/d17dc90f-0040-404a-8329-9491d678a61f" /> |


[PM-30892]: https://bitwarden.atlassian.net/browse/PM-30892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ