### PR TITLE
Remove remember ViewModel

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -106,7 +106,6 @@ User Request (UI Action)
 In addition to the Key Principles above, follow these rules:
 
 ### DO
-- Use `remember(viewModel)` for lambdas passed to composables
 - Map async results to internal actions before updating state
 - Inject `Clock` for time-dependent operations
 - Return early to reduce nesting

--- a/.claude/skills/implementing-android-code/SKILL.md
+++ b/.claude/skills/implementing-android-code/SKILL.md
@@ -148,9 +148,7 @@ fun ExampleScreen(
             BitwardenTopAppBar(
                 title = stringResource(R.string.title),
                 navigationIcon = rememberVectorPainter(BitwardenDrawable.ic_back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(ExampleAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(ExampleAction.BackClick) },
             )
         },
     ) {
@@ -165,7 +163,6 @@ fun ExampleScreen(
 - ✅ Use `hiltViewModel()` for dependency injection
 - ✅ Use `collectAsStateWithLifecycle()` for state (not `collectAsState()`)
 - ✅ Use `EventsEffect(viewModel)` for one-shot events
-- ✅ Use `remember(viewModel) { }` for stable callbacks to prevent recomposition
 - ✅ Use `Bitwarden*` prefixed components from `:ui` module
 
 **State Hoisting Rules:**

--- a/.claude/skills/implementing-android-code/templates.md
+++ b/.claude/skills/implementing-android-code/templates.md
@@ -342,9 +342,7 @@ fun ExampleScreen(
     // Dialogs
     ExampleDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(ExampleAction.ErrorDialogDismiss) }
-        },
+        onDismissRequest = { viewModel.trySendAction(ExampleAction.ErrorDialogDismiss) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -357,20 +355,14 @@ fun ExampleScreen(
                 title = stringResource(id = BitwardenString.example),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(ExampleAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(ExampleAction.BackClick) },
             )
         },
     ) {
         ExampleScreenContent(
             state = state,
-            onInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(ExampleAction.InputChanged(it)) }
-            },
-            onSubmitClick = remember(viewModel) {
-                { viewModel.trySendAction(ExampleAction.SubmitClick) }
-            },
+            onInputChanged = { viewModel.trySendAction(ExampleAction.InputChanged(it)) },
+            onSubmitClick = { viewModel.trySendAction(ExampleAction.SubmitClick) },
             modifier = Modifier
                 .fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupAutofillScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -128,10 +127,8 @@ fun SetupAutoFillScreen(
                         navigationIconContentDescription = stringResource(
                             id = BitwardenString.close,
                         ),
-                        onNavigationIconClick = remember(viewModel) {
-                            {
-                                viewModel.trySendAction(SetupAutoFillAction.CloseClick)
-                            }
+                        onNavigationIconClick = {
+                            viewModel.trySendAction(SetupAutoFillAction.CloseClick)
                         },
                     )
                 },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupBrowserAutofillScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -76,11 +75,9 @@ fun SetupBrowserAutofillScreen(
     }
     SetupBrowserAutofillDialogs(
         dialogState = state.dialogState,
-        onDismissDialog = remember(viewModel) {
-            { viewModel.trySendAction(SetupBrowserAutofillAction.DismissDialog) }
-        },
-        onTurnOnLaterConfirm = remember(viewModel) {
-            { viewModel.trySendAction(SetupBrowserAutofillAction.TurnOnLaterConfirmClick) }
+        onDismissDialog = { viewModel.trySendAction(SetupBrowserAutofillAction.DismissDialog) },
+        onTurnOnLaterConfirm = {
+            viewModel.trySendAction(SetupBrowserAutofillAction.TurnOnLaterConfirmClick)
         },
     )
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
@@ -104,8 +101,8 @@ fun SetupBrowserAutofillScreen(
                     NavigationIcon(
                         navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                         navigationIconContentDescription = stringResource(BitwardenString.close),
-                        onNavigationIconClick = remember(viewModel) {
-                            { viewModel.trySendAction(SetupBrowserAutofillAction.CloseClick) }
+                        onNavigationIconClick = {
+                            viewModel.trySendAction(SetupBrowserAutofillAction.CloseClick)
                         },
                     )
                 },
@@ -114,17 +111,15 @@ fun SetupBrowserAutofillScreen(
     ) {
         SetupBrowserAutofillContent(
             state = state,
-            onWhyIsThisStepRequiredClick = remember(viewModel) {
-                { viewModel.trySendAction(SetupBrowserAutofillAction.WhyIsThisStepRequiredClick) }
+            onWhyIsThisStepRequiredClick = {
+                viewModel.trySendAction(SetupBrowserAutofillAction.WhyIsThisStepRequiredClick)
             },
-            onBrowserClick = remember(viewModel) {
-                { viewModel.trySendAction(SetupBrowserAutofillAction.BrowserIntegrationClick(it)) }
+            onBrowserClick = {
+                viewModel.trySendAction(SetupBrowserAutofillAction.BrowserIntegrationClick(it))
             },
-            onContinueClick = remember(viewModel) {
-                { viewModel.trySendAction(SetupBrowserAutofillAction.ContinueClick) }
-            },
-            onTurnOnLaterClick = remember(viewModel) {
-                { viewModel.trySendAction(SetupBrowserAutofillAction.TurnOnLaterClick) }
+            onContinueClick = { viewModel.trySendAction(SetupBrowserAutofillAction.ContinueClick) },
+            onTurnOnLaterClick = {
+                viewModel.trySendAction(SetupBrowserAutofillAction.TurnOnLaterClick)
             },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupCompleteScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -41,10 +40,8 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
 fun SetupCompleteScreen(
     viewModel: SetupCompleteViewModel = hiltViewModel(),
 ) {
-    val setupCompleteAction: () -> Unit = remember(viewModel) {
-        {
-            viewModel.trySendAction(SetupCompleteAction.CompleteSetup)
-        }
+    val setupCompleteAction: () -> Unit = {
+        viewModel.trySendAction(SetupCompleteAction.CompleteSetup)
     }
 
     // Handle system back action to complete the setup.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/accountsetup/SetupUnlockScreen.kt
@@ -93,9 +93,7 @@ fun SetupUnlockScreen(
 
     SetupUnlockScreenDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(SetupUnlockAction.DismissDialog) }
-        },
+        onDismissRequest = { viewModel.trySendAction(SetupUnlockAction.DismissDialog) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -121,10 +119,8 @@ fun SetupUnlockScreen(
                         navigationIconContentDescription = stringResource(
                             id = BitwardenString.close,
                         ),
-                        onNavigationIconClick = remember(viewModel) {
-                            {
-                                viewModel.trySendAction(SetupUnlockAction.CloseClick)
-                            }
+                        onNavigationIconClick = {
+                            viewModel.trySendAction(SetupUnlockAction.CloseClick)
                         },
                     )
                 },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/enterprisesignon/EnterpriseSignOnScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -83,15 +82,13 @@ fun EnterpriseSignOnScreen(
 
     EnterpriseSignOnDialogs(
         dialogState = state.dialogState,
-        onConfirmKeyConnectorDomain = remember(viewModel) {
-            { viewModel.trySendAction(EnterpriseSignOnAction.ConfirmKeyConnectorDomainClick) }
+        onConfirmKeyConnectorDomain = {
+            viewModel.trySendAction(EnterpriseSignOnAction.ConfirmKeyConnectorDomainClick)
         },
-        onDismissKeyConnectorDomain = remember(viewModel) {
-            { viewModel.trySendAction(EnterpriseSignOnAction.CancelKeyConnectorDomainClick) }
+        onDismissKeyConnectorDomain = {
+            viewModel.trySendAction(EnterpriseSignOnAction.CancelKeyConnectorDomainClick)
         },
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(EnterpriseSignOnAction.DialogDismiss) }
-        },
+        onDismissRequest = { viewModel.trySendAction(EnterpriseSignOnAction.DialogDismiss) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -105,15 +102,13 @@ fun EnterpriseSignOnScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(EnterpriseSignOnAction.CloseButtonClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(EnterpriseSignOnAction.CloseButtonClick)
                 },
                 actions = {
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.log_in_verb),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(EnterpriseSignOnAction.LogInClick) }
-                        },
+                        onClick = { viewModel.trySendAction(EnterpriseSignOnAction.LogInClick) },
                         modifier = Modifier.testTag("LoginButton"),
                     )
                 },
@@ -122,8 +117,8 @@ fun EnterpriseSignOnScreen(
     ) {
         EnterpriseSignOnScreenContent(
             state = state,
-            onOrgIdentifierInputChange = remember(viewModel) {
-                { viewModel.trySendAction(EnterpriseSignOnAction.OrgIdentifierInputChange(it)) }
+            onOrgIdentifierInputChange = {
+                viewModel.trySendAction(EnterpriseSignOnAction.OrgIdentifierInputChange(it))
             },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
@@ -66,9 +65,7 @@ fun EnvironmentScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val certificateImportFilePickerLauncher = intentManager.getActivityResultLauncher { result ->
         intentManager.getFileDataFromActivityResult(result)?.let {
-            viewModel.trySendAction(
-                EnvironmentAction.ImportCertificateFilePickerResultReceive(it),
-            )
+            viewModel.trySendAction(EnvironmentAction.ImportCertificateFilePickerResultReceive(it))
         }
     }
     val scope = rememberCoroutineScope()
@@ -101,32 +98,24 @@ fun EnvironmentScreen(
             BitwardenBasicDialog(
                 title = stringResource(id = BitwardenString.an_error_has_occurred),
                 message = dialog.message(),
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
-                },
+                onDismissRequest = { viewModel.trySendAction(EnvironmentAction.DialogDismiss) },
                 throwable = dialog.throwable,
             )
         }
 
         is EnvironmentState.DialogState.SetCertificateData -> {
             BitwardenClientCertificateDialog(
-                onConfirmClick = remember(viewModel) {
-                    { alias, password ->
-                        viewModel.trySendAction(
-                            EnvironmentAction.SetCertificateInfoResultReceive(
-                                certificateFileData = dialog.certificateBytes,
-                                password = password,
-                                alias = alias,
-                            ),
-                        )
-                    }
+                onConfirmClick = { alias, password ->
+                    viewModel.trySendAction(
+                        EnvironmentAction.SetCertificateInfoResultReceive(
+                            certificateFileData = dialog.certificateBytes,
+                            password = password,
+                            alias = alias,
+                        ),
+                    )
                 },
-                onDismissRequest = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            action = EnvironmentAction.SetCertificatePasswordDialogDismiss,
-                        )
-                    }
+                onDismissRequest = {
+                    viewModel.trySendAction(EnvironmentAction.SetCertificatePasswordDialogDismiss)
                 },
             )
         }
@@ -139,16 +128,12 @@ fun EnvironmentScreen(
                     BitwardenString.system_certificates_are_not_as_secure_as_importing_certificates_to_bitwarden,
                 ),
                 confirmButtonText = stringResource(BitwardenString.continue_text),
-                onConfirmClick = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.ConfirmChooseSystemCertificateClick) }
+                onConfirmClick = {
+                    viewModel.trySendAction(EnvironmentAction.ConfirmChooseSystemCertificateClick)
                 },
                 dismissButtonText = stringResource(BitwardenString.cancel),
-                onDismissClick = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
-                },
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
-                },
+                onDismissClick = { viewModel.trySendAction(EnvironmentAction.DialogDismiss) },
+                onDismissRequest = { viewModel.trySendAction(EnvironmentAction.DialogDismiss) },
             )
         }
 
@@ -158,21 +143,15 @@ fun EnvironmentScreen(
                 message = dialog.message(),
                 confirmButtonText = stringResource(BitwardenString.replace_certificate),
                 dismissButtonText = stringResource(BitwardenString.cancel),
-                onConfirmClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            EnvironmentAction.ConfirmOverwriteCertificateClick(
-                                triggeringAction = dialog.triggeringAction,
-                            ),
-                        )
-                    }
+                onConfirmClick = {
+                    viewModel.trySendAction(
+                        EnvironmentAction.ConfirmOverwriteCertificateClick(
+                            triggeringAction = dialog.triggeringAction,
+                        ),
+                    )
                 },
-                onDismissClick = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
-                },
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.DialogDismiss) }
-                },
+                onDismissClick = { viewModel.trySendAction(EnvironmentAction.DialogDismiss) },
+                onDismissRequest = { viewModel.trySendAction(EnvironmentAction.DialogDismiss) },
             )
         }
 
@@ -189,15 +168,11 @@ fun EnvironmentScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.CloseClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(EnvironmentAction.CloseClick) },
                 actions = {
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.save),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(EnvironmentAction.SaveClick) }
-                        },
+                        onClick = { viewModel.trySendAction(EnvironmentAction.SaveClick) },
                         modifier = Modifier.testTag("SaveButton"),
                     )
                 },
@@ -230,9 +205,7 @@ fun EnvironmentScreen(
                 supportingText = stringResource(
                     id = BitwardenString.self_hosted_environment_footer,
                 ),
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.ServerUrlChange(it)) }
-                },
+                onValueChange = { viewModel.trySendAction(EnvironmentAction.ServerUrlChange(it)) },
                 autoCompleteOptions = if (BuildConfig.BUILD_TYPE != "release") {
                     persistentListOf(
                         "https://vault.qa.bitwarden.pw",
@@ -265,8 +238,8 @@ fun EnvironmentScreen(
             BitwardenTextField(
                 label = stringResource(id = BitwardenString.web_vault_url),
                 value = state.webVaultServerUrl,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.WebVaultServerUrlChange(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(EnvironmentAction.WebVaultServerUrlChange(it))
                 },
                 keyboardType = KeyboardType.Uri,
                 textFieldTestTag = "WebVaultUrlEntry",
@@ -281,8 +254,8 @@ fun EnvironmentScreen(
             BitwardenTextField(
                 label = stringResource(id = BitwardenString.api_url),
                 value = state.apiServerUrl,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.ApiServerUrlChange(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(EnvironmentAction.ApiServerUrlChange(it))
                 },
                 keyboardType = KeyboardType.Uri,
                 cardStyle = CardStyle.Full,
@@ -297,8 +270,8 @@ fun EnvironmentScreen(
             BitwardenTextField(
                 label = stringResource(id = BitwardenString.identity_url),
                 value = state.identityServerUrl,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.IdentityServerUrlChange(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(EnvironmentAction.IdentityServerUrlChange(it))
                 },
                 keyboardType = KeyboardType.Uri,
                 textFieldTestTag = "IdentityUrlEntry",
@@ -313,8 +286,8 @@ fun EnvironmentScreen(
             BitwardenTextField(
                 label = stringResource(id = BitwardenString.icons_url),
                 value = state.iconsServerUrl,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.IconsServerUrlChange(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(EnvironmentAction.IconsServerUrlChange(it))
                 },
                 supportingText = stringResource(id = BitwardenString.custom_environment_footer),
                 keyboardType = KeyboardType.Uri,
@@ -355,9 +328,7 @@ fun EnvironmentScreen(
 
             BitwardenFilledButton(
                 label = stringResource(id = BitwardenString.import_certificate),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.ImportCertificateClick) }
-                },
+                onClick = { viewModel.trySendAction(EnvironmentAction.ImportCertificateClick) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .standardHorizontalMargin()
@@ -368,8 +339,8 @@ fun EnvironmentScreen(
 
             BitwardenOutlinedButton(
                 label = stringResource(id = BitwardenString.choose_system_certificate),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(EnvironmentAction.ChooseSystemCertificateClick) }
+                onClick = {
+                    viewModel.trySendAction(EnvironmentAction.ChooseSystemCertificateClick)
                 },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/expiredregistrationlink/ExpiredRegistrationLinkScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/expiredregistrationlink/ExpiredRegistrationLinkScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -52,14 +51,8 @@ fun ExpiredRegistrationLinkScreen(
             }
         }
     }
-    val sendCloseClicked = remember(viewModel) {
-        {
-            viewModel.trySendAction(ExpiredRegistrationLinkAction.CloseClicked)
-        }
-    }
-
+    val sendCloseClicked = { viewModel.trySendAction(ExpiredRegistrationLinkAction.CloseClicked) }
     BackHandler(onBack = sendCloseClicked)
-
     BitwardenScaffold(
         topBar = {
             BitwardenTopAppBar(
@@ -74,17 +67,11 @@ fun ExpiredRegistrationLinkScreen(
         },
     ) {
         ExpiredRegistrationLinkContent(
-            onNavigateToLogin = remember(viewModel) {
-                {
-                    viewModel.trySendAction(ExpiredRegistrationLinkAction.GoToLoginClicked)
-                }
+            onNavigateToLogin = {
+                viewModel.trySendAction(ExpiredRegistrationLinkAction.GoToLoginClicked)
             },
-            onNavigateToStartRegistration = remember(viewModel) {
-                {
-                    viewModel.trySendAction(
-                        ExpiredRegistrationLinkAction.RestartRegistrationClicked,
-                    )
-                }
+            onNavigateToStartRegistration = {
+                viewModel.trySendAction(ExpiredRegistrationLinkAction.RestartRegistrationClicked)
             },
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/landing/LandingScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -91,21 +90,13 @@ fun LandingScreen(
                 ),
                 confirmButtonText = stringResource(id = BitwardenString.yes),
                 dismissButtonText = stringResource(id = BitwardenString.cancel),
-                onConfirmClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            LandingAction.ConfirmSwitchToMatchingAccountClick(
-                                accountSummary = dialog.accountSummary,
-                            ),
-                        )
-                    }
+                onConfirmClick = {
+                    viewModel.trySendAction(
+                        LandingAction.ConfirmSwitchToMatchingAccountClick(dialog.accountSummary),
+                    )
                 },
-                onDismissClick = remember(viewModel) {
-                    { viewModel.trySendAction(LandingAction.DialogDismiss) }
-                },
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(LandingAction.DialogDismiss) }
-                },
+                onDismissClick = { viewModel.trySendAction(LandingAction.DialogDismiss) },
+                onDismissRequest = { viewModel.trySendAction(LandingAction.DialogDismiss) },
             )
         }
 
@@ -113,9 +104,7 @@ fun LandingScreen(
             BitwardenBasicDialog(
                 title = stringResource(id = BitwardenString.an_error_has_occurred),
                 message = dialog.message(),
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(LandingAction.DialogDismiss) }
-                },
+                onDismissRequest = { viewModel.trySendAction(LandingAction.DialogDismiss) },
             )
         }
 
@@ -150,14 +139,14 @@ fun LandingScreen(
             BitwardenAccountSwitcher(
                 isVisible = isAccountMenuVisible,
                 accountSummaries = state.accountSummaries.toImmutableList(),
-                onSwitchAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(LandingAction.SwitchAccountClick(it)) }
+                onSwitchAccountClick = {
+                    viewModel.trySendAction(LandingAction.SwitchAccountClick(it))
                 },
-                onLockAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(LandingAction.LockAccountClick(it)) }
+                onLockAccountClick = {
+                    viewModel.trySendAction(LandingAction.LockAccountClick(it))
                 },
-                onLogoutAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(LandingAction.LogoutAccountClick(it)) }
+                onLogoutAccountClick = {
+                    viewModel.trySendAction(LandingAction.LogoutAccountClick(it))
                 },
                 onAddAccountClick = {
                     // Not available
@@ -174,24 +163,14 @@ fun LandingScreen(
     ) {
         LandingScreenContent(
             state = state,
-            onEmailInputChange = remember(viewModel) {
-                { viewModel.trySendAction(LandingAction.EmailInputChanged(it)) }
+            onEmailInputChange = { viewModel.trySendAction(LandingAction.EmailInputChanged(it)) },
+            onEnvironmentTypeSelect = {
+                viewModel.trySendAction(LandingAction.EnvironmentTypeSelect(it))
             },
-            onEnvironmentTypeSelect = remember(viewModel) {
-                { viewModel.trySendAction(LandingAction.EnvironmentTypeSelect(it)) }
-            },
-            onRememberMeToggle = remember(viewModel) {
-                { viewModel.trySendAction(LandingAction.RememberMeToggle(it)) }
-            },
-            onContinueClick = remember(viewModel) {
-                { viewModel.trySendAction(LandingAction.ContinueButtonClick) }
-            },
-            onCreateAccountClick = remember(viewModel) {
-                { viewModel.trySendAction(LandingAction.CreateAccountClick) }
-            },
-            onAppSettingsClick = remember(viewModel) {
-                { viewModel.trySendAction(LandingAction.AppSettingsClick) }
-            },
+            onRememberMeToggle = { viewModel.trySendAction(LandingAction.RememberMeToggle(it)) },
+            onContinueClick = { viewModel.trySendAction(LandingAction.ContinueButtonClick) },
+            onCreateAccountClick = { viewModel.trySendAction(LandingAction.CreateAccountClick) },
+            onAppSettingsClick = { viewModel.trySendAction(LandingAction.AppSettingsClick) },
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -96,9 +95,7 @@ fun LoginScreen(
 
     LoginDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(LoginAction.ErrorDialogDismiss) }
-        },
+        onDismissRequest = { viewModel.trySendAction(LoginAction.ErrorDialogDismiss) },
     )
 
     val isAccountButtonVisible = state.accountSummaries.isNotEmpty()
@@ -114,9 +111,7 @@ fun LoginScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(LoginAction.CloseButtonClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(LoginAction.CloseButtonClick) },
                 actions = {
                     if (isAccountButtonVisible) {
                         BitwardenPlaceholderAccountActionItem(
@@ -128,8 +123,8 @@ fun LoginScreen(
                         menuItemDataList = persistentListOf(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.get_password_hint),
-                                onClick = remember(viewModel) {
-                                    { viewModel.trySendAction(LoginAction.MasterPasswordHintClick) }
+                                onClick = {
+                                    viewModel.trySendAction(LoginAction.MasterPasswordHintClick)
                                 },
                             ),
                         ),
@@ -141,18 +136,14 @@ fun LoginScreen(
             BitwardenAccountSwitcher(
                 isVisible = isAccountMenuVisible,
                 accountSummaries = state.accountSummaries.toImmutableList(),
-                onSwitchAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(LoginAction.SwitchAccountClick(it)) }
+                onSwitchAccountClick = {
+                    viewModel.trySendAction(LoginAction.SwitchAccountClick(it))
                 },
-                onLockAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(LoginAction.LockAccountClick(it)) }
+                onLockAccountClick = { viewModel.trySendAction(LoginAction.LockAccountClick(it)) },
+                onLogoutAccountClick = {
+                    viewModel.trySendAction(LoginAction.LogoutAccountClick(it))
                 },
-                onLogoutAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(LoginAction.LogoutAccountClick(it)) }
-                },
-                onAddAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(LoginAction.AddAccountClick) }
-                },
+                onAddAccountClick = { viewModel.trySendAction(LoginAction.AddAccountClick) },
                 onDismissRequest = { isAccountMenuVisible = false },
                 topAppBarScrollBehavior = scrollBehavior,
                 modifier = Modifier.fillMaxSize(),
@@ -161,27 +152,21 @@ fun LoginScreen(
     ) {
         LoginScreenContent(
             state = state,
-            onPasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(LoginAction.PasswordInputChanged(it)) }
+            onPasswordInputChanged = {
+                viewModel.trySendAction(LoginAction.PasswordInputChanged(it))
             },
-            onMasterPasswordClick = remember(viewModel) {
-                { viewModel.trySendAction(LoginAction.MasterPasswordHintClick) }
+            onMasterPasswordClick = {
+                viewModel.trySendAction(LoginAction.MasterPasswordHintClick)
             },
-            onLoginButtonClick = remember(viewModel) {
-                {
-                    keyboardController?.hide()
-                    viewModel.trySendAction(LoginAction.LoginButtonClick)
-                }
+            onLoginButtonClick = {
+                keyboardController?.hide()
+                viewModel.trySendAction(LoginAction.LoginButtonClick)
             },
-            onLoginWithDeviceClick = remember(viewModel) {
-                { viewModel.trySendAction(LoginAction.LoginWithDeviceButtonClick) }
+            onLoginWithDeviceClick = {
+                viewModel.trySendAction(LoginAction.LoginWithDeviceButtonClick)
             },
-            onSingleSignOnClick = remember(viewModel) {
-                { viewModel.trySendAction(LoginAction.SingleSignOnClick) }
-            },
-            onNotYouButtonClick = remember(viewModel) {
-                { viewModel.trySendAction(LoginAction.NotYouButtonClick) }
-            },
+            onSingleSignOnClick = { viewModel.trySendAction(LoginAction.SingleSignOnClick) },
+            onNotYouButtonClick = { viewModel.trySendAction(LoginAction.NotYouButtonClick) },
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/loginwithdevice/LoginWithDeviceScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -63,9 +62,7 @@ fun LoginWithDeviceScreen(
 
     LoginWithDeviceDialogs(
         state = state.dialogState,
-        onDismissDialog = remember(viewModel) {
-            { viewModel.trySendAction(LoginWithDeviceAction.DismissDialog) }
-        },
+        onDismissDialog = { viewModel.trySendAction(LoginWithDeviceAction.DismissDialog) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -79,8 +76,8 @@ fun LoginWithDeviceScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(LoginWithDeviceAction.CloseButtonClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(LoginWithDeviceAction.CloseButtonClick)
                 },
             )
         },
@@ -89,11 +86,11 @@ fun LoginWithDeviceScreen(
             is LoginWithDeviceState.ViewState.Content -> {
                 LoginWithDeviceScreenContent(
                     state = viewState,
-                    onResendNotificationClick = remember(viewModel) {
-                        { viewModel.trySendAction(LoginWithDeviceAction.ResendNotificationClick) }
+                    onResendNotificationClick = {
+                        viewModel.trySendAction(LoginWithDeviceAction.ResendNotificationClick)
                     },
-                    onViewAllLogInOptionsClick = remember(viewModel) {
-                        { viewModel.trySendAction(LoginWithDeviceAction.ViewAllLogInOptionsClick) }
+                    onViewAllLogInOptionsClick = {
+                        viewModel.trySendAction(LoginWithDeviceAction.ViewAllLogInOptionsClick)
                     },
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordgenerator/MasterPasswordGeneratorScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -83,17 +82,11 @@ fun MasterPasswordGeneratorScreen(
         topBar = {
             MasterPasswordGeneratorTopBar(
                 scrollBehavior = scrollBehavior,
-                onBackClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(MasterPasswordGeneratorAction.BackClickAction)
-                    }
+                onBackClick = {
+                    viewModel.trySendAction(MasterPasswordGeneratorAction.BackClickAction)
                 },
-                onSaveClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            MasterPasswordGeneratorAction.SavePasswordClickAction,
-                        )
-                    }
+                onSaveClick = {
+                    viewModel.trySendAction(MasterPasswordGeneratorAction.SavePasswordClickAction)
                 },
             )
         },
@@ -108,19 +101,13 @@ fun MasterPasswordGeneratorScreen(
         ) {
             MasterPasswordGeneratorContent(
                 generatedPassword = state.generatedPassword,
-                onGenerateNewPassword = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            MasterPasswordGeneratorAction.GeneratePasswordClickAction,
-                        )
-                    }
+                onGenerateNewPassword = {
+                    viewModel.trySendAction(
+                        MasterPasswordGeneratorAction.GeneratePasswordClickAction,
+                    )
                 },
-                onLearnToPreventLockout = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            MasterPasswordGeneratorAction.PreventLockoutClickAction,
-                        )
-                    }
+                onLearnToPreventLockout = {
+                    viewModel.trySendAction(MasterPasswordGeneratorAction.PreventLockoutClickAction)
                 },
                 modifier = Modifier.standardHorizontalMargin(),
             )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordguidance/MasterPasswordGuidanceScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -67,21 +66,15 @@ fun MasterPasswordGuidanceScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(MasterPasswordGuidanceAction.CloseAction)
-                    }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(MasterPasswordGuidanceAction.CloseAction)
                 },
             )
         },
     ) {
         MasterPasswordGuidanceContent(
-            onTryPasswordGeneratorAction = remember(viewModel) {
-                {
-                    viewModel.trySendAction(
-                        MasterPasswordGuidanceAction.TryPasswordGeneratorAction,
-                    )
-                }
+            onTryPasswordGeneratorAction = {
+                viewModel.trySendAction(MasterPasswordGuidanceAction.TryPasswordGeneratorAction)
             },
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/masterpasswordhint/MasterPasswordHintScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -55,8 +54,8 @@ fun MasterPasswordHintScreen(
             BitwardenBasicDialog(
                 title = stringResource(id = BitwardenString.password_hint),
                 message = stringResource(id = BitwardenString.password_hint_alert),
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(MasterPasswordHintAction.DismissDialog) }
+                onDismissRequest = {
+                    viewModel.trySendAction(MasterPasswordHintAction.DismissDialog)
                 },
             )
         }
@@ -73,8 +72,8 @@ fun MasterPasswordHintScreen(
                     ?: stringResource(id = BitwardenString.an_error_has_occurred),
                 message = dialogState.message(),
                 throwable = dialogState.error,
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(MasterPasswordHintAction.DismissDialog) }
+                onDismissRequest = {
+                    viewModel.trySendAction(MasterPasswordHintAction.DismissDialog)
                 },
             )
         }
@@ -93,15 +92,13 @@ fun MasterPasswordHintScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(MasterPasswordHintAction.CloseClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(MasterPasswordHintAction.CloseClick)
                 },
                 actions = {
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.submit),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(MasterPasswordHintAction.SubmitClick) }
-                        },
+                        onClick = { viewModel.trySendAction(MasterPasswordHintAction.SubmitClick) },
                         modifier = Modifier.testTag("SubmitButton"),
                     )
                 },
@@ -117,8 +114,8 @@ fun MasterPasswordHintScreen(
                     .standardHorizontalMargin()
                     .fillMaxWidth(),
                 value = state.emailInput,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(MasterPasswordHintAction.EmailInputChange(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(MasterPasswordHintAction.EmailInputChange(it))
                 },
                 label = stringResource(id = BitwardenString.email_address),
                 keyboardType = KeyboardType.Email,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/preventaccountlockout/PreventAccountLockoutScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/preventaccountlockout/PreventAccountLockoutScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -61,10 +60,8 @@ fun PreventAccountLockoutScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(PreventAccountLockoutAction.CloseClickAction)
-                    }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(PreventAccountLockoutAction.CloseClickAction)
                 },
             )
         },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/removepassword/RemovePasswordScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -48,13 +47,9 @@ fun RemovePasswordScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     RemovePasswordDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(RemovePasswordAction.DialogDismiss) }
-        },
-        onConfirmLeaveClick = remember(viewModel) {
-            {
-                viewModel.trySendAction(RemovePasswordAction.ConfirmLeaveOrganizationClick)
-            }
+        onDismissRequest = { viewModel.trySendAction(RemovePasswordAction.DialogDismiss) },
+        onConfirmLeaveClick = {
+            viewModel.trySendAction(RemovePasswordAction.ConfirmLeaveOrganizationClick)
         },
     )
 
@@ -73,14 +68,10 @@ fun RemovePasswordScreen(
     ) {
         RemovePasswordScreenContent(
             state = state,
-            onContinueClick = remember(viewModel) {
-                { viewModel.trySendAction(RemovePasswordAction.ContinueClick) }
-            },
-            onInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(RemovePasswordAction.InputChanged(it)) }
-            },
-            onLeaveOrganizationClick = remember(viewModel) {
-                { viewModel.trySendAction(RemovePasswordAction.LeaveOrganizationClick) }
+            onContinueClick = { viewModel.trySendAction(RemovePasswordAction.ContinueClick) },
+            onInputChanged = { viewModel.trySendAction(RemovePasswordAction.InputChanged(it)) },
+            onLeaveOrganizationClick = {
+                viewModel.trySendAction(RemovePasswordAction.LeaveOrganizationClick)
             },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -75,9 +74,7 @@ fun ResetPasswordScreen(
             BitwardenBasicDialog(
                 title = dialog.title?.invoke(),
                 message = dialog.message(),
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(ResetPasswordAction.DialogDismiss) }
-                },
+                onDismissRequest = { viewModel.trySendAction(ResetPasswordAction.DialogDismiss) },
             )
         }
 
@@ -89,9 +86,7 @@ fun ResetPasswordScreen(
     }
 
     var shouldShowLogoutConfirmationDialog by rememberSaveable { mutableStateOf(false) }
-    val onLogoutClicked = remember(viewModel) {
-        { viewModel.trySendAction(ResetPasswordAction.ConfirmLogoutClick) }
-    }
+    val onLogoutClicked = { viewModel.trySendAction(ResetPasswordAction.ConfirmLogoutClick) }
     if (shouldShowLogoutConfirmationDialog) {
         BitwardenTwoButtonDialog(
             title = stringResource(id = BitwardenString.log_out),
@@ -120,9 +115,7 @@ fun ResetPasswordScreen(
                 actions = {
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.save),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(ResetPasswordAction.SaveClick) }
-                        },
+                        onClick = { viewModel.trySendAction(ResetPasswordAction.SaveClick) },
                         modifier = Modifier.testTag("SaveButton"),
                     )
                     BitwardenOverflowActionItem(
@@ -140,20 +133,20 @@ fun ResetPasswordScreen(
     ) {
         ResetPasswordScreenContent(
             state = state,
-            onCurrentPasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(ResetPasswordAction.CurrentPasswordInputChanged(it)) }
+            onCurrentPasswordInputChanged = {
+                viewModel.trySendAction(ResetPasswordAction.CurrentPasswordInputChanged(it))
             },
-            onPasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(ResetPasswordAction.PasswordInputChanged(it)) }
+            onPasswordInputChanged = {
+                viewModel.trySendAction(ResetPasswordAction.PasswordInputChanged(it))
             },
-            onRetypePasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(ResetPasswordAction.RetypePasswordInputChanged(it)) }
+            onRetypePasswordInputChanged = {
+                viewModel.trySendAction(ResetPasswordAction.RetypePasswordInputChanged(it))
             },
-            onPasswordHintInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(ResetPasswordAction.PasswordHintInputChanged(it)) }
+            onPasswordHintInputChanged = {
+                viewModel.trySendAction(ResetPasswordAction.PasswordHintInputChanged(it))
             },
-            onLearnToPreventLockout = remember(viewModel) {
-                { viewModel.trySendAction(ResetPasswordAction.LearnHowPreventLockoutClick) }
+            onLearnToPreventLockout = {
+                viewModel.trySendAction(ResetPasswordAction.LearnHowPreventLockoutClick)
             },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/setpassword/SetPasswordScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -49,9 +48,7 @@ fun SetPasswordScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     SetPasswordDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(SetPasswordAction.DialogDismiss) }
-        },
+        onDismissRequest = { viewModel.trySendAction(SetPasswordAction.DialogDismiss) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -67,16 +64,12 @@ fun SetPasswordScreen(
                 actions = {
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.cancel),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(SetPasswordAction.CancelClick) }
-                        },
+                        onClick = { viewModel.trySendAction(SetPasswordAction.CancelClick) },
                         modifier = Modifier.testTag("CancelButton"),
                     )
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.submit),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(SetPasswordAction.SubmitClick) }
-                        },
+                        onClick = { viewModel.trySendAction(SetPasswordAction.SubmitClick) },
                         modifier = Modifier.testTag("SubmitButton"),
                     )
                 },
@@ -85,14 +78,14 @@ fun SetPasswordScreen(
     ) {
         SetPasswordScreenContent(
             state = state,
-            onPasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(SetPasswordAction.PasswordInputChanged(it)) }
+            onPasswordInputChanged = {
+                viewModel.trySendAction(SetPasswordAction.PasswordInputChanged(it))
             },
-            onRetypePasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(SetPasswordAction.RetypePasswordInputChanged(it)) }
+            onRetypePasswordInputChanged = {
+                viewModel.trySendAction(SetPasswordAction.RetypePasswordInputChanged(it))
             },
-            onPasswordHintInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(SetPasswordAction.PasswordHintInputChanged(it)) }
+            onPasswordHintInputChanged = {
+                viewModel.trySendAction(SetPasswordAction.PasswordHintInputChanged(it))
             },
             modifier = Modifier
                 .fillMaxSize(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -108,9 +107,7 @@ fun StartRegistrationScreen(
 
     StartRegistrationDialogs(
         dialog = state.dialog,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(ErrorDialogDismiss) }
-        },
+        onDismissRequest = { viewModel.trySendAction(ErrorDialogDismiss) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -123,9 +122,7 @@ fun TwoFactorLoginScreen(
 
     TwoFactorLoginDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(TwoFactorLoginAction.DialogDismiss) }
-        },
+        onDismissRequest = { viewModel.trySendAction(TwoFactorLoginAction.DialogDismiss) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
@@ -143,8 +140,8 @@ fun TwoFactorLoginScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(TwoFactorLoginAction.CloseButtonClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(TwoFactorLoginAction.CloseButtonClick)
                 },
                 actions = {
                     if (!state.isNewDeviceVerification) {
@@ -154,12 +151,10 @@ fun TwoFactorLoginScreen(
                                 .map {
                                     OverflowMenuItemData(
                                         text = it.title(),
-                                        onClick = remember(viewModel) {
-                                            {
-                                                viewModel.trySendAction(
-                                                    TwoFactorLoginAction.SelectAuthMethod(it),
-                                                )
-                                            }
+                                        onClick = {
+                                            viewModel.trySendAction(
+                                                TwoFactorLoginAction.SelectAuthMethod(it),
+                                            )
                                         },
                                     )
                                 }
@@ -175,17 +170,17 @@ fun TwoFactorLoginScreen(
     ) {
         TwoFactorLoginScreenContent(
             state = state,
-            onCodeInputChange = remember(viewModel) {
-                { viewModel.trySendAction(TwoFactorLoginAction.CodeInputChanged(it)) }
+            onCodeInputChange = {
+                viewModel.trySendAction(TwoFactorLoginAction.CodeInputChanged(it))
             },
-            onContinueButtonClick = remember(viewModel) {
-                { viewModel.trySendAction(TwoFactorLoginAction.ContinueButtonClick) }
+            onContinueButtonClick = {
+                viewModel.trySendAction(TwoFactorLoginAction.ContinueButtonClick)
             },
-            onRememberMeToggle = remember(viewModel) {
-                { viewModel.trySendAction(TwoFactorLoginAction.RememberMeToggle(it)) }
+            onRememberMeToggle = {
+                viewModel.trySendAction(TwoFactorLoginAction.RememberMeToggle(it))
             },
-            onResendEmailButtonClick = remember(viewModel) {
-                { viewModel.trySendAction(TwoFactorLoginAction.ResendEmailClick) }
+            onResendEmailButtonClick = {
+                viewModel.trySendAction(TwoFactorLoginAction.ResendEmailClick)
             },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -97,11 +97,11 @@ fun VaultUnlockScreen(
         }
     }
 
-    val onBiometricsUnlockSuccess: (cipher: Cipher) -> Unit = remember(viewModel) {
-        { viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(it)) }
+    val onBiometricsUnlockSuccess: (cipher: Cipher) -> Unit = {
+        viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockSuccess(it))
     }
-    val onBiometricsLockOut: () -> Unit = remember(viewModel) {
-        { viewModel.trySendAction(VaultUnlockAction.BiometricsLockOut) }
+    val onBiometricsLockOut: () -> Unit = {
+        viewModel.trySendAction(VaultUnlockAction.BiometricsLockOut)
     }
 
     EventsEffect(viewModel = viewModel) { event ->
@@ -145,9 +145,7 @@ fun VaultUnlockScreen(
         is VaultUnlockState.VaultUnlockDialog.Error -> BitwardenBasicDialog(
             title = dialog.title(),
             message = dialog.message(),
-            onDismissRequest = remember(viewModel) {
-                { viewModel.trySendAction(VaultUnlockAction.DismissDialog) }
-            },
+            onDismissRequest = { viewModel.trySendAction(VaultUnlockAction.DismissDialog) },
             throwable = dialog.throwable,
         )
 
@@ -177,13 +175,9 @@ fun VaultUnlockScreen(
     if (showLogoutConfirmationDialog) {
         BitwardenLogoutConfirmationDialog(
             onDismissRequest = { showLogoutConfirmationDialog = false },
-            onConfirmClick = remember(viewModel) {
-                {
-                    showLogoutConfirmationDialog = false
-                    viewModel.trySendAction(
-                        VaultUnlockAction.ConfirmLogoutClick,
-                    )
-                }
+            onConfirmClick = {
+                showLogoutConfirmationDialog = false
+                viewModel.trySendAction(VaultUnlockAction.ConfirmLogoutClick)
             },
         )
     }
@@ -230,18 +224,16 @@ fun VaultUnlockScreen(
             BitwardenAccountSwitcher(
                 isVisible = accountMenuVisible,
                 accountSummaries = state.accountSummaries.toImmutableList(),
-                onSwitchAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultUnlockAction.SwitchAccountClick(it)) }
+                onSwitchAccountClick = {
+                    viewModel.trySendAction(VaultUnlockAction.SwitchAccountClick(it))
                 },
-                onLockAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultUnlockAction.LockAccountClick(it)) }
+                onLockAccountClick = {
+                    viewModel.trySendAction(VaultUnlockAction.LockAccountClick(it))
                 },
-                onLogoutAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultUnlockAction.LogoutAccountClick(it)) }
+                onLogoutAccountClick = {
+                    viewModel.trySendAction(VaultUnlockAction.LogoutAccountClick(it))
                 },
-                onAddAccountClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultUnlockAction.AddAccountClick) }
-                },
+                onAddAccountClick = { viewModel.trySendAction(VaultUnlockAction.AddAccountClick) },
                 onDismissRequest = { accountMenuVisible = false },
                 topAppBarScrollBehavior = scrollBehavior,
                 modifier = Modifier.fillMaxSize(),
@@ -270,9 +262,7 @@ fun VaultUnlockScreen(
                 BitwardenPasswordField(
                     label = state.vaultUnlockType.unlockScreenInputLabel(),
                     value = state.input,
-                    onValueChange = remember(viewModel) {
-                        { viewModel.trySendAction(VaultUnlockAction.InputChanged(it)) }
-                    },
+                    onValueChange = { viewModel.trySendAction(VaultUnlockAction.InputChanged(it)) },
                     keyboardType = state.vaultUnlockType.unlockScreenKeyboardType,
                     showPasswordTestTag = state
                         .vaultUnlockType
@@ -280,9 +270,7 @@ fun VaultUnlockScreen(
                     autoFocus = state.showKeyboard && autoFocusDelayCompleted,
                     imeAction = ImeAction.Done,
                     keyboardActions = KeyboardActions(
-                        onDone = remember(viewModel) {
-                            { viewModel.trySendAction(VaultUnlockAction.UnlockClick) }
-                        },
+                        onDone = { viewModel.trySendAction(VaultUnlockAction.UnlockClick) },
                     ),
                     passwordFieldTestTag = state.vaultUnlockType.unlockScreenInputTestTag,
                     cardStyle = CardStyle.Top(),
@@ -322,9 +310,7 @@ fun VaultUnlockScreen(
             if (state.showBiometricLogin && biometricsManager.isBiometricsSupported) {
                 BitwardenOutlinedButton(
                     label = stringResource(id = BitwardenString.use_biometrics_to_unlock),
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockClick) }
-                    },
+                    onClick = { viewModel.trySendAction(VaultUnlockAction.BiometricsUnlockClick) },
                     modifier = Modifier
                         .standardHorizontalMargin()
                         .fillMaxWidth(),
@@ -343,9 +329,7 @@ fun VaultUnlockScreen(
             if (!state.hideInput) {
                 BitwardenFilledButton(
                     label = stringResource(id = BitwardenString.unlock),
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(VaultUnlockAction.UnlockClick) }
-                    },
+                    onClick = { viewModel.trySendAction(VaultUnlockAction.UnlockClick) },
                     isEnabled = state.input.isNotEmpty(),
                     modifier = Modifier
                         .testTag("UnlockVaultButton")

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/welcome/WelcomeScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -90,18 +89,10 @@ fun WelcomeScreen(
         WelcomeScreenContent(
             state = state,
             pagerState = pagerState,
-            onPagerSwipe = remember(viewModel) {
-                { viewModel.trySendAction(WelcomeAction.PagerSwipe(it)) }
-            },
-            onDotClick = remember(viewModel) {
-                { viewModel.trySendAction(WelcomeAction.DotClick(it)) }
-            },
-            onCreateAccountClick = remember(viewModel) {
-                { viewModel.trySendAction(WelcomeAction.CreateAccountClick) }
-            },
-            onLoginClick = remember(viewModel) {
-                { viewModel.trySendAction(WelcomeAction.LoginClick) }
-            },
+            onPagerSwipe = { viewModel.trySendAction(WelcomeAction.PagerSwipe(it)) },
+            onDotClick = { viewModel.trySendAction(WelcomeAction.DotClick(it)) },
+            onCreateAccountClick = { viewModel.trySendAction(WelcomeAction.CreateAccountClick) },
+            onLoginClick = { viewModel.trySendAction(WelcomeAction.LoginClick) },
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -71,10 +70,8 @@ fun DebugMenuScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(BitwardenDrawable.ic_back),
                     navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                    onNavigationIconClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(DebugMenuAction.NavigateBack)
-                        }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(DebugMenuAction.NavigateBack)
                     },
                 ),
             )
@@ -87,13 +84,11 @@ fun DebugMenuScreen(
             if (state.featureFlags.isNotEmpty()) {
                 FeatureFlagContent(
                     featureFlagMap = state.featureFlags,
-                    onValueChange = remember(viewModel) {
-                        { key, value ->
-                            viewModel.trySendAction(DebugMenuAction.UpdateFeatureFlag(key, value))
-                        }
+                    onValueChange = { key, value ->
+                        viewModel.trySendAction(DebugMenuAction.UpdateFeatureFlag(key, value))
                     },
-                    onResetValues = remember(viewModel) {
-                        { viewModel.trySendAction(DebugMenuAction.ResetFeatureFlagValues) }
+                    onResetValues = {
+                        viewModel.trySendAction(DebugMenuAction.ResetFeatureFlagValues)
                     },
                 )
                 Spacer(Modifier.height(height = 16.dp))
@@ -101,25 +96,15 @@ fun DebugMenuScreen(
                 Spacer(Modifier.height(height = 16.dp))
             }
             OnboardingOverrideContent(
-                onStartOnboarding = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(DebugMenuAction.RestartOnboarding)
-                    }
-                },
-                onStartOnboardingCarousel = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel)
-                    }
+                onStartOnboarding = { viewModel.trySendAction(DebugMenuAction.RestartOnboarding) },
+                onStartOnboardingCarousel = {
+                    viewModel.trySendAction(DebugMenuAction.RestartOnboardingCarousel)
                 },
             )
             Spacer(Modifier.height(16.dp))
             BitwardenFilledButton(
                 label = stringResource(BitwardenString.reset_coach_mark_tour_status),
-                onClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(DebugMenuAction.ResetCoachMarkTourStatuses)
-                    }
-                },
+                onClick = { viewModel.trySendAction(DebugMenuAction.ResetCoachMarkTourStatuses) },
                 isEnabled = true,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -128,13 +113,7 @@ fun DebugMenuScreen(
             Spacer(Modifier.height(height = 8.dp))
             BitwardenFilledButton(
                 label = stringResource(BitwardenString.trigger_cookie_acquisition),
-                onClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            DebugMenuAction.TriggerCookieAcquisition,
-                        )
-                    }
-                },
+                onClick = { viewModel.trySendAction(DebugMenuAction.TriggerCookieAcquisition) },
                 isEnabled = true,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -152,9 +131,7 @@ fun DebugMenuScreen(
             Spacer(modifier = Modifier.height(height = 8.dp))
             BitwardenFilledButton(
                 label = stringResource(BitwardenString.generate_error_report),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(DebugMenuAction.GenerateErrorReportClick) }
-                },
+                onClick = { viewModel.trySendAction(DebugMenuAction.GenerateErrorReportClick) },
                 isEnabled = true,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -163,9 +140,7 @@ fun DebugMenuScreen(
             Spacer(modifier = Modifier.height(height = 8.dp))
             BitwardenFilledButton(
                 label = stringResource(BitwardenString.generate_crash),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(DebugMenuAction.GenerateCrashClick) }
-                },
+                onClick = { viewModel.trySendAction(DebugMenuAction.GenerateCrashClick) },
                 isEnabled = true,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -75,8 +74,8 @@ fun SettingsScreen(
                         navigationIconContentDescription = stringResource(
                             id = BitwardenString.close,
                         ),
-                        onNavigationIconClick = remember(viewModel) {
-                            { viewModel.trySendAction(SettingsAction.CloseClick) }
+                        onNavigationIconClick = {
+                            viewModel.trySendAction(SettingsAction.CloseClick)
                         },
                     )
                 } else {
@@ -95,8 +94,8 @@ fun SettingsScreen(
             state.settingRows.forEachIndexed { index, settingEntry ->
                 BitwardenPushRow(
                     text = settingEntry.text(),
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(SettingsAction.SettingsClick(settingEntry)) }
+                    onClick = {
+                        viewModel.trySendAction(SettingsAction.SettingsClick(settingEntry))
                     },
                     notificationCount = state.notificationBadgeCountMap.getOrDefault(
                         key = settingEntry,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -100,42 +99,32 @@ fun AboutScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(AboutAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(AboutAction.BackClick) },
             )
         },
     ) {
         AboutScreenContent(
             state = state,
             modifier = Modifier.fillMaxSize(),
-            onHelpCenterClick = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.HelpCenterClick) }
+            onHelpCenterClick = { viewModel.trySendAction(AboutAction.HelpCenterClick) },
+            onPrivacyPolicyClick = { viewModel.trySendAction(AboutAction.PrivacyPolicyClick) },
+            onLearnAboutOrgsClick = {
+                viewModel.trySendAction(AboutAction.LearnAboutOrganizationsClick)
             },
-            onPrivacyPolicyClick = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.PrivacyPolicyClick) }
+            onSubmitCrashLogsCheckedChange = {
+                viewModel.trySendAction(AboutAction.SubmitCrashLogsClick(it))
             },
-            onLearnAboutOrgsClick = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.LearnAboutOrganizationsClick) }
+            onFlightRecorderCheckedChange = {
+                viewModel.trySendAction(AboutAction.FlightRecorderCheckedChange(it))
             },
-            onSubmitCrashLogsCheckedChange = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.SubmitCrashLogsClick(it)) }
+            onFlightRecorderTooltipClick = {
+                viewModel.trySendAction(AboutAction.FlightRecorderTooltipClick)
             },
-            onFlightRecorderCheckedChange = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.FlightRecorderCheckedChange(it)) }
+            onViewRecordedLogsClick = {
+                viewModel.trySendAction(AboutAction.ViewRecordedLogsClick)
             },
-            onFlightRecorderTooltipClick = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.FlightRecorderTooltipClick) }
-            },
-            onViewRecordedLogsClick = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.ViewRecordedLogsClick) }
-            },
-            onVersionClick = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.VersionClick) }
-            },
-            onWebVaultClick = remember(viewModel) {
-                { viewModel.trySendAction(AboutAction.WebVaultClick) }
-            },
+            onVersionClick = { viewModel.trySendAction(AboutAction.VersionClick) },
+            onWebVaultClick = { viewModel.trySendAction(AboutAction.WebVaultClick) },
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -91,12 +91,8 @@ fun AccountSecurityScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     var showBiometricsPrompt by rememberSaveable { mutableStateOf(false) }
-    val unlockWithBiometricToggle: (cipher: Cipher) -> Unit = remember(viewModel) {
-        {
-            viewModel.trySendAction(
-                action = AccountSecurityAction.UnlockWithBiometricToggleEnabled(cipher = it),
-            )
-        }
+    val unlockWithBiometricToggle: (cipher: Cipher) -> Unit = {
+        viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggleEnabled(it))
     }
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -142,14 +138,12 @@ fun AccountSecurityScreen(
 
     AccountSecurityDialogs(
         state = state,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(AccountSecurityAction.DismissDialog) }
+        onDismissRequest = { viewModel.trySendAction(AccountSecurityAction.DismissDialog) },
+        onConfirmLogoutClick = {
+            viewModel.trySendAction(AccountSecurityAction.ConfirmLogoutClick)
         },
-        onConfirmLogoutClick = remember(viewModel) {
-            { viewModel.trySendAction(AccountSecurityAction.ConfirmLogoutClick) }
-        },
-        onFingerprintLearnMore = remember(viewModel) {
-            { viewModel.trySendAction(AccountSecurityAction.FingerPrintLearnMoreClick) }
+        onFingerprintLearnMore = {
+            viewModel.trySendAction(AccountSecurityAction.FingerPrintLearnMoreClick)
         },
     )
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -163,8 +157,8 @@ fun AccountSecurityScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.BackClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(AccountSecurityAction.BackClick)
                 },
             )
         },
@@ -183,15 +177,11 @@ fun AccountSecurityScreen(
                 BitwardenActionCard(
                     cardTitle = stringResource(id = BitwardenString.set_up_unlock),
                     actionText = stringResource(BitwardenString.get_started),
-                    onActionClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(AccountSecurityAction.UnlockActionCardCtaClick)
-                        }
+                    onActionClick = {
+                        viewModel.trySendAction(AccountSecurityAction.UnlockActionCardCtaClick)
                     },
-                    onDismissClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(AccountSecurityAction.UnlockActionCardDismiss)
-                        }
+                    onDismissClick = {
+                        viewModel.trySendAction(AccountSecurityAction.UnlockActionCardDismiss)
                     },
                     leadingContent = {
                         NotificationBadge(notificationCount = 1)
@@ -212,8 +202,8 @@ fun AccountSecurityScreen(
             Spacer(modifier = Modifier.height(height = 8.dp))
             BitwardenTextRow(
                 text = stringResource(id = BitwardenString.pending_log_in_requests),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.PendingLoginRequestsClick) }
+                onClick = {
+                    viewModel.trySendAction(AccountSecurityAction.PendingLoginRequestsClick)
                 },
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
@@ -240,15 +230,11 @@ fun AccountSecurityScreen(
             BitwardenUnlockWithBiometricsSwitch(
                 biometricSupportStatus = biometricSupportStatus,
                 isChecked = state.isUnlockWithBiometricsEnabled || showBiometricsPrompt,
-                onDisableBiometrics = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            AccountSecurityAction.UnlockWithBiometricToggleDisabled,
-                        )
-                    }
+                onDisableBiometrics = {
+                    viewModel.trySendAction(AccountSecurityAction.UnlockWithBiometricToggleDisabled)
                 },
-                onEnableBiometrics = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.EnableBiometricsClick) }
+                onEnableBiometrics = {
+                    viewModel.trySendAction(AccountSecurityAction.EnableBiometricsClick)
                 },
                 cardStyle = CardStyle.Full,
                 modifier = Modifier
@@ -261,8 +247,8 @@ fun AccountSecurityScreen(
                 BitwardenUnlockWithPinSwitch(
                     isUnlockWithPasswordEnabled = state.isUnlockWithPasswordEnabled,
                     isUnlockWithPinEnabled = state.isUnlockWithPinEnabled,
-                    onUnlockWithPinToggleAction = remember(viewModel) {
-                        { viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle(it)) }
+                    onUnlockWithPinToggleAction = {
+                        viewModel.trySendAction(AccountSecurityAction.UnlockWithPinToggle(it))
                     },
                     cardStyle = CardStyle.Full,
                     modifier = Modifier
@@ -275,12 +261,8 @@ fun AccountSecurityScreen(
             if (state.shouldShowEnableAuthenticatorSync) {
                 SyncWithAuthenticatorRow(
                     isChecked = state.isAuthenticatorSyncChecked,
-                    onCheckedChange = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                AccountSecurityAction.AuthenticatorSyncToggle(enabled = it),
-                            )
-                        }
+                    onCheckedChange = {
+                        viewModel.trySendAction(AccountSecurityAction.AuthenticatorSyncToggle(it))
                     },
                 )
                 Spacer(Modifier.height(16.dp))
@@ -296,8 +278,8 @@ fun AccountSecurityScreen(
             SessionTimeoutRow(
                 vaultTimeoutPolicy = state.vaultTimeoutPolicy,
                 selectedVaultTimeoutType = state.vaultTimeout.type,
-                onVaultTimeoutTypeSelect = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.VaultTimeoutTypeSelect(it)) }
+                onVaultTimeoutTypeSelect = {
+                    viewModel.trySendAction(AccountSecurityAction.VaultTimeoutTypeSelect(it))
                 },
                 modifier = Modifier
                     .testTag("VaultTimeoutChooser")
@@ -308,12 +290,8 @@ fun AccountSecurityScreen(
                 SessionCustomTimeoutRow(
                     vaultTimeoutPolicy = state.vaultTimeoutPolicy,
                     customVaultTimeout = customTimeout,
-                    onCustomVaultTimeoutSelect = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                AccountSecurityAction.CustomVaultTimeoutSelect(it),
-                            )
-                        }
+                    onCustomVaultTimeoutSelect = {
+                        viewModel.trySendAction(AccountSecurityAction.CustomVaultTimeoutSelect(it))
                     },
                     modifier = Modifier
                         .fillMaxWidth()
@@ -333,8 +311,8 @@ fun AccountSecurityScreen(
             SessionTimeoutActionRow(
                 isEnabled = state.isSessionTimeoutActionEnabled,
                 selectedVaultTimeoutAction = state.vaultTimeoutAction,
-                onVaultTimeoutActionSelect = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.VaultTimeoutActionSelect(it)) }
+                onVaultTimeoutActionSelect = {
+                    viewModel.trySendAction(AccountSecurityAction.VaultTimeoutActionSelect(it))
                 },
                 supportingText = state.sessionTimeoutActionSupportingText?.invoke(),
                 cardStyle = if (state.sessionTimeoutSupportText == null) {
@@ -359,8 +337,8 @@ fun AccountSecurityScreen(
             Spacer(modifier = Modifier.height(height = 8.dp))
             BitwardenTextRow(
                 text = stringResource(id = BitwardenString.account_fingerprint_phrase),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.AccountFingerprintPhraseClick) }
+                onClick = {
+                    viewModel.trySendAction(AccountSecurityAction.AccountFingerprintPhraseClick)
                 },
                 cardStyle = CardStyle.Top(),
                 modifier = Modifier
@@ -370,8 +348,8 @@ fun AccountSecurityScreen(
             )
             BitwardenExternalLinkRow(
                 text = stringResource(id = BitwardenString.two_step_login),
-                onConfirmClick = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.TwoStepLoginClick) }
+                onConfirmClick = {
+                    viewModel.trySendAction(AccountSecurityAction.TwoStepLoginClick)
                 },
                 withDivider = false,
                 dialogTitle = stringResource(id = BitwardenString.continue_to_web_app),
@@ -387,8 +365,8 @@ fun AccountSecurityScreen(
             if (state.isUnlockWithPasswordEnabled) {
                 BitwardenExternalLinkRow(
                     text = stringResource(id = BitwardenString.change_master_password),
-                    onConfirmClick = remember(viewModel) {
-                        { viewModel.trySendAction(AccountSecurityAction.ChangeMasterPasswordClick) }
+                    onConfirmClick = {
+                        viewModel.trySendAction(AccountSecurityAction.ChangeMasterPasswordClick)
                     },
                     withDivider = false,
                     dialogTitle = stringResource(id = BitwardenString.continue_to_web_app),
@@ -404,9 +382,7 @@ fun AccountSecurityScreen(
             if (state.hasUnlockMechanism) {
                 BitwardenTextRow(
                     text = stringResource(id = BitwardenString.lock_now),
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(AccountSecurityAction.LockNowClick) }
-                    },
+                    onClick = { viewModel.trySendAction(AccountSecurityAction.LockNowClick) },
                     cardStyle = CardStyle.Middle(),
                     modifier = Modifier
                         .testTag("LockNowLabel")
@@ -416,9 +392,7 @@ fun AccountSecurityScreen(
             }
             BitwardenTextRow(
                 text = stringResource(id = BitwardenString.log_out),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.LogoutClick) }
-                },
+                onClick = { viewModel.trySendAction(AccountSecurityAction.LogoutClick) },
                 cardStyle = CardStyle.Middle(),
                 modifier = Modifier
                     .testTag("LogOutLabel")
@@ -427,9 +401,7 @@ fun AccountSecurityScreen(
             )
             BitwardenTextRow(
                 text = stringResource(id = BitwardenString.delete_account),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(AccountSecurityAction.DeleteAccountClick) }
-                },
+                onClick = { viewModel.trySendAction(AccountSecurityAction.DeleteAccountClick) },
                 cardStyle = CardStyle.Bottom,
                 modifier = Modifier
                     .testTag("DeleteAccountLabel")

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccount/DeleteAccountScreen.kt
@@ -73,8 +73,8 @@ fun DeleteAccountScreen(
             message = stringResource(
                 id = BitwardenString.your_account_has_been_permanently_deleted,
             ),
-            onDismissRequest = remember(viewModel) {
-                { viewModel.trySendAction(DeleteAccountAction.AccountDeletionConfirm) }
+            onDismissRequest = {
+                viewModel.trySendAction(DeleteAccountAction.AccountDeletionConfirm)
             },
         )
 
@@ -82,9 +82,7 @@ fun DeleteAccountScreen(
             title = stringResource(id = BitwardenString.an_error_has_occurred),
             message = dialog.message(),
             throwable = dialog.error,
-            onDismissRequest = remember(viewModel) {
-                { viewModel.trySendAction(DeleteAccountAction.DismissDialog) }
-            },
+            onDismissRequest = { viewModel.trySendAction(DeleteAccountAction.DismissDialog) },
         )
 
         DeleteAccountState.DeleteAccountDialog.Loading -> BitwardenLoadingDialog(
@@ -105,9 +103,7 @@ fun DeleteAccountScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(DeleteAccountAction.CloseClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(DeleteAccountAction.CloseClick) },
             )
         },
     ) {
@@ -135,15 +131,13 @@ fun DeleteAccountScreen(
                 )
                 Spacer(modifier = Modifier.height(24.dp))
                 DeleteAccountButton(
-                    onDeleteAccountConfirmDialogClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                DeleteAccountAction.DeleteAccountConfirmDialogClick(it),
-                            )
-                        }
+                    onDeleteAccountConfirmDialogClick = {
+                        viewModel.trySendAction(
+                            DeleteAccountAction.DeleteAccountConfirmDialogClick(it),
+                        )
                     },
-                    onDeleteAccountClick = remember(viewModel) {
-                        { viewModel.trySendAction(DeleteAccountAction.DeleteAccountClick) }
+                    onDeleteAccountClick = {
+                        viewModel.trySendAction(DeleteAccountAction.DeleteAccountClick)
                     },
                     isUnlockWithPasswordEnabled = state.isUnlockWithPasswordEnabled,
                     modifier = Modifier
@@ -154,9 +148,7 @@ fun DeleteAccountScreen(
                 Spacer(modifier = Modifier.height(12.dp))
                 BitwardenOutlinedErrorButton(
                     label = stringResource(id = BitwardenString.cancel),
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(DeleteAccountAction.CancelClick) }
-                    },
+                    onClick = { viewModel.trySendAction(DeleteAccountAction.CancelClick) },
                     modifier = Modifier
                         .testTag("CANCEL")
                         .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/deleteaccountconfirmation/DeleteAccountConfirmationScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -57,31 +56,25 @@ fun DeleteAccountConfirmationScreen(
 
     DeleteAccountConfirmationDialogs(
         dialogState = state.dialog,
-        onDeleteAccountAcknowledge = remember(viewModel) {
-            { viewModel.trySendAction(DeleteAccountConfirmationAction.DeleteAccountAcknowledge) }
+        onDeleteAccountAcknowledge = {
+            viewModel.trySendAction(DeleteAccountConfirmationAction.DeleteAccountAcknowledge)
         },
-        onDismissDialog = remember(viewModel) {
-            { viewModel.trySendAction(DeleteAccountConfirmationAction.DismissDialog) }
+        onDismissDialog = {
+            viewModel.trySendAction(DeleteAccountConfirmationAction.DismissDialog)
         },
     )
 
     DeleteAccountConfirmationScaffold(
         state = state,
-        onCloseClick = remember(viewModel) {
-            { viewModel.trySendAction(DeleteAccountConfirmationAction.CloseClick) }
+        onCloseClick = { viewModel.trySendAction(DeleteAccountConfirmationAction.CloseClick) },
+        onDeleteAccountClick = {
+            viewModel.trySendAction(DeleteAccountConfirmationAction.DeleteAccountClick)
         },
-        onDeleteAccountClick = remember(viewModel) {
-            { viewModel.trySendAction(DeleteAccountConfirmationAction.DeleteAccountClick) }
+        onResendCodeClick = {
+            viewModel.trySendAction(DeleteAccountConfirmationAction.ResendCodeClick)
         },
-        onResendCodeClick = remember(viewModel) {
-            { viewModel.trySendAction(DeleteAccountConfirmationAction.ResendCodeClick) }
-        },
-        onVerificationCodeTextChange = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    DeleteAccountConfirmationAction.VerificationCodeTextChange(it),
-                )
-            }
+        onVerificationCodeTextChange = {
+            viewModel.trySendAction(DeleteAccountConfirmationAction.VerificationCodeTextChange(it))
         },
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/loginapproval/LoginApprovalScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -66,22 +65,16 @@ fun LoginApprovalScreen(
 
     LoginApprovalDialogs(
         state = state.dialogState,
-        onDismissError = remember(viewModel) {
-            { viewModel.trySendAction(LoginApprovalAction.ErrorDialogDismiss) }
+        onDismissError = { viewModel.trySendAction(LoginApprovalAction.ErrorDialogDismiss) },
+        onConfirmChangeAccount = {
+            viewModel.trySendAction(LoginApprovalAction.ApproveAccountChangeClick)
         },
-        onConfirmChangeAccount = remember(viewModel) {
-            { viewModel.trySendAction(LoginApprovalAction.ApproveAccountChangeClick) }
-        },
-        onDismissChangeAccount = remember(viewModel) {
-            { viewModel.trySendAction(LoginApprovalAction.CancelAccountChangeClick) }
+        onDismissChangeAccount = {
+            viewModel.trySendAction(LoginApprovalAction.CancelAccountChangeClick)
         },
     )
 
-    BackHandler(
-        onBack = remember(viewModel) {
-            { viewModel.trySendAction(LoginApprovalAction.CloseClick) }
-        },
-    )
+    BackHandler(onBack = { viewModel.trySendAction(LoginApprovalAction.CloseClick) })
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
     BitwardenScaffold(
         modifier = Modifier
@@ -93,9 +86,7 @@ fun LoginApprovalScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(LoginApprovalAction.CloseClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(LoginApprovalAction.CloseClick) },
             )
         },
     ) {
@@ -103,11 +94,11 @@ fun LoginApprovalScreen(
             is LoginApprovalState.ViewState.Content -> {
                 LoginApprovalContent(
                     state = viewState,
-                    onConfirmLoginClick = remember(viewModel) {
-                        { viewModel.trySendAction(LoginApprovalAction.ApproveRequestClick) }
+                    onConfirmLoginClick = {
+                        viewModel.trySendAction(LoginApprovalAction.ApproveRequestClick)
                     },
-                    onDeclineLoginClick = remember(viewModel) {
-                        { viewModel.trySendAction(LoginApprovalAction.DeclineRequestClick) }
+                    onDeclineLoginClick = {
+                        viewModel.trySendAction(LoginApprovalAction.DeclineRequestClick)
                     },
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/pendingrequests/PendingRequestsScreen.kt
@@ -79,9 +79,7 @@ fun PendingRequestsScreen(
     val pullToRefreshState = rememberBitwardenPullToRefreshState(
         isEnabled = state.isPullToRefreshEnabled,
         isRefreshing = state.isRefreshing,
-        onRefresh = remember(viewModel) {
-            { viewModel.trySendAction(PendingRequestsAction.RefreshPull) }
-        },
+        onRefresh = { viewModel.trySendAction(PendingRequestsAction.RefreshPull) },
     )
     val snackbarHostState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel = viewModel) { event ->
@@ -113,9 +111,7 @@ fun PendingRequestsScreen(
     BitwardenModalBottomSheet(
         showBottomSheet = !hideBottomSheet,
         sheetTitle = stringResource(BitwardenString.enable_notifications),
-        onDismiss = remember(viewModel) {
-            { viewModel.trySendAction(PendingRequestsAction.HideBottomSheet) }
-        },
+        onDismiss = { viewModel.trySendAction(PendingRequestsAction.HideBottomSheet) },
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         modifier = Modifier.statusBarsPadding(),
     ) { animatedOnDismiss ->
@@ -136,8 +132,8 @@ fun PendingRequestsScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(PendingRequestsAction.CloseClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(PendingRequestsAction.CloseClick)
                 },
             )
         },
@@ -151,19 +147,11 @@ fun PendingRequestsScreen(
                 PendingRequestsContent(
                     modifier = Modifier.fillMaxSize(),
                     state = viewState,
-                    onDeclineAllRequestsConfirm = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                PendingRequestsAction.DeclineAllRequestsConfirm,
-                            )
-                        }
+                    onDeclineAllRequestsConfirm = {
+                        viewModel.trySendAction(PendingRequestsAction.DeclineAllRequestsConfirm)
                     },
-                    onNavigateToLoginApproval = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                PendingRequestsAction.PendingRequestRowClick(it),
-                            )
-                        }
+                    onNavigateToLoginApproval = {
+                        viewModel.trySendAction(PendingRequestsAction.PendingRequestRowClick(it))
                     },
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/appearance/AppearanceScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalResources
@@ -66,12 +65,10 @@ fun AppearanceScreen(
 
     AppearanceDialogs(
         dialogState = state.dialogState,
-        onConfirmEnableDynamicColorsClick = remember(viewModel) {
-            { viewModel.trySendAction(AppearanceAction.ConfirmEnableDynamicColorsClick) }
+        onConfirmEnableDynamicColorsClick = {
+            viewModel.trySendAction(AppearanceAction.ConfirmEnableDynamicColorsClick)
         },
-        onDismissDialog = remember(viewModel) {
-            { viewModel.trySendAction(AppearanceAction.DismissDialog) }
-        },
+        onDismissDialog = { viewModel.trySendAction(AppearanceAction.DismissDialog) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -85,9 +82,7 @@ fun AppearanceScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(AppearanceAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(AppearanceAction.BackClick) },
             )
         },
     ) {
@@ -99,8 +94,8 @@ fun AppearanceScreen(
             Spacer(modifier = Modifier.height(height = 12.dp))
             LanguageSelectionRow(
                 currentSelection = state.language,
-                onLanguageSelection = remember(viewModel) {
-                    { viewModel.trySendAction(AppearanceAction.LanguageChange(it)) }
+                onLanguageSelection = {
+                    viewModel.trySendAction(AppearanceAction.LanguageChange(it))
                 },
                 modifier = Modifier
                     .testTag("LanguageChooser")
@@ -110,9 +105,7 @@ fun AppearanceScreen(
             Spacer(modifier = Modifier.height(height = 8.dp))
             ThemeSelectionRow(
                 currentSelection = state.theme,
-                onThemeSelection = remember(viewModel) {
-                    { viewModel.trySendAction(AppearanceAction.ThemeChange(it)) }
-                },
+                onThemeSelection = { viewModel.trySendAction(AppearanceAction.ThemeChange(it)) },
                 modifier = Modifier
                     .testTag("ThemeChooser")
                     .standardHorizontalMargin()
@@ -123,8 +116,8 @@ fun AppearanceScreen(
                 BitwardenSwitch(
                     label = stringResource(id = BitwardenString.use_dynamic_colors),
                     isChecked = state.isDynamicColorsEnabled,
-                    onCheckedChange = remember(viewModel) {
-                        { viewModel.trySendAction(AppearanceAction.DynamicColorsToggle(it)) }
+                    onCheckedChange = {
+                        viewModel.trySendAction(AppearanceAction.DynamicColorsToggle(it))
                     },
                     cardStyle = CardStyle.Full,
                     modifier = Modifier
@@ -140,12 +133,12 @@ fun AppearanceScreen(
                     id = BitwardenString.show_website_icons_description,
                 ),
                 isChecked = state.showWebsiteIcons,
-                onCheckedChange = remember(viewModel) {
-                    { viewModel.trySendAction(AppearanceAction.ShowWebsiteIconsToggle(it)) }
+                onCheckedChange = {
+                    viewModel.trySendAction(AppearanceAction.ShowWebsiteIconsToggle(it))
                 },
                 tooltip = TooltipData(
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(AppearanceAction.ShowWebsiteIconsTooltipClick) }
+                    onClick = {
+                        viewModel.trySendAction(AppearanceAction.ShowWebsiteIconsTooltipClick)
                     },
                     contentDescription = stringResource(
                         id = BitwardenString.show_website_icons_help,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/AutoFillScreen.kt
@@ -162,9 +162,7 @@ fun AutoFillScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(AutoFillAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(AutoFillAction.BackClick) },
             )
         },
     ) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/BlockAutoFillScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/blockautofill/BlockAutoFillScreen.kt
@@ -68,22 +68,14 @@ fun BlockAutoFillScreen(
 
     BlockAutoFillDialogs(
         dialogState = state.dialog,
-        onUriTextChange = remember(viewModel) {
-            { viewModel.trySendAction(BlockAutoFillAction.UriTextChange(uri = it)) }
+        onUriTextChange = { viewModel.trySendAction(BlockAutoFillAction.UriTextChange(uri = it)) },
+        onSaveClick = { newUri, originalUri ->
+            viewModel.trySendAction(
+                BlockAutoFillAction.SaveUri(newUri = newUri, originalUri = originalUri),
+            )
         },
-        onSaveClick = remember(viewModel) {
-            { newUri, originalUri ->
-                viewModel.trySendAction(
-                    BlockAutoFillAction.SaveUri(newUri = newUri, originalUri = originalUri),
-                )
-            }
-        },
-        onRemoveClick = remember(viewModel) {
-            { viewModel.trySendAction(BlockAutoFillAction.RemoveUriClick(it)) }
-        },
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(BlockAutoFillAction.DismissDialog) }
-        },
+        onRemoveClick = { viewModel.trySendAction(BlockAutoFillAction.RemoveUriClick(it)) },
+        onDismissRequest = { viewModel.trySendAction(BlockAutoFillAction.DismissDialog) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -97,9 +89,7 @@ fun BlockAutoFillScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(BlockAutoFillAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(BlockAutoFillAction.BackClick) },
             )
         },
         floatingActionButton = {
@@ -109,9 +99,7 @@ fun BlockAutoFillScreen(
                 exit = scaleOut(),
             ) {
                 BitwardenFloatingActionButton(
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(BlockAutoFillAction.AddUriClick) }
-                    },
+                    onClick = { viewModel.trySendAction(BlockAutoFillAction.AddUriClick) },
                     painter = rememberVectorPainter(id = BitwardenDrawable.ic_plus_large),
                     contentDescription = stringResource(id = BitwardenString.add_item),
                     modifier = Modifier.testTag(tag = "AddItemButton"),
@@ -147,12 +135,8 @@ fun BlockAutoFillScreen(
                     items(viewState.blockedUris, key = { it }) { uri ->
                         BlockAutoFillListItem(
                             label = uri,
-                            onClick = remember(viewModel) {
-                                {
-                                    viewModel.trySendAction(
-                                        BlockAutoFillAction.EditUriClick(uri),
-                                    )
-                                }
+                            onClick = {
+                                viewModel.trySendAction(BlockAutoFillAction.EditUriClick(uri))
                             },
                             modifier = Modifier
                                 .padding(horizontal = 16.dp)
@@ -164,8 +148,8 @@ fun BlockAutoFillScreen(
                 is BlockAutoFillState.ViewState.Empty -> {
                     item {
                         BlockAutoFillNoItems(
-                            addItemClickAction = remember(viewModel) {
-                                { viewModel.trySendAction(BlockAutoFillAction.AddUriClick) }
+                            addItemClickAction = {
+                                viewModel.trySendAction(BlockAutoFillAction.AddUriClick)
                             },
                             modifier = Modifier.fillMaxSize(),
                         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/list/PrivilegedAppsListScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/autofill/privilegedapps/list/PrivilegedAppsListScreen.kt
@@ -64,15 +64,11 @@ fun PrivilegedAppsListScreen(
 
     PrivilegedAppListDialogs(
         state = state,
-        onDismissDialogClick = remember(viewModel) {
-            { viewModel.trySendAction(PrivilegedAppsListAction.DismissDialogClick) }
+        onDismissDialogClick = {
+            viewModel.trySendAction(PrivilegedAppsListAction.DismissDialogClick)
         },
-        onConfirmDeleteTrustedAppClick = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    PrivilegedAppsListAction.UserTrustedAppDeleteConfirmClick(it),
-                )
-            }
+        onConfirmDeleteTrustedAppClick = {
+            viewModel.trySendAction(PrivilegedAppsListAction.UserTrustedAppDeleteConfirmClick(it))
         },
     )
 
@@ -83,8 +79,8 @@ fun PrivilegedAppsListScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(PrivilegedAppsListAction.BackClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(PrivilegedAppsListAction.BackClick)
                 },
             )
         },
@@ -94,8 +90,8 @@ fun PrivilegedAppsListScreen(
     ) {
         PrivilegedAppsListContent(
             state = state,
-            onDeleteClick = remember(viewModel) {
-                { viewModel.trySendAction(PrivilegedAppsListAction.UserTrustedAppDeleteClick(it)) }
+            onDeleteClick = {
+                viewModel.trySendAction(PrivilegedAppsListAction.UserTrustedAppDeleteClick(it))
             },
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/exportvault/ExportVaultScreen.kt
@@ -90,8 +90,8 @@ fun ExportVaultScreen(
     }
 
     var shouldShowConfirmationDialog by remember { mutableStateOf(false) }
-    val confirmExportVaultClicked = remember(viewModel) {
-        { viewModel.trySendAction(ExportVaultAction.ConfirmExportVaultClicked) }
+    val confirmExportVaultClicked = {
+        viewModel.trySendAction(ExportVaultAction.ConfirmExportVaultClicked)
     }
     if (shouldShowConfirmationDialog) {
         BitwardenTwoButtonDialog(
@@ -120,9 +120,7 @@ fun ExportVaultScreen(
                 title = dialog.title?.invoke(),
                 message = dialog.message(),
                 throwable = dialog.error,
-                onDismissRequest = remember(viewModel) {
-                    { viewModel.trySendAction(ExportVaultAction.DialogDismiss) }
-                },
+                onDismissRequest = { viewModel.trySendAction(ExportVaultAction.DialogDismiss) },
             )
         }
 
@@ -144,8 +142,8 @@ fun ExportVaultScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(ExportVaultAction.CloseButtonClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(ExportVaultAction.CloseButtonClick)
                 },
             )
         },
@@ -155,21 +153,19 @@ fun ExportVaultScreen(
     ) {
         ExportVaultScreenContent(
             state = state,
-            onConfirmFilePasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(ExportVaultAction.ConfirmFilePasswordInputChange(it)) }
+            onConfirmFilePasswordInputChanged = {
+                viewModel.trySendAction(ExportVaultAction.ConfirmFilePasswordInputChange(it))
             },
-            onExportFormatOptionSelected = remember(viewModel) {
-                { viewModel.trySendAction(ExportVaultAction.ExportFormatOptionSelect(it)) }
+            onExportFormatOptionSelected = {
+                viewModel.trySendAction(ExportVaultAction.ExportFormatOptionSelect(it))
             },
-            onFilePasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(ExportVaultAction.FilePasswordInputChange(it)) }
+            onFilePasswordInputChanged = {
+                viewModel.trySendAction(ExportVaultAction.FilePasswordInputChange(it))
             },
-            onPasswordInputChanged = remember(viewModel) {
-                { viewModel.trySendAction(ExportVaultAction.PasswordInputChanged(it)) }
+            onPasswordInputChanged = {
+                viewModel.trySendAction(ExportVaultAction.PasswordInputChanged(it))
             },
-            onSendCodeClicked = remember(viewModel) {
-                { viewModel.trySendAction(ExportVaultAction.SendCodeClick) }
-            },
+            onSendCodeClicked = { viewModel.trySendAction(ExportVaultAction.SendCodeClick) },
             onExportVaultClick = { shouldShowConfirmationDialog = true },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/FlightRecorderScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalResources
@@ -69,16 +68,12 @@ fun FlightRecorderScreen(
                 title = stringResource(id = BitwardenString.enable_flight_recorder_title),
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(FlightRecorderAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(FlightRecorderAction.BackClick) },
                 scrollBehavior = scrollBehavior,
                 actions = {
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.save),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(FlightRecorderAction.SaveClick) }
-                        },
+                        onClick = { viewModel.trySendAction(FlightRecorderAction.SaveClick) },
                         modifier = Modifier.testTag("SaveButton"),
                     )
                 },
@@ -88,12 +83,10 @@ fun FlightRecorderScreen(
     ) {
         FlightRecorderContent(
             state = state,
-            onDurationSelected = remember(viewModel) {
-                { viewModel.trySendAction(FlightRecorderAction.DurationSelect(it)) }
+            onDurationSelected = {
+                viewModel.trySendAction(FlightRecorderAction.DurationSelect(it))
             },
-            onHelpCenterClick = remember(viewModel) {
-                { viewModel.trySendAction(FlightRecorderAction.HelpCenterClick) }
-            },
+            onHelpCenterClick = { viewModel.trySendAction(FlightRecorderAction.HelpCenterClick) },
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -86,9 +85,7 @@ fun RecordedLogsScreen(
 
     RecordedLogsDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(RecordedLogsAction.DismissDialog) }
-        },
+        onDismissRequest = { viewModel.trySendAction(RecordedLogsAction.DismissDialog) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -98,18 +95,16 @@ fun RecordedLogsScreen(
                 title = stringResource(id = BitwardenString.recorded_logs_title),
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(RecordedLogsAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(RecordedLogsAction.BackClick) },
                 scrollBehavior = scrollBehavior,
                 actions = {
                     RecordedLogsOverflowMenu(
                         isOverflowEnabled = state.viewState.isOverflowEnabled,
-                        onDeleteAllClick = remember(viewModel) {
-                            { viewModel.trySendAction(RecordedLogsAction.DeleteAllClick) }
+                        onDeleteAllClick = {
+                            viewModel.trySendAction(RecordedLogsAction.DeleteAllClick)
                         },
-                        onShareAllClick = remember(viewModel) {
-                            { viewModel.trySendAction(RecordedLogsAction.ShareAllClick) }
+                        onShareAllClick = {
+                            viewModel.trySendAction(RecordedLogsAction.ShareAllClick)
                         },
                     )
                 },
@@ -122,11 +117,11 @@ fun RecordedLogsScreen(
             is RecordedLogsState.ViewState.Content -> {
                 RecordedLogsContent(
                     viewState = viewState,
-                    onShareItemClick = remember(viewModel) {
-                        { viewModel.trySendAction(RecordedLogsAction.ShareClick(it)) }
+                    onShareItemClick = {
+                        viewModel.trySendAction(RecordedLogsAction.ShareClick(it))
                     },
-                    onDeleteItemClick = remember(viewModel) {
-                        { viewModel.trySendAction(RecordedLogsAction.DeleteClick(it)) }
+                    onDeleteItemClick = {
+                        viewModel.trySendAction(RecordedLogsAction.DeleteClick(it))
                     },
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/FoldersScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -80,16 +79,12 @@ fun FoldersScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(FoldersAction.CloseButtonClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(FoldersAction.CloseButtonClick) },
             )
         },
         floatingActionButton = {
             BitwardenFloatingActionButton(
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(FoldersAction.AddFolderButtonClick) }
-                },
+                onClick = { viewModel.trySendAction(FoldersAction.AddFolderButtonClick) },
                 painter = rememberVectorPainter(id = BitwardenDrawable.ic_plus_large),
                 contentDescription = stringResource(id = BitwardenString.add_item),
                 modifier = Modifier
@@ -103,9 +98,7 @@ fun FoldersScreen(
             is FoldersState.ViewState.Content -> {
                 FoldersContent(
                     foldersList = viewState.folderList.toImmutableList(),
-                    onItemClick = remember(viewModel) {
-                        { viewModel.trySendAction(FoldersAction.FolderClick(it)) }
-                    },
+                    onItemClick = { viewModel.trySendAction(FoldersAction.FolderClick(it)) },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -62,9 +61,7 @@ fun FolderAddEditScreen(
 
     FolderAddEditItemDialogs(
         dialogState = state.dialog,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(FolderAddEditAction.DismissDialog) }
-        },
+        onDismissRequest = { viewModel.trySendAction(FolderAddEditAction.DismissDialog) },
     )
 
     if (shouldShowConfirmationDialog) {
@@ -94,15 +91,11 @@ fun FolderAddEditScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(FolderAddEditAction.CloseClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(FolderAddEditAction.CloseClick) },
                 actions = {
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.save),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(FolderAddEditAction.SaveClick) }
-                        },
+                        onClick = { viewModel.trySendAction(FolderAddEditAction.SaveClick) },
                         modifier = Modifier.testTag("SaveButton"),
                     )
                     if (state.shouldShowOverflowMenu) {
@@ -129,8 +122,8 @@ fun FolderAddEditScreen(
                     BitwardenTextField(
                         label = stringResource(id = BitwardenString.name),
                         value = viewState.folderName,
-                        onValueChange = remember(viewModel) {
-                            { viewModel.trySendAction(FolderAddEditAction.NameTextChange(it)) }
+                        onValueChange = {
+                            viewModel.trySendAction(FolderAddEditAction.NameTextChange(it))
                         },
                         textFieldTestTag = "FolderNameField",
                         cardStyle = CardStyle.Full,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/other/OtherScreen.kt
@@ -71,9 +71,7 @@ fun OtherScreen(
 
     OtherDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(OtherAction.DismissDialog) }
-        },
+        onDismissRequest = { viewModel.trySendAction(OtherAction.DismissDialog) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -87,9 +85,7 @@ fun OtherScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(OtherAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(OtherAction.BackClick) },
             )
         },
         snackbarHost = {
@@ -98,17 +94,13 @@ fun OtherScreen(
     ) {
         OtherContent(
             state = state,
-            onEnableSyncCheckChange = remember(viewModel) {
-                { viewModel.trySendAction(OtherAction.AllowSyncToggle(it)) }
+            onEnableSyncCheckChange = { viewModel.trySendAction(OtherAction.AllowSyncToggle(it)) },
+            onSyncClick = { viewModel.trySendAction(OtherAction.SyncNowButtonClick) },
+            onClipboardFrequencyChange = {
+                viewModel.trySendAction(OtherAction.ClearClipboardFrequencyChange(it))
             },
-            onSyncClick = remember(viewModel) {
-                { viewModel.trySendAction(OtherAction.SyncNowButtonClick) }
-            },
-            onClipboardFrequencyChange = remember(viewModel) {
-                { viewModel.trySendAction(OtherAction.ClearClipboardFrequencyChange(it)) }
-            },
-            onScreenCaptureChange = remember(viewModel) {
-                { viewModel.trySendAction(OtherAction.AllowScreenCaptureToggle(it)) }
+            onScreenCaptureChange = {
+                viewModel.trySendAction(OtherAction.AllowScreenCaptureToggle(it))
             },
             modifier = Modifier.fillMaxSize(),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/vault/VaultSettingsScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -81,9 +80,7 @@ fun VaultSettingsScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultSettingsAction.BackClick) }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(VaultSettingsAction.BackClick) },
             )
         },
         snackbarHost = {
@@ -107,17 +104,11 @@ fun VaultSettingsScreen(
                     cardTitle = stringResource(id = BitwardenString.import_saved_logins),
                     actionText = stringResource(BitwardenString.get_started),
                     cardSubtitle = stringResource(BitwardenString.use_a_computer_to_import_logins),
-                    onActionClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
-                        }
+                    onActionClick = {
+                        viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardCtaClick)
                     },
-                    onDismissClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                VaultSettingsAction.ImportLoginsCardDismissClick,
-                            )
-                        }
+                    onDismissClick = {
+                        viewModel.trySendAction(VaultSettingsAction.ImportLoginsCardDismissClick)
                     },
                     leadingContent = {
                         NotificationBadge(notificationCount = 1)
@@ -129,9 +120,7 @@ fun VaultSettingsScreen(
             }
             BitwardenTextRow(
                 text = stringResource(BitwardenString.folders),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultSettingsAction.FoldersButtonClick) }
-                },
+                onClick = { viewModel.trySendAction(VaultSettingsAction.FoldersButtonClick) },
                 withDivider = false,
                 cardStyle = CardStyle.Top(),
                 modifier = Modifier
@@ -142,9 +131,7 @@ fun VaultSettingsScreen(
 
             BitwardenTextRow(
                 text = stringResource(BitwardenString.export_vault),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultSettingsAction.ExportVaultClick) }
-                },
+                onClick = { viewModel.trySendAction(VaultSettingsAction.ExportVaultClick) },
                 withDivider = false,
                 cardStyle = CardStyle.Middle(),
                 modifier = Modifier
@@ -155,9 +142,7 @@ fun VaultSettingsScreen(
 
             BitwardenTextRow(
                 text = stringResource(BitwardenString.import_items),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultSettingsAction.ImportItemsClick) }
-                },
+                onClick = { viewModel.trySendAction(VaultSettingsAction.ImportItemsClick) },
                 withDivider = false,
                 cardStyle = CardStyle.Bottom,
                 modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
@@ -92,17 +91,15 @@ fun VaultUnlockedNavBarScreen(
         navigateToFolders = onNavigateToFolders,
         navigateToPendingRequests = onNavigateToPendingRequests,
         navigateToPasswordHistory = onNavigateToPasswordHistory,
-        generatorTabClickedAction = remember(viewModel) {
-            { viewModel.trySendAction(VaultUnlockedNavBarAction.GeneratorTabClick) }
+        generatorTabClickedAction = {
+            viewModel.trySendAction(VaultUnlockedNavBarAction.GeneratorTabClick)
         },
-        sendTabClickedAction = remember(viewModel) {
-            { viewModel.trySendAction(VaultUnlockedNavBarAction.SendTabClick) }
+        sendTabClickedAction = { viewModel.trySendAction(VaultUnlockedNavBarAction.SendTabClick) },
+        vaultTabClickedAction = {
+            viewModel.trySendAction(VaultUnlockedNavBarAction.VaultTabClick)
         },
-        vaultTabClickedAction = remember(viewModel) {
-            { viewModel.trySendAction(VaultUnlockedNavBarAction.VaultTabClick) }
-        },
-        settingsTabClickedAction = remember(viewModel) {
-            { viewModel.trySendAction(VaultUnlockedNavBarAction.SettingsTabClick) }
+        settingsTabClickedAction = {
+            viewModel.trySendAction(VaultUnlockedNavBarAction.SettingsTabClick)
         },
         onNavigateToSetupUnlockScreen = onNavigateToSetupUnlockScreen,
         onNavigateToSetupAutoFillScreen = onNavigateToSetupAutoFillScreen,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -176,26 +176,17 @@ fun GeneratorScreen(
             }
         }
     }
-    val onRegenerateClick: () -> Unit = remember(viewModel) {
-        { viewModel.trySendAction(GeneratorAction.RegenerateClick) }
+    val onRegenerateClick: () -> Unit = { viewModel.trySendAction(GeneratorAction.RegenerateClick) }
+
+    val onCopyClick: () -> Unit = { viewModel.trySendAction(GeneratorAction.CopyClick) }
+
+    val onMainStateOptionClicked: (GeneratorState.MainTypeOption) -> Unit = {
+        viewModel.trySendAction(GeneratorAction.MainTypeOptionSelect(it))
     }
 
-    val onCopyClick: () -> Unit = remember(viewModel) {
-        { viewModel.trySendAction(GeneratorAction.CopyClick) }
+    val onUsernameOptionClicked: (GeneratorState.MainType.Username.UsernameTypeOption) -> Unit = {
+        viewModel.trySendAction(GeneratorAction.MainType.Username.UsernameTypeOptionSelect(it))
     }
-
-    val onMainStateOptionClicked: (GeneratorState.MainTypeOption) -> Unit = remember(viewModel) {
-        { viewModel.trySendAction(GeneratorAction.MainTypeOptionSelect(it)) }
-    }
-
-    val onUsernameOptionClicked: (GeneratorState.MainType.Username.UsernameTypeOption) -> Unit =
-        remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    GeneratorAction.MainType.Username.UsernameTypeOptionSelect(it),
-                )
-            }
-        }
 
     val onShowNextCoachMark: () -> Unit = remember {
         { scope.launch { coachMarkState.showNextCoachMark() } }
@@ -227,20 +218,16 @@ fun GeneratorScreen(
                         ModalAppBar(
                             generatorMode = generatorMode,
                             scrollBehavior = scrollBehavior,
-                            onCloseClick = remember(viewModel) {
-                                { viewModel.trySendAction(GeneratorAction.CloseClick) }
-                            },
-                            onSaveClick = remember(viewModel) {
-                                { viewModel.trySendAction(GeneratorAction.SaveClick) }
-                            },
+                            onCloseClick = { viewModel.trySendAction(GeneratorAction.CloseClick) },
+                            onSaveClick = { viewModel.trySendAction(GeneratorAction.SaveClick) },
                         )
                     }
 
                     GeneratorMode.Default -> {
                         DefaultAppBar(
                             scrollBehavior = scrollBehavior,
-                            onPasswordHistoryClick = remember(viewModel) {
-                                { viewModel.trySendAction(GeneratorAction.PasswordHistoryClick) }
+                            onPasswordHistoryClick = {
+                                viewModel.trySendAction(GeneratorAction.PasswordHistoryClick)
                             },
                         )
                     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -67,8 +66,8 @@ fun PasswordHistoryScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(PasswordHistoryAction.CloseClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(PasswordHistoryAction.CloseClick)
                 },
                 actions = {
                     if (state.menuEnabled) {
@@ -77,12 +76,10 @@ fun PasswordHistoryScreen(
                             menuItemDataList = persistentListOf(
                                 OverflowMenuItemData(
                                     text = stringResource(id = BitwardenString.clear),
-                                    onClick = remember(viewModel) {
-                                        {
-                                            viewModel.trySendAction(
-                                                PasswordHistoryAction.PasswordClearClick,
-                                            )
-                                        }
+                                    onClick = {
+                                        viewModel.trySendAction(
+                                            PasswordHistoryAction.PasswordClearClick,
+                                        )
                                     },
                                 ),
                             ),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -71,9 +71,7 @@ fun SendScreen(
     val pullToRefreshState = rememberBitwardenPullToRefreshState(
         isEnabled = state.isPullToRefreshEnabled,
         isRefreshing = state.isRefreshing,
-        onRefresh = remember(viewModel) {
-            { viewModel.trySendAction(SendAction.RefreshPull) }
-        },
+        onRefresh = { viewModel.trySendAction(SendAction.RefreshPull) },
     )
 
     RegisterScreenDataOnLifecycleEffect(
@@ -122,12 +120,8 @@ fun SendScreen(
 
     SendDialogs(
         dialogState = state.dialogState,
-        onAddSendSelected = remember(viewModel) {
-            { viewModel.trySendAction(SendAction.AddSendSelected(it)) }
-        },
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(SendAction.DismissDialog) }
-        },
+        onAddSendSelected = { viewModel.trySendAction(SendAction.AddSendSelected(it)) },
+        onDismissRequest = { viewModel.trySendAction(SendAction.DismissDialog) },
     )
 
     val sendHandlers = remember(viewModel) { SendHandlers.create(viewModel) }
@@ -143,30 +137,22 @@ fun SendScreen(
                 actions = {
                     BitwardenSearchActionItem(
                         contentDescription = stringResource(id = BitwardenString.search_sends),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(SendAction.SearchClick) }
-                        },
+                        onClick = { viewModel.trySendAction(SendAction.SearchClick) },
                     )
                     BitwardenOverflowActionItem(
                         contentDescription = stringResource(BitwardenString.more),
                         menuItemDataList = persistentListOf(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.sync),
-                                onClick = remember(viewModel) {
-                                    { viewModel.trySendAction(SendAction.SyncClick) }
-                                },
+                                onClick = { viewModel.trySendAction(SendAction.SyncClick) },
                             ),
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.lock),
-                                onClick = remember(viewModel) {
-                                    { viewModel.trySendAction(SendAction.LockClick) }
-                                },
+                                onClick = { viewModel.trySendAction(SendAction.LockClick) },
                             ),
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.about_send),
-                                onClick = remember(viewModel) {
-                                    { viewModel.trySendAction(SendAction.AboutSendClick) }
-                                },
+                                onClick = { viewModel.trySendAction(SendAction.AboutSendClick) },
                             ),
                         ),
                     )
@@ -180,9 +166,7 @@ fun SendScreen(
                 exit = scaleOut(),
             ) {
                 BitwardenFloatingActionButton(
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(SendAction.AddSendClick) }
-                    },
+                    onClick = { viewModel.trySendAction(SendAction.AddSendClick) },
                     painter = rememberVectorPainter(id = BitwardenDrawable.ic_plus_large),
                     contentDescription = stringResource(id = BitwardenString.add_item),
                     modifier = Modifier.testTag(tag = "AddItemButton"),
@@ -204,17 +188,13 @@ fun SendScreen(
 
             SendState.ViewState.Empty -> SendEmpty(
                 policyDisablesSend = state.policyDisablesSend,
-                onAddItemClick = remember(viewModel) {
-                    { viewModel.trySendAction(SendAction.AddSendClick) }
-                },
+                onAddItemClick = { viewModel.trySendAction(SendAction.AddSendClick) },
                 modifier = modifier,
             )
 
             is SendState.ViewState.Error -> BitwardenErrorContent(
                 message = viewState.message(),
-                onTryAgainClick = remember(viewModel) {
-                    { viewModel.trySendAction(SendAction.RefreshClick) }
-                },
+                onTryAgainClick = { viewModel.trySendAction(SendAction.RefreshClick) },
                 modifier = modifier,
             )
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.ui.tools.feature.send.addedit
 
 import androidx.activity.compose.BackHandler
-import androidx.core.net.toUri
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
@@ -13,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.core.util.persistentListOfNotNull
@@ -69,9 +69,7 @@ fun AddEditSendScreen(
 
     val snackbarHostState = rememberBitwardenSnackbarHostState()
     BackHandler(
-        onBack = remember(viewModel) {
-            { viewModel.trySendAction(AddEditSendAction.CloseClick) }
-        },
+        onBack = { viewModel.trySendAction(AddEditSendAction.CloseClick) },
     )
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -105,11 +103,9 @@ fun AddEditSendScreen(
 
     AddEditSendDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(AddEditSendAction.DismissDialogClick) }
-        },
-        onUpgradeToPremiumClick = remember(viewModel) {
-            { viewModel.trySendAction(AddEditSendAction.UpgradeToPremiumClick) }
+        onDismissRequest = { viewModel.trySendAction(AddEditSendAction.DismissDialogClick) },
+        onUpgradeToPremiumClick = {
+            viewModel.trySendAction(AddEditSendAction.UpgradeToPremiumClick)
         },
     )
     BitwardenScaffold(
@@ -122,8 +118,8 @@ fun AddEditSendScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                     navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(AddEditSendAction.CloseClick) }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(AddEditSendAction.CloseClick)
                     },
                 )
                     .takeUnless { state.isShared },
@@ -133,9 +129,7 @@ fun AddEditSendScreen(
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.save),
                         isEnabled = !state.policyDisablesSend,
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(AddEditSendAction.SaveClick) }
-                        },
+                        onClick = { viewModel.trySendAction(AddEditSendAction.SaveClick) },
                         modifier = Modifier.testTag("SaveButton"),
                     )
                     if (!state.isAddMode) {
@@ -144,30 +138,24 @@ fun AddEditSendScreen(
                             menuItemDataList = persistentListOfNotNull(
                                 OverflowMenuItemData(
                                     text = stringResource(id = BitwardenString.remove_password),
-                                    onClick = remember(viewModel) {
-                                        {
-                                            viewModel.trySendAction(
-                                                AddEditSendAction.RemovePasswordClick,
-                                            )
-                                        }
+                                    onClick = {
+                                        viewModel.trySendAction(
+                                            AddEditSendAction.RemovePasswordClick,
+                                        )
                                     },
                                 )
                                     .takeIf { state.hasPassword && !state.policyDisablesSend },
                                 OverflowMenuItemData(
                                     text = stringResource(id = BitwardenString.copy_link),
-                                    onClick = remember(viewModel) {
-                                        { viewModel.trySendAction(AddEditSendAction.CopyLinkClick) }
+                                    onClick = {
+                                        viewModel.trySendAction(AddEditSendAction.CopyLinkClick)
                                     },
                                 )
                                     .takeIf { !state.policyDisablesSend },
                                 OverflowMenuItemData(
                                     text = stringResource(id = BitwardenString.share_link),
-                                    onClick = remember(viewModel) {
-                                        {
-                                            viewModel.trySendAction(
-                                                AddEditSendAction.ShareLinkClick,
-                                            )
-                                        }
+                                    onClick = {
+                                        viewModel.trySendAction(AddEditSendAction.ShareLinkClick)
                                     },
                                 )
                                     .takeIf { !state.policyDisablesSend },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -28,14 +28,13 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -88,8 +87,7 @@ fun ViewSendScreen(
     intentManager: IntentManager = LocalIntentManager.current,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val resources = context.resources
+    val resources = LocalResources.current
     val snackbarHostState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -114,9 +112,7 @@ fun ViewSendScreen(
 
     ViewSendDialogs(
         dialogState = state.dialogState,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(ViewSendAction.DialogDismiss) }
-        },
+        onDismissRequest = { viewModel.trySendAction(ViewSendAction.DialogDismiss) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -130,9 +126,7 @@ fun ViewSendScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                     navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(ViewSendAction.CloseClick) }
-                    },
+                    onNavigationIconClick = { viewModel.trySendAction(ViewSendAction.CloseClick) },
                 ),
                 scrollBehavior = scrollBehavior,
             )
@@ -144,9 +138,7 @@ fun ViewSendScreen(
                 exit = scaleOut(),
             ) {
                 BitwardenFloatingActionButton(
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(ViewSendAction.EditClick) }
-                    },
+                    onClick = { viewModel.trySendAction(ViewSendAction.EditClick) },
                     painter = rememberVectorPainter(id = BitwardenDrawable.ic_pencil),
                     contentDescription = stringResource(id = BitwardenString.edit_send),
                     modifier = Modifier.testTag(tag = "EditItemButton"),
@@ -158,18 +150,10 @@ fun ViewSendScreen(
         ViewSendScreenContent(
             state = state,
             modifier = Modifier.fillMaxSize(),
-            onCopyClick = remember(viewModel) {
-                { viewModel.trySendAction(ViewSendAction.CopyClick) }
-            },
-            onCopyNotesClick = remember(viewModel) {
-                { viewModel.trySendAction(ViewSendAction.CopyNotesClick) }
-            },
-            onDeleteClick = remember(viewModel) {
-                { viewModel.trySendAction(ViewSendAction.DeleteClick) }
-            },
-            onShareClick = remember(viewModel) {
-                { viewModel.trySendAction(ViewSendAction.ShareClick) }
-            },
+            onCopyClick = { viewModel.trySendAction(ViewSendAction.CopyClick) },
+            onCopyNotesClick = { viewModel.trySendAction(ViewSendAction.CopyNotesClick) },
+            onDeleteClick = { viewModel.trySendAction(ViewSendAction.DeleteClick) },
+            onShareClick = { viewModel.trySendAction(ViewSendAction.ShareClick) },
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -217,94 +217,52 @@ fun VaultAddEditScreen(
         VaultAddEditSshKeyTypeHandlers.create(viewModel = viewModel)
     }
 
-    val archiveClickAction = remember(viewModel) {
-        { viewModel.trySendAction(VaultAddEditAction.Common.ArchiveClick) }
-    }
+    val archiveClickAction = { viewModel.trySendAction(VaultAddEditAction.Common.ArchiveClick) }
 
-    val unarchiveClickAction = remember(viewModel) {
-        { viewModel.trySendAction(VaultAddEditAction.Common.UnarchiveClick) }
-    }
+    val unarchiveClickAction = { viewModel.trySendAction(VaultAddEditAction.Common.UnarchiveClick) }
 
-    val confirmDeleteClickAction = remember(viewModel) {
-        { viewModel.trySendAction(VaultAddEditAction.Common.ConfirmDeleteClick) }
+    val confirmDeleteClickAction = {
+        viewModel.trySendAction(VaultAddEditAction.Common.ConfirmDeleteClick)
     }
 
     var pendingDeleteCipher by rememberSaveable { mutableStateOf(false) }
 
     VaultAddEditItemDialogs(
         dialogState = state.dialog,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(VaultAddEditAction.Common.DismissDialog) }
+        onDismissRequest = { viewModel.trySendAction(VaultAddEditAction.Common.DismissDialog) },
+        onAutofillDismissRequest = {
+            viewModel.trySendAction(VaultAddEditAction.Common.InitialAutofillDialogDismissed)
         },
-        onAutofillDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(VaultAddEditAction.Common.InitialAutofillDialogDismissed) }
+        onCredentialErrorDismiss = { errorMessage ->
+            viewModel.trySendAction(
+                VaultAddEditAction.Common.CredentialErrorDialogDismissed(message = errorMessage),
+            )
         },
-        onCredentialErrorDismiss = remember(viewModel) {
-            { errorMessage ->
-                viewModel.trySendAction(
-                    VaultAddEditAction
-                        .Common
-                        .CredentialErrorDialogDismissed(
-                            message = errorMessage,
-                        ),
-                )
-            }
+        onConfirmOverwriteExistingPasskey = {
+            viewModel.trySendAction(VaultAddEditAction.Common.ConfirmOverwriteExistingPasskeyClick)
         },
-        onConfirmOverwriteExistingPasskey = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    action = VaultAddEditAction.Common.ConfirmOverwriteExistingPasskeyClick,
-                )
-            }
+        onSubmitMasterPasswordFido2Verification = {
+            viewModel.trySendAction(
+                action = VaultAddEditAction.Common.MasterPasswordFido2VerificationSubmit(it),
+            )
         },
-        onSubmitMasterPasswordFido2Verification = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    action = VaultAddEditAction.Common.MasterPasswordFido2VerificationSubmit(it),
-                )
-            }
+        onRetryFido2PasswordVerification = {
+            viewModel.trySendAction(VaultAddEditAction.Common.RetryFido2PasswordVerificationClick)
         },
-        onRetryFido2PasswordVerification = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    action = VaultAddEditAction.Common.RetryFido2PasswordVerificationClick,
-                )
-            }
+        onSubmitPinFido2Verification = {
+            viewModel.trySendAction(VaultAddEditAction.Common.PinFido2VerificationSubmit(it))
         },
-        onSubmitPinFido2Verification = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    VaultAddEditAction.Common.PinFido2VerificationSubmit(it),
-                )
-            }
+        onRetryFido2PinVerification = {
+            viewModel.trySendAction(VaultAddEditAction.Common.RetryFido2PinVerificationClick)
         },
-        onRetryFido2PinVerification = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    VaultAddEditAction.Common.RetryFido2PinVerificationClick,
-                )
-            }
+        onSubmitPinSetUpFido2Verification = {
+            viewModel.trySendAction(VaultAddEditAction.Common.PinFido2SetUpSubmit(it))
         },
-        onSubmitPinSetUpFido2Verification = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    VaultAddEditAction.Common.PinFido2SetUpSubmit(it),
-                )
-            }
+        onRetryPinSetUpFido2Verification = {
+            viewModel.trySendAction(VaultAddEditAction.Common.PinFido2SetUpRetryClick)
         },
-        onRetryPinSetUpFido2Verification = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    VaultAddEditAction.Common.PinFido2SetUpRetryClick,
-                )
-            }
-        },
-        onDismissFido2Verification = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    VaultAddEditAction.Common.DismissFido2VerificationDialogClick,
-                )
-            }
+        onDismissFido2Verification = {
+            viewModel.trySendAction(VaultAddEditAction.Common.DismissFido2VerificationDialogClick)
         },
         onUpgradeToPremiumClick = {
             viewModel.trySendAction(VaultAddEditAction.Common.UpgradeToPremiumClick)
@@ -350,8 +308,8 @@ fun VaultAddEditScreen(
                         navigationIconContentDescription = stringResource(
                             id = BitwardenString.close,
                         ),
-                        onNavigationIconClick = remember(viewModel) {
-                            { viewModel.trySendAction(VaultAddEditAction.Common.CloseClick) }
+                        onNavigationIconClick = {
+                            viewModel.trySendAction(VaultAddEditAction.Common.CloseClick)
                         },
                     )
                         .takeIf { state.shouldShowCloseButton },
@@ -359,8 +317,8 @@ fun VaultAddEditScreen(
                     actions = {
                         BitwardenTextButton(
                             label = stringResource(id = BitwardenString.save),
-                            onClick = remember(viewModel) {
-                                { viewModel.trySendAction(VaultAddEditAction.Common.SaveClick) }
+                            onClick = {
+                                viewModel.trySendAction(VaultAddEditAction.Common.SaveClick)
                             },
                             modifier = Modifier.testTag("SaveButton"),
                         )
@@ -369,12 +327,10 @@ fun VaultAddEditScreen(
                             menuItemDataList = persistentListOfNotNull(
                                 OverflowMenuItemData(
                                     text = stringResource(id = BitwardenString.attachments),
-                                    onClick = remember(viewModel) {
-                                        {
-                                            viewModel.trySendAction(
-                                                VaultAddEditAction.Common.AttachmentsClick,
-                                            )
-                                        }
+                                    onClick = {
+                                        viewModel.trySendAction(
+                                            VaultAddEditAction.Common.AttachmentsClick,
+                                        )
                                     },
                                 )
                                     .takeUnless { state.isAddItemMode },
@@ -382,23 +338,19 @@ fun VaultAddEditScreen(
                                     text = stringResource(
                                         id = BitwardenString.move_to_organization,
                                     ),
-                                    onClick = remember(viewModel) {
-                                        {
-                                            viewModel.trySendAction(
-                                                VaultAddEditAction.Common.MoveToOrganizationClick,
-                                            )
-                                        }
+                                    onClick = {
+                                        viewModel.trySendAction(
+                                            VaultAddEditAction.Common.MoveToOrganizationClick,
+                                        )
                                     },
                                 )
                                     .takeUnless { !state.shouldShowMoveToOrganization },
                                 OverflowMenuItemData(
                                     text = stringResource(id = BitwardenString.collections),
-                                    onClick = remember(viewModel) {
-                                        {
-                                            viewModel.trySendAction(
-                                                VaultAddEditAction.Common.CollectionsClick,
-                                            )
-                                        }
+                                    onClick = {
+                                        viewModel.trySendAction(
+                                            VaultAddEditAction.Common.CollectionsClick,
+                                        )
                                     },
                                 )
                                     .takeUnless {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -118,24 +118,20 @@ fun VaultItemScreen(
 
     VaultItemDialogs(
         dialog = state.dialog,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(VaultItemAction.Common.DismissDialogClick) }
+        onDismissRequest = { viewModel.trySendAction(VaultItemAction.Common.DismissDialogClick) },
+        onConfirmDeleteClick = {
+            viewModel.trySendAction(VaultItemAction.Common.ConfirmDeleteClick)
         },
-        onConfirmDeleteClick = remember(viewModel) {
-            { viewModel.trySendAction(VaultItemAction.Common.ConfirmDeleteClick) }
+        onConfirmCloneWithoutFido2Credential = {
+            viewModel.trySendAction(
+                VaultItemAction.Common.ConfirmCloneWithoutFido2CredentialClick,
+            )
         },
-        onConfirmCloneWithoutFido2Credential = remember(viewModel) {
-            {
-                viewModel.trySendAction(
-                    VaultItemAction.Common.ConfirmCloneWithoutFido2CredentialClick,
-                )
-            }
+        onConfirmRestoreAction = {
+            viewModel.trySendAction(VaultItemAction.Common.ConfirmRestoreClick)
         },
-        onConfirmRestoreAction = remember(viewModel) {
-            { viewModel.trySendAction(VaultItemAction.Common.ConfirmRestoreClick) }
-        },
-        onUpgradeToPremiumClick = remember(viewModel) {
-            { viewModel.trySendAction(VaultItemAction.Common.UpgradeToPremiumClick) }
+        onUpgradeToPremiumClick = {
+            viewModel.trySendAction(VaultItemAction.Common.UpgradeToPremiumClick)
         },
     )
 
@@ -150,19 +146,17 @@ fun VaultItemScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(VaultItemAction.Common.CloseClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(VaultItemAction.Common.CloseClick)
                 },
                 actions = {
                     if (state.canRestore) {
                         BitwardenTextButton(
                             label = stringResource(id = BitwardenString.restore),
-                            onClick = remember(viewModel) {
-                                {
-                                    viewModel.trySendAction(
-                                        VaultItemAction.Common.RestoreVaultItemClick,
-                                    )
-                                }
+                            onClick = {
+                                viewModel.trySendAction(
+                                    VaultItemAction.Common.RestoreVaultItemClick,
+                                )
                             },
                             modifier = Modifier.testTag("RestoreButton"),
                         )
@@ -172,29 +166,25 @@ fun VaultItemScreen(
                         menuItemDataList = persistentListOfNotNull(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.attachments),
-                                onClick = remember(viewModel) {
-                                    {
-                                        viewModel.trySendAction(
-                                            VaultItemAction.Common.AttachmentsClick,
-                                        )
-                                    }
+                                onClick = {
+                                    viewModel.trySendAction(
+                                        VaultItemAction.Common.AttachmentsClick,
+                                    )
                                 },
                             ),
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.clone),
-                                onClick = remember(viewModel) {
-                                    { viewModel.trySendAction(VaultItemAction.Common.CloneClick) }
+                                onClick = {
+                                    viewModel.trySendAction(VaultItemAction.Common.CloneClick)
                                 },
                             )
                                 .takeUnless { state.isCipherInCollection },
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.move_to_organization),
-                                onClick = remember(viewModel) {
-                                    {
-                                        viewModel.trySendAction(
-                                            VaultItemAction.Common.MoveToOrganizationClick,
-                                        )
-                                    }
+                                onClick = {
+                                    viewModel.trySendAction(
+                                        VaultItemAction.Common.MoveToOrganizationClick,
+                                    )
                                 },
                             )
                                 .takeUnless {
@@ -203,12 +193,8 @@ fun VaultItemScreen(
                                 },
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.collections),
-                                onClick = remember(viewModel) {
-                                    {
-                                        viewModel.trySendAction(
-                                            VaultItemAction.Common.CollectionsClick,
-                                        )
-                                    }
+                                onClick = {
+                                    viewModel.trySendAction(VaultItemAction.Common.CollectionsClick)
                                 },
                             )
                                 .takeIf {
@@ -217,30 +203,22 @@ fun VaultItemScreen(
                                 },
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.archive_verb),
-                                onClick = remember(viewModel) {
-                                    { viewModel.trySendAction(VaultItemAction.Common.ArchiveClick) }
+                                onClick = {
+                                    viewModel.trySendAction(VaultItemAction.Common.ArchiveClick)
                                 },
                             )
                                 .takeIf { state.displayArchiveButton },
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.unarchive),
-                                onClick = remember(viewModel) {
-                                    {
-                                        viewModel.trySendAction(
-                                            VaultItemAction.Common.UnarchiveClick,
-                                        )
-                                    }
+                                onClick = {
+                                    viewModel.trySendAction(VaultItemAction.Common.UnarchiveClick)
                                 },
                             )
                                 .takeIf { state.displayUnarchiveButton },
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.delete),
-                                onClick = remember(viewModel) {
-                                    {
-                                        viewModel.trySendAction(
-                                            VaultItemAction.Common.DeleteClick,
-                                        )
-                                    }
+                                onClick = {
+                                    viewModel.trySendAction(VaultItemAction.Common.DeleteClick)
                                 },
                             )
                                 .takeIf { state.canDelete },
@@ -256,9 +234,7 @@ fun VaultItemScreen(
                 exit = scaleOut(),
             ) {
                 BitwardenFloatingActionButton(
-                    onClick = remember(viewModel) {
-                        { viewModel.trySendAction(VaultItemAction.Common.EditClick) }
-                    },
+                    onClick = { viewModel.trySendAction(VaultItemAction.Common.EditClick) },
                     painter = rememberVectorPainter(id = BitwardenDrawable.ic_pencil),
                     contentDescription = stringResource(id = BitwardenString.edit_item),
                     modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -99,9 +99,7 @@ fun VaultItemListingScreen(
     val pullToRefreshState = rememberBitwardenPullToRefreshState(
         isEnabled = state.isPullToRefreshEnabled,
         isRefreshing = state.isRefreshing,
-        onRefresh = remember(viewModel) {
-            { viewModel.trySendAction(VaultItemListingsAction.RefreshPull) }
-        },
+        onRefresh = { viewModel.trySendAction(VaultItemListingsAction.RefreshPull) },
     )
     val snackbarHostState = rememberBitwardenSnackbarHostState()
     EventsEffect(viewModel = viewModel) { event ->

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -94,9 +93,7 @@ fun ManualCodeEntryScreen(
             ),
             confirmButtonText = stringResource(id = BitwardenString.settings),
             dismissButtonText = stringResource(id = BitwardenString.no_thanks),
-            onConfirmClick = remember(viewModel) {
-                { viewModel.trySendAction(ManualCodeEntryAction.SettingsClick) }
-            },
+            onConfirmClick = { viewModel.trySendAction(ManualCodeEntryAction.SettingsClick) },
             onDismissClick = { shouldShowPermissionDialog = false },
             onDismissRequest = { shouldShowPermissionDialog = false },
             title = null,
@@ -105,9 +102,7 @@ fun ManualCodeEntryScreen(
 
     ManualCodeEntryDialogs(
         state = state.dialog,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(ManualCodeEntryAction.DialogDismiss) }
-        },
+        onDismissRequest = { viewModel.trySendAction(ManualCodeEntryAction.DialogDismiss) },
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -120,8 +115,8 @@ fun ManualCodeEntryScreen(
                 title = stringResource(id = BitwardenString.authenticator_key_scanner),
                 navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(ManualCodeEntryAction.CloseClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(ManualCodeEntryAction.CloseClick)
                 },
                 scrollBehavior = scrollBehavior,
             )
@@ -158,8 +153,8 @@ fun ManualCodeEntryScreen(
                 singleLine = false,
                 label = stringResource(id = BitwardenString.authenticator_key_scanner),
                 value = state.code,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(ManualCodeEntryAction.CodeTextChange(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(ManualCodeEntryAction.CodeTextChange(it))
                 },
                 textFieldTestTag = "AddManualTOTPField",
                 cardStyle = CardStyle.Full,
@@ -171,9 +166,7 @@ fun ManualCodeEntryScreen(
             Spacer(modifier = Modifier.height(height = 24.dp))
             BitwardenFilledButton(
                 label = stringResource(id = BitwardenString.add_totp),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(ManualCodeEntryAction.CodeSubmit) }
-                },
+                onClick = { viewModel.trySendAction(ManualCodeEntryAction.CodeSubmit) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .standardHorizontalMargin()
@@ -185,13 +178,11 @@ fun ManualCodeEntryScreen(
                 annotatedResId = BitwardenString.cannot_add_authenticator_key_scan_qr_code,
                 annotationKey = "scanQrCode",
                 accessibilityString = stringResource(id = BitwardenString.scan_qr_code),
-                onClick = remember(viewModel) {
-                    {
-                        if (permissionsManager.checkPermission(Manifest.permission.CAMERA)) {
-                            viewModel.trySendAction(ManualCodeEntryAction.ScanQrCodeTextClick)
-                        } else {
-                            launcher.launch(Manifest.permission.CAMERA)
-                        }
+                onClick = {
+                    if (permissionsManager.checkPermission(Manifest.permission.CAMERA)) {
+                        viewModel.trySendAction(ManualCodeEntryAction.ScanQrCodeTextClick)
+                    } else {
+                        launcher.launch(Manifest.permission.CAMERA)
                     }
                 },
                 modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/movetoorganization/VaultMoveToOrganizationScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -42,20 +41,14 @@ fun VaultMoveToOrganizationScreen(
     }
     VaultMoveToOrganizationScaffold(
         state = state,
-        closeClick = remember(viewModel) {
-            { viewModel.trySendAction(VaultMoveToOrganizationAction.BackClick) }
+        closeClick = { viewModel.trySendAction(VaultMoveToOrganizationAction.BackClick) },
+        moveClick = { viewModel.trySendAction(VaultMoveToOrganizationAction.MoveClick) },
+        dismissClick = { viewModel.trySendAction(VaultMoveToOrganizationAction.DismissClick) },
+        organizationSelect = {
+            viewModel.trySendAction(VaultMoveToOrganizationAction.OrganizationSelect(it))
         },
-        moveClick = remember(viewModel) {
-            { viewModel.trySendAction(VaultMoveToOrganizationAction.MoveClick) }
-        },
-        dismissClick = remember(viewModel) {
-            { viewModel.trySendAction(VaultMoveToOrganizationAction.DismissClick) }
-        },
-        organizationSelect = remember(viewModel) {
-            { viewModel.trySendAction(VaultMoveToOrganizationAction.OrganizationSelect(it)) }
-        },
-        collectionSelect = remember(viewModel) {
-            { viewModel.trySendAction(VaultMoveToOrganizationAction.CollectionSelect(it)) }
+        collectionSelect = {
+            viewModel.trySendAction(VaultMoveToOrganizationAction.CollectionSelect(it))
         },
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -57,13 +56,11 @@ fun QrCodeScanScreen(
     viewModel: QrCodeScanViewModel = hiltViewModel(),
     qrCodeAnalyzer: QrCodeAnalyzer = LocalQrCodeAnalyzer.current,
 ) {
-    qrCodeAnalyzer.onQrCodeScanned = remember(viewModel) {
-        { viewModel.trySendAction(QrCodeScanAction.QrCodeScanReceive(it)) }
+    qrCodeAnalyzer.onQrCodeScanned = {
+        viewModel.trySendAction(QrCodeScanAction.QrCodeScanReceive(it))
     }
 
-    val onEnterKeyManuallyClick = remember(viewModel) {
-        { viewModel.trySendAction(QrCodeScanAction.ManualEntryTextClick) }
-    }
+    val onEnterKeyManuallyClick = { viewModel.trySendAction(QrCodeScanAction.ManualEntryTextClick) }
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -86,8 +83,8 @@ fun QrCodeScanScreen(
                     title = stringResource(id = BitwardenString.scan_qr_code),
                     navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_close),
                     navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(QrCodeScanAction.CloseClick) }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(QrCodeScanAction.CloseClick)
                     },
                     scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(
                         state = rememberTopAppBarState(),
@@ -96,8 +93,8 @@ fun QrCodeScanScreen(
             },
         ) {
             CameraPreview(
-                cameraErrorReceive = remember(viewModel) {
-                    { viewModel.trySendAction(QrCodeScanAction.CameraSetupErrorReceive) }
+                cameraErrorReceive = {
+                    viewModel.trySendAction(QrCodeScanAction.CameraSetupErrorReceive)
                 },
                 qrCodeAnalyzer = qrCodeAnalyzer,
                 modifier = Modifier.fillMaxSize(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -102,9 +102,7 @@ fun VaultScreen(
     val pullToRefreshState = rememberBitwardenPullToRefreshState(
         isEnabled = state.isPullToRefreshEnabled,
         isRefreshing = state.isRefreshing,
-        onRefresh = remember(viewModel) {
-            { viewModel.trySendAction(VaultAction.RefreshPull) }
-        },
+        onRefresh = { viewModel.trySendAction(VaultAction.RefreshPull) },
     )
     val snackbarHostState = rememberBitwardenSnackbarHostState()
     LifecycleEventEffect { _, event ->

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreen.kt
@@ -72,9 +72,7 @@ fun VerificationCodeScreen(
     val pullToRefreshState = rememberBitwardenPullToRefreshState(
         isEnabled = state.isPullToRefreshEnabled,
         isRefreshing = state.isRefreshing,
-        onRefresh = remember(viewModel) {
-            { viewModel.trySendAction(VerificationCodeAction.RefreshPull) }
-        },
+        onRefresh = { viewModel.trySendAction(VerificationCodeAction.RefreshPull) },
     )
 
     RegisterScreenDataOnLifecycleEffect(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/auth/unlock/UnlockScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -44,11 +43,11 @@ fun UnlockScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
-    val onBiometricsUnlockSuccess: (cipher: Cipher) -> Unit = remember(viewModel) {
-        { viewModel.trySendAction(UnlockAction.BiometricsUnlockSuccess(it)) }
+    val onBiometricsUnlockSuccess: (cipher: Cipher) -> Unit = {
+        viewModel.trySendAction(UnlockAction.BiometricsUnlockSuccess(it))
     }
-    val onBiometricsLockOut: () -> Unit = remember(viewModel) {
-        { viewModel.trySendAction(UnlockAction.BiometricsLockout) }
+    val onBiometricsLockOut: () -> Unit = {
+        viewModel.trySendAction(UnlockAction.BiometricsLockout)
     }
 
     EventsEffect(viewModel = viewModel) { event ->
@@ -71,9 +70,7 @@ fun UnlockScreen(
 
     UnlockDialogs(
         dialog = state.dialog,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(UnlockAction.DismissDialog) }
-        },
+        onDismissRequest = { viewModel.trySendAction(UnlockAction.DismissDialog) },
     )
 
     BitwardenScaffold(
@@ -97,9 +94,7 @@ fun UnlockScreen(
             Spacer(modifier = Modifier.height(32.dp))
             BitwardenFilledButton(
                 label = stringResource(id = BitwardenString.unlock),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(UnlockAction.BiometricsUnlockClick) }
-                },
+                onClick = { viewModel.trySendAction(UnlockAction.BiometricsUnlockClick) },
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
                     .fillMaxWidth(),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/edititem/EditItemScreen.kt
@@ -85,17 +85,11 @@ fun EditItemScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(EditItemAction.CancelClick)
-                    }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(EditItemAction.CancelClick) },
                 actions = {
                     BitwardenTextButton(
                         label = stringResource(id = BitwardenString.save),
-                        onClick = remember(viewModel) {
-                            { viewModel.trySendAction(EditItemAction.SaveClick) }
-                        },
+                        onClick = { viewModel.trySendAction(EditItemAction.SaveClick) },
                         modifier = Modifier.semantics { testTag = "SaveButton" },
                     )
                 },
@@ -107,68 +101,32 @@ fun EditItemScreen(
             is EditItemState.ViewState.Content -> {
                 EditItemContent(
                     viewState = viewState,
-                    onIssuerNameTextChange = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.IssuerNameTextChange(it),
-                            )
-                        }
+                    onIssuerNameTextChange = {
+                        viewModel.trySendAction(EditItemAction.IssuerNameTextChange(it))
                     },
-                    onUsernameTextChange = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.UsernameTextChange(it),
-                            )
-                        }
+                    onUsernameTextChange = {
+                        viewModel.trySendAction(EditItemAction.UsernameTextChange(it))
                     },
-                    onToggleFavorite = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.FavoriteToggleClick(it),
-                            )
-                        }
+                    onToggleFavorite = {
+                        viewModel.trySendAction(EditItemAction.FavoriteToggleClick(it))
                     },
-                    onTypeOptionClicked = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.TypeOptionClick(it),
-                            )
-                        }
+                    onTypeOptionClicked = {
+                        viewModel.trySendAction(EditItemAction.TypeOptionClick(it))
                     },
-                    onTotpCodeTextChange = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.TotpCodeTextChange(it),
-                            )
-                        }
+                    onTotpCodeTextChange = {
+                        viewModel.trySendAction(EditItemAction.TotpCodeTextChange(it))
                     },
-                    onAlgorithmOptionClicked = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.AlgorithmOptionClick(it),
-                            )
-                        }
+                    onAlgorithmOptionClicked = {
+                        viewModel.trySendAction(EditItemAction.AlgorithmOptionClick(it))
                     },
-                    onRefreshPeriodOptionClicked = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.RefreshPeriodOptionClick(it),
-                            )
-                        }
+                    onRefreshPeriodOptionClicked = {
+                        viewModel.trySendAction(EditItemAction.RefreshPeriodOptionClick(it))
                     },
-                    onNumberOfDigitsChanged = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.NumberOfDigitsOptionClick(it),
-                            )
-                        }
+                    onNumberOfDigitsChanged = {
+                        viewModel.trySendAction(EditItemAction.NumberOfDigitsOptionClick(it))
                     },
-                    onExpandAdvancedOptionsClicked = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(
-                                EditItemAction.ExpandAdvancedOptionsClick,
-                            )
-                        }
+                    onExpandAdvancedOptionsClicked = {
+                        viewModel.trySendAction(EditItemAction.ExpandAdvancedOptionsClick)
                     },
                 )
             }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -134,11 +133,9 @@ fun ItemListingScreen(
 
     ItemListingDialogs(
         dialog = state.dialog,
-        onDismissRequest = remember(viewModel) {
-            { viewModel.trySendAction(ItemListingAction.DialogDismiss) }
-        },
-        onConfirmDeleteClick = remember(viewModel) {
-            { viewModel.trySendAction(ItemListingAction.ConfirmDeleteClick(it)) }
+        onDismissRequest = { viewModel.trySendAction(ItemListingAction.DialogDismiss) },
+        onConfirmDeleteClick = {
+            viewModel.trySendAction(ItemListingAction.ConfirmDeleteClick(it))
         },
     )
 
@@ -171,9 +168,7 @@ fun ItemListingScreen(
                             contentDescription = BitwardenString.scan_a_qr_code.asText(),
                             testTag = "ScanQRCodeButton",
                         ),
-                        onFabOptionClick = remember(viewModel) {
-                            { launcher.launch(Manifest.permission.CAMERA) }
-                        },
+                        onFabOptionClick = { launcher.launch(Manifest.permission.CAMERA) },
                     ),
                     ExpandableFabOption(
                         label = BitwardenString.enter_key_manually.asText(),
@@ -182,8 +177,8 @@ fun ItemListingScreen(
                             contentDescription = BitwardenString.enter_key_manually.asText(),
                             testTag = "EnterSetupKeyButton",
                         ),
-                        onFabOptionClick = remember(viewModel) {
-                            { viewModel.trySendAction(ItemListingAction.EnterSetupKeyClick) }
+                        onFabOptionClick = {
+                            viewModel.trySendAction(ItemListingAction.EnterSetupKeyClick)
                         },
                     ),
                 ),
@@ -203,36 +198,29 @@ fun ItemListingScreen(
             is ItemListingState.ViewState.Content -> {
                 ItemListingContent(
                     state = currentState,
-                    onItemClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.ItemClick(it)) }
+                    onItemClick = { viewModel.trySendAction(ItemListingAction.ItemClick(it)) },
+                    onDropdownMenuClick = { action, item ->
+                        viewModel.trySendAction(
+                            ItemListingAction.DropdownMenuClick(menuAction = action, item = item),
+                        )
                     },
-                    onDropdownMenuClick = remember(viewModel) {
-                        { action, item ->
-                            viewModel.trySendAction(
-                                ItemListingAction.DropdownMenuClick(
-                                    menuAction = action,
-                                    item = item,
-                                ),
-                            )
-                        }
+                    onDownloadBitwardenClick = {
+                        viewModel.trySendAction(ItemListingAction.DownloadBitwardenClick)
                     },
-                    onDownloadBitwardenClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.DownloadBitwardenClick) }
+                    onDismissDownloadBitwardenClick = {
+                        viewModel.trySendAction(ItemListingAction.DownloadBitwardenDismiss)
                     },
-                    onDismissDownloadBitwardenClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.DownloadBitwardenDismiss) }
+                    onSyncWithBitwardenClick = {
+                        viewModel.trySendAction(ItemListingAction.SyncWithBitwardenClick)
                     },
-                    onSyncWithBitwardenClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.SyncWithBitwardenClick) }
+                    onDismissSyncWithBitwardenClick = {
+                        viewModel.trySendAction(ItemListingAction.SyncWithBitwardenDismiss)
                     },
-                    onDismissSyncWithBitwardenClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.SyncWithBitwardenDismiss) }
+                    onSyncLearnMoreClick = {
+                        viewModel.trySendAction(ItemListingAction.SyncLearnMoreClick)
                     },
-                    onSyncLearnMoreClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.SyncLearnMoreClick) }
-                    },
-                    onSectionExpandedClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.SectionExpandedClick(it)) }
+                    onSectionExpandedClick = {
+                        viewModel.trySendAction(ItemListingAction.SectionExpandedClick(it))
                     },
                 )
             }
@@ -244,23 +232,21 @@ fun ItemListingScreen(
             is ItemListingState.ViewState.NoItems -> {
                 EmptyItemListingContent(
                     actionCardState = currentState.actionCard,
-                    onAddCodeClick = remember(viewModel) {
-                        { launcher.launch(Manifest.permission.CAMERA) }
+                    onAddCodeClick = { launcher.launch(Manifest.permission.CAMERA) },
+                    onDownloadBitwardenClick = {
+                        viewModel.trySendAction(ItemListingAction.DownloadBitwardenClick)
                     },
-                    onDownloadBitwardenClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.DownloadBitwardenClick) }
+                    onDismissDownloadBitwardenClick = {
+                        viewModel.trySendAction(ItemListingAction.DownloadBitwardenDismiss)
                     },
-                    onDismissDownloadBitwardenClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.DownloadBitwardenDismiss) }
+                    onSyncWithBitwardenClick = {
+                        viewModel.trySendAction(ItemListingAction.SyncWithBitwardenClick)
                     },
-                    onSyncWithBitwardenClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.SyncWithBitwardenClick) }
+                    onSyncLearnMoreClick = {
+                        viewModel.trySendAction(ItemListingAction.SyncLearnMoreClick)
                     },
-                    onSyncLearnMoreClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.SyncLearnMoreClick) }
-                    },
-                    onDismissSyncWithBitwardenClick = remember(viewModel) {
-                        { viewModel.trySendAction(ItemListingAction.SyncWithBitwardenDismiss) }
+                    onDismissSyncWithBitwardenClick = {
+                        viewModel.trySendAction(ItemListingAction.SyncWithBitwardenDismiss)
                     },
                 )
             }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/ManualCodeEntryScreen.kt
@@ -96,9 +96,7 @@ fun ManualCodeEntryScreen(
             ),
             confirmButtonText = stringResource(id = BitwardenString.settings),
             dismissButtonText = stringResource(id = BitwardenString.no_thanks),
-            onConfirmClick = remember(viewModel) {
-                { viewModel.trySendAction(ManualCodeEntryAction.SettingsClick) }
-            },
+            onConfirmClick = { viewModel.trySendAction(ManualCodeEntryAction.SettingsClick) },
             onDismissClick = { shouldShowPermissionDialog = false },
             onDismissRequest = { shouldShowPermissionDialog = false },
             title = null,
@@ -119,8 +117,8 @@ fun ManualCodeEntryScreen(
                 title = stringResource(id = BitwardenString.create_verification_code),
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
                 navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                onNavigationIconClick = remember(viewModel) {
-                    { viewModel.trySendAction(ManualCodeEntryAction.CloseClick) }
+                onNavigationIconClick = {
+                    viewModel.trySendAction(ManualCodeEntryAction.CloseClick)
                 },
                 scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState()),
             )
@@ -128,25 +126,19 @@ fun ManualCodeEntryScreen(
     ) {
         ManualCodeEntryContent(
             state = state,
-            onNameChange = remember(viewModel) {
-                { viewModel.trySendAction(ManualCodeEntryAction.IssuerTextChange(it)) }
+            onNameChange = { viewModel.trySendAction(ManualCodeEntryAction.IssuerTextChange(it)) },
+            onKeyChange = { viewModel.trySendAction(ManualCodeEntryAction.CodeTextChange(it)) },
+            onSaveLocallyClick = {
+                viewModel.trySendAction(ManualCodeEntryAction.SaveLocallyClick)
             },
-            onKeyChange = remember(viewModel) {
-                { viewModel.trySendAction(ManualCodeEntryAction.CodeTextChange(it)) }
+            onSaveToBitwardenClick = {
+                viewModel.trySendAction(ManualCodeEntryAction.SaveToBitwardenClick)
             },
-            onSaveLocallyClick = remember(viewModel) {
-                { viewModel.trySendAction(ManualCodeEntryAction.SaveLocallyClick) }
-            },
-            onSaveToBitwardenClick = remember(viewModel) {
-                { viewModel.trySendAction(ManualCodeEntryAction.SaveToBitwardenClick) }
-            },
-            onScanQrCodeClick = remember(viewModel) {
-                {
-                    if (permissionsManager.checkPermission(Manifest.permission.CAMERA)) {
-                        viewModel.trySendAction(ManualCodeEntryAction.ScanQrCodeTextClick)
-                    } else {
-                        launcher.launch(Manifest.permission.CAMERA)
-                    }
+            onScanQrCodeClick = {
+                if (permissionsManager.checkPermission(Manifest.permission.CAMERA)) {
+                    viewModel.trySendAction(ManualCodeEntryAction.ScanQrCodeTextClick)
+                } else {
+                    launcher.launch(Manifest.permission.CAMERA)
                 }
             },
         )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -60,11 +59,11 @@ fun QrCodeScanScreen(
     qrCodeAnalyzer: QrCodeAnalyzer = LocalQrCodeAnalyzer.current,
     onNavigateToManualCodeEntryScreen: () -> Unit,
 ) {
-    qrCodeAnalyzer.onQrCodeScanned = remember(viewModel) {
-        { viewModel.trySendAction(QrCodeScanAction.QrCodeScanReceive(it)) }
+    qrCodeAnalyzer.onQrCodeScanned = {
+        viewModel.trySendAction(QrCodeScanAction.QrCodeScanReceive(it))
     }
-    val onEnterCodeManuallyClick = remember(viewModel) {
-        { viewModel.trySendAction(QrCodeScanAction.ManualEntryTextClick) }
+    val onEnterCodeManuallyClick = {
+        viewModel.trySendAction(QrCodeScanAction.ManualEntryTextClick)
     }
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     EventsEffect(viewModel = viewModel) { event ->
@@ -84,14 +83,12 @@ fun QrCodeScanScreen(
         StatusBarsAppearanceAffect(isLightStatusBars = false)
         QrCodeScanDialogs(
             dialogState = state.dialog,
-            onSaveHereClick = remember(viewModel) {
-                { viewModel.trySendAction(QrCodeScanAction.SaveLocallyClick(it)) }
+            onSaveHereClick = { viewModel.trySendAction(QrCodeScanAction.SaveLocallyClick(it)) },
+            onTakeMeToBitwardenClick = {
+                viewModel.trySendAction(QrCodeScanAction.SaveToBitwardenClick(it))
             },
-            onTakeMeToBitwardenClick = remember(viewModel) {
-                { viewModel.trySendAction(QrCodeScanAction.SaveToBitwardenClick(it)) }
-            },
-            onDismissRequest = remember(viewModel) {
-                { viewModel.trySendAction(QrCodeScanAction.SaveToBitwardenErrorDismiss) }
+            onDismissRequest = {
+                viewModel.trySendAction(QrCodeScanAction.SaveToBitwardenErrorDismiss)
             },
         )
 
@@ -102,16 +99,16 @@ fun QrCodeScanScreen(
                     title = stringResource(id = BitwardenString.scan_qr_code),
                     navigationIcon = painterResource(id = BitwardenDrawable.ic_close),
                     navigationIconContentDescription = stringResource(id = BitwardenString.close),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(QrCodeScanAction.CloseClick) }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(QrCodeScanAction.CloseClick)
                     },
                     scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
                 )
             },
         ) {
             CameraPreview(
-                cameraErrorReceive = remember(viewModel) {
-                    { viewModel.trySendAction(QrCodeScanAction.CameraSetupErrorReceive) }
+                cameraErrorReceive = {
+                    viewModel.trySendAction(QrCodeScanAction.CameraSetupErrorReceive)
                 },
                 qrCodeAnalyzer = qrCodeAnalyzer,
                 modifier = Modifier.fillMaxSize(),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -66,10 +65,8 @@ fun DebugMenuScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(BitwardenDrawable.ic_back),
                     navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                    onNavigationIconClick = remember(viewModel) {
-                        {
-                            viewModel.trySendAction(DebugMenuAction.NavigateBack)
-                        }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(DebugMenuAction.NavigateBack)
                     },
                 ),
             )
@@ -83,14 +80,10 @@ fun DebugMenuScreen(
         } else {
             FeatureFlagContent(
                 featureFlagMap = state.featureFlags,
-                onValueChange = remember(viewModel) {
-                    { key, value ->
-                        viewModel.trySendAction(DebugMenuAction.UpdateFeatureFlag(key, value))
-                    }
+                onValueChange = { key, value ->
+                    viewModel.trySendAction(DebugMenuAction.UpdateFeatureFlag(key, value))
                 },
-                onResetValues = remember(viewModel) {
-                    { viewModel.trySendAction(DebugMenuAction.ResetFeatureFlagValues) }
-                },
+                onResetValues = { viewModel.trySendAction(DebugMenuAction.ResetFeatureFlagValues) },
                 modifier = Modifier
                     .verticalScroll(rememberScrollState()),
             )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -67,10 +67,8 @@ fun RootNavScreen(
 
     BiometricChanges(
         biometricsManager = biometricsManager,
-        onBiometricSupportChange = remember(viewModel) {
-            {
-                viewModel.trySendAction(RootNavAction.BiometricSupportChanged(it))
-            }
+        onBiometricSupportChange = {
+            viewModel.trySendAction(RootNavAction.BiometricSupportChanged(it))
         },
     )
 

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -98,12 +98,8 @@ fun SettingsScreen(
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val snackbarState = rememberBitwardenSnackbarHostState()
     var showBiometricsPrompt by rememberSaveable { mutableStateOf(false) }
-    val unlockWithBiometricToggle: (cipher: Cipher) -> Unit = remember(viewModel) {
-        {
-            viewModel.trySendAction(
-                SettingsAction.SecurityClick.UnlockWithBiometricToggleEnabled(cipher = it),
-            )
-        }
+    val unlockWithBiometricToggle: (cipher: Cipher) -> Unit = {
+        viewModel.trySendAction(SettingsAction.SecurityClick.UnlockWithBiometricToggleEnabled(it))
     }
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -165,10 +161,8 @@ fun SettingsScreen(
 
     BiometricChanges(
         biometricsManager = biometricsManager,
-        onBiometricSupportChange = remember(viewModel) {
-            {
-                viewModel.trySendAction(SettingsAction.BiometricSupportChanged(it))
-            }
+        onBiometricSupportChange = {
+            viewModel.trySendAction(SettingsAction.BiometricSupportChanged(it))
         },
     )
 
@@ -192,55 +186,33 @@ fun SettingsScreen(
         ) {
             SecuritySettings(
                 state = state,
-                onBiometricToggle = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            SettingsAction.SecurityClick.UnlockWithBiometricToggle(it),
-                        )
-                    }
+                onBiometricToggle = {
+                    viewModel.trySendAction(
+                        SettingsAction.SecurityClick.UnlockWithBiometricToggle(it),
+                    )
                 },
-                onScreenCaptureChange = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            SettingsAction.SecurityClick.AllowScreenCaptureToggle(it),
-                        )
-                    }
+                onScreenCaptureChange = {
+                    viewModel.trySendAction(
+                        SettingsAction.SecurityClick.AllowScreenCaptureToggle(it),
+                    )
                 },
-                onAppTimeoutChange = remember(viewModel) {
-                    { viewModel.trySendAction(SettingsAction.SecurityClick.AppTimeoutChange(it)) }
+                onAppTimeoutChange = {
+                    viewModel.trySendAction(SettingsAction.SecurityClick.AppTimeoutChange(it))
                 },
             )
             Spacer(modifier = Modifier.height(16.dp))
             VaultSettings(
-                onExportClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(SettingsAction.DataClick.ExportClick)
-                    }
+                onExportClick = { viewModel.trySendAction(SettingsAction.DataClick.ExportClick) },
+                onImportClick = { viewModel.trySendAction(SettingsAction.DataClick.ImportClick) },
+                onBackupClick = { viewModel.trySendAction(SettingsAction.DataClick.BackupClick) },
+                onSyncWithBitwardenClick = {
+                    viewModel.trySendAction(SettingsAction.DataClick.SyncWithBitwardenClick)
                 },
-                onImportClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(SettingsAction.DataClick.ImportClick)
-                    }
+                onSyncLearnMoreClick = {
+                    viewModel.trySendAction(SettingsAction.DataClick.SyncLearnMoreClick)
                 },
-                onBackupClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(SettingsAction.DataClick.BackupClick)
-                    }
-                },
-                onSyncWithBitwardenClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(SettingsAction.DataClick.SyncWithBitwardenClick)
-                    }
-                },
-                onSyncLearnMoreClick = remember(viewModel) {
-                    { viewModel.trySendAction(SettingsAction.DataClick.SyncLearnMoreClick) }
-                },
-                onDefaultSaveOptionUpdated = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            SettingsAction.DataClick.DefaultSaveOptionUpdated(it),
-                        )
-                    }
+                onDefaultSaveOptionUpdated = {
+                    viewModel.trySendAction(SettingsAction.DataClick.DefaultSaveOptionUpdated(it))
                 },
                 defaultSaveOption = state.defaultSaveOption,
                 shouldShowDefaultSaveOptions = state.showDefaultSaveOptionRow,
@@ -249,46 +221,36 @@ fun SettingsScreen(
             Spacer(modifier = Modifier.height(16.dp))
             AppearanceSettings(
                 state = state.appearance,
-                onLanguageSelection = remember(viewModel) {
-                    { viewModel.trySendAction(SettingsAction.AppearanceChange.LanguageChange(it)) }
+                onLanguageSelection = {
+                    viewModel.trySendAction(SettingsAction.AppearanceChange.LanguageChange(it))
                 },
-                onThemeSelection = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(SettingsAction.AppearanceChange.ThemeChange(it))
-                    }
+                onThemeSelection = {
+                    viewModel.trySendAction(SettingsAction.AppearanceChange.ThemeChange(it))
                 },
-                onDynamicColorChange = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            SettingsAction.AppearanceChange.DynamicColorChange(it),
-                        )
-                    }
+                onDynamicColorChange = {
+                    viewModel.trySendAction(SettingsAction.AppearanceChange.DynamicColorChange(it))
                 },
             )
             Spacer(Modifier.height(16.dp))
             HelpSettings(
-                onTutorialClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(SettingsAction.HelpClick.ShowTutorialClick)
-                    }
+                onTutorialClick = {
+                    viewModel.trySendAction(SettingsAction.HelpClick.ShowTutorialClick)
                 },
-                onHelpCenterClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(SettingsAction.HelpClick.HelpCenterClick)
-                    }
+                onHelpCenterClick = {
+                    viewModel.trySendAction(SettingsAction.HelpClick.HelpCenterClick)
                 },
             )
             Spacer(modifier = Modifier.height(16.dp))
             AboutSettings(
                 state = state,
-                onSubmitCrashLogsCheckedChange = remember(viewModel) {
-                    { viewModel.trySendAction(SettingsAction.AboutClick.SubmitCrashLogsClick(it)) }
+                onSubmitCrashLogsCheckedChange = {
+                    viewModel.trySendAction(SettingsAction.AboutClick.SubmitCrashLogsClick(it))
                 },
-                onPrivacyPolicyClick = remember(viewModel) {
-                    { viewModel.trySendAction(SettingsAction.AboutClick.PrivacyPolicyClick) }
+                onPrivacyPolicyClick = {
+                    viewModel.trySendAction(SettingsAction.AboutClick.PrivacyPolicyClick)
                 },
-                onVersionClick = remember(viewModel) {
-                    { viewModel.trySendAction(SettingsAction.AboutClick.VersionClick) }
+                onVersionClick = {
+                    viewModel.trySendAction(SettingsAction.AboutClick.VersionClick)
                 },
             )
             Box(

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
@@ -62,10 +62,8 @@ fun ExportScreen(
     onNavigateBack: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val exportLocationReceive: (Uri) -> Unit = remember {
-        {
-            viewModel.trySendAction(ExportAction.ExportLocationReceive(it))
-        }
+    val exportLocationReceive: (Uri) -> Unit = {
+        viewModel.trySendAction(ExportAction.ExportLocationReceive(it))
     }
     val fileSaveLauncher = intentManager.getActivityResultLauncher { activityResult ->
         intentManager.getFileDataFromActivityResult(activityResult)?.let {
@@ -91,11 +89,7 @@ fun ExportScreen(
     }
 
     var shouldShowConfirmationPrompt by remember { mutableStateOf(false) }
-    val confirmExportClick = remember(viewModel) {
-        {
-            viewModel.trySendAction(ExportAction.ConfirmExportClick)
-        }
-    }
+    val confirmExportClick = { viewModel.trySendAction(ExportAction.ConfirmExportClick) }
     if (shouldShowConfirmationPrompt) {
         BitwardenTwoButtonDialog(
             title = stringResource(id = BitwardenString.export_confirmation_title),
@@ -118,11 +112,7 @@ fun ExportScreen(
             BitwardenBasicDialog(
                 title = dialog.title?.invoke(),
                 message = dialog.message(),
-                onDismissRequest = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(ExportAction.DialogDismiss)
-                    }
-                },
+                onDismissRequest = { viewModel.trySendAction(ExportAction.DialogDismiss) },
             )
         }
 
@@ -144,11 +134,7 @@ fun ExportScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(ExportAction.CloseButtonClick)
-                    }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(ExportAction.CloseButtonClick) },
             )
         },
         snackbarHost = { BitwardenSnackbarHost(snackbarState) },
@@ -156,10 +142,8 @@ fun ExportScreen(
         ExportScreenContent(
             modifier = Modifier.fillMaxSize(),
             state = state,
-            onExportFormatOptionSelected = remember(viewModel) {
-                {
-                    viewModel.trySendAction(ExportAction.ExportFormatOptionSelect(it))
-                }
+            onExportFormatOptionSelected = {
+                viewModel.trySendAction(ExportAction.ExportFormatOptionSelect(it))
             },
             onExportClick = { shouldShowConfirmationPrompt = true },
         )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalResources
@@ -54,10 +53,8 @@ fun ImportingScreen(
     onNavigateBack: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
-    val importLocationReceive: (FileData) -> Unit = remember {
-        {
-            viewModel.trySendAction(ImportAction.ImportLocationReceive(it))
-        }
+    val importLocationReceive: (FileData) -> Unit = {
+        viewModel.trySendAction(ImportAction.ImportLocationReceive(it))
     }
     val launcher = intentManager.getActivityResultLauncher { activityResult ->
         intentManager.getFileDataFromActivityResult(activityResult)?.let {
@@ -116,27 +113,17 @@ fun ImportingScreen(
                 scrollBehavior = scrollBehavior,
                 navigationIcon = painterResource(id = BitwardenDrawable.ic_back),
                 navigationIconContentDescription = stringResource(id = BitwardenString.back),
-                onNavigationIconClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(ImportAction.CloseButtonClick)
-                    }
-                },
+                onNavigationIconClick = { viewModel.trySendAction(ImportAction.CloseButtonClick) },
             )
         },
     ) {
         ImportScreenContent(
             modifier = Modifier.fillMaxSize(),
             state = state,
-            onImportFormatOptionSelected = remember(viewModel) {
-                {
-                    viewModel.trySendAction(ImportAction.ImportFormatOptionSelect(it))
-                }
+            onImportFormatOptionSelected = {
+                viewModel.trySendAction(ImportAction.ImportFormatOptionSelect(it))
             },
-            onImportClick = remember(viewModel) {
-                {
-                    viewModel.trySendAction(ImportAction.ImportClick)
-                }
-            },
+            onImportClick = { viewModel.trySendAction(ImportAction.ImportClick) },
         )
     }
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -83,18 +82,10 @@ fun TutorialScreen(
         TutorialScreenContent(
             state = state,
             pagerState = pagerState,
-            onPagerSwipe = remember(viewModel) {
-                { viewModel.trySendAction(TutorialAction.PagerSwipe(it)) }
-            },
-            onDotClick = remember(viewModel) {
-                { viewModel.trySendAction(TutorialAction.DotClick(it)) }
-            },
-            continueClick = remember(viewModel) {
-                { viewModel.trySendAction(TutorialAction.ContinueClick(it)) }
-            },
-            skipClick = remember(viewModel) {
-                { viewModel.trySendAction(TutorialAction.SkipClick) }
-            },
+            onPagerSwipe = { viewModel.trySendAction(TutorialAction.PagerSwipe(it)) },
+            onDotClick = { viewModel.trySendAction(TutorialAction.DotClick(it)) },
+            continueClick = { viewModel.trySendAction(TutorialAction.ContinueClick(it)) },
+            skipClick = { viewModel.trySendAction(TutorialAction.SkipClick) },
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -366,11 +366,7 @@ fun ExampleScreen(
         BitwardenSwitch(
             label = stringResource(id = R.string.toggle_label),
             isChecked = state.isToggleEnabled,
-            // Use remember(viewModel) to ensure the unstable lambda doesn't trigger unnecessary
-            // recompositions.
-            onCheckedChange = remember(viewModel) {
-                { viewModel.trySendAction(ExampleAction.ToggleValueUpdate(it)) }
-            },
+            onCheckedChange = { viewModel.trySendAction(ExampleAction.ToggleValueUpdate(it)) },
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth(),
@@ -380,9 +376,7 @@ fun ExampleScreen(
 
         BitwardenFilledButton(
             label = stringResource(id = R.string.continue_text),
-            onClick = remember(viewModel) {
-                { viewModel.trySendAction(ExampleAction.ContinueButtonClick) }
-            },
+            onClick = { viewModel.trySendAction(ExampleAction.ContinueButtonClick) },
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth(),

--- a/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/createpassword/CreatePasswordScreen.kt
+++ b/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/createpassword/CreatePasswordScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -63,8 +62,8 @@ fun CreatePasswordScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                     navigationIconContentDescription = stringResource(BitwardenString.back),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(CreatePasswordAction.BackClick) }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(CreatePasswordAction.BackClick)
                     },
                 ),
             )
@@ -81,8 +80,8 @@ fun CreatePasswordScreen(
             BitwardenTextField(
                 label = stringResource(R.string.username),
                 value = state.username,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(CreatePasswordAction.UsernameChanged(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(CreatePasswordAction.UsernameChanged(it))
                 },
                 cardStyle = null,
                 modifier = Modifier
@@ -95,8 +94,8 @@ fun CreatePasswordScreen(
             BitwardenTextField(
                 label = stringResource(R.string.password),
                 value = state.password,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(CreatePasswordAction.PasswordChanged(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(CreatePasswordAction.PasswordChanged(it))
                 },
                 cardStyle = null,
                 modifier = Modifier
@@ -108,9 +107,7 @@ fun CreatePasswordScreen(
 
             BitwardenFilledButton(
                 label = stringResource(R.string.execute),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(CreatePasswordAction.ExecuteClick) }
-                },
+                onClick = { viewModel.trySendAction(CreatePasswordAction.ExecuteClick) },
                 isEnabled = !state.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -121,9 +118,7 @@ fun CreatePasswordScreen(
 
             BitwardenTextButton(
                 label = stringResource(BitwardenString.clear),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(CreatePasswordAction.ClearResultClick) }
-                },
+                onClick = { viewModel.trySendAction(CreatePasswordAction.ClearResultClick) },
                 isEnabled = !state.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/credentialmanager/CredentialManagerListScreen.kt
+++ b/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/credentialmanager/CredentialManagerListScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -83,8 +82,8 @@ fun CredentialManagerListScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                     navigationIconContentDescription = stringResource(BitwardenString.back),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(CredentialManagerListAction.BackClick) }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(CredentialManagerListAction.BackClick)
                     },
                 ),
             )
@@ -108,21 +107,15 @@ fun CredentialManagerListScreen(
 
             BitwardenPushRow(
                 text = stringResource(id = R.string.get_password),
-                onClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(CredentialManagerListAction.GetPasswordClick)
-                    }
-                },
+                onClick = { viewModel.trySendAction(CredentialManagerListAction.GetPasswordClick) },
                 cardStyle = CardStyle.Top(),
                 modifier = Modifier.standardHorizontalMargin(),
             )
 
             BitwardenPushRow(
                 text = stringResource(id = R.string.create_password),
-                onClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(CredentialManagerListAction.CreatePasswordClick)
-                    }
+                onClick = {
+                    viewModel.trySendAction(CredentialManagerListAction.CreatePasswordClick)
                 },
                 cardStyle = CardStyle.Middle(),
                 modifier = Modifier.standardHorizontalMargin(),
@@ -130,21 +123,15 @@ fun CredentialManagerListScreen(
 
             BitwardenPushRow(
                 text = stringResource(id = R.string.get_passkey),
-                onClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(CredentialManagerListAction.GetPasskeyClick)
-                    }
-                },
+                onClick = { viewModel.trySendAction(CredentialManagerListAction.GetPasskeyClick) },
                 cardStyle = CardStyle.Middle(),
                 modifier = Modifier.standardHorizontalMargin(),
             )
 
             BitwardenPushRow(
                 text = stringResource(id = R.string.create_passkey),
-                onClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(CredentialManagerListAction.CreatePasskeyClick)
-                    }
+                onClick = {
+                    viewModel.trySendAction(CredentialManagerListAction.CreatePasskeyClick)
                 },
                 cardStyle = CardStyle.Middle(),
                 modifier = Modifier.standardHorizontalMargin(),
@@ -152,12 +139,8 @@ fun CredentialManagerListScreen(
 
             BitwardenPushRow(
                 text = stringResource(id = R.string.get_password_or_passkey),
-                onClick = remember(viewModel) {
-                    {
-                        viewModel.trySendAction(
-                            CredentialManagerListAction.GetPasswordOrPasskeyClick,
-                        )
-                    }
+                onClick = {
+                    viewModel.trySendAction(CredentialManagerListAction.GetPasswordOrPasskeyClick)
                 },
                 cardStyle = CardStyle.Bottom,
                 modifier = Modifier.standardHorizontalMargin(),

--- a/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/getpasskey/GetPasskeyScreen.kt
+++ b/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/getpasskey/GetPasskeyScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -63,9 +62,7 @@ fun GetPasskeyScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                     navigationIconContentDescription = stringResource(BitwardenString.back),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(GetPasskeyAction.BackClick) }
-                    },
+                    onNavigationIconClick = { viewModel.trySendAction(GetPasskeyAction.BackClick) },
                 ),
             )
         },
@@ -81,9 +78,7 @@ fun GetPasskeyScreen(
             BitwardenTextField(
                 label = stringResource(R.string.relying_party_id),
                 value = state.rpId,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasskeyAction.RpIdChanged(it)) }
-                },
+                onValueChange = { viewModel.trySendAction(GetPasskeyAction.RpIdChanged(it)) },
                 placeholder = stringResource(R.string.rp_id_hint),
                 cardStyle = null,
                 modifier = Modifier
@@ -96,9 +91,7 @@ fun GetPasskeyScreen(
             BitwardenTextField(
                 label = stringResource(R.string.origin_optional),
                 value = state.origin,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasskeyAction.OriginChanged(it)) }
-                },
+                onValueChange = { viewModel.trySendAction(GetPasskeyAction.OriginChanged(it)) },
                 placeholder = stringResource(R.string.origin_hint),
                 cardStyle = null,
                 modifier = Modifier
@@ -110,9 +103,7 @@ fun GetPasskeyScreen(
 
             BitwardenFilledButton(
                 label = stringResource(R.string.execute),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasskeyAction.ExecuteClick) }
-                },
+                onClick = { viewModel.trySendAction(GetPasskeyAction.ExecuteClick) },
                 isEnabled = !state.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -123,9 +114,7 @@ fun GetPasskeyScreen(
 
             BitwardenTextButton(
                 label = stringResource(R.string.clear),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasskeyAction.ClearResultClick) }
-                },
+                onClick = { viewModel.trySendAction(GetPasskeyAction.ClearResultClick) },
                 isEnabled = !state.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/getpassword/GetPasswordScreen.kt
+++ b/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/getpassword/GetPasswordScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -65,8 +64,8 @@ fun GetPasswordScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                     navigationIconContentDescription = stringResource(BitwardenString.back),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(GetPasswordAction.BackClick) }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(GetPasswordAction.BackClick)
                     },
                 ),
             )
@@ -93,9 +92,7 @@ fun GetPasswordScreen(
 
             BitwardenFilledButton(
                 label = stringResource(R.string.execute),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasswordAction.ExecuteClick) }
-                },
+                onClick = { viewModel.trySendAction(GetPasswordAction.ExecuteClick) },
                 isEnabled = !state.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -106,9 +103,7 @@ fun GetPasswordScreen(
 
             BitwardenTextButton(
                 label = stringResource(R.string.clear),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasswordAction.ClearResultClick) }
-                },
+                onClick = { viewModel.trySendAction(GetPasswordAction.ClearResultClick) },
                 isEnabled = !state.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/getpasswordorpasskey/GetPasswordOrPasskeyScreen.kt
+++ b/testharness/src/main/kotlin/com/bitwarden/testharness/ui/platform/feature/getpasswordorpasskey/GetPasswordOrPasskeyScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -68,8 +67,8 @@ fun GetPasswordOrPasskeyScreen(
                 navigationIcon = NavigationIcon(
                     navigationIcon = rememberVectorPainter(id = BitwardenDrawable.ic_back),
                     navigationIconContentDescription = stringResource(BitwardenString.back),
-                    onNavigationIconClick = remember(viewModel) {
-                        { viewModel.trySendAction(GetPasswordOrPasskeyAction.BackClick) }
+                    onNavigationIconClick = {
+                        viewModel.trySendAction(GetPasswordOrPasskeyAction.BackClick)
                     },
                 ),
             )
@@ -86,8 +85,8 @@ fun GetPasswordOrPasskeyScreen(
             BitwardenTextField(
                 label = stringResource(R.string.relying_party_id),
                 value = state.rpId,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasswordOrPasskeyAction.RpIdChanged(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(GetPasswordOrPasskeyAction.RpIdChanged(it))
                 },
                 placeholder = stringResource(R.string.rp_id_hint),
                 cardStyle = null,
@@ -101,8 +100,8 @@ fun GetPasswordOrPasskeyScreen(
             BitwardenTextField(
                 label = stringResource(R.string.origin_optional),
                 value = state.origin,
-                onValueChange = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasswordOrPasskeyAction.OriginChanged(it)) }
+                onValueChange = {
+                    viewModel.trySendAction(GetPasswordOrPasskeyAction.OriginChanged(it))
                 },
                 placeholder = stringResource(R.string.origin_hint),
                 cardStyle = null,
@@ -115,9 +114,7 @@ fun GetPasswordOrPasskeyScreen(
 
             BitwardenFilledButton(
                 label = stringResource(R.string.execute),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasswordOrPasskeyAction.ExecuteClick) }
-                },
+                onClick = { viewModel.trySendAction(GetPasswordOrPasskeyAction.ExecuteClick) },
                 isEnabled = !state.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -128,9 +125,7 @@ fun GetPasswordOrPasskeyScreen(
 
             BitwardenTextButton(
                 label = stringResource(R.string.clear),
-                onClick = remember(viewModel) {
-                    { viewModel.trySendAction(GetPasswordOrPasskeyAction.ClearResultClick) }
-                },
+                onClick = { viewModel.trySendAction(GetPasswordOrPasskeyAction.ClearResultClick) },
                 isEnabled = !state.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes all the instances of `remeber(viewModel)` from the click listeners in the codebase. These extra remebers are no longer needed since [strong skipping](https://developer.android.com/develop/ui/compose/performance/stability/strongskipping) will handle this for us. This will simplify a lot of our UIs.

