### PR TITLE
[PM-32714] Add cookie domain-suffix resolution and fix cloud config path exclusion

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/network/NetworkCookieManagerImpl.kt
@@ -7,6 +7,7 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.model.CookieConfigurati
 import com.x8bit.bitwarden.data.platform.manager.CookieAcquisitionRequestManager
 import com.x8bit.bitwarden.data.platform.manager.model.CookieAcquisitionRequest
 import com.x8bit.bitwarden.data.platform.manager.util.toNetworkCookieList
+import timber.log.Timber
 
 private const val BOOTSTRAP_TYPE_SSO_COOKIE_VENDOR = "ssoCookieVendor"
 
@@ -19,35 +20,55 @@ class NetworkCookieManagerImpl(
     private val cookieAcquisitionRequestManager: CookieAcquisitionRequestManager,
 ) : NetworkCookieManager {
 
-    override fun needsBootstrap(hostname: String): Boolean = configDiskSource
-        .serverConfig
-        ?.serverData
-        ?.communication
-        ?.bootstrap
-        ?.type
-        ?.let { bootstrapType ->
-            when (bootstrapType) {
-                BOOTSTRAP_TYPE_SSO_COOKIE_VENDOR -> {
-                    // When the bootstrap type is SSO cookie vendor, but we do not yet have any
-                    // cookies, the cookie manager needs to be bootstrapped. This includes the
-                    // case where no cookie config exists for the hostname at all.
-                    cookieDiskSource
-                        .getCookieConfig(hostname = hostname)
-                        ?.cookies
-                        ?.none() != false
+    /**
+     * Returns the configured cookie domain from the server config, or null if not set.
+     */
+    private val cookieDomain: String?
+        get() = configDiskSource
+            .serverConfig
+            ?.serverData
+            ?.communication
+            ?.bootstrap
+            ?.takeIf { it.type == BOOTSTRAP_TYPE_SSO_COOKIE_VENDOR }
+            ?.cookieDomain
+
+    override fun needsBootstrap(hostname: String): Boolean {
+        val result = configDiskSource
+            .serverConfig
+            ?.serverData
+            ?.communication
+            ?.bootstrap
+            ?.type
+            ?.let { bootstrapType ->
+                when (bootstrapType) {
+                    BOOTSTRAP_TYPE_SSO_COOKIE_VENDOR -> {
+                        val resolved = resolveHostname(hostname)
+                        cookieDiskSource
+                            .getCookieConfig(hostname = resolved)
+                            ?.cookies
+                            ?.none() != false
+                    }
+
+                    else -> false
                 }
-
-                else -> false
             }
-        }
-        ?: false
+            ?: false
+        Timber.d("needsBootstrap($hostname): $result (cookieDomain=$cookieDomain)")
+        return result
+    }
 
-    override fun getCookies(hostname: String): List<NetworkCookie> = cookieDiskSource
-        .getCookieConfig(hostname = hostname)
-        ?.cookies
-        .toNetworkCookieList()
+    override fun getCookies(hostname: String): List<NetworkCookie> {
+        val resolved = resolveHostname(hostname)
+        val cookies = cookieDiskSource
+            .getCookieConfig(hostname = resolved)
+            ?.cookies
+            .toNetworkCookieList()
+        Timber.d("getCookies($hostname): resolved=$resolved, count=${cookies.size}")
+        return cookies
+    }
 
     override fun acquireCookies(hostname: String) {
+        Timber.d("acquireCookies($hostname): requesting cookie acquisition")
         cookieAcquisitionRequestManager.setPendingCookieAcquisition(
             CookieAcquisitionRequest(
                 hostname = hostname,
@@ -56,14 +77,44 @@ class NetworkCookieManagerImpl(
     }
 
     override fun storeCookies(hostname: String, cookies: Map<String, String>) {
+        val resolvedHostname = cookieDomain ?: hostname
+        Timber.d(
+            "storeCookies($hostname): storing ${cookies.size} cookies under $resolvedHostname",
+        )
         cookieDiskSource.storeCookieConfig(
-            hostname = hostname,
+            hostname = resolvedHostname,
             config = CookieConfigurationData(
-                hostname = hostname,
+                hostname = resolvedHostname,
                 cookies = cookies.map { (name, value) ->
                     CookieConfigurationData.Cookie(name = name, value = value)
                 },
             ),
         )
+    }
+
+    /**
+     * Resolves the storage key for a given [hostname] by performing domain-suffix fallback.
+     *
+     * Tries the exact hostname first, then progressively strips the leftmost DNS label
+     * until a stored cookie configuration is found or no labels remain. This supports
+     * the case where cookies are stored under a parent domain (e.g., "bitwarden.com")
+     * but looked up by a subdomain (e.g., "api.bitwarden.com").
+     */
+    private fun resolveHostname(hostname: String): String {
+        var domain = hostname
+        while (true) {
+            if (cookieDiskSource.getCookieConfig(hostname = domain) != null) {
+                if (domain != hostname) {
+                    Timber.d("resolveHostname($hostname): resolved to $domain")
+                }
+                return domain
+            }
+            val dotIndex = domain.indexOf('.')
+            if (dotIndex < 0) {
+                Timber.d("resolveHostname($hostname): no stored config found, using original")
+                return hostname
+            }
+            domain = domain.substring(dotIndex + 1)
+        }
     }
 }

--- a/network/src/test/kotlin/com/bitwarden/network/interceptor/CookieInterceptorTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/interceptor/CookieInterceptorTest.kt
@@ -184,25 +184,9 @@ class CookieInterceptorTest {
     }
 
     @Test
-    fun `intercept should skip cookie handling for config subpath`() {
+    fun `intercept should skip cookie handling for cloud config path`() {
         val originalRequest = Request.Builder()
-            .url("https://api.bitwarden.com/api/config/sub-path")
-            .build()
-        val chain = FakeInterceptorChain(originalRequest)
-
-        val response = interceptor.intercept(chain)
-
-        assertEquals(originalRequest, response.request)
-        verify(exactly = 0) {
-            mockCookieProvider.needsBootstrap(any())
-            mockCookieProvider.getCookies(any())
-        }
-    }
-
-    @Test
-    fun `intercept should skip cookie handling for path that starts with excluded prefix`() {
-        val originalRequest = Request.Builder()
-            .url("https://vault.bitwarden.com/api/configuration")
+            .url("https://api.bitwarden.com/config")
             .build()
         val chain = FakeInterceptorChain(originalRequest)
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32714

## 📔 Objective

Cookies stored under a parent cookieDomain (e.g., "bitwarden.com") were not found when requesting via subdomains (e.g., "api.bitwarden.com"). Additionally, cloud servers use "/config" instead of "/api/config", causing the config endpoint to hit cookie handling and read stale state.

This adds a `resolveHostname` helper for domain-suffix fallback, updates `storeCookies` to key on `cookieDomain`, fixes excluded path matching to cover both cloud and self-hosted config paths, and adds debug logging along the cookie management path.