### PR TITLE
PM-29871: bug: Add external link callouts for buttons

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/checkemail/CheckEmailScreen.kt
@@ -173,6 +173,7 @@ private fun CheckEmailContent(
         BitwardenFilledButton(
             label = stringResource(id = BitwardenString.open_email_app),
             onClick = onOpenEmailAppClick,
+            isExternalLink = true,
             modifier = Modifier
                 .testTag("OpenEmailApp")
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/environment/EnvironmentScreen.kt
@@ -329,6 +329,7 @@ fun EnvironmentScreen(
             BitwardenFilledButton(
                 label = stringResource(id = BitwardenString.import_certificate),
                 onClick = { viewModel.trySendAction(EnvironmentAction.ImportCertificateClick) },
+                isExternalLink = true,
                 modifier = Modifier
                     .fillMaxWidth()
                     .standardHorizontalMargin()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionScreen.kt
@@ -182,6 +182,7 @@ private fun CookieAcquisitionContent(
             label = stringResource(id = BitwardenString.launch_browser),
             onClick = handler.onLaunchBrowserClick,
             icon = rememberVectorPainter(id = BitwardenDrawable.ic_external_link),
+            isExternalLink = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),
@@ -202,6 +203,7 @@ private fun CookieAcquisitionContent(
         BitwardenTextButton(
             label = stringResource(id = BitwardenString.why_am_i_seeing_this),
             onClick = handler.onWhyAmISeeingThisClick,
+            isExternalLink = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/accountsecurity/AccountSecurityScreen.kt
@@ -626,6 +626,7 @@ private fun FingerPrintPhraseDialog(
         confirmButton = {
             BitwardenTextButton(
                 label = stringResource(id = BitwardenString.learn_more),
+                isExternalLink = true,
                 onClick = onLearnMore,
             )
         },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
@@ -329,6 +329,7 @@ private fun ColumnScope.FileTypeContent(
                     chooseFileCameraPermissionLauncher.launch(Manifest.permission.CAMERA)
                 }
             },
+            isExternalLink = true,
             modifier = Modifier
                 .testTag(tag = "SendChooseFileButton")
                 .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsContent.kt
@@ -112,6 +112,7 @@ fun AttachmentsContent(
             BitwardenOutlinedButton(
                 label = stringResource(id = BitwardenString.choose_file),
                 onClick = attachmentsHandlers.onChooseFileClick,
+                isExternalLink = true,
                 modifier = Modifier
                     .fillMaxWidth()
                     .standardHorizontalMargin()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/exportitems/reviewexport/ReviewExportScreen.kt
@@ -272,6 +272,7 @@ private fun ReviewExportContent(
         BitwardenFilledButton(
             label = stringResource(BitwardenString.import_items),
             onClick = onImportItemsClick,
+            isExternalLink = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .nullableTestTag("ImportItemsButton"),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/leaveorganization/LeaveOrganizationScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/leaveorganization/LeaveOrganizationScreen.kt
@@ -200,6 +200,7 @@ private fun LeaveOrganizationContent(
         BitwardenTextButton(
             label = stringResource(id = BitwardenString.how_to_manage_my_vault),
             onClick = onHelpLinkClick,
+            isExternalLink = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/migratetomyitems/MigrateToMyItemsScreen.kt
@@ -218,6 +218,7 @@ private fun MigrateToMyItemsActions(
         BitwardenTextButton(
             label = stringResource(id = BitwardenString.why_am_i_seeing_this),
             onClick = onHelpClick,
+            isExternalLink = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .standardHorizontalMargin(),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/SaveManualCodeButtons.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/SaveManualCodeButtons.kt
@@ -48,6 +48,7 @@ fun SaveManualCodeButtons(
                 BitwardenOutlinedButton(
                     label = stringResource(BitwardenString.save_to_bitwarden),
                     onClick = onSaveToBitwardenClick,
+                    isExternalLink = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
             }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/ChooseSaveLocationDialog.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/ChooseSaveLocationDialog.kt
@@ -110,6 +110,7 @@ fun ChooseSaveLocationDialog(
                     modifier = Modifier
                         .padding(horizontal = 4.dp),
                     label = stringResource(BitwardenString.save_to_bitwarden),
+                    isExternalLink = true,
                     onClick = { onTakeMeToBitwardenClick.invoke(isSaveAsDefaultChecked) },
                 )
             }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/export/ExportScreen.kt
@@ -212,6 +212,7 @@ private fun ExportScreenContent(
         BitwardenFilledButton(
             label = stringResource(id = BitwardenString.export),
             onClick = onExportClick,
+            isExternalLink = true,
             modifier = Modifier
                 .testTag("ExportVaultButton")
                 .standardHorizontalMargin()

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/settings/importing/ImportingScreen.kt
@@ -163,6 +163,7 @@ private fun ImportScreenContent(
         BitwardenFilledButton(
             label = stringResource(id = BitwardenString.import_vault),
             onClick = onImportClick,
+            isExternalLink = true,
             modifier = Modifier
                 .testTag("ImportVaultButton")
                 .standardHorizontalMargin()

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenFilledButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenFilledButton.kt
@@ -11,6 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -20,6 +23,7 @@ import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.components.util.throttledClick
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
@@ -30,6 +34,7 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  * @param modifier The [Modifier] to be applied to the button.
  * @param icon The icon for the button.
  * @param isEnabled Whether the button is enabled.
+ * @param isExternalLink Indicates that this button launches an external link.
  * @param cardStyle The optional card style to surround the button.
  * @param cardInsets The internal insets for the card, only applied when the [cardStyle] is not
  * `null`.
@@ -41,13 +46,24 @@ fun BitwardenFilledButton(
     modifier: Modifier = Modifier,
     icon: Painter? = null,
     isEnabled: Boolean = true,
+    isExternalLink: Boolean = false,
     colors: ButtonColors = bitwardenFilledButtonColors(),
     cardStyle: CardStyle? = null,
     cardInsets: PaddingValues = PaddingValues(horizontal = 16.dp),
 ) {
+    val formattedContentDescription = if (isExternalLink) {
+        stringResource(
+            id = BitwardenString.external_link_format,
+            formatArgs = arrayOf(label),
+        )
+    } else {
+        label
+    }
     Button(
         modifier = modifier
-            .semantics(mergeDescendants = true) {}
+            .semantics(mergeDescendants = true) {
+                contentDescription = formattedContentDescription
+            }
             .cardStyle(cardStyle = cardStyle, padding = cardInsets),
         onClick = throttledClick(onClick = onClick),
         enabled = isEnabled,
@@ -69,6 +85,7 @@ fun BitwardenFilledButton(
         Text(
             text = label,
             style = BitwardenTheme.typography.labelLarge,
+            modifier = Modifier.semantics { hideFromAccessibility() },
         )
     }
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenOutlinedButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenOutlinedButton.kt
@@ -11,6 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -21,6 +24,7 @@ import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.components.util.throttledClick
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
@@ -31,6 +35,7 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  * @param modifier The [Modifier] to be applied to the button.
  * @param icon The icon for the button.
  * @param isEnabled Whether the button is enabled.
+ * @param isExternalLink Indicates that this button launches an external link.
  * @param cardStyle The optional card style to surround the button.
  * @param cardInsets The internal insets for the card, only applied when the [cardStyle] is not
  * `null`.
@@ -42,13 +47,24 @@ fun BitwardenOutlinedButton(
     modifier: Modifier = Modifier,
     icon: Painter? = null,
     isEnabled: Boolean = true,
+    isExternalLink: Boolean = false,
     colors: BitwardenOutlinedButtonColors = bitwardenOutlinedButtonColors(),
     cardStyle: CardStyle? = null,
     cardInsets: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
 ) {
+    val formattedContentDescription = if (isExternalLink) {
+        stringResource(
+            id = BitwardenString.external_link_format,
+            formatArgs = arrayOf(label),
+        )
+    } else {
+        label
+    }
     OutlinedButton(
         modifier = modifier
-            .semantics(mergeDescendants = true) { }
+            .semantics(mergeDescendants = true) {
+                contentDescription = formattedContentDescription
+            }
             .cardStyle(cardStyle = cardStyle, padding = cardInsets),
         onClick = throttledClick(onClick = onClick),
         enabled = isEnabled,
@@ -78,6 +94,7 @@ fun BitwardenOutlinedButton(
         Text(
             text = label,
             style = BitwardenTheme.typography.labelLarge,
+            modifier = Modifier.semantics { hideFromAccessibility() },
         )
     }
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenTextButton.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/button/BitwardenTextButton.kt
@@ -11,11 +11,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.components.button.color.bitwardenTextButtonColors
 import com.bitwarden.ui.platform.components.util.throttledClick
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
@@ -25,6 +29,8 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  * @param onClick The callback when the button is clicked.
  * @param modifier The [Modifier] to be applied to the button.
  * @param icon The icon for the button.
+ * @param isEnabled Whether the button is enabled.
+ * @param isExternalLink Indicates that this button launches an external link.
  * @param contentColor The color for the label text and icon.
  */
 @Composable
@@ -34,10 +40,21 @@ fun BitwardenTextButton(
     modifier: Modifier = Modifier,
     icon: Painter? = null,
     isEnabled: Boolean = true,
+    isExternalLink: Boolean = false,
     contentColor: Color = BitwardenTheme.colorScheme.outlineButton.foreground,
 ) {
+    val formattedContentDescription = if (isExternalLink) {
+        stringResource(
+            id = BitwardenString.external_link_format,
+            formatArgs = arrayOf(label),
+        )
+    } else {
+        label
+    }
     TextButton(
-        modifier = modifier.semantics(mergeDescendants = true) {},
+        modifier = modifier.semantics(mergeDescendants = true) {
+            contentDescription = formattedContentDescription
+        },
         onClick = throttledClick(onClick = onClick),
         enabled = isEnabled,
         contentPadding = PaddingValues(
@@ -59,6 +76,7 @@ fun BitwardenTextButton(
         Text(
             text = label,
             style = BitwardenTheme.typography.labelLarge,
+            modifier = Modifier.semantics { hideFromAccessibility() },
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29871](https://bitwarden.atlassian.net/browse/PM-29871)

## 📔 Objective

This PR adds more `External link` callouts for the buttons that leave the app in any way.

* Open email app
* Import certificate
* Why am I seeing this
* Launch Browser
* Learn more
* Choose file
* Import items
* How to manage my vault
* Save to Bitwarden
* Export
* Import vault

[PM-29871]: https://bitwarden.atlassian.net/browse/PM-29871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ