### PR TITLE
[PM-33505] feat: Add MobilePremiumUpgrade feature flag

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -37,6 +37,7 @@ sealed class FlagKey<out T : Any> {
                 MigrateMyVaultToMyItems,
                 ArchiveItems,
                 SendEmailVerification,
+                MobilePremiumUpgrade,
             )
         }
     }
@@ -104,6 +105,14 @@ sealed class FlagKey<out T : Any> {
      */
     data object SendEmailVerification : FlagKey<Boolean>() {
         override val keyName: String = "pm-19051-send-email-verification"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for the mobile premium upgrade feature.
+     */
+    data object MobilePremiumUpgrade : FlagKey<Boolean>() {
+        override val keyName: String = "PM-31697-premium-upgrade-path"
         override val defaultValue: Boolean = false
     }
 

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -36,6 +36,10 @@ class FlagKeyTest {
             FlagKey.SendEmailVerification.keyName,
             "pm-19051-send-email-verification",
         )
+        assertEquals(
+            FlagKey.MobilePremiumUpgrade.keyName,
+            "PM-31697-premium-upgrade-path",
+        )
     }
 
     @Test
@@ -49,6 +53,7 @@ class FlagKeyTest {
                 FlagKey.MigrateMyVaultToMyItems,
                 FlagKey.ArchiveItems,
                 FlagKey.SendEmailVerification,
+                FlagKey.MobilePremiumUpgrade,
             ).all {
                 !it.defaultValue
             },

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
@@ -31,6 +31,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.MigrateMyVaultToMyItems,
     FlagKey.ArchiveItems,
     FlagKey.SendEmailVerification,
+    FlagKey.MobilePremiumUpgrade,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -83,4 +84,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.MigrateMyVaultToMyItems -> stringResource(BitwardenString.migrate_my_vault_to_my_items)
     FlagKey.ArchiveItems -> stringResource(BitwardenString.archive_items)
     FlagKey.SendEmailVerification -> stringResource(BitwardenString.send_email_verification)
+    FlagKey.MobilePremiumUpgrade -> stringResource(BitwardenString.mobile_premium_upgrade)
 }

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -42,6 +42,7 @@
     <string name="send_email_verification">Send Email Verification</string>
     <string name="trigger_cookie_acquisition">Trigger cookie acquisition</string>
     <string name="clear_sso_cookies">Clear SSO cookies</string>
+    <string name="mobile_premium_upgrade">Mobile Premium Upgrade</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33505](https://bitwarden.atlassian.net/browse/PM-33505)

## 📔 Objective

Add `MobilePremiumUpgrade` feature flag to `FlagKey.kt` and register it in `activePasswordManagerFlags`. This is the foundation flag that gates the entire premium upgrade flow. Default is off; controlled via LaunchDarkly.

[PM-33505]: https://bitwarden.atlassian.net/browse/PM-33505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-33137]: https://bitwarden.atlassian.net/browse/PM-33137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ