### PR TITLE
PM-29861: Update overflow content description to 'More options'

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreen.kt
@@ -119,7 +119,6 @@ fun LoginScreen(
                         )
                     }
                     BitwardenOverflowActionItem(
-                        contentDescription = stringResource(BitwardenString.more),
                         menuItemDataList = persistentListOf(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.get_password_hint),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordScreen.kt
@@ -119,7 +119,6 @@ fun ResetPasswordScreen(
                         modifier = Modifier.testTag("SaveButton"),
                     )
                     BitwardenOverflowActionItem(
-                        contentDescription = stringResource(BitwardenString.more),
                         menuItemDataList = persistentListOf(
                             OverflowMenuItemData(
                                 text = stringResource(BitwardenString.log_out),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreen.kt
@@ -144,23 +144,22 @@ fun TwoFactorLoginScreen(
                     viewModel.trySendAction(TwoFactorLoginAction.CloseButtonClick)
                 },
                 actions = {
-                    if (!state.isNewDeviceVerification) {
-                        BitwardenOverflowActionItem(
-                            contentDescription = stringResource(BitwardenString.more),
-                            menuItemDataList = state.availableAuthMethods
-                                .map {
-                                    OverflowMenuItemData(
-                                        text = it.title(),
-                                        onClick = {
-                                            viewModel.trySendAction(
-                                                TwoFactorLoginAction.SelectAuthMethod(it),
-                                            )
-                                        },
-                                    )
-                                }
-                                .toPersistentList(),
-                        )
-                    }
+                    BitwardenOverflowActionItem(
+                        isVisible = !state.isNewDeviceVerification,
+                        menuItemDataList = state
+                            .availableAuthMethods
+                            .map {
+                                OverflowMenuItemData(
+                                    text = it.title(),
+                                    onClick = {
+                                        viewModel.trySendAction(
+                                            TwoFactorLoginAction.SelectAuthMethod(it),
+                                        )
+                                    },
+                                )
+                            }
+                            .toPersistentList(),
+                    )
                 },
             )
         },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreen.kt
@@ -209,7 +209,6 @@ fun VaultUnlockScreen(
                         )
                     }
                     BitwardenOverflowActionItem(
-                        contentDescription = stringResource(BitwardenString.more),
                         menuItemDataList = persistentListOf(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.log_out),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/listitem/BitwardenListItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/listitem/BitwardenListItem.kt
@@ -143,7 +143,7 @@ fun BitwardenListItem(
         if (selectionDataList.isNotEmpty()) {
             BitwardenStandardIconButton(
                 vectorIconRes = BitwardenDrawable.ic_ellipsis_horizontal,
-                contentDescription = stringResource(id = BitwardenString.options),
+                contentDescription = stringResource(id = BitwardenString.more_options),
                 onClick = { shouldShowDialog = true },
                 modifier = Modifier.nullableTestTag(tag = optionsTestTag),
             )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedLogs/RecordedLogsScreen.kt
@@ -168,7 +168,6 @@ private fun RecordedLogsOverflowMenu(
         )
     }
     BitwardenOverflowActionItem(
-        contentDescription = stringResource(BitwardenString.more),
         modifier = modifier,
         menuItemDataList = persistentListOf(
             OverflowMenuItemData(
@@ -310,7 +309,6 @@ private fun LogRow(
         }
         Spacer(modifier = Modifier.width(width = 12.dp))
         BitwardenOverflowActionItem(
-            contentDescription = stringResource(BitwardenString.more),
             menuItemDataList = persistentListOf(
                 OverflowMenuItemData(
                     text = stringResource(id = BitwardenString.share),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreen.kt
@@ -98,17 +98,15 @@ fun FolderAddEditScreen(
                         onClick = { viewModel.trySendAction(FolderAddEditAction.SaveClick) },
                         modifier = Modifier.testTag("SaveButton"),
                     )
-                    if (state.shouldShowOverflowMenu) {
-                        BitwardenOverflowActionItem(
-                            contentDescription = stringResource(BitwardenString.more),
-                            menuItemDataList = persistentListOf(
-                                OverflowMenuItemData(
-                                    text = stringResource(id = BitwardenString.delete),
-                                    onClick = { shouldShowConfirmationDialog = true },
-                                ),
+                    BitwardenOverflowActionItem(
+                        isVisible = state.shouldShowOverflowMenu,
+                        menuItemDataList = persistentListOf(
+                            OverflowMenuItemData(
+                                text = stringResource(id = BitwardenString.delete),
+                                onClick = { shouldShowConfirmationDialog = true },
                             ),
-                        )
-                    }
+                        ),
+                    )
                 },
             )
         },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -298,7 +298,6 @@ private fun DefaultAppBar(
         dividerStyle = TopAppBarDividerStyle.NONE,
         actions = {
             BitwardenOverflowActionItem(
-                contentDescription = stringResource(BitwardenString.more),
                 menuItemDataList = persistentListOf(
                     OverflowMenuItemData(
                         text = stringResource(id = BitwardenString.password_history),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreen.kt
@@ -70,21 +70,19 @@ fun PasswordHistoryScreen(
                     viewModel.trySendAction(PasswordHistoryAction.CloseClick)
                 },
                 actions = {
-                    if (state.menuEnabled) {
-                        BitwardenOverflowActionItem(
-                            contentDescription = stringResource(BitwardenString.more),
-                            menuItemDataList = persistentListOf(
-                                OverflowMenuItemData(
-                                    text = stringResource(id = BitwardenString.clear),
-                                    onClick = {
-                                        viewModel.trySendAction(
-                                            PasswordHistoryAction.PasswordClearClick,
-                                        )
-                                    },
-                                ),
+                    BitwardenOverflowActionItem(
+                        isVisible = state.menuEnabled,
+                        menuItemDataList = persistentListOf(
+                            OverflowMenuItemData(
+                                text = stringResource(id = BitwardenString.clear),
+                                onClick = {
+                                    viewModel.trySendAction(
+                                        PasswordHistoryAction.PasswordClearClick,
+                                    )
+                                },
                             ),
-                        )
-                    }
+                        ),
+                    )
                 },
             )
         },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -140,7 +140,6 @@ fun SendScreen(
                         onClick = { viewModel.trySendAction(SendAction.SearchClick) },
                     )
                     BitwardenOverflowActionItem(
-                        contentDescription = stringResource(BitwardenString.more),
                         menuItemDataList = persistentListOf(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.sync),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -132,36 +132,32 @@ fun AddEditSendScreen(
                         onClick = { viewModel.trySendAction(AddEditSendAction.SaveClick) },
                         modifier = Modifier.testTag("SaveButton"),
                     )
-                    if (!state.isAddMode) {
-                        BitwardenOverflowActionItem(
-                            contentDescription = stringResource(BitwardenString.more),
-                            menuItemDataList = persistentListOfNotNull(
-                                OverflowMenuItemData(
-                                    text = stringResource(id = BitwardenString.remove_password),
-                                    onClick = {
-                                        viewModel.trySendAction(
-                                            AddEditSendAction.RemovePasswordClick,
-                                        )
-                                    },
-                                )
-                                    .takeIf { state.hasPassword && !state.policyDisablesSend },
-                                OverflowMenuItemData(
-                                    text = stringResource(id = BitwardenString.copy_link),
-                                    onClick = {
-                                        viewModel.trySendAction(AddEditSendAction.CopyLinkClick)
-                                    },
-                                )
-                                    .takeIf { !state.policyDisablesSend },
-                                OverflowMenuItemData(
-                                    text = stringResource(id = BitwardenString.share_link),
-                                    onClick = {
-                                        viewModel.trySendAction(AddEditSendAction.ShareLinkClick)
-                                    },
-                                )
-                                    .takeIf { !state.policyDisablesSend },
-                            ),
-                        )
-                    }
+                    BitwardenOverflowActionItem(
+                        isVisible = !state.isAddMode,
+                        menuItemDataList = persistentListOfNotNull(
+                            OverflowMenuItemData(
+                                text = stringResource(id = BitwardenString.remove_password),
+                                onClick = {
+                                    viewModel.trySendAction(AddEditSendAction.RemovePasswordClick)
+                                },
+                            )
+                                .takeIf { state.hasPassword && !state.policyDisablesSend },
+                            OverflowMenuItemData(
+                                text = stringResource(id = BitwardenString.copy_link),
+                                onClick = {
+                                    viewModel.trySendAction(AddEditSendAction.CopyLinkClick)
+                                },
+                            )
+                                .takeIf { !state.policyDisablesSend },
+                            OverflowMenuItemData(
+                                text = stringResource(id = BitwardenString.share_link),
+                                onClick = {
+                                    viewModel.trySendAction(AddEditSendAction.ShareLinkClick)
+                                },
+                            )
+                                .takeIf { !state.policyDisablesSend },
+                        ),
+                    )
                 },
             )
         },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -323,7 +323,6 @@ fun VaultAddEditScreen(
                             modifier = Modifier.testTag("SaveButton"),
                         )
                         BitwardenOverflowActionItem(
-                            contentDescription = stringResource(BitwardenString.more),
                             menuItemDataList = persistentListOfNotNull(
                                 OverflowMenuItemData(
                                     text = stringResource(id = BitwardenString.attachments),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditUriItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditUriItem.kt
@@ -66,7 +66,7 @@ fun VaultAddEditUriItem(
         actions = {
             BitwardenStandardIconButton(
                 vectorIconRes = BitwardenDrawable.ic_cog,
-                contentDescription = stringResource(id = BitwardenString.options),
+                contentDescription = stringResource(id = BitwardenString.more_options),
                 onClick = { shouldShowOptionsDialog = true },
                 modifier = Modifier.testTag(tag = "LoginUriOptionsButton"),
             )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -162,7 +162,6 @@ fun VaultItemScreen(
                         )
                     }
                     BitwardenOverflowActionItem(
-                        contentDescription = stringResource(BitwardenString.more),
                         menuItemDataList = persistentListOfNotNull(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.attachments),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -455,21 +455,19 @@ private fun VaultItemListingScaffold(
                         contentDescription = stringResource(id = BitwardenString.search_vault),
                         onClick = vaultItemListingHandlers.searchIconClick,
                     )
-                    if (state.shouldShowOverflowMenu) {
-                        BitwardenOverflowActionItem(
-                            contentDescription = stringResource(BitwardenString.more),
-                            menuItemDataList = persistentListOf(
-                                OverflowMenuItemData(
-                                    text = stringResource(id = BitwardenString.sync),
-                                    onClick = vaultItemListingHandlers.syncClick,
-                                ),
-                                OverflowMenuItemData(
-                                    text = stringResource(id = BitwardenString.lock),
-                                    onClick = vaultItemListingHandlers.lockClick,
-                                ),
+                    BitwardenOverflowActionItem(
+                        isVisible = state.shouldShowOverflowMenu,
+                        menuItemDataList = persistentListOf(
+                            OverflowMenuItemData(
+                                text = stringResource(id = BitwardenString.sync),
+                                onClick = vaultItemListingHandlers.syncClick,
                             ),
-                        )
-                    }
+                            OverflowMenuItemData(
+                                text = stringResource(id = BitwardenString.lock),
+                                onClick = vaultItemListingHandlers.lockClick,
+                            ),
+                        ),
+                    )
                 },
             )
         },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreen.kt
@@ -236,7 +236,6 @@ private fun VaultScreenScaffold(
                         onClick = vaultHandlers.searchIconClickAction,
                     )
                     BitwardenOverflowActionItem(
-                        contentDescription = stringResource(BitwardenString.more),
                         menuItemDataList = persistentListOf(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.sync),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreen.kt
@@ -117,7 +117,6 @@ fun VerificationCodeScreen(
                         onClick = verificationCodeHandler.searchIconClick,
                     )
                     BitwardenOverflowActionItem(
-                        contentDescription = stringResource(BitwardenString.more),
                         menuItemDataList = persistentListOf(
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.sync),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/login/LoginScreenTest.kt
@@ -291,7 +291,7 @@ class LoginScreenTest : BitwardenComposeTest() {
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Click on the password hint item in the dropdown
         composeTestRule
             .onAllNodesWithText("Get your master password hint")

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetPassword/ResetPasswordScreenTest.kt
@@ -93,7 +93,7 @@ class ResetPasswordScreenTest : BitwardenComposeTest() {
     @Test
     fun `logout button click from more menu should display confirmation dialog and emit ConfirmLogoutClick`() {
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/twofactorlogin/TwoFactorLoginScreenTest.kt
@@ -247,13 +247,13 @@ class TwoFactorLoginScreenTest : BitwardenComposeTest() {
 
     @Test
     fun `options menu icon click should show the auth method options`() {
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
         composeTestRule.onNodeWithText("Recovery code").assertIsDisplayed()
     }
 
     @Test
     fun `options menu option click should should send SelectAuthMethod and close the menu`() {
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
         composeTestRule.onNodeWithText("Recovery code").performClick()
         verify {
             viewModel.trySendAction(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/vaultunlock/VaultUnlockScreenTest.kt
@@ -381,7 +381,7 @@ class VaultUnlockScreenTest : BitwardenComposeTest() {
         composeTestRule.onNode(isDialog()).assertDoesNotExist()
 
         // Expand the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
         composeTestRule.onNode(isPopup()).assertIsDisplayed()
         composeTestRule.onNode(isDialog()).assertDoesNotExist()
 
@@ -408,7 +408,7 @@ class VaultUnlockScreenTest : BitwardenComposeTest() {
     @Test
     fun `Yes click in the logout confirmation dialog should send the ConfirmLogoutClick action`() {
         // Expand the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
 
         // Click on the logout item to display the dialog
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
@@ -602,7 +602,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
 
@@ -625,7 +625,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -646,7 +646,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -667,7 +667,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -686,7 +686,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -706,7 +706,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -726,7 +726,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -762,7 +762,7 @@ class SearchScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
 
@@ -791,7 +791,7 @@ class SearchScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -839,7 +839,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
 
@@ -862,7 +862,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription(label = "Options")
+            .onNodeWithContentDescription(label = "More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -881,7 +881,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -900,7 +900,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -918,7 +918,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -936,7 +936,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -970,7 +970,7 @@ class SearchScreenTest : BitwardenComposeTest() {
         composeTestRule.onNodeWithText(message).assertDoesNotExist()
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
             .performClick()
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/flightrecorder/recordedlogs/RecordedLogsScreenTest.kt
@@ -144,7 +144,7 @@ class RecordedLogsScreenTest : BitwardenComposeTest() {
         mutableStateFlow.update {
             it.copy(viewState = RecordedLogsState.ViewState.Content(items = persistentListOf()))
         }
-        composeTestRule.onNodeWithContentDescription(label = "More").performClick()
+        composeTestRule.onNodeWithContentDescription(label = "More options").performClick()
         composeTestRule.onNodeWithText(text = "Share all").performClick()
 
         verify(exactly = 1) {
@@ -157,7 +157,7 @@ class RecordedLogsScreenTest : BitwardenComposeTest() {
         mutableStateFlow.update {
             it.copy(viewState = RecordedLogsState.ViewState.Content(items = persistentListOf()))
         }
-        composeTestRule.onNodeWithContentDescription(label = "More").performClick()
+        composeTestRule.onNodeWithContentDescription(label = "More options").performClick()
         composeTestRule.onNodeWithText(text = "Delete all").performClick()
         composeTestRule
             .onAllNodesWithText(text = "Delete logs")
@@ -195,7 +195,7 @@ class RecordedLogsScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "title")
             .performScrollTo()
             .onSiblings()
-            .filterToOne(matcher = hasContentDescription(value = "More"))
+            .filterToOne(matcher = hasContentDescription(value = "More options"))
             .performClick()
         composeTestRule.onNodeWithText(text = "Delete").assertIsEnabled()
 
@@ -218,7 +218,7 @@ class RecordedLogsScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "title")
             .performScrollTo()
             .onSiblings()
-            .filterToOne(matcher = hasContentDescription(value = "More"))
+            .filterToOne(matcher = hasContentDescription(value = "More options"))
             .performClick()
         composeTestRule.onNodeWithText(text = "Delete").assertIsNotEnabled()
     }
@@ -243,7 +243,7 @@ class RecordedLogsScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "title")
             .performScrollTo()
             .onSiblings()
-            .filterToOne(matcher = hasContentDescription(value = "More"))
+            .filterToOne(matcher = hasContentDescription(value = "More options"))
             .performClick()
         composeTestRule.onNodeWithText(text = "Share").performClick()
 
@@ -272,7 +272,7 @@ class RecordedLogsScreenTest : BitwardenComposeTest() {
             .onNodeWithText(text = "title")
             .performScrollTo()
             .onSiblings()
-            .filterToOne(matcher = hasContentDescription(value = "More"))
+            .filterToOne(matcher = hasContentDescription(value = "More options"))
             .performClick()
         composeTestRule.onNodeWithText(text = "Delete").performClick()
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/folders/addedit/FolderAddEditScreenTest.kt
@@ -79,7 +79,7 @@ class FolderAddEditScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
     }
 
@@ -96,7 +96,7 @@ class FolderAddEditScreenTest : BitwardenComposeTest() {
 
         // Open the overflow menu
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
         // Click on the delete item in the dropdown
         composeTestRule
@@ -131,7 +131,7 @@ class FolderAddEditScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -148,7 +148,7 @@ class GeneratorScreenTest : BitwardenComposeTest() {
         updateState(DEFAULT_STATE.copy(generatorMode = GeneratorMode.Default))
 
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .assertIsDisplayed()
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryScreenTest.kt
@@ -113,7 +113,7 @@ class PasswordHistoryScreenTest : BitwardenComposeTest() {
     @Test
     fun `clicking the Clear button in the overflow menu should send PasswordClearClick action`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -128,7 +128,7 @@ class PasswordHistoryScreenTest : BitwardenComposeTest() {
     @Test
     fun `Clear button should depend on state`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -142,7 +142,7 @@ class PasswordHistoryScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .assertIsNotDisplayed()
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
@@ -1,19 +1,20 @@
 package com.x8bit.bitwarden.ui.tools.feature.send
 
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollToNodeAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.isPopup
-import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onFirst
-import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -160,7 +161,7 @@ class SendScreenTest : BitwardenComposeTest() {
     @Test
     fun `on overflow item click should display menu`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -180,7 +181,7 @@ class SendScreenTest : BitwardenComposeTest() {
     @Test
     fun `on sync click should send SyncClick`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -196,7 +197,7 @@ class SendScreenTest : BitwardenComposeTest() {
     @Test
     fun `on lock click should send LockClick`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -212,7 +213,7 @@ class SendScreenTest : BitwardenComposeTest() {
     @Test
     fun `on about send click should send AboutSendClick`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -451,7 +452,9 @@ class SendScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText(DEFAULT_SEND_ITEM.name)
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
 
         mutableStateFlow.update {
@@ -461,8 +464,10 @@ class SendScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
-            .assertDoesNotExist()
+            .onNodeWithText(DEFAULT_SEND_ITEM.name)
+            .onChildren()
+            .filter(hasContentDescription("More options"))
+            .assertCountEquals(0)
     }
 
     @Test
@@ -474,7 +479,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -483,9 +488,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -504,7 +514,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -513,9 +523,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -540,7 +555,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -549,9 +564,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -576,7 +596,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -585,9 +605,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -612,7 +637,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -621,9 +646,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -648,7 +678,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -657,9 +687,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -684,7 +719,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -693,9 +728,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -719,7 +759,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -728,9 +768,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -760,7 +805,7 @@ class SendScreenTest : BitwardenComposeTest() {
                     fileTypeCount = 1,
                     sendItems = listOf(
                         DEFAULT_SEND_ITEM,
-                        DEFAULT_SEND_ITEM.copy(id = "mockId-2"),
+                        DEFAULT_SEND_ITEM.copy(id = "mockId-2", name = "mockName-2"),
                     ),
                 ),
             )
@@ -769,9 +814,14 @@ class SendScreenTest : BitwardenComposeTest() {
 
         // We scroll to the last item but click the first one to avoid clicking the FAB by mistake
         composeTestRule
-            .onAllNodesWithContentDescription("Options")
-            .apply { onLast().performScrollTo() }
-            .onFirst()
+            .onNodeWithText("mockName-2")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText("mockName-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -303,7 +303,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -342,7 +342,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -357,7 +357,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -376,7 +376,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -395,7 +395,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         )
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -1331,7 +1331,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1358,7 +1358,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1383,7 +1383,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1444,7 +1444,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1489,7 +1489,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1516,7 +1516,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1545,7 +1545,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1573,7 +1573,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1620,7 +1620,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1660,7 +1660,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTextAfterScroll(text = "Website (URI)")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -3552,7 +3552,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -3598,7 +3598,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
 
         // Open the overflow menu
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         // Confirm Collections option is present
@@ -3645,7 +3645,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -3729,7 +3729,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -3777,7 +3777,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -4330,7 +4330,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .assertCountEquals(0)
         // Open the overflow menu
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         // Confirm it does not exist
@@ -4365,7 +4365,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .assertCountEquals(0)
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -4433,7 +4433,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .assertCountEquals(0)
 
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -4469,7 +4469,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             .assertCountEquals(0)
 
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -285,7 +285,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .assertCountEquals(0)
 
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -322,7 +322,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .assertCountEquals(0)
 
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -1187,7 +1187,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
 
         // Open the overflow menu
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         // Confirm Delete option is present
@@ -1454,7 +1454,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Click on the attachments hint item in the dropdown
         composeTestRule
             .onAllNodesWithText("Attachments")
@@ -1473,7 +1473,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Click on the clone item in the dropdown
         composeTestRule
             .onAllNodesWithText("Clone")
@@ -1498,7 +1498,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Click on the move to organization hint item in the dropdown
         composeTestRule
             .onAllNodesWithText("Move to Organization")
@@ -1525,7 +1525,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .filter(hasAnyAncestor(isPopup()))
             .assertCountEquals(0)
         // Open the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
         // Confirm it does not exist
         composeTestRule
             .onAllNodesWithText("Move to Organization")
@@ -1552,7 +1552,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
 
         // Open the overflow menu
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         // Confirm Collections option is present
@@ -1595,7 +1595,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             .assertCountEquals(0)
         // Open the overflow menu
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
         // Click on the move to organization hint item in the dropdown
         composeTestRule
@@ -1624,7 +1624,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule
@@ -1657,7 +1657,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
     fun `Menu should display correct items when cipher is not in a collection`() {
         mutableStateFlow.update { it.copy(viewState = DEFAULT_LOGIN_VIEW_STATE) }
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .performClick()
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -1,13 +1,17 @@
 package com.x8bit.bitwarden.ui.vault.feature.itemlisting
 
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.isPopup
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -187,13 +191,13 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
     @Test
     fun `overflow menu should update according to state`() {
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .assertIsDisplayed()
 
         mutableStateFlow.value = STATE_FOR_AUTOFILL
 
         composeTestRule
-            .onNodeWithContentDescription("More")
+            .onNodeWithContentDescription("More options")
             .assertDoesNotExist()
     }
 
@@ -1352,7 +1356,7 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
     @Test
     fun `on overflow item click should display menu`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -1368,7 +1372,7 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
     @Test
     fun `on sync click should send SyncClick`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -1384,7 +1388,7 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
     @Test
     fun `on lock click should send LockClick`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -1413,7 +1417,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText("mockTitle-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -1456,7 +1462,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText("mockTitle-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -1482,8 +1490,8 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
             )
         }
         composeTestRule
-            .onNodeWithContentDescription("Options")
-            .assertIsDisplayed()
+            .onAllNodesWithContentDescription("More options")
+            .assertCountEquals(2)
 
         mutableStateFlow.update {
             it.copy(
@@ -1492,8 +1500,8 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
-            .assertDoesNotExist()
+            .onAllNodesWithContentDescription("More options")
+            .assertCountEquals(1)
     }
 
     @Test
@@ -1511,7 +1519,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText("mockTitle-$number")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
 
@@ -1537,7 +1547,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         composeTestRule.assertNoDialogExists()
 
         composeTestRule
-            .onNodeWithContentDescription(label = "Options")
+            .onNodeWithText("mockTitle-$number")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -1556,7 +1568,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText("mockTitle-$number")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -1575,7 +1589,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText("mockTitle-$number")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -1593,7 +1609,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText("mockTitle-$number")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -1611,7 +1629,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText("mockTitle-$number")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
         composeTestRule
@@ -1647,7 +1667,9 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         composeTestRule.onNodeWithText(message).assertDoesNotExist()
 
         composeTestRule
-            .onNodeWithContentDescription("Options")
+            .onNodeWithText("mockTitle-1")
+            .onChildren()
+            .filterToOne(hasContentDescription("More options"))
             .assertIsDisplayed()
             .performClick()
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -413,7 +413,7 @@ class VaultScreenTest : BitwardenComposeTest() {
         composeTestRule.onNodeWithText("Sync").assertDoesNotExist()
         composeTestRule.onNodeWithText("Lock").assertDoesNotExist()
 
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
 
         composeTestRule.onNode(isPopup()).assertIsDisplayed()
         composeTestRule
@@ -429,7 +429,7 @@ class VaultScreenTest : BitwardenComposeTest() {
     @Test
     fun `sync click in the overflow menu should send SyncClick`() {
         // Expand the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
 
         composeTestRule
             .onAllNodesWithText("Sync")
@@ -442,7 +442,7 @@ class VaultScreenTest : BitwardenComposeTest() {
     @Test
     fun `lock click in the overflow menu should send LockClick`() {
         // Expand the overflow menu
-        composeTestRule.onNodeWithContentDescription("More").performClick()
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
 
         composeTestRule
             .onAllNodesWithText("Lock")
@@ -1359,7 +1359,7 @@ class VaultScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = itemText)
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1430,7 +1430,7 @@ class VaultScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = itemText)
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1674,7 +1674,7 @@ class VaultScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = itemText)
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule
@@ -1745,7 +1745,7 @@ class VaultScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = itemText)
             .onChildren()
-            .filterToOne(hasContentDescription(value = "Options"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeScreenTest.kt
@@ -407,7 +407,7 @@ class VerificationCodeScreenTest : BitwardenComposeTest() {
     @Test
     fun `on overflow item click should display menu`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -424,7 +424,7 @@ class VerificationCodeScreenTest : BitwardenComposeTest() {
     @Test
     fun `on sync click should send SyncClick`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule
@@ -440,7 +440,7 @@ class VerificationCodeScreenTest : BitwardenComposeTest() {
     @Test
     fun `on lock click should send LockClick`() {
         composeTestRule
-            .onNodeWithContentDescription(label = "More")
+            .onNodeWithContentDescription(label = "More options")
             .performClick()
 
         composeTestRule

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/VaultVerificationCodeItem.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/VaultVerificationCodeItem.kt
@@ -161,7 +161,6 @@ fun VaultVerificationCodeItem(
 
         if (showOverflow) {
             BitwardenOverflowActionItem(
-                contentDescription = stringResource(id = BitwardenString.more),
                 menuItemDataList = persistentListOfNotNull(
                     OverflowMenuItemData(
                         text = stringResource(id = BitwardenString.copy),

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
@@ -363,7 +363,7 @@ class ItemListingScreenTest : AuthenticatorComposeTest() {
         composeTestRule
             .onNodeWithText(text = "issuer")
             .onChildren()
-            .filterToOne(hasContentDescription(value = "More"))
+            .filterToOne(hasContentDescription(value = "More options"))
             .performClick()
 
         composeTestRule

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/appbar/action/BitwardenOverflowActionItem.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/appbar/action/BitwardenOverflowActionItem.kt
@@ -43,16 +43,22 @@ import kotlinx.collections.immutable.persistentListOf
  *
  * @param menuItemDataList The list of [OverflowMenuItemData] that will populate the overflow
  * dropdown menu.
+ * @param modifier The [Modifier] for this composable.
+ * @param isVisible Indicates if this composable should be shown.
+ * @param contentDescription The content description for the icon button.
+ * @param vectorIconRes The resource indicating what icon to display.
+ * @param testTag The test tag applied to this composable.
  */
 @Composable
 fun BitwardenOverflowActionItem(
     menuItemDataList: ImmutableList<OverflowMenuItemData>,
-    contentDescription: String,
     modifier: Modifier = Modifier,
+    isVisible: Boolean = true,
+    contentDescription: String = stringResource(id = BitwardenString.more_options),
     @DrawableRes vectorIconRes: Int = BitwardenDrawable.ic_ellipsis_vertical,
     testTag: String? = "HeaderBarOptionsButton",
 ) {
-    if (menuItemDataList.isEmpty()) return
+    if (menuItemDataList.isEmpty() || !isVisible) return
     var isOverflowMenuVisible by rememberSaveable { mutableStateOf(false) }
     Box(
         contentAlignment = Alignment.Center,
@@ -134,7 +140,6 @@ private fun BitwardenDropdownMenuItem(
 private fun BitwardenOverflowActionItem_preview() {
     BitwardenTheme {
         BitwardenOverflowActionItem(
-            contentDescription = "More",
             menuItemDataList = persistentListOf(
                 OverflowMenuItemData(
                     text = "Test",

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="master_password">Master password</string>
     <string name="master_password_required">Master password (required)</string>
     <string name="new_master_password_required">New master password (required)</string>
-    <string name="more">More</string>
+    <string name="more_options">More options</string>
     <string name="my_vault">My vault</string>
     <string name="name">Name</string>
     <string name="item_name_required">Item name (required)</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29861](https://bitwarden.atlassian.net/browse/PM-29861)

## 📔 Objective

This PR updates the content description for the TopAppBar overflow menu and the individual item overflow menus. In both cases, the content description has been updated to be `More options`. Additionally, I have added an `isVisible` property to the `BitwardenOverflowActionItem` which reduces the amount of nested code surrounding the menus.


[PM-29861]: https://bitwarden.atlassian.net/browse/PM-29861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ