### PR TITLE
[PM-32780] Disable Claude Code attribution in commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "extraKnownMarketplaces": {
     "bitwarden-marketplace": {
       "source": {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32780

## 📔 Objective

Disable Claude Code's automatic co-authored-by attribution from being appended to git commits and pull request descriptions by setting `attribution.commit` and `attribution.pr` to empty strings in `.claude/settings.json`.