### PR TITLE
BWA-235: Update Authenticator to use state-based navigation for top-level navigation

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/auth/repository/AuthRepository.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/auth/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.bitwarden.authenticator.data.auth.repository
 
 import com.bitwarden.authenticator.data.platform.manager.BiometricsEncryptionManager
+import com.bitwarden.authenticator.data.platform.manager.lock.model.AppLockState
 import com.bitwarden.authenticator.data.platform.repository.model.BiometricsKeyResult
 import com.bitwarden.authenticator.data.platform.repository.model.BiometricsUnlockResult
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +21,11 @@ interface AuthRepository : BiometricsEncryptionManager {
      * Tracks whether or not biometric unlocking is enabled for the current user.
      */
     val isUnlockWithBiometricsEnabledFlow: StateFlow<Boolean>
+
+    /**
+     * Tracks the current state of the app lock.
+     */
+    val appLockStateFlow: StateFlow<AppLockState>
 
     /**
      * Stores the encrypted user key for biometrics, allowing it to be used to unlock the current

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/auth/repository/di/AuthRepositoryModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/auth/repository/di/AuthRepositoryModule.kt
@@ -5,6 +5,7 @@ import com.bitwarden.authenticator.data.auth.repository.AuthRepository
 import com.bitwarden.authenticator.data.auth.repository.AuthRepositoryImpl
 import com.bitwarden.authenticator.data.authenticator.datasource.sdk.AuthenticatorSdkSource
 import com.bitwarden.authenticator.data.platform.manager.BiometricsEncryptionManager
+import com.bitwarden.authenticator.data.platform.manager.lock.AppLockManager
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.manager.realtime.RealtimeManager
 import dagger.Module
@@ -26,11 +27,13 @@ object AuthRepositoryModule {
         biometricsEncryptionManager: BiometricsEncryptionManager,
         realtimeManager: RealtimeManager,
         dispatcherManager: DispatcherManager,
+        appLockManager: AppLockManager,
     ): AuthRepository = AuthRepositoryImpl(
         authDiskSource = authDiskSource,
         authenticatorSdkSource = authenticatorSdkSource,
         biometricsEncryptionManager = biometricsEncryptionManager,
         realtimeManager = realtimeManager,
         dispatcherManager = dispatcherManager,
+        appLockManager = appLockManager,
     )
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/di/PlatformManagerModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/di/PlatformManagerModule.kt
@@ -19,6 +19,8 @@ import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClip
 import com.bitwarden.authenticator.data.platform.manager.clipboard.BitwardenClipboardManagerImpl
 import com.bitwarden.authenticator.data.platform.manager.imports.ImportManager
 import com.bitwarden.authenticator.data.platform.manager.imports.ImportManagerImpl
+import com.bitwarden.authenticator.data.platform.manager.lock.AppLockManager
+import com.bitwarden.authenticator.data.platform.manager.lock.AppLockManagerImpl
 import com.bitwarden.authenticator.data.platform.repository.DebugMenuRepository
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.core.data.manager.UuidManager
@@ -43,6 +45,16 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object PlatformManagerModule {
+
+    @Provides
+    @Singleton
+    fun provideAppLockManager(
+        authDiskSource: AuthDiskSource,
+        dispatcherManager: DispatcherManager,
+    ): AppLockManager = AppLockManagerImpl(
+        authDiskSource = authDiskSource,
+        dispatcherManager = dispatcherManager,
+    )
 
     @Provides
     @Singleton

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/lock/AppLockManager.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/lock/AppLockManager.kt
@@ -1,0 +1,19 @@
+package com.bitwarden.authenticator.data.platform.manager.lock
+
+import com.bitwarden.authenticator.data.platform.manager.lock.model.AppLockState
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Provides an API for handling the app's lock state.
+ */
+interface AppLockManager {
+    /**
+     * Tracks the current state of the app lock.
+     */
+    val appLockStateFlow: StateFlow<AppLockState>
+
+    /**
+     * Performs a manual app unlock.
+     */
+    fun manualAppUnlock()
+}

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/lock/AppLockManagerImpl.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/lock/AppLockManagerImpl.kt
@@ -1,0 +1,61 @@
+package com.bitwarden.authenticator.data.platform.manager.lock
+
+import com.bitwarden.authenticator.data.auth.datasource.disk.AuthDiskSource
+import com.bitwarden.authenticator.data.platform.manager.lock.model.AppLockState
+import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+
+/**
+ * The default implementation of the [AppLockManager].
+ */
+internal class AppLockManagerImpl(
+    authDiskSource: AuthDiskSource,
+    dispatcherManager: DispatcherManager,
+) : AppLockManager {
+    private val unconfinedScope: CoroutineScope = CoroutineScope(dispatcherManager.unconfined)
+
+    private val internalHasUserUnlocked: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    override val appLockStateFlow: StateFlow<AppLockState> = combine(
+        internalHasUserUnlocked,
+        authDiskSource.userBiometricUnlockKeyFlow,
+    ) { hasUserUnlocked, userBiometricUnlockKey ->
+        getAppLockState(
+            hasUserUnlocked = hasUserUnlocked,
+            userBiometricUnlockKey = userBiometricUnlockKey,
+        )
+    }
+        .stateIn(
+            scope = unconfinedScope,
+            started = SharingStarted.Eagerly,
+            initialValue = getAppLockState(
+                hasUserUnlocked = internalHasUserUnlocked.value,
+                userBiometricUnlockKey = authDiskSource.getUserBiometricUnlockKey(),
+            ),
+        )
+
+    override fun manualAppUnlock() {
+        internalHasUserUnlocked.update { true }
+    }
+
+    private fun getAppLockState(
+        hasUserUnlocked: Boolean,
+        userBiometricUnlockKey: String?,
+    ): AppLockState =
+        if (hasUserUnlocked) {
+            // The user has manually unlocked, so we are unlocked.
+            AppLockState.UNLOCKED
+        } else if (userBiometricUnlockKey != null) {
+            // The user has not yet manually unlocked and we have a biometric key so we are locked.
+            AppLockState.LOCKED
+        } else {
+            // The user has not yet setup biometrics, so we cannot be locked.
+            AppLockState.UNLOCKED
+        }
+}

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/lock/model/AppLockState.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/manager/lock/model/AppLockState.kt
@@ -1,0 +1,9 @@
+package com.bitwarden.authenticator.data.platform.manager.lock.model
+
+/**
+ * An enum indicating representing the app's lock state.
+ */
+enum class AppLockState {
+    LOCKED,
+    UNLOCKED,
+}

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockNavigation.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockNavigation.kt
@@ -24,10 +24,8 @@ fun NavController.navigateToUnlock(
 /**
  * Add the unlock screen to the nav graph.
  */
-fun NavGraphBuilder.unlockDestination(
-    onUnlocked: () -> Unit,
-) {
+fun NavGraphBuilder.unlockDestination() {
     composable<UnlockRoute> {
-        UnlockScreen(onUnlocked = onUnlocked)
+        UnlockScreen()
     }
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
@@ -41,7 +41,6 @@ import javax.crypto.Cipher
 fun UnlockScreen(
     viewModel: UnlockViewModel = hiltViewModel(),
     biometricsManager: BiometricsManager = LocalBiometricsManager.current,
-    onUnlocked: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
@@ -54,7 +53,6 @@ fun UnlockScreen(
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
-            UnlockEvent.NavigateToItemListing -> onUnlocked()
             is UnlockEvent.PromptForBiometrics -> {
                 biometricsManager.promptBiometrics(
                     onSuccess = onBiometricsUnlockSuccess,

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockViewModel.kt
@@ -97,7 +97,7 @@ class UnlockViewModel @Inject constructor(
 
             BiometricsUnlockResult.Success -> {
                 mutableStateFlow.update { it.copy(dialog = null) }
-                sendEvent(UnlockEvent.NavigateToItemListing)
+                // State-based navigation will take it from here.
             }
         }
     }
@@ -182,11 +182,6 @@ sealed class UnlockEvent {
      * Prompts the user for biometrics unlock.
      */
     data class PromptForBiometrics(val cipher: Cipher) : UnlockEvent(), BackgroundEvent
-
-    /**
-     * Navigates to the item listing screen.
-     */
-    data object NavigateToItemListing : UnlockEvent()
 }
 
 /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -83,16 +83,8 @@ fun RootNavScreen(
         popExitTransition = { toExitTransition()(this) },
     ) {
         splashDestination()
-        tutorialDestination(
-            onTutorialFinished = {
-                viewModel.trySendAction(RootNavAction.Internal.TutorialFinished)
-            },
-        )
-        unlockDestination(
-            onUnlocked = {
-                viewModel.trySendAction(RootNavAction.Internal.AppUnlocked)
-            },
-        )
+        tutorialDestination()
+        unlockDestination()
         authenticatorGraph(navController = navController)
     }
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -3,14 +3,14 @@ package com.bitwarden.authenticator.ui.platform.feature.rootnav
 import android.os.Parcelable
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.authenticator.data.auth.repository.AuthRepository
+import com.bitwarden.authenticator.data.platform.manager.lock.model.AppLockState
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.ui.platform.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
@@ -20,48 +20,37 @@ import javax.inject.Inject
 @HiltViewModel
 class RootNavViewModel @Inject constructor(
     private val authRepository: AuthRepository,
-    private val settingsRepository: SettingsRepository,
+    settingsRepository: SettingsRepository,
 ) : BaseViewModel<RootNavState, Unit, RootNavAction>(
     initialState = RootNavState(
-        hasSeenWelcomeGuide = settingsRepository.hasSeenWelcomeTutorial,
         navState = RootNavState.NavState.Splash,
     ),
 ) {
-
     init {
-        viewModelScope.launch {
-            settingsRepository.hasSeenWelcomeTutorialFlow
-                .map { RootNavAction.Internal.HasSeenWelcomeTutorialChange(it) }
-                .onEach(::sendAction)
-                .launchIn(viewModelScope)
+        combine(
+            authRepository.appLockStateFlow,
+            settingsRepository.hasSeenWelcomeTutorialFlow,
+        ) { appLockState, hasSeenWelcomeTutorial ->
+            RootNavAction.Internal.StateReceived(
+                appLockState = appLockState,
+                hasSeenWelcomeTutorial = hasSeenWelcomeTutorial,
+            )
         }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
     }
 
     override fun handleAction(action: RootNavAction) {
         when (action) {
-            RootNavAction.BackStackUpdate -> {
-                handleBackStackUpdate()
-            }
+            RootNavAction.BackStackUpdate -> handleBackStackUpdate()
+            is RootNavAction.BiometricSupportChanged -> handleBiometricSupportChanged(action)
+            is RootNavAction.Internal -> handleInternalAction(action)
+        }
+    }
 
-            is RootNavAction.Internal.HasSeenWelcomeTutorialChange -> {
-                handleHasSeenWelcomeTutorialChange(action)
-            }
-
-            RootNavAction.Internal.TutorialFinished -> {
-                handleTutorialFinished()
-            }
-
-            RootNavAction.Internal.SplashScreenDismissed -> {
-                handleSplashScreenDismissed()
-            }
-
-            RootNavAction.Internal.AppUnlocked -> {
-                handleAppUnlocked()
-            }
-
-            is RootNavAction.BiometricSupportChanged -> {
-                handleBiometricSupportChanged(action)
-            }
+    private fun handleInternalAction(action: RootNavAction.Internal) {
+        when (action) {
+            is RootNavAction.Internal.StateReceived -> handleStateReceived(action)
         }
     }
 
@@ -69,65 +58,35 @@ class RootNavViewModel @Inject constructor(
         authRepository.updateLastActiveTime()
     }
 
-    private fun handleHasSeenWelcomeTutorialChange(
-        action: RootNavAction.Internal.HasSeenWelcomeTutorialChange,
-    ) {
-        settingsRepository.hasSeenWelcomeTutorial = action.hasSeenWelcomeGuide
-        if (action.hasSeenWelcomeGuide) {
-            if (authRepository.isUnlockWithBiometricsEnabled &&
-                authRepository.isBiometricIntegrityValid()
-            ) {
-                mutableStateFlow.update { it.copy(navState = RootNavState.NavState.Locked) }
-            } else {
-                mutableStateFlow.update { it.copy(navState = RootNavState.NavState.Unlocked) }
-            }
-        } else {
-            mutableStateFlow.update { it.copy(navState = RootNavState.NavState.Tutorial) }
-        }
-    }
-
-    private fun handleTutorialFinished() {
-        settingsRepository.hasSeenWelcomeTutorial = true
-        mutableStateFlow.update { it.copy(navState = RootNavState.NavState.Unlocked) }
-    }
-
-    private fun handleSplashScreenDismissed() {
-        if (settingsRepository.hasSeenWelcomeTutorial) {
-            mutableStateFlow.update { it.copy(navState = RootNavState.NavState.Unlocked) }
-        } else {
-            mutableStateFlow.update { it.copy(navState = RootNavState.NavState.Tutorial) }
-        }
-    }
-
-    private fun handleAppUnlocked() {
-        mutableStateFlow.update {
-            it.copy(navState = RootNavState.NavState.Unlocked)
-        }
-    }
-
     private fun handleBiometricSupportChanged(
         action: RootNavAction.BiometricSupportChanged,
     ) {
         if (!action.isBiometricsSupported) {
             authRepository.clearBiometrics()
-
-            // If currently locked, navigate to unlocked since biometrics are no longer available
-            if (mutableStateFlow.value.navState is RootNavState.NavState.Locked) {
-                mutableStateFlow.update { it.copy(navState = RootNavState.NavState.Unlocked) }
-            }
+            // State-based navigation should trigger an unlock now.
         }
+    }
+
+    private fun handleStateReceived(action: RootNavAction.Internal.StateReceived) {
+        val newState = if (action.hasSeenWelcomeTutorial) {
+            when (action.appLockState) {
+                AppLockState.LOCKED -> RootNavState.NavState.Locked
+                AppLockState.UNLOCKED -> RootNavState.NavState.Unlocked
+            }
+        } else {
+            RootNavState.NavState.Tutorial
+        }
+        mutableStateFlow.update { it.copy(navState = newState) }
     }
 }
 
 /**
  * Models root level navigation state for the app.
  *
- * @property hasSeenWelcomeGuide Indicates if the user has seen the Welcome Guide screen.
  * @property navState Current destination state of the app.
  */
 @Parcelize
 data class RootNavState(
-    val hasSeenWelcomeGuide: Boolean,
     val navState: NavState,
 ) : Parcelable {
 
@@ -180,25 +139,12 @@ sealed class RootNavAction {
      * Models actions the [RootNavViewModel] itself may send.
      */
     sealed class Internal : RootNavAction() {
-
         /**
-         * Splash screen has been dismissed.
+         * Received all data required to determine the state of the top-level UI.
          */
-        data object SplashScreenDismissed : Internal()
-
-        /**
-         * Indicates the user finished or skipped opening tutorial slides.
-         */
-        data object TutorialFinished : Internal()
-
-        /**
-         * Indicates the application has been unlocked.
-         */
-        data object AppUnlocked : Internal()
-
-        /**
-         * Indicates an update in the welcome guide being seen has been received.
-         */
-        data class HasSeenWelcomeTutorialChange(val hasSeenWelcomeGuide: Boolean) : Internal()
+        data class StateReceived(
+            val appLockState: AppLockState,
+            val hasSeenWelcomeTutorial: Boolean,
+        ) : Internal()
     }
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialNavigation.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialNavigation.kt
@@ -22,10 +22,12 @@ data object SettingsTutorialRoute
 /**
  * Add the top level Tutorial screen to the nav graph.
  */
-fun NavGraphBuilder.tutorialDestination(onTutorialFinished: () -> Unit) {
+fun NavGraphBuilder.tutorialDestination() {
     composableWithStayTransitions<TutorialRoute> {
         TutorialScreen(
-            onTutorialFinished = onTutorialFinished,
+            onTutorialFinished = {
+                // State-based navigation will handle this.
+            },
         )
     }
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialViewModel.kt
@@ -1,6 +1,7 @@
 package com.bitwarden.authenticator.ui.platform.feature.tutorial
 
 import android.os.Parcelable
+import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -13,17 +14,18 @@ import javax.inject.Inject
  * View model for the [TutorialScreen].
  */
 @HiltViewModel
-class TutorialViewModel @Inject constructor() :
-    BaseViewModel<TutorialState, TutorialEvent, TutorialAction>(
-        initialState = TutorialState(
-            index = 0,
-            pages = listOf(
-                TutorialState.TutorialSlide.IntroSlide,
-                TutorialState.TutorialSlide.QrScannerSlide,
-                TutorialState.TutorialSlide.UniqueCodesSlide,
-            ),
+class TutorialViewModel @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) : BaseViewModel<TutorialState, TutorialEvent, TutorialAction>(
+    initialState = TutorialState(
+        index = 0,
+        pages = listOf(
+            TutorialState.TutorialSlide.IntroSlide,
+            TutorialState.TutorialSlide.QrScannerSlide,
+            TutorialState.TutorialSlide.UniqueCodesSlide,
         ),
-    ) {
+    ),
+) {
     override fun handleAction(action: TutorialAction) {
         when (action) {
             is TutorialAction.PagerSwipe -> handlePagerSwipe(action)
@@ -45,6 +47,7 @@ class TutorialViewModel @Inject constructor() :
     private fun handleContinueClick(action: TutorialAction.ContinueClick) {
         if (mutableStateFlow.value.isLastPage) {
             sendEvent(TutorialEvent.NavigateToAuthenticator)
+            settingsRepository.hasSeenWelcomeTutorial = true
         } else {
             mutableStateFlow.update { it.copy(index = action.index + 1) }
             sendEvent(TutorialEvent.UpdatePager(index = action.index + 1))
@@ -53,6 +56,7 @@ class TutorialViewModel @Inject constructor() :
 
     private fun handleSkipClick() {
         sendEvent(TutorialEvent.NavigateToAuthenticator)
+        settingsRepository.hasSeenWelcomeTutorial = true
     }
 }
 

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/lock/AppLockManagerTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/data/platform/manager/lock/AppLockManagerTest.kt
@@ -1,0 +1,49 @@
+package com.bitwarden.authenticator.data.platform.manager.lock
+
+import app.cash.turbine.test
+import com.bitwarden.authenticator.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.bitwarden.authenticator.data.platform.manager.lock.model.AppLockState
+import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AppLockManagerTest {
+
+    private val authDiskSource = FakeAuthDiskSource()
+
+    private val appLockManager: AppLockManager = AppLockManagerImpl(
+        authDiskSource = authDiskSource,
+        dispatcherManager = FakeDispatcherManager(),
+    )
+
+    @Test
+    fun `appLockStateFlow should update according to internal state changes`() = runTest {
+        // The app has a key, so it should start out locked.
+        authDiskSource.storeUserBiometricUnlockKey(biometricsKey = "biometricsKey")
+
+        appLockManager.appLockStateFlow.test {
+            assertEquals(AppLockState.LOCKED, awaitItem())
+
+            // Clearing biometric key means the app cannot be locked.
+            authDiskSource.storeUserBiometricUnlockKey(biometricsKey = null)
+            assertEquals(AppLockState.UNLOCKED, awaitItem())
+
+            // Resetting the biometric key means the app is locked again.
+            authDiskSource.storeUserBiometricUnlockKey(biometricsKey = "biometricsKey")
+            assertEquals(AppLockState.LOCKED, awaitItem())
+
+            // Manual unlock should update state to unlocked.
+            appLockManager.manualAppUnlock()
+            assertEquals(AppLockState.UNLOCKED, awaitItem())
+
+            // Clearing the key should keep the state as unlocked.
+            authDiskSource.storeUserBiometricUnlockKey(biometricsKey = null)
+            expectNoEvents()
+
+            // Resetting the biometric key should keep the app is unlocked.
+            authDiskSource.storeUserBiometricUnlockKey(biometricsKey = "biometricsKey")
+            expectNoEvents()
+        }
+    }
+}

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreenTest.kt
@@ -20,14 +20,11 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import javax.crypto.Cipher
 
 class UnlockScreenTest : AuthenticatorComposeTest() {
-
-    private var onUnlockedCalled = false
 
     private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
     private val mutableEventFlow = bufferedMutableSharedFlow<UnlockEvent>()
@@ -48,7 +45,6 @@ class UnlockScreenTest : AuthenticatorComposeTest() {
         ) {
             UnlockScreen(
                 viewModel = mockViewModel,
-                onUnlocked = { onUnlockedCalled = true },
             )
         }
     }
@@ -76,13 +72,6 @@ class UnlockScreenTest : AuthenticatorComposeTest() {
         verify {
             mockViewModel.trySendAction(UnlockAction.BiometricsUnlockClick)
         }
-    }
-
-    @Test
-    fun `NavigateToItemListing event should call onUnlocked callback`() {
-        mutableEventFlow.tryEmit(UnlockEvent.NavigateToItemListing)
-
-        assertTrue(onUnlockedCalled)
     }
 
     @Test

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockViewModelTest.kt
@@ -201,12 +201,14 @@ class UnlockViewModelTest : BaseViewModelTest() {
 
         val viewModel = createViewModel()
 
-        viewModel.eventFlow.test {
-            expectNoEvents()
+        viewModel.stateFlow.test {
+            assertEquals(DEFAULT_STATE, awaitItem())
 
             viewModel.trySendAction(UnlockAction.BiometricsUnlockSuccess(mockCipher))
 
-            assertEquals(UnlockEvent.NavigateToItemListing, awaitItem())
+            assertEquals(DEFAULT_STATE.copy(dialog = UnlockState.Dialog.Loading), awaitItem())
+
+            assertEquals(DEFAULT_STATE, awaitItem())
         }
     }
 
@@ -486,3 +488,10 @@ class UnlockViewModelTest : BaseViewModelTest() {
         authRepository = mockAuthRepository,
     )
 }
+
+private val DEFAULT_STATE = UnlockState(
+    isBiometricsEnabled = true,
+    isBiometricsValid = true,
+    showBiometricInvalidatedMessage = false,
+    dialog = null,
+)

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/tutorial/TutorialViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/tutorial/TutorialViewModelTest.kt
@@ -1,22 +1,34 @@
 package com.bitwarden.authenticator.ui.authenticator.feature.tutorial
 
 import app.cash.turbine.test
+import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.authenticator.ui.platform.feature.tutorial.TutorialAction
 import com.bitwarden.authenticator.ui.platform.feature.tutorial.TutorialEvent
 import com.bitwarden.authenticator.ui.platform.feature.tutorial.TutorialState
 import com.bitwarden.authenticator.ui.platform.feature.tutorial.TutorialViewModel
 import com.bitwarden.ui.platform.base.BaseViewModelTest
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class TutorialViewModelTest : BaseViewModelTest() {
+    private val settingsRepository: SettingsRepository = mockk {
+        every { hasSeenWelcomeTutorial = true } just runs
+    }
+
     private lateinit var viewModel: TutorialViewModel
 
     @BeforeEach
     fun setUp() {
-        viewModel = TutorialViewModel()
+        viewModel = TutorialViewModel(
+            settingsRepository = settingsRepository,
+        )
     }
 
     @Test
@@ -94,6 +106,9 @@ class TutorialViewModelTest : BaseViewModelTest() {
                 awaitItem(),
             )
         }
+        verify(exactly = 1) {
+            settingsRepository.hasSeenWelcomeTutorial = true
+        }
     }
 
     @Test
@@ -105,6 +120,9 @@ class TutorialViewModelTest : BaseViewModelTest() {
                 TutorialEvent.NavigateToAuthenticator,
                 awaitItem(),
             )
+        }
+        verify(exactly = 1) {
+            settingsRepository.hasSeenWelcomeTutorial = true
         }
     }
 }

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -309,6 +309,5 @@ class RootNavScreenTest : AuthenticatorComposeTest() {
 }
 
 private val DEFAULT_STATE = RootNavState(
-    hasSeenWelcomeGuide = false,
     navState = RootNavState.NavState.Splash,
 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavViewModelTest.kt
@@ -2,6 +2,7 @@ package com.bitwarden.authenticator.ui.platform.feature.rootnav
 
 import app.cash.turbine.test
 import com.bitwarden.authenticator.data.auth.repository.AuthRepository
+import com.bitwarden.authenticator.data.platform.manager.lock.model.AppLockState
 import com.bitwarden.authenticator.data.platform.repository.SettingsRepository
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import io.mockk.every
@@ -10,52 +11,24 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class RootNavViewModelTest : BaseViewModelTest() {
 
+    private val mutableAppLockStateFlow = MutableStateFlow(AppLockState.LOCKED)
     private val mutableHasSeenWelcomeTutorialFlow = MutableStateFlow(false)
     private val authRepository: AuthRepository = mockk {
+        every { appLockStateFlow } returns mutableAppLockStateFlow
         every { updateLastActiveTime() } just runs
         every { isUnlockWithBiometricsEnabled } returns false
         every { clearBiometrics() } just runs
     }
     private val settingsRepository: SettingsRepository = mockk {
-        every { hasSeenWelcomeTutorial } returns false
-        every { hasSeenWelcomeTutorial = any() } just runs
+        every { hasSeenWelcomeTutorial } answers { mutableHasSeenWelcomeTutorialFlow.value }
         every { hasSeenWelcomeTutorialFlow } returns mutableHasSeenWelcomeTutorialFlow
-    }
-
-    @Test
-    fun `initialState should be correct when hasSeenWelcomeTutorial is false`() = runTest {
-        every { settingsRepository.hasSeenWelcomeTutorial } returns false
-        mutableHasSeenWelcomeTutorialFlow.value = false
-        val viewModel = createViewModel()
-        // When hasSeenWelcomeTutorial is false, the flow emits and triggers navigation to Tutorial
-        assertEquals(
-            RootNavState(
-                hasSeenWelcomeGuide = false,
-                navState = RootNavState.NavState.Tutorial,
-            ),
-            viewModel.stateFlow.value,
-        )
-    }
-
-    @Test
-    fun `initialState should be correct when hasSeenWelcomeTutorial is true`() = runTest {
-        every { settingsRepository.hasSeenWelcomeTutorial } returns true
-        mutableHasSeenWelcomeTutorialFlow.value = true
-        val viewModel = createViewModel()
-        // When hasSeenWelcomeTutorial is true and biometrics is not enabled, navigates to Unlocked
-        assertEquals(
-            RootNavState(
-                hasSeenWelcomeGuide = true,
-                navState = RootNavState.NavState.Unlocked,
-            ),
-            viewModel.stateFlow.value,
-        )
     }
 
     @Test
@@ -63,188 +36,6 @@ class RootNavViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         viewModel.trySendAction(RootNavAction.BackStackUpdate)
         verify(exactly = 1) { authRepository.updateLastActiveTime() }
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `on HasSeenWelcomeTutorialChange with true and biometrics enabled and valid should navigate to Locked`() {
-        every { authRepository.isUnlockWithBiometricsEnabled } returns true
-        every { authRepository.isBiometricIntegrityValid() } returns true
-        val viewModel = createViewModel()
-
-        viewModel.trySendAction(
-            RootNavAction.Internal.HasSeenWelcomeTutorialChange(true),
-        )
-
-        assertEquals(
-            RootNavState(
-                hasSeenWelcomeGuide = false,
-                navState = RootNavState.NavState.Locked,
-            ),
-            viewModel.stateFlow.value,
-        )
-        verify(exactly = 1) { settingsRepository.hasSeenWelcomeTutorial = true }
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `on HasSeenWelcomeTutorialChange with true and biometrics enabled but invalid should navigate to Unlocked`() {
-        every { authRepository.isUnlockWithBiometricsEnabled } returns true
-        every { authRepository.isBiometricIntegrityValid() } returns false
-        val viewModel = createViewModel()
-
-        viewModel.trySendAction(
-            RootNavAction.Internal.HasSeenWelcomeTutorialChange(true),
-        )
-
-        assertEquals(
-            RootNavState(
-                hasSeenWelcomeGuide = false,
-                navState = RootNavState.NavState.Unlocked,
-            ),
-            viewModel.stateFlow.value,
-        )
-        verify(exactly = 1) { settingsRepository.hasSeenWelcomeTutorial = true }
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `on HasSeenWelcomeTutorialChange with true and biometrics disabled should navigate to Unlocked`() {
-        every { authRepository.isUnlockWithBiometricsEnabled } returns false
-        val viewModel = createViewModel()
-
-        viewModel.trySendAction(
-            RootNavAction.Internal.HasSeenWelcomeTutorialChange(true),
-        )
-
-        assertEquals(
-            RootNavState(
-                hasSeenWelcomeGuide = false,
-                navState = RootNavState.NavState.Unlocked,
-            ),
-            viewModel.stateFlow.value,
-        )
-        verify(exactly = 1) { settingsRepository.hasSeenWelcomeTutorial = true }
-    }
-
-    @Test
-    fun `on HasSeenWelcomeTutorialChange with false should navigate to Tutorial`() {
-        val viewModel = createViewModel()
-
-        viewModel.trySendAction(
-            RootNavAction.Internal.HasSeenWelcomeTutorialChange(false),
-        )
-
-        assertEquals(
-            RootNavState(
-                hasSeenWelcomeGuide = false,
-                navState = RootNavState.NavState.Tutorial,
-            ),
-            viewModel.stateFlow.value,
-        )
-        // Called twice: once during init when flow emits, once from the action
-        verify(exactly = 2) { settingsRepository.hasSeenWelcomeTutorial = false }
-    }
-
-    @Test
-    fun `on TutorialFinished should update settingsRepository and navigate to Unlocked`() {
-        val viewModel = createViewModel()
-
-        viewModel.trySendAction(RootNavAction.Internal.TutorialFinished)
-
-        assertEquals(
-            RootNavState(
-                hasSeenWelcomeGuide = false,
-                navState = RootNavState.NavState.Unlocked,
-            ),
-            viewModel.stateFlow.value,
-        )
-        verify(exactly = 1) { settingsRepository.hasSeenWelcomeTutorial = true }
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `on SplashScreenDismissed when hasSeenWelcomeTutorial is true and currently Splash should navigate to Unlocked`() =
-        runTest {
-            // Set hasSeenWelcomeTutorial to false initially to stay on Splash
-            every { settingsRepository.hasSeenWelcomeTutorial } returns false
-            mutableHasSeenWelcomeTutorialFlow.value = false
-            val viewModel = createViewModel()
-
-            viewModel.stateFlow.test {
-                // Initial state - Tutorial from init flow
-                assertEquals(
-                    RootNavState(
-                        hasSeenWelcomeGuide = false,
-                        navState = RootNavState.NavState.Tutorial,
-                    ),
-                    awaitItem(),
-                )
-
-                // Now change the repository value and trigger SplashScreenDismissed
-                every { settingsRepository.hasSeenWelcomeTutorial } returns true
-
-                viewModel.trySendAction(RootNavAction.Internal.SplashScreenDismissed)
-
-                // Should navigate to Unlocked based on new repository value
-                assertEquals(
-                    RootNavState(
-                        hasSeenWelcomeGuide = false,
-                        navState = RootNavState.NavState.Unlocked,
-                    ),
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `on SplashScreenDismissed when hasSeenWelcomeTutorial is false and currently in different state should navigate to Tutorial`() =
-        runTest {
-            // Start with hasSeenWelcomeTutorial = true to go to Unlocked
-            every { settingsRepository.hasSeenWelcomeTutorial } returns true
-            mutableHasSeenWelcomeTutorialFlow.value = true
-            val viewModel = createViewModel()
-
-            viewModel.stateFlow.test {
-                // Initial state - Unlocked from init flow
-                assertEquals(
-                    RootNavState(
-                        hasSeenWelcomeGuide = true,
-                        navState = RootNavState.NavState.Unlocked,
-                    ),
-                    awaitItem(),
-                )
-
-                // Change the repository value and trigger SplashScreenDismissed
-                every { settingsRepository.hasSeenWelcomeTutorial } returns false
-
-                viewModel.trySendAction(RootNavAction.Internal.SplashScreenDismissed)
-
-                // Should navigate to Tutorial based on new repository value
-                assertEquals(
-                    RootNavState(
-                        hasSeenWelcomeGuide = true,
-                        navState = RootNavState.NavState.Tutorial,
-                    ),
-                    awaitItem(),
-                )
-            }
-        }
-
-    @Test
-    fun `on AppUnlocked should navigate to Unlocked`() {
-        val viewModel = createViewModel()
-
-        viewModel.trySendAction(RootNavAction.Internal.AppUnlocked)
-
-        assertEquals(
-            RootNavState(
-                hasSeenWelcomeGuide = false,
-                navState = RootNavState.NavState.Unlocked,
-            ),
-            viewModel.stateFlow.value,
-        )
     }
 
     @Test
@@ -266,94 +57,37 @@ class RootNavViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `on BiometricSupportChanged with false when Locked should navigate to Unlocked`() =
+    fun `on BiometricSupportChanged with false when Locked should clear biometrics`() =
         runTest {
-            every { settingsRepository.hasSeenWelcomeTutorial } returns true
-            every { authRepository.isUnlockWithBiometricsEnabled } returns true
-            every { authRepository.isBiometricIntegrityValid() } returns true
-            mutableHasSeenWelcomeTutorialFlow.value = true
             val viewModel = createViewModel()
-
-            // Verify initial state is Locked
-            assertEquals(
-                RootNavState(
-                    hasSeenWelcomeGuide = true,
-                    navState = RootNavState.NavState.Locked,
-                ),
-                viewModel.stateFlow.value,
-            )
 
             // Send BiometricSupportChanged with false
             viewModel.trySendAction(RootNavAction.BiometricSupportChanged(false))
 
-            // Should navigate to Unlocked and clear biometric key
-            assertEquals(
-                RootNavState(
-                    hasSeenWelcomeGuide = true,
-                    navState = RootNavState.NavState.Unlocked,
-                ),
-                viewModel.stateFlow.value,
-            )
             verify(exactly = 1) { authRepository.clearBiometrics() }
         }
 
     @Test
-    @Suppress("MaxLineLength")
-    fun `on BiometricSupportChanged with false when not Locked should not change navigation state`() =
+    fun `updates from StateReceived should update the navState accordingly`() =
         runTest {
-            every { settingsRepository.hasSeenWelcomeTutorial } returns true
-            mutableHasSeenWelcomeTutorialFlow.value = true
+            mutableHasSeenWelcomeTutorialFlow.update { false }
+            mutableAppLockStateFlow.update { AppLockState.LOCKED }
             val viewModel = createViewModel()
-
-            // Verify initial state is Unlocked (biometrics not enabled)
-            assertEquals(
-                RootNavState(
-                    hasSeenWelcomeGuide = true,
-                    navState = RootNavState.NavState.Unlocked,
-                ),
-                viewModel.stateFlow.value,
-            )
-
-            // Send BiometricSupportChanged with false
-            viewModel.trySendAction(RootNavAction.BiometricSupportChanged(false))
-
-            // Should remain Unlocked and clear biometric key
-            assertEquals(
-                RootNavState(
-                    hasSeenWelcomeGuide = true,
-                    navState = RootNavState.NavState.Unlocked,
-                ),
-                viewModel.stateFlow.value,
-            )
-            verify(exactly = 1) { authRepository.clearBiometrics() }
-        }
-
-    @Test
-    @Suppress("MaxLineLength")
-    fun `hasSeenWelcomeTutorialFlow updates should trigger HasSeenWelcomeTutorialChange action`() =
-        runTest {
-            every { authRepository.isUnlockWithBiometricsEnabled } returns false
-            val viewModel = createViewModel()
-
             viewModel.stateFlow.test {
-                // Initial emission after flow subscription - navigates to Tutorial since hasSeenWelcomeTutorial is false
                 assertEquals(
-                    RootNavState(
-                        hasSeenWelcomeGuide = false,
-                        navState = RootNavState.NavState.Tutorial,
-                    ),
+                    DEFAULT_STATE.copy(navState = RootNavState.NavState.Tutorial),
                     awaitItem(),
                 )
 
-                // Update the flow value to true
-                mutableHasSeenWelcomeTutorialFlow.value = true
-
-                // Should navigate to Unlocked since biometrics is not enabled
+                mutableHasSeenWelcomeTutorialFlow.update { true }
                 assertEquals(
-                    RootNavState(
-                        hasSeenWelcomeGuide = false,
-                        navState = RootNavState.NavState.Unlocked,
-                    ),
+                    DEFAULT_STATE.copy(navState = RootNavState.NavState.Locked),
+                    awaitItem(),
+                )
+
+                mutableAppLockStateFlow.update { AppLockState.UNLOCKED }
+                assertEquals(
+                    DEFAULT_STATE.copy(navState = RootNavState.NavState.Unlocked),
                     awaitItem(),
                 )
             }
@@ -364,3 +98,7 @@ class RootNavViewModelTest : BaseViewModelTest() {
         settingsRepository = settingsRepository,
     )
 }
+
+private val DEFAULT_STATE: RootNavState = RootNavState(
+    navState = RootNavState.NavState.Splash,
+)


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-235](https://bitwarden.atlassian.net/browse/BWA-235)

## 📔 Objective

This PR updates the `Authenticator` to use state-based navigation in the `RootNavViewModel`. This will make it much easier to add app lock timeouts in a future PR.


[BWA-235]: https://bitwarden.atlassian.net/browse/BWA-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ