### PR TITLE
🍒[PM-33394] debt: Add userFriendlyMessage extension and errorMessage to result types

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/ThrowableExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/ThrowableExtensions.kt
@@ -1,0 +1,13 @@
+package com.x8bit.bitwarden.data.platform.util
+
+import com.bitwarden.network.exception.CookieRedirectException
+
+/**
+ * Returns a user-friendly error message if this [Throwable] is an allow-listed
+ * exception type that carries one, or `null` otherwise.
+ */
+val Throwable.userFriendlyMessage: String?
+    get() = when (this) {
+        is CookieRedirectException -> message
+        else -> null
+    }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/ArchiveCipherResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/ArchiveCipherResult.kt
@@ -11,7 +11,11 @@ sealed class ArchiveCipherResult {
     data object Success : ArchiveCipherResult()
 
     /**
-     * Generic error while archiving a cipher.
+     * Generic error while archiving a cipher. The optional [errorMessage] may be displayed
+     * directly in the UI when present.
      */
-    data class Error(val error: Throwable) : ArchiveCipherResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : ArchiveCipherResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/CreateFolderResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/CreateFolderResult.kt
@@ -13,7 +13,11 @@ sealed class CreateFolderResult {
     data class Success(val folderView: FolderView) : CreateFolderResult()
 
     /**
-     * Generic error while creating a folder.
+     * Generic error while creating a folder. The optional [errorMessage] may be displayed
+     * directly in the UI when present.
      */
-    data class Error(val error: Throwable) : CreateFolderResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : CreateFolderResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DeleteAttachmentResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DeleteAttachmentResult.kt
@@ -11,7 +11,11 @@ sealed class DeleteAttachmentResult {
     data object Success : DeleteAttachmentResult()
 
     /**
-     * Generic error while deleting an attachment.
+     * Generic error while deleting an attachment. The optional [errorMessage] may be
+     * displayed directly in the UI when present.
      */
-    data class Error(val error: Throwable) : DeleteAttachmentResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : DeleteAttachmentResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DeleteCipherResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DeleteCipherResult.kt
@@ -11,7 +11,11 @@ sealed class DeleteCipherResult {
     data object Success : DeleteCipherResult()
 
     /**
-     * Generic error while deleting a cipher.
+     * Generic error while deleting a cipher. The optional [errorMessage] may be displayed
+     * directly in the UI when present.
      */
-    data class Error(val error: Throwable) : DeleteCipherResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : DeleteCipherResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DeleteFolderResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DeleteFolderResult.kt
@@ -11,7 +11,11 @@ sealed class DeleteFolderResult {
     data object Success : DeleteFolderResult()
 
     /**
-     * Generic error while deleting a folder.
+     * Generic error while deleting a folder. The optional [errorMessage] may be displayed
+     * directly in the UI when present.
      */
-    data class Error(val error: Throwable) : DeleteFolderResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : DeleteFolderResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DeleteSendResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DeleteSendResult.kt
@@ -11,7 +11,11 @@ sealed class DeleteSendResult {
     data object Success : DeleteSendResult()
 
     /**
-     * Generic error while deleting a send.
+     * Generic error while deleting a send. The optional [errorMessage] may be displayed
+     * directly in the UI when present.
      */
-    data class Error(val error: Throwable) : DeleteSendResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : DeleteSendResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/ImportCredentialsResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/ImportCredentialsResult.kt
@@ -22,9 +22,13 @@ sealed class ImportCredentialsResult {
     data class SyncFailed(val error: Throwable) : ImportCredentialsResult()
 
     /**
-     * Indicates there was an error importing the vault data.
+     * Indicates there was an error importing the vault data. The optional [errorMessage] may be
+     * displayed directly in the UI when present.
      *
      * @param error The error that occurred during import.
      */
-    data class Error(val error: Throwable) : ImportCredentialsResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : ImportCredentialsResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/RestoreCipherResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/RestoreCipherResult.kt
@@ -11,7 +11,11 @@ sealed class RestoreCipherResult {
     data object Success : RestoreCipherResult()
 
     /**
-     * Generic error while restoring a cipher.
+     * Generic error while restoring a cipher. The optional [errorMessage] may be displayed
+     * directly in the UI when present.
      */
-    data class Error(val error: Throwable) : RestoreCipherResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : RestoreCipherResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/ShareCipherResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/ShareCipherResult.kt
@@ -10,7 +10,11 @@ sealed class ShareCipherResult {
     data object Success : ShareCipherResult()
 
     /**
-     * Generic error while sharing cipher.
+     * Generic error while sharing cipher. The optional [errorMessage] may be displayed
+     * directly in the UI when present.
      */
-    data class Error(val error: Throwable) : ShareCipherResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : ShareCipherResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/UnarchiveCipherResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/UnarchiveCipherResult.kt
@@ -11,7 +11,11 @@ sealed class UnarchiveCipherResult {
     data object Success : UnarchiveCipherResult()
 
     /**
-     * Generic error while unarchiving a cipher.
+     * Generic error while unarchiving a cipher. The optional [errorMessage] may be
+     * displayed directly in the UI when present.
      */
-    data class Error(val error: Throwable) : UnarchiveCipherResult()
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = null,
+    ) : UnarchiveCipherResult()
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/util/ThrowableExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/util/ThrowableExtensionsTest.kt
@@ -1,0 +1,32 @@
+package com.x8bit.bitwarden.data.platform.util
+
+import com.bitwarden.network.exception.CookieRedirectException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class ThrowableExtensionsTest {
+
+    @Test
+    fun `userFriendlyMessage should return message for CookieRedirectException`() {
+        val exception = CookieRedirectException(hostname = "example.com")
+        assertEquals(
+            "Your request was interrupted because the app needed to " +
+                "re-authenticate. Please try again.",
+            exception.userFriendlyMessage,
+        )
+    }
+
+    @Test
+    fun `userFriendlyMessage should return null for IOException`() {
+        val exception = IOException("io error")
+        assertNull(exception.userFriendlyMessage)
+    }
+
+    @Test
+    fun `userFriendlyMessage should return null for RuntimeException`() {
+        val exception = RuntimeException("runtime error")
+        assertNull(exception.userFriendlyMessage)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-33394
Cherry-picked from #6642

## 📔 Objective

Adds infrastructure for propagating user-friendly error messages from exceptions through vault operation result types.

- Introduces `Throwable.userFriendlyMessage` extension that extracts display-safe messages from allow-listed exception types (currently `CookieRedirectException`)
- Adds optional `errorMessage` parameter to `Error` variants of 9 vault result sealed classes, enabling ViewModels to display specific error text when available
- Includes unit tests for the new extension property
