### PR TITLE
[PM-32751] ci: Fix version name output in run summary

### DIFF
--- a/.github/scripts/set-build-version.sh
+++ b/.github/scripts/set-build-version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs fastlane setBuildVersionInfo and appends Version Name/Number to GITHUB_STEP_SUMMARY.
+# Usage: set-build-version.sh <version_code> [version_name] [toml_path]
+
+VERSION_CODE="${1:?Usage: $0 <version_code> [version_name] [toml_path]}"
+VERSION_NAME="${2:-}"
+TOML_FILE="${3:-gradle/libs.versions.toml}"
+
+bundle exec fastlane setBuildVersionInfo \
+  versionCode:"$VERSION_CODE" \
+  versionName:"$VERSION_NAME"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    VERSION_NAME=""
+    regex='appVersionName = "([^"]+)"'
+    if [[ "$(cat "$TOML_FILE")" =~ $regex ]]; then
+        VERSION_NAME="${BASH_REMATCH[1]}"
+    fi
+    echo "Version Name: ${VERSION_NAME}" >> "$GITHUB_STEP_SUMMARY"
+    echo "Version Number: $VERSION_CODE" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/workflows/build-authenticator.yml
+++ b/.github/workflows/build-authenticator.yml
@@ -242,22 +242,9 @@ jobs:
 
       - name: Increment version
         env:
-          DEFAULT_VERSION_CODE: ${{ github.run_number }}
-          INPUT_VERSION_CODE: "${{ needs.version.outputs.version_number }}"
-          INPUT_VERSION_NAME: ${{ needs.version.outputs.version_name }}
-        run: |
-          VERSION_CODE="${INPUT_VERSION_CODE:-$DEFAULT_VERSION_CODE}"
-          VERSION_NAME_INPUT="${INPUT_VERSION_NAME:-}"
-          bundle exec fastlane setBuildVersionInfo \
-          versionCode:"$VERSION_CODE" \
-          versionName:"$VERSION_NAME_INPUT"
-
-          regex='appVersionName = "([^"]+)"'
-          if [[ "$(cat gradle/libs.versions.toml)" =~ $regex ]]; then
-            VERSION_NAME="${BASH_REMATCH[1]}"
-          fi
-          echo "Version Name: ${VERSION_NAME}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Version Number: $VERSION_CODE" >> "$GITHUB_STEP_SUMMARY"
+          VERSION_CODE: ${{ needs.version.outputs.version_number || github.run_number }}
+          VERSION_NAME: ${{ needs.version.outputs.version_name }}
+        run: ./.github/scripts/set-build-version.sh "$VERSION_CODE" "$VERSION_NAME"
 
       - name: Generate release Play Store bundle
         if: ${{ matrix.variant == 'aab' }}

--- a/.github/workflows/build-testharness.yml
+++ b/.github/workflows/build-testharness.yml
@@ -94,22 +94,9 @@ jobs:
 
       - name: Increment version
         env:
-          DEFAULT_VERSION_CODE: ${{ github.run_number }}
-          INPUT_VERSION_CODE: "${{ needs.version.outputs.version_number }}"
-          INPUT_VERSION_NAME: ${{ needs.version.outputs.version_name }}
-        run: |
-          VERSION_CODE="${INPUT_VERSION_CODE:-$DEFAULT_VERSION_CODE}"
-          VERSION_NAME_INPUT="${INPUT_VERSION_NAME:-}"
-          bundle exec fastlane setBuildVersionInfo \
-          versionCode:"$VERSION_CODE" \
-          versionName:"$VERSION_NAME_INPUT"
-
-          regex='appVersionName = "(.+)"'
-          if [[ "$(cat gradle/libs.versions.toml)" =~ $regex ]]; then
-            VERSION_NAME="${BASH_REMATCH[1]}"
-          fi
-          echo "Version Name: ${VERSION_NAME}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Version Number: $VERSION_CODE" >> "$GITHUB_STEP_SUMMARY"
+          VERSION_CODE: ${{ needs.version.outputs.version_number || github.run_number }}
+          VERSION_NAME: ${{ needs.version.outputs.version_name }}
+        run: ./.github/scripts/set-build-version.sh "$VERSION_CODE" "$VERSION_NAME"
 
       - name: Build Test Harness Debug APK
         run: ./gradlew :testharness:assembleDebug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,13 +238,9 @@ jobs:
 
       - name: Increment version
         env:
-          VERSION_CODE: ${{ needs.version.outputs.version_number }}
+          VERSION_CODE: ${{ needs.version.outputs.version_number || github.run_number }}
           VERSION_NAME: ${{ needs.version.outputs.version_name }}
-        run: |
-          VERSION_CODE="${VERSION_CODE:-$GITHUB_RUN_NUMBER}"
-          bundle exec fastlane setBuildVersionInfo \
-          versionCode:$VERSION_CODE \
-          versionName:$VERSION_NAME
+        run: ./.github/scripts/set-build-version.sh "$VERSION_CODE" "$VERSION_NAME"
 
       - name: Generate release Play Store bundle
         if: ${{ matrix.variant == 'prod' && matrix.artifact == 'aab' }}
@@ -542,20 +538,9 @@ jobs:
 
       - name: Increment version
         env:
-          VERSION_CODE: ${{ needs.version.outputs.version_number }}
+          VERSION_CODE: ${{ needs.version.outputs.version_number || github.run_number }}
           VERSION_NAME: ${{ needs.version.outputs.version_name }}
-        run: |
-          VERSION_CODE="${VERSION_CODE:-$GITHUB_RUN_NUMBER}"
-          bundle exec fastlane setBuildVersionInfo \
-          versionCode:$VERSION_CODE \
-          versionName:$VERSION_NAME
-
-          regex='appVersionName = "([^"]+)"'
-          if [[ "$(cat gradle/libs.versions.toml)" =~ $regex ]]; then
-            VERSION_NAME="${BASH_REMATCH[1]}"
-          fi
-          echo "Version Name: ${VERSION_NAME}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Version Number: $VERSION_CODE" >> "$GITHUB_STEP_SUMMARY"
+        run: ./.github/scripts/set-build-version.sh "$VERSION_CODE" "$VERSION_NAME"
       - name: Generate F-Droid artifacts
         env:
           FDROID_STORE_PASSWORD: ${{ steps.get-kv-secrets.outputs.FDROID-KEYSTORE-PASSWORD }}


### PR DESCRIPTION
## 🎟️ Tracking

PM-32751

## 📔 Objective

While testing other work I noticed the build workflows were unintentionally listing most of the content of libs.versions.toml. Took the time to move this bit to a script so it can be reused in other places, mitigating regexp differences between them.
