### PR TITLE
[PM-33507] feat: Add premium upgrade banner dismissal persistence

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSource.kt
@@ -124,6 +124,24 @@ interface SettingsDiskSource : FlightRecorderDiskSource {
     fun getIntroducingArchiveActionCardDismissedFlow(userId: String): Flow<Boolean?>
 
     /**
+     * Retrieves the stored value of whether the premium upgrade banner has been dismissed.
+     */
+    fun getPremiumUpgradeBannerDismissed(userId: String): Boolean?
+
+    /**
+     * Stores whether the premium upgrade banner has been dismissed.
+     */
+    fun storePremiumUpgradeBannerDismissed(
+        userId: String,
+        isDismissed: Boolean?,
+    )
+
+    /**
+     * Emits updates that track [getPremiumUpgradeBannerDismissed] for the given [userId].
+     */
+    fun getPremiumUpgradeBannerDismissedFlow(userId: String): Flow<Boolean?>
+
+    /**
      * Retrieves the biometric integrity validity for the given [userId] and
      * [systemBioIntegrityState].
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceImpl.kt
@@ -51,6 +51,8 @@ private const val IS_DYNAMIC_COLORS_ENABLED = "isDynamicColorsEnabled"
 private const val BROWSER_AUTOFILL_DIALOG_RESHOW_TIME = "browserAutofillDialogReshowTime"
 private const val INTRODUCING_ARCHIVE_ACTION_CARD_DISMISSED =
     "introducingArchiveActionCardDismissed"
+private const val PREMIUM_UPGRADE_BANNER_DISMISSED =
+    "premiumUpgradeBannerDismissed"
 
 /**
  * Primary implementation of [SettingsDiskSource].
@@ -90,6 +92,9 @@ class SettingsDiskSourceImpl(
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     private val mutableIntroducingArchiveActionCardDismissedFlowMap =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutablePremiumUpgradeBannerDismissedFlowMap =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     private val mutableIsIconLoadingDisabledFlow = bufferedMutableSharedFlow<Boolean?>()
@@ -246,6 +251,7 @@ class SettingsDiskSourceImpl(
         // - should show add login coach mark
         // - should show generator coach mark
         // - should show introducing archive action card dismissed
+        // - premium upgrade banner dismissed
     }
 
     override fun getIntroducingArchiveActionCardDismissed(userId: String): Boolean? =
@@ -267,6 +273,26 @@ class SettingsDiskSourceImpl(
     override fun getIntroducingArchiveActionCardDismissedFlow(userId: String): Flow<Boolean?> =
         getMutableIntroducingArchiveActionCardDismissedFlow(userId = userId)
             .onSubscription { emit(getIntroducingArchiveActionCardDismissed(userId = userId)) }
+
+    override fun getPremiumUpgradeBannerDismissed(userId: String): Boolean? =
+        getBoolean(
+            key = PREMIUM_UPGRADE_BANNER_DISMISSED.appendIdentifier(identifier = userId),
+        )
+
+    override fun storePremiumUpgradeBannerDismissed(
+        userId: String,
+        isDismissed: Boolean?,
+    ) {
+        putBoolean(
+            key = PREMIUM_UPGRADE_BANNER_DISMISSED.appendIdentifier(identifier = userId),
+            value = isDismissed,
+        )
+        getMutablePremiumUpgradeBannerDismissedFlow(userId = userId).tryEmit(isDismissed)
+    }
+
+    override fun getPremiumUpgradeBannerDismissedFlow(userId: String): Flow<Boolean?> =
+        getMutablePremiumUpgradeBannerDismissedFlow(userId = userId)
+            .onSubscription { emit(getPremiumUpgradeBannerDismissed(userId = userId)) }
 
     override fun getAccountBiometricIntegrityValidity(
         userId: String,
@@ -609,6 +635,13 @@ class SettingsDiskSourceImpl(
         userId: String,
     ): MutableSharedFlow<Boolean?> =
         mutableIntroducingArchiveActionCardDismissedFlowMap.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutablePremiumUpgradeBannerDismissedFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> =
+        mutablePremiumUpgradeBannerDismissedFlowMap.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepository.kt
@@ -253,6 +253,16 @@ interface SettingsRepository : FlightRecorderManager {
     fun dismissIntroducingArchiveActionCard()
 
     /**
+     * Gets updates for whether the premium upgrade banner is dismissed.
+     */
+    fun getPremiumUpgradeBannerDismissedFlow(): StateFlow<Boolean>
+
+    /**
+     * Stores that the premium upgrade banner has been dismissed for the active user.
+     */
+    fun dismissPremiumUpgradeBanner()
+
+    /**
      * Stores the encrypted user key for biometrics, allowing it to be used to unlock the current
      * user's vault.
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryImpl.kt
@@ -523,6 +523,29 @@ class SettingsRepositoryImpl(
         }
     }
 
+    override fun getPremiumUpgradeBannerDismissedFlow(): StateFlow<Boolean> {
+        val userId = activeUserId ?: return MutableStateFlow(value = false)
+        return settingsDiskSource
+            .getPremiumUpgradeBannerDismissedFlow(userId = userId)
+            .map { it ?: false }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = settingsDiskSource
+                    .getPremiumUpgradeBannerDismissed(userId = userId)
+                    ?: false,
+            )
+    }
+
+    override fun dismissPremiumUpgradeBanner() {
+        activeUserId?.let {
+            settingsDiskSource.storePremiumUpgradeBannerDismissed(
+                userId = it,
+                isDismissed = true,
+            )
+        }
+    }
+
     override suspend fun setupBiometricsKey(cipher: Cipher): BiometricsKeyResult {
         val userId = activeUserId
             ?: return BiometricsKeyResult.Error(error = NoActiveUserException())

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/SettingsDiskSourceTest.kt
@@ -142,6 +142,10 @@ class SettingsDiskSourceTest {
             userId = userId,
             isDismissed = true,
         )
+        settingsDiskSource.storePremiumUpgradeBannerDismissed(
+            userId = userId,
+            isDismissed = true,
+        )
         settingsDiskSource.storeInlineAutofillEnabled(
             userId = userId,
             isInlineAutofillEnabled = true,
@@ -174,6 +178,9 @@ class SettingsDiskSourceTest {
         assertTrue(settingsDiskSource.getShowAutoFillSettingBadge(userId = userId) ?: false)
         assertTrue(
             settingsDiskSource.getIntroducingArchiveActionCardDismissed(userId = userId) ?: false,
+        )
+        assertTrue(
+            settingsDiskSource.getPremiumUpgradeBannerDismissed(userId = userId) ?: false,
         )
 
         // These should be cleared
@@ -817,6 +824,44 @@ class SettingsDiskSourceTest {
 
                     // Updating the disk source updates shared preferences
                     settingsDiskSource.storeIntroducingArchiveActionCardDismissed(
+                        userId = mockUserId,
+                        isDismissed = true,
+                    )
+                    assertEquals(true, awaitItem())
+                }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getPremiumUpgradeBannerDismissed when values are present should pull from SharedPreferences`() {
+        val baseKey = "bwPreferencesStorage:premiumUpgradeBannerDismissed"
+        val mockUserId = "mockUserId"
+        val key = "${baseKey}_$mockUserId"
+        assertNull(settingsDiskSource.getPremiumUpgradeBannerDismissed(userId = mockUserId))
+        fakeSharedPreferences.edit { putBoolean(key, true) }
+        assertEquals(
+            true,
+            settingsDiskSource.getPremiumUpgradeBannerDismissed(userId = mockUserId),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getPremiumUpgradeBannerDismissedFlow should react to changes in storePremiumUpgradeBannerDismissed`() =
+        runTest {
+            val mockUserId = "mockUserId"
+            settingsDiskSource
+                .getPremiumUpgradeBannerDismissedFlow(userId = mockUserId)
+                .test {
+                    // The initial values of the Flow and the property are in sync
+                    assertNull(
+                        settingsDiskSource
+                            .getPremiumUpgradeBannerDismissed(userId = mockUserId),
+                    )
+                    assertNull(awaitItem())
+
+                    // Updating the disk source updates shared preferences
+                    settingsDiskSource.storePremiumUpgradeBannerDismissed(
                         userId = mockUserId,
                         isDismissed = true,
                     )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/datasource/disk/util/FakeSettingsDiskSource.kt
@@ -67,6 +67,7 @@ class FakeSettingsDiskSource(
     private val storedDisableAutofillSavePrompt = mutableMapOf<String, Boolean?>()
     private val storedPullToRefreshEnabled = mutableMapOf<String, Boolean?>()
     private var storedIntroducingArchiveActionCardDismissed = mutableMapOf<String, Boolean?>()
+    private var storedPremiumUpgradeBannerDismissed = mutableMapOf<String, Boolean?>()
     private val storedInlineAutofillEnabled = mutableMapOf<String, Boolean?>()
     private val storedBlockedAutofillUris = mutableMapOf<String, List<String>?>()
     private var storedIsIconLoadingDisabled: Boolean? = null
@@ -110,6 +111,9 @@ class FakeSettingsDiskSource(
         bufferedMutableSharedFlow<Boolean?>()
 
     private val mutableIntroducingArchiveActionCardDismissedFlow =
+        mutableMapOf<String, MutableSharedFlow<Boolean?>>()
+
+    private val mutablePremiumUpgradeBannerDismissedFlow =
         mutableMapOf<String, MutableSharedFlow<Boolean?>>()
 
     override var appLanguage: AppLanguage?
@@ -341,6 +345,18 @@ class FakeSettingsDiskSource(
         getMutableIntroducingArchiveActionCardDismissedFlow(userId = userId).tryEmit(isDismissed)
     }
 
+    override fun getPremiumUpgradeBannerDismissed(userId: String): Boolean? =
+        storedPremiumUpgradeBannerDismissed[userId]
+
+    override fun getPremiumUpgradeBannerDismissedFlow(userId: String): Flow<Boolean?> =
+        getMutablePremiumUpgradeBannerDismissedFlow(userId = userId)
+            .onSubscription { emit(getPremiumUpgradeBannerDismissed(userId = userId)) }
+
+    override fun storePremiumUpgradeBannerDismissed(userId: String, isDismissed: Boolean?) {
+        storedPremiumUpgradeBannerDismissed[userId] = isDismissed
+        getMutablePremiumUpgradeBannerDismissedFlow(userId = userId).tryEmit(isDismissed)
+    }
+
     override fun getInlineAutofillEnabled(userId: String): Boolean? =
         storedInlineAutofillEnabled[userId]
 
@@ -499,6 +515,13 @@ class FakeSettingsDiskSource(
     }
 
     /**
+     * Asserts that the stored premium upgrade banner dismissed matches the [expected] one.
+     */
+    fun assertPremiumUpgradeBannerDismissed(userId: String, expected: Boolean?) {
+        assertEquals(expected, storedPremiumUpgradeBannerDismissed[userId])
+    }
+
+    /**
      * Asserts that the stored last sync time matches the [expected] one.
      */
     fun assertLastSyncTime(userId: String, expected: Instant?) {
@@ -559,6 +582,13 @@ class FakeSettingsDiskSource(
         userId: String,
     ): MutableSharedFlow<Boolean?> =
         mutableIntroducingArchiveActionCardDismissedFlow.getOrPut(userId) {
+            bufferedMutableSharedFlow(replay = 1)
+        }
+
+    private fun getMutablePremiumUpgradeBannerDismissedFlow(
+        userId: String,
+    ): MutableSharedFlow<Boolean?> =
+        mutablePremiumUpgradeBannerDismissedFlow.getOrPut(userId) {
             bufferedMutableSharedFlow(replay = 1)
         }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/repository/SettingsRepositoryTest.kt
@@ -887,6 +887,38 @@ class SettingsRepositoryTest {
         }
 
     @Test
+    fun `dismissPremiumUpgradeBanner should properly update SettingsDiskSource`() {
+        fakeAuthDiskSource.userState = MOCK_USER_STATE
+        settingsRepository.dismissPremiumUpgradeBanner()
+        assertEquals(
+            true,
+            fakeSettingsDiskSource.getPremiumUpgradeBannerDismissed(userId = USER_ID),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getPremiumUpgradeBannerDismissedFlow should react to changes in SettingsDiskSource`() =
+        runTest {
+            fakeAuthDiskSource.userState = MOCK_USER_STATE
+            settingsRepository
+                .getPremiumUpgradeBannerDismissedFlow()
+                .test {
+                    assertFalse(awaitItem())
+                    fakeSettingsDiskSource.storePremiumUpgradeBannerDismissed(
+                        userId = USER_ID,
+                        isDismissed = true,
+                    )
+                    assertTrue(awaitItem())
+                    fakeSettingsDiskSource.storePremiumUpgradeBannerDismissed(
+                        userId = USER_ID,
+                        isDismissed = false,
+                    )
+                    assertFalse(awaitItem())
+                }
+        }
+
+    @Test
     fun `storePullToRefreshEnabled should properly update SettingsDiskSource`() {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         settingsRepository.storePullToRefreshEnabled(true)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33507](https://bitwarden.atlassian.net/browse/PM-33507)
Parent: [PM-33137](https://bitwarden.atlassian.net/browse/PM-33137)

## 📔 Objective

Add per-user banner dismissed state to `SettingsDiskSource` and `SettingsRepository`, following the existing archive action card pattern.

- Add `get/storePremiumUpgradeBannerDismissed` + flow to `SettingsDiskSource`
- Implement in `SettingsDiskSourceImpl` with per-userId SharedPreferences storage
- Expose `dismissPremiumUpgradeBanner()` and `getPremiumUpgradeBannerDismissedFlow()` via `SettingsRepository`
- Dismissed state cleared on logout

[PM-33507]: https://bitwarden.atlassian.net/browse/PM-33507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-33137]: https://bitwarden.atlassian.net/browse/PM-33137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ