### PR TITLE
misc: Add an error message to the DownloadAttachmentResult

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DownloadAttachmentResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/model/DownloadAttachmentResult.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.vault.repository.model
 
+import com.x8bit.bitwarden.data.platform.util.userFriendlyMessage
 import java.io.File
 
 /**
@@ -12,7 +13,11 @@ sealed class DownloadAttachmentResult {
     data class Success(val file: File) : DownloadAttachmentResult()
 
     /**
-     * The attachment could not be downloaded.
+     * The attachment could not be downloaded. The optional [errorMessage] may be displayed
+     * directly in the UI when present.
      */
-    data class Failure(val error: Throwable) : DownloadAttachmentResult()
+    data class Failure(
+        val error: Throwable,
+        val errorMessage: String? = error.userFriendlyMessage,
+    ) : DownloadAttachmentResult()
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -1237,7 +1237,8 @@ class VaultItemViewModel @Inject constructor(
             is DownloadAttachmentResult.Failure -> {
                 updateDialogState(
                     VaultItemState.DialogState.Generic(
-                        message = BitwardenString.unable_to_download_file.asText(),
+                        message = result.errorMessage?.asText()
+                            ?: BitwardenString.unable_to_download_file.asText(),
                         error = result.error,
                     ),
                 )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds support for an error message in the `DownloadAttachmentResult`.
