### PR TITLE
[PM-33553] fix: Remove "Why am I seeing this?" link from cookie sync screen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionScreen.kt
@@ -34,7 +34,6 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
-import com.bitwarden.ui.platform.components.button.BitwardenTextButton
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
@@ -69,10 +68,6 @@ fun CookieAcquisitionScreen(
                     authTabData = event.authTabData,
                     launcher = authTabLaunchers.cookie,
                 )
-            }
-
-            is CookieAcquisitionEvent.NavigateToHelp -> {
-                intentManager.launchUri(event.uri.toUri())
             }
 
             CookieAcquisitionEvent.NavigateBack -> onDismiss()
@@ -198,17 +193,6 @@ private fun CookieAcquisitionContent(
                 .standardHorizontalMargin(),
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
-
-        BitwardenTextButton(
-            label = stringResource(id = BitwardenString.why_am_i_seeing_this),
-            onClick = handler.onWhyAmISeeingThisClick,
-            isExternalLink = true,
-            modifier = Modifier
-                .fillMaxWidth()
-                .standardHorizontalMargin(),
-        )
-
         Spacer(modifier = Modifier.navigationBarsPadding())
     }
 }
@@ -227,7 +211,6 @@ private fun CookieAcquisitionScreen_preview() {
                 handler = CookieAcquisitionHandler(
                     onLaunchBrowserClick = {},
                     onContinueWithoutSyncingClick = {},
-                    onWhyAmISeeingThisClick = {},
                     onDismissDialogClick = {},
                 ),
                 modifier = Modifier.fillMaxSize(),
@@ -250,7 +233,6 @@ private fun CookieAcquisitionScreen_darkPreview() {
                 handler = CookieAcquisitionHandler(
                     onLaunchBrowserClick = {},
                     onContinueWithoutSyncingClick = {},
-                    onWhyAmISeeingThisClick = {},
                     onDismissDialogClick = {},
                 ),
                 modifier = Modifier.fillMaxSize(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionViewModel.kt
@@ -27,7 +27,6 @@ import javax.inject.Inject
 private const val KEY_STATE = "state"
 private const val PROXY_URL = "/proxy-cookie-redirect-connector.html"
 private const val COOKIE_CALLBACK_URL = "bitwarden://sso-cookie-vendor"
-private const val HELP_URL = "https://bitwarden.com/help"
 
 /**
  * ViewModel for the Cookie Acquisition screen.
@@ -79,7 +78,6 @@ class CookieAcquisitionViewModel @Inject constructor(
                 handleContinueWithoutSyncingClick()
             }
 
-            CookieAcquisitionAction.WhyAmISeeingThisClick -> handleWhyAmISeeingThisClick()
             CookieAcquisitionAction.DismissDialogClick -> handleDismissDialogClick()
             is CookieAcquisitionAction.Internal.CookieAcquisitionResultReceived -> {
                 handleCookieAcquisitionResultReceived(action)
@@ -101,10 +99,6 @@ class CookieAcquisitionViewModel @Inject constructor(
     private fun handleContinueWithoutSyncingClick() {
         cookieAcquisitionRequestManager.setPendingCookieAcquisition(data = null)
         sendEvent(CookieAcquisitionEvent.NavigateBack)
-    }
-
-    private fun handleWhyAmISeeingThisClick() {
-        sendEvent(CookieAcquisitionEvent.NavigateToHelp(uri = HELP_URL))
     }
 
     private fun handleDismissDialogClick() {
@@ -175,11 +169,6 @@ sealed class CookieAcquisitionEvent {
     ) : CookieAcquisitionEvent()
 
     /**
-     * Navigate to the help page.
-     */
-    data class NavigateToHelp(val uri: String) : CookieAcquisitionEvent()
-
-    /**
      * Navigate back, dismissing the cookie acquisition screen.
      *
      * Implements [BackgroundEvent] because the cookie callback result may arrive while
@@ -201,11 +190,6 @@ sealed class CookieAcquisitionAction {
      * User clicked the "Continue without syncing" button.
      */
     data object ContinueWithoutSyncingClick : CookieAcquisitionAction()
-
-    /**
-     * User clicked the "Why am I seeing this?" link.
-     */
-    data object WhyAmISeeingThisClick : CookieAcquisitionAction()
 
     /**
      * User dismissed the error dialog.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/handlers/CookieAcquisitionHandler.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/handlers/CookieAcquisitionHandler.kt
@@ -11,7 +11,6 @@ import com.x8bit.bitwarden.ui.platform.feature.cookieacquisition.CookieAcquisiti
 data class CookieAcquisitionHandler(
     val onLaunchBrowserClick: () -> Unit,
     val onContinueWithoutSyncingClick: () -> Unit,
-    val onWhyAmISeeingThisClick: () -> Unit,
     val onDismissDialogClick: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
@@ -32,11 +31,6 @@ data class CookieAcquisitionHandler(
                 onContinueWithoutSyncingClick = {
                     viewModel.trySendAction(
                         CookieAcquisitionAction.ContinueWithoutSyncingClick,
-                    )
-                },
-                onWhyAmISeeingThisClick = {
-                    viewModel.trySendAction(
-                        CookieAcquisitionAction.WhyAmISeeingThisClick,
                     )
                 },
                 onDismissDialogClick = {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionScreenTest.kt
@@ -42,7 +42,6 @@ class CookieAcquisitionScreenTest : BitwardenComposeTest() {
     }
     private val intentManager = mockk<IntentManager> {
         every { startAuthTab(uri = any(), authTabData = any(), launcher = any()) } just runs
-        every { launchUri(any()) } just runs
     }
 
     @Before
@@ -85,15 +84,6 @@ class CookieAcquisitionScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `NavigateToHelp event should call launchUri`() {
-        val uri = "https://bitwarden.com/help"
-        mutableEventFlow.tryEmit(CookieAcquisitionEvent.NavigateToHelp(uri = uri))
-        verify {
-            intentManager.launchUri(uri.toUri())
-        }
-    }
-
-    @Test
     fun `title should be displayed`() {
         composeTestRule
             .onNodeWithText("Sync with browser")
@@ -131,20 +121,6 @@ class CookieAcquisitionScreenTest : BitwardenComposeTest() {
         verify {
             viewModel.trySendAction(
                 CookieAcquisitionAction.ContinueWithoutSyncingClick,
-            )
-        }
-    }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `why am I seeing this button click should send WhyAmISeeingThisClick action`() {
-        composeTestRule
-            .onNodeWithText("Why am I seeing this?")
-            .performScrollTo()
-            .performClick()
-        verify {
-            viewModel.trySendAction(
-                CookieAcquisitionAction.WhyAmISeeingThisClick,
             )
         }
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/cookieacquisition/CookieAcquisitionViewModelTest.kt
@@ -102,20 +102,6 @@ class CookieAcquisitionViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `WhyAmISeeingThisClick should emit NavigateToHelp event`() = runTest {
-        val viewModel = createViewModel()
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(CookieAcquisitionAction.WhyAmISeeingThisClick)
-            assertEquals(
-                CookieAcquisitionEvent.NavigateToHelp(
-                    uri = "https://bitwarden.com/help",
-                ),
-                awaitItem(),
-            )
-        }
-    }
-
-    @Test
     fun `CookieCallbackResult Success should store cookies and emit NavigateBack`() =
         runTest {
             val cookies = mapOf("sessionToken" to "abc123")


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33553

## 📔 Objective

Remove the "Why am I seeing this?" text button and link from the "Sync with browser" (cookie acquisition) screen.

The link currently directs users to a generic help page (`bitwarden.com/help`) that provides no relevant information about the cookie sync feature. The docs team confirmed there is no appropriate destination for this link, so it is removed entirely per PM-33553.

**Changes:**
- Removed `WhyAmISeeingThisClick` action, `NavigateToHelp` event, and `HELP_URL` constant from `CookieAcquisitionViewModel`
- Removed `onWhyAmISeeingThisClick` handler from `CookieAcquisitionHandler`
- Removed `BitwardenTextButton` and `NavigateToHelp` event handling from `CookieAcquisitionScreen`
- Removed corresponding test cases from ViewModel and Screen tests

Note: The `why_am_i_seeing_this` string resource is retained as it is still used by `MigrateToMyItemsScreen`.