### PR TITLE
PM-33441: bug: Add external link callout for start registration screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreen.kt
@@ -274,8 +274,14 @@ private fun TermsAndPrivacyText(
     onPrivacyPolicyClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val strTerms = stringResource(id = BitwardenString.terms_of_service)
-    val strPrivacy = stringResource(id = BitwardenString.privacy_policy)
+    val strTerms = stringResource(
+        id = BitwardenString.external_link_format,
+        formatArgs = arrayOf(stringResource(id = BitwardenString.terms_of_service)),
+    )
+    val strPrivacy = stringResource(
+        id = BitwardenString.external_link_format,
+        formatArgs = arrayOf(stringResource(id = BitwardenString.privacy_policy)),
+    )
     Row(
         horizontalArrangement = Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/dropdown/EnvironmentSelector.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/components/dropdown/EnvironmentSelector.kt
@@ -97,7 +97,12 @@ fun EnvironmentSelector(
         if (isHelpEnabled) {
             BitwardenStandardIconButton(
                 vectorIconRes = BitwardenDrawable.ic_question_circle_small,
-                contentDescription = stringResource(BitwardenString.help_with_server_geolocations),
+                contentDescription = stringResource(
+                    id = BitwardenString.external_link_format,
+                    formatArgs = arrayOf(
+                        stringResource(id = BitwardenString.help_with_server_geolocations),
+                    ),
+                ),
                 onClick = onHelpClick,
                 contentColor = BitwardenTheme.colorScheme.icon.secondary,
                 // Align with design but keep accessible touch target of IconButton.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/auth/feature/startregistration/StartRegistrationScreenTest.kt
@@ -185,7 +185,7 @@ class StartRegistrationScreenTest : BitwardenComposeTest() {
     @Test
     fun `clicking the server tool tip should send ServerGeologyHelpClickAction`() {
         composeTestRule
-            .onNodeWithContentDescription("Help with server geolocations.")
+            .onNodeWithContentDescription("Help with server geolocations, External link")
             .performScrollTo()
             .performClick()
 
@@ -262,7 +262,7 @@ class StartRegistrationScreenTest : BitwardenComposeTest() {
     fun `when terms and conditions custom action invoked should send TermsClick`() {
         composeTestRule
             .onNodeWithText("By continuing, you agree to the Terms of Service and Privacy Policy")
-            .performCustomAccessibilityAction("Terms of Service")
+            .performCustomAccessibilityAction("Terms of Service, External link")
 
         verify { viewModel.trySendAction(StartRegistrationAction.TermsClick) }
     }
@@ -271,7 +271,7 @@ class StartRegistrationScreenTest : BitwardenComposeTest() {
     fun `when privacy policy custom action invoked should send TermsClick`() {
         composeTestRule
             .onNodeWithText("By continuing, you agree to the Terms of Service and Privacy Policy")
-            .performCustomAccessibilityAction("Privacy Policy")
+            .performCustomAccessibilityAction("Privacy Policy, External link")
 
         verify { viewModel.trySendAction(StartRegistrationAction.PrivacyPolicyClick) }
     }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/SettingsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -707,6 +708,7 @@ private fun CopyRow(
         ) {
             Text(
                 modifier = Modifier
+                    .semantics { hideFromAccessibility() }
                     .padding(end = 16.dp)
                     .weight(1f),
                 text = text(),
@@ -715,7 +717,7 @@ private fun CopyRow(
             )
             Icon(
                 painter = rememberVectorPainter(id = BitwardenDrawable.ic_copy),
-                contentDescription = null,
+                contentDescription = stringResource(id = BitwardenString.copy),
                 tint = BitwardenTheme.colorScheme.icon.primary,
             )
         }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -766,7 +766,7 @@ Do you want to switch to this account?</string>
     <string name="write_this_password_down_and_keep_it_somewhere_safe">Write this password down and keep it somewhere safe.</string>
     <string name="learn_about_other_ways_to_prevent_account_lockout">Learn about other ways to prevent account lockout</string>
     <string name="learn_about_ways_to_prevent_account_lockout"><annotation link="onPreventAccountLockout">Learn about ways to prevent account lockout</annotation></string>
-    <string name="help_with_server_geolocations">Help with server geolocations.</string>
+    <string name="help_with_server_geolocations">Help with server geolocations</string>
     <string name="email_address_required">Email address (required)</string>
     <string name="select_the_link_in_the_email_to_verify_your_email_address_and_continue_creating_your_account">Select the link in the email to verify your email address and continue creating your account.</string>
     <string name="change_email_address">Change email address</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33441](https://bitwarden.atlassian.net/browse/PM-33441)

## 📔 Objective

This PR adds additional `External link` callouts for the `Terms of Service`, `Privacy Policy`, Environment Selector help icon, and the copy version button in Authenticator.



[PM-33441]: https://bitwarden.atlassian.net/browse/PM-33441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ