### PR TITLE
misc: Rename the VaultDiskSource Flows

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
@@ -80,12 +80,12 @@ interface VaultDiskSource {
     /**
      * Retrieves all collections from the data source for a given [userId].
      */
-    fun getCollections(userId: String): Flow<List<SyncResponseJson.Collection>>
+    fun getCollectionsFlow(userId: String): Flow<List<SyncResponseJson.Collection>>
 
     /**
      * Retrieves all domains from the data source for a given [userId].
      */
-    fun getDomains(userId: String): Flow<SyncResponseJson.Domains?>
+    fun getDomainsFlow(userId: String): Flow<SyncResponseJson.Domains?>
 
     /**
      * Deletes a folder from the data source for the given [userId] and [folderId].
@@ -100,34 +100,34 @@ interface VaultDiskSource {
     /**
      * Retrieves all folders from the data source for a given [userId].
      */
-    fun getFolders(userId: String): Flow<List<SyncResponseJson.Folder>>
+    fun getFoldersFlow(userId: String): Flow<List<SyncResponseJson.Folder>>
 
     /**
-     * Saves a send to the data source for the given [userId].
+     * Saves a Send to the data source for the given [userId].
      */
     suspend fun saveSend(userId: String, send: SyncResponseJson.Send)
 
     /**
-     * Deletes a send from the data source for the given [userId] and [sendId].
+     * Deletes a Send from the data source for the given [userId] and [sendId].
      */
     suspend fun deleteSend(userId: String, sendId: String)
 
     /**
      * Retrieves all sends from the data source for a given [userId].
      */
-    fun getSends(userId: String): Flow<List<SyncResponseJson.Send>>
+    fun getSendsFlow(userId: String): Flow<List<SyncResponseJson.Send>>
 
     /**
      * Replaces all [vault] data for a given [userId] with the new `vault`.
      *
-     * This will always cause the [getCiphersFlow], [getCollections], and [getFolders] functions to
-     * re-emit even if the underlying data has not changed.
+     * This will always cause the [getCiphersFlow], [getCollectionsFlow], and [getFoldersFlow]
+     * functions to re-emit even if the underlying data has not changed.
      */
     suspend fun replaceVaultData(userId: String, vault: SyncResponseJson)
 
     /**
-     * Trigger re-emissions from the [getCiphersFlow], [getCollections], [getFolders], and [getSends]
-     * functions.
+     * Trigger re-emissions from the [getCiphersFlow], [getCollectionsFlow], [getFoldersFlow],
+     * and [getSendsFlow] functions.
      */
     suspend fun resyncVaultData(userId: String)
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -200,13 +200,13 @@ class VaultDiskSourceImpl(
         )
     }
 
-    override fun getCollections(
+    override fun getCollectionsFlow(
         userId: String,
     ): Flow<List<SyncResponseJson.Collection>> =
         merge(
             forceCollectionsFlow,
             collectionsDao
-                .getAllCollections(userId = userId)
+                .getAllCollectionsFlow(userId = userId)
                 .map { entities ->
                     entities.map { entity ->
                         SyncResponseJson.Collection(
@@ -224,9 +224,9 @@ class VaultDiskSourceImpl(
                 },
         )
 
-    override fun getDomains(userId: String): Flow<SyncResponseJson.Domains?> =
+    override fun getDomainsFlow(userId: String): Flow<SyncResponseJson.Domains?> =
         domainsDao
-            .getDomains(userId)
+            .getDomainsFlow(userId)
             .map { entity ->
                 withContext(dispatcherManager.default) {
                     entity?.domainsJson?.let { domains ->
@@ -252,13 +252,13 @@ class VaultDiskSourceImpl(
         )
     }
 
-    override fun getFolders(
+    override fun getFoldersFlow(
         userId: String,
     ): Flow<List<SyncResponseJson.Folder>> =
         merge(
             forceFolderFlow,
             foldersDao
-                .getAllFolders(userId = userId)
+                .getAllFoldersFlow(userId = userId)
                 .map { entities ->
                     entities.map { entity ->
                         SyncResponseJson.Folder(
@@ -287,13 +287,13 @@ class VaultDiskSourceImpl(
         sendsDao.deleteSend(userId, sendId)
     }
 
-    override fun getSends(
+    override fun getSendsFlow(
         userId: String,
     ): Flow<List<SyncResponseJson.Send>> =
         merge(
             forceSendFlow,
             sendsDao
-                .getAllSends(userId = userId)
+                .getAllSendsFlow(userId = userId)
                 .map { entities ->
                     withContext(context = dispatcherManager.default) {
                         entities
@@ -403,9 +403,9 @@ class VaultDiskSourceImpl(
     override suspend fun resyncVaultData(userId: String) {
         coroutineScope {
             val deferredCiphers = async { getCiphersFlow(userId = userId).first() }
-            val deferredCollections = async { getCollections(userId = userId).first() }
-            val deferredFolders = async { getFolders(userId = userId).first() }
-            val deferredSends = async { getSends(userId = userId).first() }
+            val deferredCollections = async { getCollectionsFlow(userId = userId).first() }
+            val deferredFolders = async { getFoldersFlow(userId = userId).first() }
+            val deferredSends = async { getSendsFlow(userId = userId).first() }
 
             forceCiphersFlow.tryEmit(deferredCiphers.await())
             forceCollectionsFlow.tryEmit(deferredCollections.await())

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/CollectionsDao.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/CollectionsDao.kt
@@ -31,7 +31,7 @@ interface CollectionsDao {
      * Retrieves all collections from the database for a given [userId].
      */
     @Query("SELECT * FROM collections WHERE user_id = :userId")
-    fun getAllCollections(userId: String): Flow<List<CollectionEntity>>
+    fun getAllCollectionsFlow(userId: String): Flow<List<CollectionEntity>>
 
     /**
      * Deletes all the stored collections associated with the given [userId]. This will return the

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/DomainsDao.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/DomainsDao.kt
@@ -23,7 +23,7 @@ interface DomainsDao {
      * Retrieves domains from the database for a given [userId].
      */
     @Query("SELECT * FROM domains WHERE user_id = :userId")
-    fun getDomains(
+    fun getDomainsFlow(
         userId: String,
     ): Flow<DomainsEntity?>
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FoldersDao.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FoldersDao.kt
@@ -31,7 +31,7 @@ interface FoldersDao {
      * Retrieves all folders from the database for a given [userId].
      */
     @Query("SELECT * FROM folders WHERE user_id = :userId")
-    fun getAllFolders(
+    fun getAllFoldersFlow(
         userId: String,
     ): Flow<List<FolderEntity>>
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/SendsDao.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/SendsDao.kt
@@ -25,7 +25,7 @@ interface SendsDao {
      * Retrieves all sends from the database for a given [userId].
      */
     @Query("SELECT * FROM sends WHERE user_id = :userId")
-    fun getAllSends(
+    fun getAllSendsFlow(
         userId: String,
     ): Flow<List<SendEntity>>
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerImpl.kt
@@ -801,7 +801,7 @@ class CipherManagerImpl(
         if (!shouldUpdate && shouldCheckCollections && organizationId != null) {
             // Check if there are any collections in common
             shouldUpdate = vaultDiskSource
-                .getCollections(userId = userId)
+                .getCollectionsFlow(userId = userId)
                 .first()
                 .any { collectionIds?.contains(it.id) == true }
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/FolderManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/FolderManagerImpl.kt
@@ -156,7 +156,7 @@ class FolderManagerImpl(
         val isUpdate = syncFolderUpsertData.isUpdate
         val revisionDate = syncFolderUpsertData.revisionDate
         val localFolder = vaultDiskSource
-            .getFolders(userId = userId)
+            .getFoldersFlow(userId = userId)
             .first()
             .find { it.id == folderId }
         val isValidCreate = !isUpdate && localFolder == null

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManagerImpl.kt
@@ -273,7 +273,7 @@ class SendManagerImpl(
         val isUpdate = syncSendUpsertData.isUpdate
         val revisionDate = syncSendUpsertData.revisionDate
         val localSend = vaultDiskSource
-            .getSends(userId = userId)
+            .getSendsFlow(userId = userId)
             .first()
             .find { it.id == sendId }
         val isValidCreate = !isUpdate && localSend == null

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerImpl.kt
@@ -427,7 +427,7 @@ class VaultSyncManagerImpl(
         userId: String,
     ): Flow<DataState<DomainsData>> =
         vaultDiskSource
-            .getDomains(userId = userId)
+            .getDomainsFlow(userId = userId)
             .onStart { mutableDomainsStateFlow.updateToPendingOrLoading() }
             .map { DataState.Loaded(data = it.toDomainsData()) }
             .onEach { mutableDomainsStateFlow.value = it }
@@ -436,7 +436,7 @@ class VaultSyncManagerImpl(
         userId: String,
     ): Flow<DataState<List<FolderView>>> =
         vaultDiskSource
-            .getFolders(userId = userId)
+            .getFoldersFlow(userId = userId)
             .onStart { mutableFoldersStateFlow.updateToPendingOrLoading() }
             .map {
                 vaultLockManager.waitUntilUnlocked(userId = userId)
@@ -454,7 +454,7 @@ class VaultSyncManagerImpl(
         userId: String,
     ): Flow<DataState<List<CollectionView>>> =
         vaultDiskSource
-            .getCollections(userId = userId)
+            .getCollectionsFlow(userId = userId)
             .onStart { mutableCollectionsStateFlow.updateToPendingOrLoading() }
             .map {
                 vaultLockManager.waitUntilUnlocked(userId = userId)
@@ -483,7 +483,7 @@ class VaultSyncManagerImpl(
         userId: String,
     ): Flow<DataState<SendData>> =
         vaultDiskSource
-            .getSends(userId = userId)
+            .getSendsFlow(userId = userId)
             .onStart { mutableSendDataStateFlow.updateToPendingOrLoading() }
             .map {
                 vaultLockManager.waitUntilUnlocked(userId = userId)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -444,7 +444,7 @@ class VaultRepositoryImpl(
         val userId = activeUserId
             ?: return ExportVaultDataResult.Error(error = NoActiveUserException())
         val folders = vaultDiskSource
-            .getFolders(userId)
+            .getFoldersFlow(userId)
             .firstOrNull()
             .orEmpty()
             .map { it.toEncryptedSdkFolder() }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -209,12 +209,12 @@ class VaultDiskSourceTest {
     }
 
     @Test
-    fun `getCollections should emit all CollectionsDao updates`() = runTest {
+    fun `getCollectionsFlow should emit all CollectionsDao updates`() = runTest {
         val collectionEntities = listOf(COLLECTION_ENTITY)
         val collection = listOf(COLLECTION_1)
 
         vaultDiskSource
-            .getCollections(USER_ID)
+            .getCollectionsFlow(USER_ID)
             .test {
                 assertEquals(emptyList<SyncResponseJson.Collection>(), awaitItem())
                 collectionsDao.insertCollections(collectionEntities)
@@ -223,9 +223,9 @@ class VaultDiskSourceTest {
     }
 
     @Test
-    fun `getDomains should emit DomainsDao updates`() = runTest {
+    fun `getDomainsFlow should emit DomainsDao updates`() = runTest {
         vaultDiskSource
-            .getDomains(USER_ID)
+            .getDomainsFlow(USER_ID)
             .test {
                 expectNoEvents()
                 domainsDao.insertDomains(DOMAINS_ENTITY)
@@ -257,12 +257,12 @@ class VaultDiskSourceTest {
     }
 
     @Test
-    fun `getFolders should emit all FoldersDao updates`() = runTest {
+    fun `getFoldersFlow should emit all FoldersDao updates`() = runTest {
         val folderEntities = listOf(FOLDER_ENTITY)
         val folders = listOf(FOLDER_1)
 
         vaultDiskSource
-            .getFolders(USER_ID)
+            .getFoldersFlow(USER_ID)
             .test {
                 assertEquals(emptyList<SyncResponseJson.Folder>(), awaitItem())
                 foldersDao.insertFolders(folderEntities)
@@ -300,12 +300,12 @@ class VaultDiskSourceTest {
     }
 
     @Test
-    fun `getSends should emit all SendsDao updates`() = runTest {
+    fun `getSendsFlow should emit all SendsDao updates`() = runTest {
         val sendEntities = listOf(SEND_ENTITY)
         val sends = listOf(SEND_1)
 
         vaultDiskSource
-            .getSends(USER_ID)
+            .getSendsFlow(USER_ID)
             .test {
                 assertEquals(emptyList<SyncResponseJson.Send>(), awaitItem())
                 sendsDao.insertSends(sendEntities)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeCollectionsDao.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeCollectionsDao.kt
@@ -33,7 +33,7 @@ class FakeCollectionsDao : CollectionsDao {
         collectionsFlow.tryEmit(storedCollections.toList())
     }
 
-    override fun getAllCollections(userId: String): Flow<List<CollectionEntity>> =
+    override fun getAllCollectionsFlow(userId: String): Flow<List<CollectionEntity>> =
         collectionsFlow.map { ciphers -> ciphers.filter { it.userId == userId } }
 
     override suspend fun insertCollections(collections: List<CollectionEntity>) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeDomainsDao.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeDomainsDao.kt
@@ -17,7 +17,7 @@ class FakeDomainsDao : DomainsDao {
         deleteDomainsCalled = true
     }
 
-    override fun getDomains(userId: String): Flow<DomainsEntity?> {
+    override fun getDomainsFlow(userId: String): Flow<DomainsEntity?> {
         getDomainsCalled = true
         return mutableDomainsFlow
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeFoldersDao.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeFoldersDao.kt
@@ -33,7 +33,7 @@ class FakeFoldersDao : FoldersDao {
         foldersFlow.tryEmit(storedFolders.toList())
     }
 
-    override fun getAllFolders(userId: String): Flow<List<FolderEntity>> =
+    override fun getAllFoldersFlow(userId: String): Flow<List<FolderEntity>> =
         foldersFlow.map { ciphers -> ciphers.filter { it.userId == userId } }
 
     override suspend fun insertFolders(folders: List<FolderEntity>) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeSendsDao.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeSendsDao.kt
@@ -35,7 +35,7 @@ class FakeSendsDao : SendsDao {
         return count
     }
 
-    override fun getAllSends(userId: String): Flow<List<SendEntity>> =
+    override fun getAllSendsFlow(userId: String): Flow<List<SendEntity>> =
         sendsFlow.map { ciphers -> ciphers.filter { it.userId == userId } }
 
     override suspend fun insertSends(sends: List<SendEntity>) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/CipherManagerTest.kt
@@ -2616,7 +2616,7 @@ class CipherManagerTest {
                 vaultDiskSource.getCipher(userId = userId, cipherId = cipherId)
             } returns originalCipher
             coEvery {
-                vaultDiskSource.getCollections(userId = userId)
+                vaultDiskSource.getCollectionsFlow(userId = userId)
             } returns MutableStateFlow(listOf(collection))
             coEvery {
                 ciphersService.getCipher(cipherId = cipherId)
@@ -2660,7 +2660,7 @@ class CipherManagerTest {
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             coEvery { vaultDiskSource.getCipher(any(), any()) } returns originalCipher
             coEvery {
-                vaultDiskSource.getCollections(userId = userId)
+                vaultDiskSource.getCollectionsFlow(userId = userId)
             } returns MutableStateFlow(listOf(collection))
 
             coEvery { ciphersService.getCipher(cipherId) } returns updatedCipher.asSuccess()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/FolderManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/FolderManagerTest.kt
@@ -431,7 +431,7 @@ class FolderManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         val folder = createMockFolder(number = number)
         coEvery {
-            vaultDiskSource.getFolders(userId = userId)
+            vaultDiskSource.getFoldersFlow(userId = userId)
         } returns MutableStateFlow(listOf(folder))
 
         mutableSyncFolderUpsertFlow.tryEmit(
@@ -457,7 +457,7 @@ class FolderManagerTest {
 
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         coEvery {
-            vaultDiskSource.getFolders(userId = userId)
+            vaultDiskSource.getFoldersFlow(userId = userId)
         } returns MutableStateFlow(emptyList())
 
         mutableSyncFolderUpsertFlow.tryEmit(
@@ -484,7 +484,7 @@ class FolderManagerTest {
         fakeAuthDiskSource.userState = MOCK_USER_STATE
         val folder = createMockFolder(number = number)
         coEvery {
-            vaultDiskSource.getFolders(userId = userId)
+            vaultDiskSource.getFoldersFlow(userId = userId)
         } returns MutableStateFlow(listOf(folder))
 
         mutableSyncFolderUpsertFlow.tryEmit(
@@ -512,7 +512,7 @@ class FolderManagerTest {
 
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             coEvery {
-                vaultDiskSource.getFolders(userId = userId)
+                vaultDiskSource.getFoldersFlow(userId = userId)
             } returns MutableStateFlow(emptyList())
             val folder = mockk<SyncResponseJson.Folder>()
             coEvery { folderService.getFolder(folderId = folderId) } returns folder.asSuccess()
@@ -547,7 +547,7 @@ class FolderManagerTest {
                 revisionDate = FIXED_CLOCK.instant().minus(5, ChronoUnit.MINUTES),
             )
             coEvery {
-                vaultDiskSource.getFolders(userId = userId)
+                vaultDiskSource.getFoldersFlow(userId = userId)
             } returns MutableStateFlow(listOf(folderView))
             val folder = mockk<SyncResponseJson.Folder>()
             coEvery { folderService.getFolder(folderId = folderId) } returns folder.asSuccess()
@@ -582,7 +582,7 @@ class FolderManagerTest {
             revisionDate = FIXED_CLOCK.instant().minus(5, ChronoUnit.MINUTES),
         )
         coEvery {
-            vaultDiskSource.getFolders(userId = userId)
+            vaultDiskSource.getFoldersFlow(userId = userId)
         } returns MutableStateFlow(listOf(folderView))
 
         mutableSyncFolderUpsertFlow.tryEmit(
@@ -596,7 +596,7 @@ class FolderManagerTest {
 
         fakeSettingsDiskSource.assertLastSyncTime(userId = userId, expected = null)
         coVerify(exactly = 1) {
-            vaultDiskSource.getFolders(userId = userId)
+            vaultDiskSource.getFoldersFlow(userId = userId)
         }
         coVerify(exactly = 0) {
             folderService.getFolder(folderId = folderId)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManagerTest.kt
@@ -7,6 +7,7 @@ import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.data.manager.file.FileManager
+import com.bitwarden.network.exception.CookieRedirectException
 import com.bitwarden.network.model.CreateFileSendResponse
 import com.bitwarden.network.model.CreateSendJsonResponse
 import com.bitwarden.network.model.SendTypeJson
@@ -15,7 +16,6 @@ import com.bitwarden.network.model.UpdateSendResponseJson
 import com.bitwarden.network.model.createMockFileSendResponseJson
 import com.bitwarden.network.model.createMockSend
 import com.bitwarden.network.model.createMockSendJsonRequest
-import com.bitwarden.network.exception.CookieRedirectException
 import com.bitwarden.network.service.SendsService
 import com.bitwarden.send.SendType
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
@@ -129,7 +129,9 @@ class SendManagerTest {
         val send = createMockSend(number = 1, id = sendId)
 
         fakeAuthDiskSource.userState = MOCK_USER_STATE
-        coEvery { vaultDiskSource.getSends(userId = userId) } returns MutableStateFlow(listOf(send))
+        coEvery {
+            vaultDiskSource.getSendsFlow(userId = userId)
+        } returns MutableStateFlow(listOf(send))
 
         mutableSyncSendUpsertFlow.tryEmit(
             SyncSendUpsertData(
@@ -153,7 +155,9 @@ class SendManagerTest {
         val sendId = "mockId-$number"
 
         fakeAuthDiskSource.userState = MOCK_USER_STATE
-        coEvery { vaultDiskSource.getSends(userId = userId) } returns MutableStateFlow(emptyList())
+        coEvery {
+            vaultDiskSource.getSendsFlow(userId = userId)
+        } returns MutableStateFlow(emptyList())
 
         mutableSyncSendUpsertFlow.tryEmit(
             SyncSendUpsertData(
@@ -182,7 +186,9 @@ class SendManagerTest {
             revisionDate = FIXED_CLOCK.instant(),
         )
         val updatedSend = createMockSend(number = number)
-        coEvery { vaultDiskSource.getSends(userId = userId) } returns MutableStateFlow(listOf(send))
+        coEvery {
+            vaultDiskSource.getSendsFlow(userId = userId)
+        } returns MutableStateFlow(listOf(send))
         coEvery { sendsService.getSend(sendId = sendId) } returns updatedSend.asSuccess()
         coEvery { vaultDiskSource.saveSend(userId = userId, send = updatedSend) } just runs
 
@@ -223,7 +229,7 @@ class SendManagerTest {
                 revisionDate = FIXED_CLOCK.instant().minus(5, ChronoUnit.MINUTES),
             )
             coEvery {
-                vaultDiskSource.getSends(userId = userId)
+                vaultDiskSource.getSendsFlow(userId = userId)
             } returns MutableStateFlow(listOf(sendView))
 
             mutableSyncSendUpsertFlow.tryEmit(
@@ -254,7 +260,7 @@ class SendManagerTest {
             }
             coEvery { sendsService.getSend(sendId = sendId) } returns response.asFailure()
             coEvery {
-                vaultDiskSource.getSends(userId = userId)
+                vaultDiskSource.getSendsFlow(userId = userId)
             } returns MutableStateFlow(emptyList())
 
             mutableSyncSendUpsertFlow.tryEmit(
@@ -284,7 +290,7 @@ class SendManagerTest {
 
             fakeAuthDiskSource.userState = MOCK_USER_STATE
             coEvery {
-                vaultDiskSource.getSends(userId = userId)
+                vaultDiskSource.getSendsFlow(userId = userId)
             } returns MutableStateFlow(emptyList())
             val send = mockk<SyncResponseJson.Send>()
             coEvery { sendsService.getSend(sendId = sendId) } returns send.asSuccess()
@@ -319,7 +325,7 @@ class SendManagerTest {
                 revisionDate = FIXED_CLOCK.instant().minus(5, ChronoUnit.MINUTES),
             )
             coEvery {
-                vaultDiskSource.getSends(userId = userId)
+                vaultDiskSource.getSendsFlow(userId = userId)
             } returns MutableStateFlow(listOf(sendView))
 
             val send = mockk<SyncResponseJson.Send>()
@@ -355,7 +361,7 @@ class SendManagerTest {
             revisionDate = FIXED_CLOCK.instant().minus(5, ChronoUnit.MINUTES),
         )
         coEvery {
-            vaultDiskSource.getSends(userId = userId)
+            vaultDiskSource.getSendsFlow(userId = userId)
         } returns MutableStateFlow(listOf(sendView))
 
         mutableSyncSendUpsertFlow.tryEmit(
@@ -369,7 +375,7 @@ class SendManagerTest {
 
         fakeSettingsDiskSource.assertLastSyncTime(userId = userId, expected = null)
         coVerify(exactly = 1) {
-            vaultDiskSource.getSends(userId = userId)
+            vaultDiskSource.getSendsFlow(userId = userId)
         }
         coVerify(exactly = 0) {
             sendsService.getSend(sendId = sendId)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultSyncManagerTest.kt
@@ -1275,10 +1275,10 @@ class VaultSyncManagerTest {
         sendsFlow: Flow<List<SyncResponseJson.Send>> = bufferedMutableSharedFlow(),
     ) {
         coEvery { vaultDiskSource.getCiphersFlow(userId = userId) } returns ciphersFlow
-        coEvery { vaultDiskSource.getCollections(userId = userId) } returns collectionsFlow
-        coEvery { vaultDiskSource.getDomains(userId = userId) } returns domainsFlow
-        coEvery { vaultDiskSource.getFolders(userId = userId) } returns foldersFlow
-        coEvery { vaultDiskSource.getSends(userId = userId) } returns sendsFlow
+        coEvery { vaultDiskSource.getCollectionsFlow(userId = userId) } returns collectionsFlow
+        coEvery { vaultDiskSource.getDomainsFlow(userId = userId) } returns domainsFlow
+        coEvery { vaultDiskSource.getFoldersFlow(userId = userId) } returns foldersFlow
+        coEvery { vaultDiskSource.getSendsFlow(userId = userId) } returns sendsFlow
     }
 
     private fun setupEmptyDecryptionResults(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryTest.kt
@@ -1128,7 +1128,7 @@ class VaultRepositoryTest {
             } returns flowOf(listOf(userCipher, deletedCipher, orgCipher))
 
             coEvery {
-                vaultDiskSource.getFolders(userId)
+                vaultDiskSource.getFoldersFlow(userId)
             } returns flowOf(listOf(createMockFolder(1)))
 
             coEvery {
@@ -1181,7 +1181,7 @@ class VaultRepositoryTest {
             } returns flowOf(listOf(userCipher, userCipherCard, deletedCipher, orgCipher))
 
             coEvery {
-                vaultDiskSource.getFolders(userId)
+                vaultDiskSource.getFoldersFlow(userId)
             } returns flowOf(listOf(createMockFolder(1)))
 
             coEvery {
@@ -1221,7 +1221,7 @@ class VaultRepositoryTest {
             } returns flowOf(listOf(createMockCipher(1)))
 
             coEvery {
-                vaultDiskSource.getFolders(userId)
+                vaultDiskSource.getFoldersFlow(userId)
             } returns flowOf(listOf(createMockFolder(1)))
             val error = Throwable("Fail")
             coEvery {


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the function names that return a flow in the `VaultDiskSource` to include the word `Flow`. This will be useful as we add new functions that retrieve similar data as a suspending call instead of a Flow.
