### PR TITLE
llm: Clarify @Suppress("MaxLineLength") usage in testing skill

### DIFF
--- a/.claude/skills/testing-android-code/SKILL.md
+++ b/.claude/skills/testing-android-code/SKILL.md
@@ -263,7 +263,7 @@ Common testing mistakes in Bitwarden. **For complete details and examples:** See
 - **Null stream testing** - Test null returns from ContentResolver operations
 - **bufferedMutableSharedFlow** - Use with `.onSubscription { emit(state) }` in Fakes
 - **Test factory methods** - Accept domain state types, not SavedStateHandle
-- **@Suppress("MaxLineLength")** - Only add when the `fun` declaration line **actually exceeds 100 chars**; many existing tests have it unnecessarily — do not copy the pattern blindly
+- **@Suppress("MaxLineLength")** - Only add when the `fun` declaration line **actually exceeds 100 chars** — do not copy the pattern blindly
 
 ---
 


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket — Claude Code tooling improvement.

## 📔 Objective

Many existing test files use `@Suppress("MaxLineLength")` on test functions where the `fun` declaration does not actually exceed the 100 character line limit. This adds explicit guidance to the `testing-android-code` skill to prevent blindly copying the pattern from existing tests.

The rule: only add `@Suppress("MaxLineLength")` when the `fun` declaration line **actually exceeds 100 characters**.