### PR TITLE
PM-33565: Update premium dialog for attachments

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemAttachmentContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemAttachmentContent.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -19,7 +18,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.components.button.BitwardenStandardIconButton
-import com.bitwarden.ui.platform.components.button.BitwardenTextButton
 import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
@@ -34,6 +32,7 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
 fun AttachmentItemContent(
     attachmentItem: VaultItemState.ViewState.Content.Common.AttachmentItem,
     onAttachmentDownloadClick: (VaultItemState.ViewState.Content.Common.AttachmentItem) -> Unit,
+    onUpgradeToPremiumClick: () -> Unit,
     cardStyle: CardStyle,
     modifier: Modifier = Modifier,
 ) {
@@ -91,24 +90,17 @@ fun AttachmentItemContent(
     }
 
     if (shouldShowPremiumWarningDialog) {
-        AlertDialog(
+        BitwardenTwoButtonDialog(
+            title = stringResource(id = BitwardenString.attachments_unavailable),
+            message = stringResource(id = BitwardenString.attachments_are_a_premium_feature),
+            confirmButtonText = stringResource(id = BitwardenString.upgrade_to_premium),
+            dismissButtonText = stringResource(id = BitwardenString.cancel),
+            onConfirmClick = {
+                shouldShowPremiumWarningDialog = false
+                onUpgradeToPremiumClick()
+            },
+            onDismissClick = { shouldShowPremiumWarningDialog = false },
             onDismissRequest = { shouldShowPremiumWarningDialog = false },
-            confirmButton = {
-                BitwardenTextButton(
-                    label = stringResource(BitwardenString.okay),
-                    onClick = { shouldShowPremiumWarningDialog = false },
-                )
-            },
-            text = {
-                Text(
-                    text = stringResource(BitwardenString.premium_required),
-                    style = BitwardenTheme.typography.bodyMedium,
-                )
-            },
-            containerColor = BitwardenTheme.colorScheme.background.primary,
-            iconContentColor = BitwardenTheme.colorScheme.icon.secondary,
-            titleContentColor = BitwardenTheme.colorScheme.text.primary,
-            textContentColor = BitwardenTheme.colorScheme.text.primary,
         )
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemCardContent.kt
@@ -300,6 +300,7 @@ fun VaultItemCardContent(
                     attachmentItem = attachmentItem,
                     onAttachmentDownloadClick = vaultCommonItemTypeHandlers
                         .onAttachmentDownloadClick,
+                    onUpgradeToPremiumClick = vaultCommonItemTypeHandlers.onUpgradeToPremiumClick,
                     cardStyle = attachments.toListItemCardStyle(index = index),
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
@@ -361,6 +361,7 @@ fun VaultItemIdentityContent(
                     attachmentItem = attachmentItem,
                     onAttachmentDownloadClick = vaultCommonItemTypeHandlers
                         .onAttachmentDownloadClick,
+                    onUpgradeToPremiumClick = vaultCommonItemTypeHandlers.onUpgradeToPremiumClick,
                     cardStyle = attachments.toListItemCardStyle(index = index),
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemLoginContent.kt
@@ -266,6 +266,7 @@ fun VaultItemLoginContent(
                     cardStyle = attachments.toListItemCardStyle(index = index),
                     onAttachmentDownloadClick = vaultCommonItemTypeHandlers
                         .onAttachmentDownloadClick,
+                    onUpgradeToPremiumClick = vaultCommonItemTypeHandlers.onUpgradeToPremiumClick,
                 )
             }
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSecureNoteContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSecureNoteContent.kt
@@ -148,6 +148,7 @@ fun VaultItemSecureNoteContent(
                     attachmentItem = attachmentItem,
                     onAttachmentDownloadClick = vaultCommonItemTypeHandlers
                         .onAttachmentDownloadClick,
+                    onUpgradeToPremiumClick = vaultCommonItemTypeHandlers.onUpgradeToPremiumClick,
                     cardStyle = attachments.toListItemCardStyle(index = index),
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSshKeyContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemSshKeyContent.kt
@@ -233,6 +233,7 @@ fun VaultItemSshKeyContent(
                     attachmentItem = attachmentItem,
                     onAttachmentDownloadClick = vaultCommonItemTypeHandlers
                         .onAttachmentDownloadClick,
+                    onUpgradeToPremiumClick = vaultCommonItemTypeHandlers.onUpgradeToPremiumClick,
                     cardStyle = attachments.toListItemCardStyle(index = index),
                 )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/handlers/VaultCommonItemTypeHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/handlers/VaultCommonItemTypeHandlers.kt
@@ -19,6 +19,7 @@ data class VaultCommonItemTypeHandlers(
     val onAttachmentDownloadClick: (VaultItemState.ViewState.Content.Common.AttachmentItem) -> Unit,
     val onCopyNotesClick: () -> Unit,
     val onPasswordHistoryClick: () -> Unit,
+    val onUpgradeToPremiumClick: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -55,6 +56,9 @@ data class VaultCommonItemTypeHandlers(
                 },
                 onPasswordHistoryClick = {
                     viewModel.trySendAction(VaultItemAction.Common.PasswordHistoryClick)
+                },
+                onUpgradeToPremiumClick = {
+                    viewModel.trySendAction(VaultItemAction.Common.UpgradeToPremiumClick)
                 },
             )
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -767,17 +767,21 @@ class VaultItemScreenTest : BitwardenComposeTest() {
 
         composeTestRule
             .onAllNodesWithText(
-                "A premium membership is required to use this feature.",
+                text = "Attachments are a Premium feature. " +
+                    "Your current plan does not include access to this feature.",
             )
             .filterToOne(hasAnyAncestor(isDialog()))
             .assertIsDisplayed()
 
         composeTestRule
-            .onAllNodesWithText(text = "Okay")
+            .onAllNodesWithText(text = "Upgrade to premium")
             .filterToOne(hasAnyAncestor(isDialog()))
             .performClick()
 
         composeTestRule.assertNoDialogExists()
+        verify(exactly = 1) {
+            viewModel.trySendAction(VaultItemAction.Common.UpgradeToPremiumClick)
+        }
     }
 
     @Suppress("MaxLineLength")

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -200,6 +200,8 @@ Scanning will happen automatically.</string>
     <string name="copy_totp_automatically">Copy TOTP automatically</string>
     <string name="premium_required">A premium membership is required to use this feature.</string>
     <string name="attachment_deleted">Attachment deleted</string>
+    <string name="attachments_unavailable">Attachments unavailable</string>
+    <string name="attachments_are_a_premium_feature">Attachments are a Premium feature. Your current plan does not include access to this feature.</string>
     <string name="choose_file">Choose file</string>
     <string name="file">File</string>
     <string name="no_file_chosen">No file chosen</string>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33565](https://bitwarden.atlassian.net/browse/PM-33565)

## 📔 Objective

This PR updates the premium dialog when trying to download an attachment.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/ea3fabf0-de4c-4acb-a2cd-0bfc963d0f24" /> | <img width="350" src="https://github.com/user-attachments/assets/cd072c90-a799-451d-83a6-a829cc462922" /> |


[PM-33565]: https://bitwarden.atlassian.net/browse/PM-33565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ