### PR TITLE
PM-26059: Remove CipherKeyEncryption feature flag

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerImpl.kt
@@ -19,8 +19,7 @@ class FeatureFlagManagerImpl(
 
     override val sdkFeatureFlags: Map<String, Boolean>
         get() = mapOf(
-            CIPHER_KEY_ENCRYPTION_KEY to
-                getCipherKeyEncryptionFlagState(),
+            CIPHER_KEY_ENCRYPTION_KEY to serverConfigRepository.isCipherKeyEncryptionEnabled,
         )
 
     override fun <T : Any> getFeatureFlagFlow(key: FlagKey<T>): Flow<T> =
@@ -43,17 +42,13 @@ class FeatureFlagManagerImpl(
             .serverConfigStateFlow
             .value
             .getFlagValueOrDefault(key = key)
-
-    /**
-     * Get the computed value of the cipher key encryption flag based on server version and
-     * remote flag.
-     */
-    private fun getCipherKeyEncryptionFlagState() =
-        isServerVersionAtLeast(
-            serverConfigRepository.serverConfigStateFlow.value,
-            CIPHER_KEY_ENC_MIN_SERVER_VERSION,
-        ) && getFeatureFlag(FlagKey.CipherKeyEncryption)
 }
+
+/**
+ * Get the computed value of the cipher key encryption flag based on server version.
+ */
+private val ServerConfigRepository.isCipherKeyEncryptionEnabled: Boolean
+    get() = isServerVersionAtLeast(serverConfigStateFlow.value, CIPHER_KEY_ENC_MIN_SERVER_VERSION)
 
 /**
  * Extract the value of a [FlagKey] from the [ServerConfig]. If there is an issue with retrieving

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/FeatureFlagManagerTest.kt
@@ -27,7 +27,7 @@ class FeatureFlagManagerTest {
 
     @Test
     fun `sdkFeatureFlags should return set feature flags`() {
-        val expected = mapOf("enableCipherKeyEncryption" to false)
+        val expected = mapOf("enableCipherKeyEncryption" to true)
 
         val actual = manager.sdkFeatureFlags
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -110,11 +110,9 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
     @Test
     fun `handleUpdateFeatureFlag should update the feature flag via the repository`() {
         val viewModel = createViewModel()
-        viewModel.trySendAction(
-            DebugMenuAction.UpdateFeatureFlag(FlagKey.CipherKeyEncryption, false),
-        )
+        viewModel.trySendAction(DebugMenuAction.UpdateFeatureFlag(FlagKey.DummyBoolean, false))
         verify(exactly = 1) {
-            mockDebugMenuRepository.updateFeatureFlag(FlagKey.CipherKeyEncryption, false)
+            mockDebugMenuRepository.updateFeatureFlag(FlagKey.DummyBoolean, false)
         }
     }
 

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -33,7 +33,6 @@ sealed class FlagKey<out T : Any> {
                 CredentialExchangeProtocolImport,
                 CredentialExchangeProtocolExport,
                 ForceUpdateKdfSettings,
-                CipherKeyEncryption,
                 NoLogoutOnKdfChange,
                 MigrateMyVaultToMyItems,
                 ArchiveItems,
@@ -57,14 +56,6 @@ sealed class FlagKey<out T : Any> {
      */
     data object CredentialExchangeProtocolExport : FlagKey<Boolean>() {
         override val keyName: String = "cxp-export-mobile"
-        override val defaultValue: Boolean = false
-    }
-
-    /**
-     * Data object holding the feature flag key for the Cipher Key Encryption feature.
-     */
-    data object CipherKeyEncryption : FlagKey<Boolean>() {
-        override val keyName: String = "cipher-key-encryption"
         override val defaultValue: Boolean = false
     }
 

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -17,10 +17,6 @@ class FlagKeyTest {
             "cxp-export-mobile",
         )
         assertEquals(
-            FlagKey.CipherKeyEncryption.keyName,
-            "cipher-key-encryption",
-        )
-        assertEquals(
             FlagKey.BitwardenAuthenticationEnabled.keyName,
             "bitwarden-authentication-enabled",
         )
@@ -48,7 +44,6 @@ class FlagKeyTest {
             listOf(
                 FlagKey.CredentialExchangeProtocolImport,
                 FlagKey.CredentialExchangeProtocolExport,
-                FlagKey.CipherKeyEncryption,
                 FlagKey.BitwardenAuthenticationEnabled,
                 FlagKey.ForceUpdateKdfSettings,
                 FlagKey.MigrateMyVaultToMyItems,

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
@@ -26,7 +26,6 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.BitwardenAuthenticationEnabled,
     FlagKey.CredentialExchangeProtocolImport,
     FlagKey.CredentialExchangeProtocolExport,
-    FlagKey.CipherKeyEncryption,
     FlagKey.ForceUpdateKdfSettings,
     FlagKey.NoLogoutOnKdfChange,
     FlagKey.MigrateMyVaultToMyItems,
@@ -75,7 +74,6 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
 
     FlagKey.CredentialExchangeProtocolImport -> stringResource(BitwardenString.cxp_import)
     FlagKey.CredentialExchangeProtocolExport -> stringResource(BitwardenString.cxp_export)
-    FlagKey.CipherKeyEncryption -> stringResource(BitwardenString.cipher_key_encryption)
     FlagKey.ForceUpdateKdfSettings -> stringResource(BitwardenString.force_update_kdf_settings)
     FlagKey.NoLogoutOnKdfChange -> stringResource(BitwardenString.avoid_logout_on_kdf_change)
     FlagKey.BitwardenAuthenticationEnabled -> {

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -26,7 +26,6 @@
     <string name="restart_onboarding_details">This will reset the onboarding status for the current user, if available. After clicking the button you will immediately be redirected to the onboarding flow. Onboarding flag must be enabled.</string>
     <string name="restart_onboarding_carousel">Show Onboarding Carousel</string>
     <string name="restart_onboarding_carousel_details">This will force the change to app state which will cause the first time carousel to show. The carousel will continue to show for any \"new\" account until a login is completed. May need to exit debug menu manually.</string>
-    <string name="cipher_key_encryption">Cipher Key Encryption</string>
     <string name="reset_coach_mark_tour_status">Reset all coach mark tours</string>
     <string name="generate_crash">Generate crash</string>
     <string name="generate_error_report">Generate error report</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26059](https://bitwarden.atlassian.net/browse/PM-26059)

## 📔 Objective

This PR removes the `CipherKeyEncryption` feature flag from the app.

Note that there is still a server version check for this feature to ensure older servers that do not support the feature do not receive updated ciphers.


[PM-26059]: https://bitwarden.atlassian.net/browse/PM-26059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ