### PR TITLE
PM-18596: feat: SSN field should be hidden by default

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditIdentityItems.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
+import com.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.bitwarden.ui.platform.components.model.CardStyle
@@ -124,11 +125,12 @@ fun LazyListScope.vaultAddEditIdentityItems(
         Spacer(modifier = Modifier.height(height = 8.dp))
     }
     item {
-        BitwardenTextField(
+        BitwardenPasswordField(
             label = stringResource(id = BitwardenString.ssn),
             value = identityState.ssn,
             onValueChange = identityItemTypeHandlers.onSsnTextChange,
-            textFieldTestTag = "IdentitySsnEntry",
+            showPasswordTestTag = "IdentityShowSsnNumberButton",
+            passwordFieldTestTag = "IdentitySsnEntry",
             cardStyle = CardStyle.Top(),
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.base.util.toListItemCardStyle
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
+import com.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.bitwarden.ui.platform.components.icon.model.IconData
@@ -137,13 +138,21 @@ fun VaultItemIdentityContent(
         }
         identityState.ssn?.let { ssn ->
             item(key = "ssn") {
-                IdentityCopyField(
+                BitwardenPasswordField(
                     label = stringResource(id = BitwardenString.ssn),
                     value = ssn,
-                    copyContentDescription = stringResource(id = BitwardenString.copy_ssn),
-                    textFieldTestTag = "IdentitySsnEntry",
-                    copyActionTestTag = "IdentityCopySsnButton",
-                    onCopyClick = vaultIdentityItemTypeHandlers.onCopySsnClick,
+                    onValueChange = {},
+                    readOnly = true,
+                    actions = {
+                        BitwardenStandardIconButton(
+                            vectorIconRes = BitwardenDrawable.ic_copy,
+                            contentDescription = stringResource(id = BitwardenString.copy_ssn),
+                            onClick = vaultIdentityItemTypeHandlers.onCopySsnClick,
+                            modifier = Modifier.testTag(tag = "IdentityCopySsnButton"),
+                        )
+                    },
+                    passwordFieldTestTag = "IdentitySsnEntry",
+                    showPasswordTestTag = "IdentityViewSsnButton",
                     cardStyle = identityState
                         .propertyList
                         .toListItemCardStyle(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18596](https://bitwarden.atlassian.net/browse/PM-18596)

## 📔 Objective

This PR hides the Identity SSN by default and requires the user to toggle it visible.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="450" src="https://github.com/user-attachments/assets/d16412ed-c680-49f8-8c80-7f1673a4d2fa" /> | <img width="450" src="https://github.com/user-attachments/assets/8f5c3560-78d1-4e2e-a51e-dcd3f7fd332c" /> |


[PM-18596]: https://bitwarden.atlassian.net/browse/PM-18596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ