### PR TITLE
[PM-33512] feat: Add PremiumStateManager for upgrade banner eligibility

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/di/BillingModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/di/BillingModule.kt
@@ -3,15 +3,23 @@ package com.x8bit.bitwarden.data.billing.di
 import android.content.Context
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.network.service.BillingService
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManager
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManagerImpl
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManagerImpl
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.BillingRepositoryImpl
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import java.time.Clock
 import javax.inject.Singleton
 
 /**
@@ -39,5 +47,27 @@ object BillingModule {
     ): BillingRepository = BillingRepositoryImpl(
         playBillingManager = playBillingManager,
         billingService = billingService,
+    )
+
+    @Provides
+    @Singleton
+    fun providePremiumStateManager(
+        authDiskSource: AuthDiskSource,
+        authRepository: AuthRepository,
+        billingRepository: BillingRepository,
+        settingsDiskSource: SettingsDiskSource,
+        vaultRepository: VaultRepository,
+        featureFlagManager: FeatureFlagManager,
+        clock: Clock,
+        dispatcherManager: DispatcherManager,
+    ): PremiumStateManager = PremiumStateManagerImpl(
+        authDiskSource = authDiskSource,
+        authRepository = authRepository,
+        billingRepository = billingRepository,
+        settingsDiskSource = settingsDiskSource,
+        vaultRepository = vaultRepository,
+        featureFlagManager = featureFlagManager,
+        clock = clock,
+        dispatcherManager = dispatcherManager,
     )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -1,0 +1,23 @@
+package com.x8bit.bitwarden.data.billing.manager
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Manages the consolidated eligibility state for the premium upgrade banner.
+ *
+ * Combines multiple upstream signals (premium status, billing support, feature flag,
+ * banner dismissal, account age, and vault item count) into a single observable flow.
+ */
+interface PremiumStateManager {
+
+    /**
+     * Emits `true` when the current user is eligible to see the premium upgrade banner,
+     * or `false` otherwise.
+     */
+    val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean>
+
+    /**
+     * Marks the premium upgrade banner as dismissed for the current user.
+     */
+    fun dismissPremiumUpgradeBanner()
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -1,0 +1,123 @@
+package com.x8bit.bitwarden.data.billing.manager
+
+import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
+import com.bitwarden.core.data.manager.model.FlagKey
+import com.bitwarden.core.data.repository.model.DataState
+import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
+import com.x8bit.bitwarden.data.billing.repository.BillingRepository
+import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.data.vault.repository.model.VaultData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Default implementation of [PremiumStateManager].
+ *
+ * Combines five upstream flows into a single eligibility signal using [combine].
+ */
+@Suppress("LongParameterList")
+class PremiumStateManagerImpl(
+    private val authDiskSource: AuthDiskSource,
+    authRepository: AuthRepository,
+    billingRepository: BillingRepository,
+    private val settingsDiskSource: SettingsDiskSource,
+    vaultRepository: VaultRepository,
+    featureFlagManager: FeatureFlagManager,
+    private val clock: Clock,
+    dispatcherManager: DispatcherManager,
+) : PremiumStateManager {
+
+    private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean> =
+        combine(
+            authRepository.userStateFlow,
+            billingRepository.isInAppBillingSupportedFlow,
+            featureFlagManager.getFeatureFlagFlow(FlagKey.MobilePremiumUpgrade),
+            authDiskSource.activeUserIdChangesFlow
+                .flatMapLatest { userId ->
+                    userId
+                        ?.let { id ->
+                            settingsDiskSource
+                                .getPremiumUpgradeBannerDismissedFlow(id)
+                                .map { it ?: false }
+                        }
+                        ?: flowOf(false)
+                },
+            vaultRepository.vaultDataStateFlow,
+        ) { userState,
+            isInAppBillingSupported,
+            featureFlagEnabled,
+            isDismissed,
+            vaultDataState,
+            ->
+            val activeAccount = userState?.activeAccount
+                ?: return@combine false
+            val isPremium = activeAccount.isPremium
+            val isAccountOldEnough = activeAccount.creationDate.isOlderThanDays(
+                days = PREMIUM_UPGRADE_MINIMUM_ACCOUNT_AGE_DAYS,
+                clock = clock,
+            )
+            val itemCount = vaultDataState.activeVaultItemCount()
+
+            !isPremium &&
+                isInAppBillingSupported &&
+                featureFlagEnabled &&
+                !isDismissed &&
+                isAccountOldEnough &&
+                itemCount >= PREMIUM_UPGRADE_MINIMUM_VAULT_ITEMS
+        }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = false,
+            )
+
+    override fun dismissPremiumUpgradeBanner() {
+        val activeUserId = authDiskSource.userState?.activeUserId ?: return
+        settingsDiskSource.storePremiumUpgradeBannerDismissed(
+            userId = activeUserId,
+            isDismissed = true,
+        )
+    }
+}
+
+/**
+ * Returns `true` if this [Instant] is older than the given number of [days] based on
+ * the provided [clock]. Returns `false` if the receiver is `null`.
+ */
+private fun Instant?.isOlderThanDays(days: Long, clock: Clock): Boolean {
+    this ?: return false
+    val now = clock.instant()
+    val ageInDays = Duration.between(this, now).toDays()
+    return ageInDays >= days
+}
+
+/**
+ * Extracts the count of active (non-deleted, non-archived) vault items from the
+ * current [DataState].
+ */
+private fun DataState<VaultData>.activeVaultItemCount(): Int =
+    data
+        ?.decryptCipherListResult
+        ?.successes
+        ?.count { it.deletedDate == null && it.archivedDate == null }
+        ?: 0
+
+private const val PREMIUM_UPGRADE_MINIMUM_VAULT_ITEMS: Int = 5
+private const val PREMIUM_UPGRADE_MINIMUM_ACCOUNT_AGE_DAYS: Long = 7L

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
@@ -1,0 +1,403 @@
+package com.x8bit.bitwarden.data.billing.manager
+
+import app.cash.turbine.test
+import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
+import com.bitwarden.core.data.manager.model.FlagKey
+import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.vault.DecryptCipherListResult
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
+import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
+import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.billing.repository.BillingRepository
+import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
+import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
+import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import com.x8bit.bitwarden.data.vault.repository.model.VaultData
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+@Suppress("LargeClass")
+class PremiumStateManagerImplTest {
+
+    private val fixedClock: Clock = Clock.fixed(
+        Instant.parse(FIXED_DATETIME),
+        ZoneOffset.UTC,
+    )
+
+    private val fakeAuthDiskSource = FakeAuthDiskSource().apply {
+        userState = DISK_USER_STATE
+    }
+
+    private val mutableUserStateFlow = MutableStateFlow<UserState?>(DEFAULT_USER_STATE)
+    private val authRepository: AuthRepository = mockk {
+        every { userStateFlow } returns mutableUserStateFlow
+    }
+
+    private val mutableIsInAppBillingSupportedFlow = MutableStateFlow(true)
+    private val billingRepository: BillingRepository = mockk {
+        every { isInAppBillingSupportedFlow } returns mutableIsInAppBillingSupportedFlow
+    }
+
+    private val fakeSettingsDiskSource = FakeSettingsDiskSource()
+
+    private val mutableVaultDataStateFlow =
+        MutableStateFlow<DataState<VaultData>>(
+            DataState.Loaded(createVaultDataWithItemCount(count = 5)),
+        )
+    private val vaultRepository: VaultRepository = mockk {
+        every { vaultDataStateFlow } returns mutableVaultDataStateFlow
+    }
+
+    private val mutableMobilePremiumUpgradeFlagFlow = MutableStateFlow(true)
+    private val featureFlagManager: FeatureFlagManager = mockk {
+        every {
+            getFeatureFlagFlow(FlagKey.MobilePremiumUpgrade)
+        } returns mutableMobilePremiumUpgradeFlagFlow
+    }
+
+    private val dispatcherManager = FakeDispatcherManager()
+
+    private fun createManager(): PremiumStateManagerImpl = PremiumStateManagerImpl(
+        authDiskSource = fakeAuthDiskSource,
+        authRepository = authRepository,
+        billingRepository = billingRepository,
+        settingsDiskSource = fakeSettingsDiskSource,
+        vaultRepository = vaultRepository,
+        featureFlagManager = featureFlagManager,
+        clock = fixedClock,
+        dispatcherManager = dispatcherManager,
+    )
+
+    @Test
+    fun `eligible when all conditions met should emit true`() = runTest {
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `ineligible when user is premium should emit false`() = runTest {
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `ineligible when in-app billing is not supported should emit false`() =
+        runTest {
+            mutableIsInAppBillingSupportedFlow.value = false
+            val manager = createManager()
+            manager.isPremiumUpgradeBannerEligibleFlow.test {
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `ineligible when feature flag is disabled should emit false`() = runTest {
+        mutableMobilePremiumUpgradeFlagFlow.value = false
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `ineligible when banner is dismissed should emit false`() = runTest {
+        fakeSettingsDiskSource.storePremiumUpgradeBannerDismissed(
+            userId = ACTIVE_USER_ID,
+            isDismissed = true,
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `ineligible when account is too new should emit false`() = runTest {
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(
+                DEFAULT_ACTIVE_ACCOUNT.copy(
+                    creationDate = Instant.parse("2023-10-25T12:00:00Z"),
+                ),
+            ),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `ineligible when creation date is null should emit false`() = runTest {
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(
+                DEFAULT_ACTIVE_ACCOUNT.copy(creationDate = null),
+            ),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `ineligible when vault has fewer than 5 items should emit false`() = runTest {
+        mutableVaultDataStateFlow.value = DataState.Loaded(
+            createVaultDataWithItemCount(count = 4),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `ineligible when userState is null should emit false`() = runTest {
+        mutableUserStateFlow.value = null
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `vault data Loading should emit false`() = runTest {
+        mutableVaultDataStateFlow.value = DataState.Loading
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `vault data Pending with enough items should emit true`() = runTest {
+        mutableVaultDataStateFlow.value = DataState.Pending(
+            createVaultDataWithItemCount(count = 5),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `vault data NoNetwork with enough items should emit true`() = runTest {
+        mutableVaultDataStateFlow.value = DataState.NoNetwork(
+            createVaultDataWithItemCount(count = 5),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `vault data Error with enough items should emit true`() = runTest {
+        mutableVaultDataStateFlow.value = DataState.Error(
+            error = IllegalStateException("test"),
+            data = createVaultDataWithItemCount(count = 5),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `vault data NoNetwork without data should emit false`() = runTest {
+        mutableVaultDataStateFlow.value = DataState.NoNetwork(data = null)
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `vault data Error without data should emit false`() = runTest {
+        mutableVaultDataStateFlow.value = DataState.Error(
+            error = IllegalStateException("test"),
+            data = null,
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `deleted items should not be counted toward vault item threshold`() =
+        runTest {
+            val ciphers = (1..4).map {
+                createMockCipherListView(number = it)
+            } + createMockCipherListView(number = 5, isDeleted = true)
+            mutableVaultDataStateFlow.value = DataState.Loaded(
+                VaultData(
+                    decryptCipherListResult = DecryptCipherListResult(
+                        successes = ciphers,
+                        failures = emptyList(),
+                    ),
+                    collectionViewList = emptyList(),
+                    folderViewList = emptyList(),
+                    sendViewList = emptyList(),
+                ),
+            )
+            val manager = createManager()
+            manager.isPremiumUpgradeBannerEligibleFlow.test {
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `archived items should not be counted toward vault item threshold`() =
+        runTest {
+            val ciphers = (1..4).map {
+                createMockCipherListView(number = it)
+            } + createMockCipherListView(number = 5, isArchived = true)
+            mutableVaultDataStateFlow.value = DataState.Loaded(
+                VaultData(
+                    decryptCipherListResult = DecryptCipherListResult(
+                        successes = ciphers,
+                        failures = emptyList(),
+                    ),
+                    collectionViewList = emptyList(),
+                    folderViewList = emptyList(),
+                    sendViewList = emptyList(),
+                ),
+            )
+            val manager = createManager()
+            manager.isPremiumUpgradeBannerEligibleFlow.test {
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `eligible when account age is exactly 7 days should emit true`() =
+        runTest {
+            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                accounts = listOf(
+                    DEFAULT_ACTIVE_ACCOUNT.copy(
+                        creationDate = Instant.parse("2023-10-20T12:00:00Z"),
+                    ),
+                ),
+            )
+            val manager = createManager()
+            manager.isPremiumUpgradeBannerEligibleFlow.test {
+                assertTrue(awaitItem())
+            }
+        }
+
+    @Test
+    fun `eligible when vault items exactly 5 should emit true`() = runTest {
+        mutableVaultDataStateFlow.value = DataState.Loaded(
+            createVaultDataWithItemCount(count = 5),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `eligibility should update when upstream flows change`() = runTest {
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertTrue(awaitItem())
+
+            mutableIsInAppBillingSupportedFlow.value = false
+            assertFalse(awaitItem())
+
+            mutableIsInAppBillingSupportedFlow.value = true
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun `dismissPremiumUpgradeBanner should store dismissed state for active user`() {
+        val manager = createManager()
+        manager.dismissPremiumUpgradeBanner()
+        fakeSettingsDiskSource.assertPremiumUpgradeBannerDismissed(
+            userId = ACTIVE_USER_ID,
+            expected = true,
+        )
+    }
+
+    @Test
+    fun `dismissPremiumUpgradeBanner should do nothing when no active user`() {
+        fakeAuthDiskSource.userState = null
+        val manager = createManager()
+        manager.dismissPremiumUpgradeBanner()
+        fakeSettingsDiskSource.assertPremiumUpgradeBannerDismissed(
+            userId = ACTIVE_USER_ID,
+            expected = null,
+        )
+    }
+}
+
+/**
+ * Creates [VaultData] with the given number of non-deleted cipher items.
+ */
+private fun createVaultDataWithItemCount(count: Int): VaultData = VaultData(
+    decryptCipherListResult = DecryptCipherListResult(
+        successes = (1..count).map { createMockCipherListView(number = it) },
+        failures = emptyList(),
+    ),
+    collectionViewList = emptyList(),
+    folderViewList = emptyList(),
+    sendViewList = emptyList(),
+)
+
+private const val ACTIVE_USER_ID = "activeUserId"
+private const val FIXED_DATETIME = "2023-10-27T12:00:00Z"
+
+private val DEFAULT_ACTIVE_ACCOUNT = UserState.Account(
+    userId = ACTIVE_USER_ID,
+    name = "Active User",
+    email = "active@bitwarden.com",
+    avatarColorHex = "#aa00aa",
+    environment = com.bitwarden.data.repository.model.Environment.Us,
+    isPremium = false,
+    isLoggedIn = true,
+    isVaultUnlocked = true,
+    needsPasswordReset = false,
+    isBiometricsEnabled = false,
+    organizations = emptyList(),
+    needsMasterPassword = false,
+    trustedDevice = null,
+    hasMasterPassword = true,
+    isUsingKeyConnector = false,
+    onboardingStatus = OnboardingStatus.COMPLETE,
+    firstTimeState = FirstTimeState(),
+    isExportable = true,
+    creationDate = Instant.parse("2023-10-01T12:00:00Z"),
+)
+
+private val DEFAULT_USER_STATE = UserState(
+    activeUserId = ACTIVE_USER_ID,
+    accounts = listOf(DEFAULT_ACTIVE_ACCOUNT),
+)
+
+private val DISK_USER_STATE = UserStateJson(
+    activeUserId = ACTIVE_USER_ID,
+    accounts = mapOf(
+        ACTIVE_USER_ID to mockk<AccountJson>(),
+    ),
+)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33512

## 📔 Objective

Add `PremiumStateManager` that consolidates all premium upgrade banner eligibility logic into a single `StateFlow<Boolean>`. This centralizes the eligibility decision so downstream consumers (e.g., `VaultViewModel`, Settings) observe one signal instead of combining multiple flows themselves.

**Eligibility formula** (all must be true):
- User is not premium
- In-app billing is supported (Play Billing or F-Droid)
- `MobilePremiumUpgrade` feature flag is enabled
- Banner has not been dismissed
- Account is at least 7 days old
- Vault contains at least 5 non-deleted items

**Changes:**
- `PremiumStateManager` interface with `isPremiumUpgradeBannerEligibleFlow` and `dismissPremiumUpgradeBanner()`
- `PremiumStateManagerImpl` combining 5 upstream flows via `combine` with `Clock` injection for account age calculation
- `BillingModule` wiring with `@Provides @Singleton`
- 18 unit tests covering all eligibility conditions, boundary values, `DataState` variants, and reactive updates