### PR TITLE
PM-33428: bug: Fix loading dialog statusbar content color

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
@@ -71,7 +71,7 @@ fun QrCodeScanScreen(
     }
     // This screen should always look like it's in dark mode
     CompositionLocalProvider(LocalBitwardenColorScheme provides darkBitwardenColorScheme) {
-        StatusBarsAppearanceAffect(isLightStatusBars = false)
+        StatusBarsAppearanceAffect()
         BitwardenScaffold(
             modifier = Modifier.fillMaxSize(),
             topBar = {

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
@@ -77,7 +77,7 @@ fun QrCodeScanScreen(
 
     // This screen should always look like it's in dark mode
     CompositionLocalProvider(LocalBitwardenColorScheme provides darkBitwardenColorScheme) {
-        StatusBarsAppearanceAffect(isLightStatusBars = false)
+        StatusBarsAppearanceAffect()
         QrCodeScanDialogs(
             dialogState = state.dialog,
             onSaveHereClick = { viewModel.trySendAction(QrCodeScanAction.SaveLocallyClick(it)) },

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StatusBarsAppearanceAffect.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StatusBarsAppearanceAffect.kt
@@ -4,8 +4,10 @@ import android.app.Activity
 import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
+import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
  * Sets the appearance of the StatusBars to the [isLightStatusBars] value and clears the value once
@@ -13,12 +15,14 @@ import androidx.lifecycle.Lifecycle
  */
 @Composable
 fun StatusBarsAppearanceAffect(
-    isLightStatusBars: Boolean,
+    isLightStatusBars: Boolean = !BitwardenTheme.colorScheme.isDarkTheme,
     view: View = LocalView.current,
 ) {
     if (view.isInEditMode) return
-    val activity = view.context as Activity
-    val insetsController = WindowCompat.getInsetsController(activity.window, view)
+    val window = (view.context as? Activity)?.window
+        ?: (view.parent as? DialogWindowProvider)?.window
+        ?: return
+    val insetsController = WindowCompat.getInsetsController(window, view)
     val originalStatusBarValue = insetsController.isAppearanceLightStatusBars
     LifecycleEventEffect { _, event ->
         when (event) {

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dialog/BitwardenLoadingDialog.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/dialog/BitwardenLoadingDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.bitwarden.ui.platform.base.util.StatusBarsAppearanceAffect
 import com.bitwarden.ui.platform.components.content.BitwardenLoadingContent
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 
@@ -40,6 +41,7 @@ fun BitwardenLoadingDialog(
         ),
         onDismissRequest = {},
     ) {
+        StatusBarsAppearanceAffect()
         BitwardenLoadingContent(
             text = text,
             modifier = Modifier

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/color/BitwardenColorScheme.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/color/BitwardenColorScheme.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
  */
 @Immutable
 data class BitwardenColorScheme(
+    val isDarkTheme: Boolean,
     val text: TextColors,
     val background: BackgroundColors,
     val stroke: StrokeColors,

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/color/ColorScheme.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/theme/color/ColorScheme.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
  * The default [BitwardenColorScheme] for dark mode.
  */
 val darkBitwardenColorScheme: BitwardenColorScheme = BitwardenColorScheme(
+    isDarkTheme = true,
     text = BitwardenColorScheme.TextColors(
         primary = PrimitiveColors.gray200,
         secondary = PrimitiveColors.gray600,
@@ -84,6 +85,7 @@ val darkBitwardenColorScheme: BitwardenColorScheme = BitwardenColorScheme(
  * The default [BitwardenColorScheme] for light mode.
  */
 val lightBitwardenColorScheme: BitwardenColorScheme = BitwardenColorScheme(
+    isDarkTheme = false,
     text = BitwardenColorScheme.TextColors(
         primary = PrimitiveColors.gray1300,
         secondary = PrimitiveColors.gray700,
@@ -167,6 +169,7 @@ fun dynamicBitwardenColorScheme(
 ): BitwardenColorScheme {
     val defaultTheme = if (isDarkTheme) darkBitwardenColorScheme else lightBitwardenColorScheme
     return BitwardenColorScheme(
+        isDarkTheme = isDarkTheme,
         text = BitwardenColorScheme.TextColors(
             primary = materialColorScheme.onBackground,
             secondary = materialColorScheme.onSurface,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33428](https://bitwarden.atlassian.net/browse/PM-33428)

## 📔 Objective

This PR updates the `StatusBarsAppearanceAffect` to function from within a dialog and then uses it to ensure the statusbar content using the correct colors when the `BitwardenLoadingDialog` is being displayed.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/c29a1bb3-8597-4e94-b942-4fffa670ee94" /> | <img width="350"  src="https://github.com/user-attachments/assets/595fc3a1-95da-4abe-8ea9-d0a0e6c501f6" /> |


[PM-33428]: https://bitwarden.atlassian.net/browse/PM-33428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ