### PR TITLE
PM-31772: Simplify origin for verified sources

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensions.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.platform.util
 
 import android.util.Base64
 import androidx.credentials.provider.CallingAppInfo
+import com.bitwarden.ui.platform.base.util.prefixHttpsIfNecessary
 import com.x8bit.bitwarden.data.credentials.model.ValidateOriginResult
 import java.security.MessageDigest
 
@@ -21,8 +22,11 @@ fun CallingAppInfo.getSignatureFingerprintAsHexString(): String? {
  * Returns true if this [CallingAppInfo] is present in the privileged app [allowList]. Otherwise,
  * returns false.
  */
-fun CallingAppInfo.validatePrivilegedApp(allowList: String): ValidateOriginResult {
-
+fun CallingAppInfo.validatePrivilegedApp(
+    relyingPartyId: String,
+    allowList: String,
+    isVerifiedSource: Boolean,
+): ValidateOriginResult {
     if (!allowList.contains("\"$packageName\"")) {
         return ValidateOriginResult.Error.PrivilegedAppNotAllowed
     }
@@ -32,7 +36,15 @@ fun CallingAppInfo.validatePrivilegedApp(allowList: String): ValidateOriginResul
         if (origin.isNullOrEmpty()) {
             ValidateOriginResult.Error.PasskeyNotSupportedForApp
         } else {
-            ValidateOriginResult.Success(origin)
+            ValidateOriginResult.Success(
+                origin = if (isVerifiedSource) {
+                    // For verified sources we simplify the `origin` before passing it to the SDK
+                    // in order to trivially match the Relying Party ID.
+                    relyingPartyId.prefixHttpsIfNecessary()
+                } else {
+                    origin
+                },
+            )
         }
     } catch (_: IllegalStateException) {
         // We know the package name is in the allow list so we can infer that this exception is

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/manager/OriginManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/credentials/manager/OriginManagerTest.kt
@@ -85,7 +85,7 @@ class OriginManagerTest {
                 mockAssetManager.readAsset(GOOGLE_ALLOW_LIST_FILENAME)
             }
             assertEquals(
-                ValidateOriginResult.Success(DEFAULT_ORIGIN),
+                ValidateOriginResult.Success("https://$DEFAULT_ORIGIN"),
                 result,
             )
         }
@@ -139,7 +139,7 @@ class OriginManagerTest {
                 mockPrivilegedAppRepository.getUserTrustedAllowListJson()
             }
             assertEquals(
-                ValidateOriginResult.Success(DEFAULT_ORIGIN),
+                ValidateOriginResult.Success("https://$DEFAULT_ORIGIN"),
                 result,
             )
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/util/CallingAppInfoExtensionsTest.kt
@@ -72,8 +72,9 @@ class CallingAppInfoExtensionsTest {
         assertNull(appInfo.getSignatureFingerprintAsHexString())
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `validatePrivilegedApp should return Success when privileged app is allowed`() {
+    fun `validatePrivilegedApp should return Success with raw origin when privileged app is allowed from non-verified source`() {
         val mockAppInfo = mockk<CallingAppInfo> {
             every { getOrigin(any()) } returns "origin"
             every { packageName } returns "com.x8bit.bitwarden"
@@ -83,6 +84,27 @@ class CallingAppInfoExtensionsTest {
             ValidateOriginResult.Success("origin"),
             mockAppInfo.validatePrivilegedApp(
                 allowList = DEFAULT_ALLOW_LIST,
+                relyingPartyId = "relying_party_id",
+                isVerifiedSource = false,
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `validatePrivilegedApp should return Success with modified origin when privileged app is allowed from verified source`() {
+        val relyingPartyId = "relying_party_id"
+        val mockAppInfo = mockk<CallingAppInfo> {
+            every { getOrigin(any()) } returns "origin"
+            every { packageName } returns "com.x8bit.bitwarden"
+        }
+
+        assertEquals(
+            ValidateOriginResult.Success("https://$relyingPartyId"),
+            mockAppInfo.validatePrivilegedApp(
+                allowList = DEFAULT_ALLOW_LIST,
+                relyingPartyId = relyingPartyId,
+                isVerifiedSource = true,
             ),
         )
     }
@@ -99,6 +121,8 @@ class CallingAppInfoExtensionsTest {
             ValidateOriginResult.Error.PasskeyNotSupportedForApp,
             appInfo.validatePrivilegedApp(
                 allowList = INVALID_ALLOW_LIST,
+                relyingPartyId = "relying_party_id",
+                isVerifiedSource = false,
             ),
         )
     }
@@ -115,6 +139,8 @@ class CallingAppInfoExtensionsTest {
             ValidateOriginResult.Error.PrivilegedAppSignatureNotFound,
             appInfo.validatePrivilegedApp(
                 allowList = INVALID_ALLOW_LIST,
+                relyingPartyId = "relying_party_id",
+                isVerifiedSource = true,
             ),
         )
     }
@@ -131,6 +157,8 @@ class CallingAppInfoExtensionsTest {
             ValidateOriginResult.Error.PrivilegedAppNotAllowed,
             appInfo.validatePrivilegedApp(
                 allowList = DEFAULT_ALLOW_LIST,
+                relyingPartyId = "relying_party_id",
+                isVerifiedSource = false,
             ),
         )
     }
@@ -144,7 +172,11 @@ class CallingAppInfoExtensionsTest {
 
         assertEquals(
             ValidateOriginResult.Error.PasskeyNotSupportedForApp,
-            appInfo.validatePrivilegedApp(DEFAULT_ALLOW_LIST),
+            appInfo.validatePrivilegedApp(
+                allowList = DEFAULT_ALLOW_LIST,
+                relyingPartyId = "relying_party_id",
+                isVerifiedSource = false,
+            ),
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31772](https://bitwarden.atlassian.net/browse/PM-31772)

## 📔 Objective

This PR simplifies the origin passed to the SDK when the request comes from a verified web source. Currently only sources in the `fido2_privileged_google.json` file and user approved sources are considered verified.


[PM-31772]: https://bitwarden.atlassian.net/browse/PM-31772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ