### PR TITLE
🍒[PM-33227] feat: Add Clear SSO Cookies button to debug menu

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/CookieDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/CookieDiskSource.kt
@@ -22,4 +22,9 @@ interface CookieDiskSource {
      * @param config The [CookieConfigurationData] to persist, or `null` to delete.
      */
     fun storeCookieConfig(hostname: String, config: CookieConfigurationData?)
+
+    /**
+     * Clears all stored cookie configurations across all hostnames.
+     */
+    fun clearCookies()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/CookieDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/CookieDiskSourceImpl.kt
@@ -1,12 +1,14 @@
 package com.x8bit.bitwarden.data.platform.datasource.disk
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.bitwarden.core.data.util.decodeFromStringOrNull
 import com.bitwarden.data.datasource.disk.BaseEncryptedDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.model.CookieConfigurationData
 import kotlinx.serialization.json.Json
 
 private const val CONFIG_PREFIX = "elb_cookie_config"
+private const val ENCRYPTED_PREFIX = "bwSecureStorage:$CONFIG_PREFIX"
 
 /**
  * Implementation of [CookieDiskSource] using encrypted SharedPreferences.
@@ -15,7 +17,7 @@ private const val CONFIG_PREFIX = "elb_cookie_config"
  */
 class CookieDiskSourceImpl(
     sharedPreferences: SharedPreferences,
-    encryptedSharedPreferences: SharedPreferences,
+    private val encryptedSharedPreferences: SharedPreferences,
     private val json: Json,
 ) : CookieDiskSource,
     BaseEncryptedDiskSource(
@@ -32,5 +34,15 @@ class CookieDiskSourceImpl(
     override fun storeCookieConfig(hostname: String, config: CookieConfigurationData?) {
         val key = CONFIG_PREFIX.appendIdentifier(hostname)
         putEncryptedString(key, config?.let { json.encodeToString(it) })
+    }
+
+    override fun clearCookies() {
+        val keysToRemove = encryptedSharedPreferences
+            .all
+            .keys
+            .filter { it.startsWith(ENCRYPTED_PREFIX) }
+        encryptedSharedPreferences.edit {
+            keysToRemove.forEach { key -> remove(key) }
+        }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepository.kt
@@ -49,4 +49,9 @@ interface DebugMenuRepository {
      * @param userStateUpdateTrigger A passable lambda to trigger a user state update.
      */
     fun modifyStateToShowOnboardingCarousel(userStateUpdateTrigger: () -> Unit)
+
+    /**
+     * Clears all stored SSO cookie configurations.
+     */
+    fun clearSsoCookies()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.bitwarden.data.repository.ServerConfigRepository
 import com.x8bit.bitwarden.BuildConfig
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
+import com.x8bit.bitwarden.data.platform.datasource.disk.CookieDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.getFlagValueOrDefault
@@ -20,6 +21,7 @@ class DebugMenuRepositoryImpl(
     private val serverConfigRepository: ServerConfigRepository,
     private val settingsDiskSource: SettingsDiskSource,
     private val authDiskSource: AuthDiskSource,
+    private val cookieDiskSource: CookieDiskSource,
 ) : DebugMenuRepository {
 
     private val mutableOverridesUpdatedFlow = bufferedMutableSharedFlow<Unit>(replay = 1)
@@ -67,5 +69,9 @@ class DebugMenuRepositoryImpl(
     ) {
         settingsDiskSource.hasUserLoggedInOrCreatedAccount = false
         userStateUpdateTrigger.invoke()
+    }
+
+    override fun clearSsoCookies() {
+        cookieDiskSource.clearCookies()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/di/PlatformRepositoryModule.kt
@@ -7,6 +7,7 @@ import com.bitwarden.data.repository.ServerConfigRepository
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilityEnabledManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillEnabledManager
+import com.x8bit.bitwarden.data.platform.datasource.disk.CookieDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.EnvironmentDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
@@ -92,10 +93,12 @@ object PlatformRepositoryModule {
         serverConfigRepository: ServerConfigRepository,
         authDiskSource: AuthDiskSource,
         settingsDiskSource: SettingsDiskSource,
+        cookieDiskSource: CookieDiskSource,
     ): DebugMenuRepository = DebugMenuRepositoryImpl(
         featureFlagOverrideDiskSource = featureFlagOverrideDiskSource,
         serverConfigRepository = serverConfigRepository,
         authDiskSource = authDiskSource,
         settingsDiskSource = settingsDiskSource,
+        cookieDiskSource = cookieDiskSource,
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreen.kt
@@ -140,6 +140,19 @@ fun DebugMenuScreen(
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
             )
+            Spacer(Modifier.height(height = 8.dp))
+            BitwardenFilledButton(
+                label = stringResource(BitwardenString.clear_sso_cookies),
+                onClick = {
+                    viewModel.trySendAction(
+                        DebugMenuAction.ClearSsoCookies,
+                    )
+                },
+                isEnabled = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
             Spacer(Modifier.height(height = 16.dp))
             BitwardenHorizontalDivider()
             Spacer(Modifier.height(height = 16.dp))

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModel.kt
@@ -64,6 +64,7 @@ class DebugMenuViewModel @Inject constructor(
             DebugMenuAction.GenerateCrashClick -> handleCrashClick()
             DebugMenuAction.GenerateErrorReportClick -> handleErrorReportClick()
             DebugMenuAction.TriggerCookieAcquisition -> handleTriggerCookieAcquisition()
+            DebugMenuAction.ClearSsoCookies -> handleClearSsoCookies()
         }
     }
 
@@ -98,6 +99,10 @@ class DebugMenuViewModel @Inject constructor(
         featureFlagResetJob = viewModelScope.launch {
             debugMenuRepository.resetFeatureFlagOverrides()
         }
+    }
+
+    private fun handleClearSsoCookies() {
+        debugMenuRepository.clearSsoCookies()
     }
 
     private fun handleTriggerCookieAcquisition() {
@@ -195,6 +200,11 @@ sealed class DebugMenuAction {
      * The user has clicked trigger cookie acquisition button.
      */
     data object TriggerCookieAcquisition : DebugMenuAction()
+
+    /**
+     * The user has clicked clear SSO cookies button.
+     */
+    data object ClearSsoCookies : DebugMenuAction()
 
     /**
      * Internal actions not triggered from the UI.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/CookieDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/CookieDiskSourceTest.kt
@@ -139,6 +139,38 @@ class CookieDiskSourceTest {
     }
 
     @Test
+    fun `clearCookies should remove all stored cookie configs`() {
+        val hostname1 = "vault.bitwarden.com"
+        val hostname2 = "other.bitwarden.com"
+        val config1 = CookieConfigurationData(
+            hostname = hostname1,
+            cookies = listOf(
+                CookieConfigurationData.Cookie(name = "A", value = "1"),
+            ),
+        )
+        val config2 = CookieConfigurationData(
+            hostname = hostname2,
+            cookies = listOf(
+                CookieConfigurationData.Cookie(name = "B", value = "2"),
+            ),
+        )
+
+        cookieDiskSource.storeCookieConfig(hostname1, config1)
+        cookieDiskSource.storeCookieConfig(hostname2, config2)
+
+        cookieDiskSource.clearCookies()
+
+        assertNull(cookieDiskSource.getCookieConfig(hostname1))
+        assertNull(cookieDiskSource.getCookieConfig(hostname2))
+    }
+
+    @Test
+    fun `clearCookies should be safe to call when no cookies are stored`() {
+        cookieDiskSource.clearCookies()
+        assertNull(cookieDiskSource.getCookieConfig("vault.bitwarden.com"))
+    }
+
+    @Test
     fun `storage should isolate configs by hostname`() {
         val hostname1 = "vault.bitwarden.com"
         val hostname2 = "other.bitwarden.com"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/DebugMenuRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.bitwarden.data.repository.ServerConfigRepository
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.platform.datasource.disk.CookieDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.FeatureFlagOverrideDiskSource
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import io.mockk.every
@@ -42,11 +43,16 @@ class DebugMenuRepositoryTest {
         every { hasUserLoggedInOrCreatedAccount = any() } just runs
     }
 
+    private val mockCookieDiskSource = mockk<CookieDiskSource> {
+        every { clearCookies() } just runs
+    }
+
     private val debugMenuRepository = DebugMenuRepositoryImpl(
         featureFlagOverrideDiskSource = mockFeatureFlagOverrideDiskSource,
         serverConfigRepository = mockServerConfigRepository,
         settingsDiskSource = mockSettingsDiskSource,
         authDiskSource = mockAuthDiskSource,
+        cookieDiskSource = mockCookieDiskSource,
     )
 
     @Test
@@ -167,6 +173,13 @@ class DebugMenuRepositoryTest {
         verify(exactly = 1) {
             mockSettingsDiskSource.storeShouldShowGeneratorCoachMark(shouldShow = null)
             mockSettingsDiskSource.storeShouldShowAddLoginCoachMark(shouldShow = null)
+        }
+    }
+    @Test
+    fun `clearSsoCookies should call clearCookies on CookieDiskSource`() {
+        debugMenuRepository.clearSsoCookies()
+        verify(exactly = 1) {
+            mockCookieDiskSource.clearCookies()
         }
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuScreenTest.kt
@@ -150,6 +150,16 @@ class DebugMenuScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `clear SSO cookies should send ClearSsoCookies action`() {
+        composeTestRule
+            .onNodeWithText("Clear SSO cookies")
+            .performScrollTo()
+            .performClick()
+
+        verify(exactly = 1) { viewModel.trySendAction(DebugMenuAction.ClearSsoCookies) }
+    }
+
+    @Test
     fun `reset all coach mark tours should send ResetCoachMarkTourStatuses action`() {
         composeTestRule
             .onNodeWithText("Reset all coach mark tours")

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/debugmenu/DebugMenuViewModelTest.kt
@@ -146,6 +146,15 @@ class DebugMenuViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `ClearSsoCookies should call clearSsoCookies on DebugMenuRepository`() {
+        val viewModel = createViewModel()
+        viewModel.trySendAction(DebugMenuAction.ClearSsoCookies)
+        verify(exactly = 1) {
+            mockDebugMenuRepository.clearSsoCookies()
+        }
+    }
+
+    @Test
     fun `TriggerCookieAcquisition should set pending cookie acquisition`() =
         runTest {
             val viewModel = createViewModel()

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -42,6 +42,7 @@
     <string name="archive_items">Archive Items</string>
     <string name="send_email_verification">Send Email Verification</string>
     <string name="trigger_cookie_acquisition">Trigger cookie acquisition</string>
+    <string name="clear_sso_cookies">Clear SSO cookies</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33227
Cherry-picked from #6620

## 📔 Objective

Add a "Clear SSO cookies" button to the Android debug menu to achieve parity with iOS. The button clears all stored SSO cookies across all environments from encrypted SharedPreferences, enabling developers to test expired/invalid cookie scenarios during SSO flows.

### Changes

- Add `clearCookies()` method to `CookieDiskSource` interface and implementation
- Add `ClearSsoCookies` action to `DebugMenuViewModel` with `CookieDiskSource` injection
- Add "Clear SSO cookies" button to `DebugMenuScreen` below existing "Trigger cookie acquisition" button
- Add corresponding unit tests for data source, ViewModel, and screen