### PR TITLE
PM-32607: Label headers for accesibility

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/header/BitwardenExpandingHeader.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/header/BitwardenExpandingHeader.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
@@ -60,7 +61,7 @@ fun BitwardenExpandingHeader(
             .minimumInteractiveComponentSize()
             .padding(horizontal = 16.dp)
             .padding(paddingValues = insets)
-            .semantics(mergeDescendants = true) {},
+            .semantics(mergeDescendants = true) { heading() },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Crossfade(

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/header/BitwardenListHeaderText.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/header/BitwardenListHeaderText.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 
@@ -25,7 +27,7 @@ fun BitwardenListHeaderText(
         text = "${label.uppercase()}$supportLabel",
         style = BitwardenTheme.typography.eyebrowMedium,
         color = BitwardenTheme.colorScheme.text.secondary,
-        modifier = modifier,
+        modifier = modifier.semantics { heading() },
     )
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32607](https://bitwarden.atlassian.net/browse/PM-32607)

## 📔 Objective

This PR adds the `heading()` semantic modifier to the `BitwardenExpandingHeader` and `BitwardenListHeaderText` to improve navigation when using TalkBack.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/4cd0f0d5-e2ce-45a7-99e6-326dca714b32" width="350" />


[PM-32607]: https://bitwarden.atlassian.net/browse/PM-32607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ