### PR TITLE
PM-29866: Remove redundant content description in icon buttons

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenFilledIconButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenFilledIconButton.kt
@@ -40,7 +40,7 @@ fun BitwardenFilledIconButton(
     ) {
         Icon(
             painter = rememberVectorPainter(id = vectorIconRes),
-            contentDescription = contentDescription,
+            contentDescription = null,
         )
     }
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenStandardIconButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenStandardIconButton.kt
@@ -71,7 +71,7 @@ fun BitwardenStandardIconButton(
     ) {
         Icon(
             painter = painter,
-            contentDescription = contentDescription,
+            contentDescription = null,
         )
     }
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenTonalIconButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenTonalIconButton.kt
@@ -40,7 +40,7 @@ fun BitwardenTonalIconButton(
     ) {
         Icon(
             painter = rememberVectorPainter(id = vectorIconRes),
-            contentDescription = contentDescription,
+            contentDescription = null,
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29866](https://bitwarden.atlassian.net/browse/PM-29866)

## 📔 Objective

This PR removes the duplicate announcement of the content description on all icon buttons.


[PM-29866]: https://bitwarden.atlassian.net/browse/PM-29866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ