### PR TITLE
chore: Implement Folder Repo interface for Bitwarden SDK

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/SdkRepositoryFactoryImpl.kt
@@ -23,7 +23,7 @@ class SdkRepositoryFactoryImpl(
 ) : SdkRepositoryFactory {
     override fun getRepositories(userId: String?): Repositories =
         Repositories(
-            cipher = getSdkRepository(userId = userId),
+            cipher = getSdkCipherRepository(userId = userId),
             folder = null,
             userKeyState = null,
             localUserDataKeyState = SdkLocalUserDataKeyStateRepository(
@@ -46,7 +46,7 @@ class SdkRepositoryFactoryImpl(
             configDiskSource = configDiskSource,
         )
 
-    private fun getSdkRepository(
+    private fun getSdkCipherRepository(
         userId: String?,
     ): SdkCipherRepository? = userId?.let {
         SdkCipherRepository(userId = it, vaultDiskSource = vaultDiskSource)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkFolderRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkFolderRepository.kt
@@ -1,0 +1,68 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk.repository
+
+import com.bitwarden.sdk.FolderRepository
+import com.bitwarden.vault.Folder
+import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedNetworkFolderResponse
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkFolder
+import timber.log.Timber
+
+/**
+ * A user-scoped implementation of a Bitwarden SDK [FolderRepository].
+ */
+class SdkFolderRepository(
+    private val userId: String,
+    private val vaultDiskSource: VaultDiskSource,
+) : FolderRepository {
+    override suspend fun get(id: String): Folder? =
+        vaultDiskSource
+            .getFolder(userId = userId, folderId = id)
+            ?.toEncryptedSdkFolder()
+
+    override suspend fun list(): List<Folder> =
+        vaultDiskSource
+            .getFolders(userId = userId)
+            .map { it.toEncryptedSdkFolder() }
+
+    override suspend fun set(id: String, value: Folder) {
+        if (id != value.id) {
+            Timber.e("SDK Folder 'set' operation: ID's do not match")
+            return
+        }
+        vaultDiskSource.saveFolder(
+            userId = userId,
+            folder = value.toEncryptedNetworkFolderResponse(),
+        )
+    }
+
+    override suspend fun setBulk(values: Map<String, Folder>) {
+        val validEntries = values.filter { (id, cipher) ->
+            if (id != cipher.id) {
+                Timber.e("SDK Folder 'setBulk' operation: ID's do not match for '$id'")
+                false
+            } else {
+                true
+            }
+        }
+        if (validEntries.isEmpty()) return
+        vaultDiskSource.saveFolders(
+            userId = userId,
+            folders = validEntries.values.map { it.toEncryptedNetworkFolderResponse() },
+        )
+    }
+
+    override suspend fun remove(id: String) {
+        vaultDiskSource.deleteFolder(userId = userId, folderId = id)
+    }
+
+    override suspend fun removeBulk(keys: List<String>) {
+        if (keys.isEmpty()) return
+        vaultDiskSource.deleteSelectedFolders(userId = userId, folderIds = keys)
+    }
+
+    override suspend fun removeAll() {
+        vaultDiskSource.deleteAllFolders(userId = userId)
+    }
+
+    override suspend fun has(id: String): Boolean = this.get(id = id) != null
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSource.kt
@@ -93,9 +93,34 @@ interface VaultDiskSource {
     suspend fun deleteFolder(userId: String, folderId: String)
 
     /**
+     * Deletes folders with the given [folderIds] from the data source for the given [userId].
+     */
+    suspend fun deleteSelectedFolders(userId: String, folderIds: List<String>)
+
+    /**
+     * Deletes all folders from the data source for the given [userId].
+     */
+    suspend fun deleteAllFolders(userId: String)
+
+    /**
      * Saves a folder to the data source for the given [userId].
      */
     suspend fun saveFolder(userId: String, folder: SyncResponseJson.Folder)
+
+    /**
+     * Saves multiple folders to the data source for the given [userId].
+     */
+    suspend fun saveFolders(userId: String, folders: List<SyncResponseJson.Folder>)
+
+    /**
+     * Retrieves a folder from the data source for a given [userId] and [folderId].
+     */
+    suspend fun getFolder(userId: String, folderId: String): SyncResponseJson.Folder?
+
+    /**
+     * Retrieves all folders from the data source for a given [userId].
+     */
+    suspend fun getFolders(userId: String): List<SyncResponseJson.Folder>
 
     /**
      * Retrieves all folders from the data source for a given [userId].

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceImpl.kt
@@ -241,6 +241,14 @@ class VaultDiskSourceImpl(
         foldersDao.deleteFolder(userId = userId, folderId = folderId)
     }
 
+    override suspend fun deleteSelectedFolders(userId: String, folderIds: List<String>) {
+        foldersDao.deleteSelectedFolders(userId = userId, folderIds = folderIds)
+    }
+
+    override suspend fun deleteAllFolders(userId: String) {
+        foldersDao.deleteAllFolders(userId = userId)
+    }
+
     override suspend fun saveFolder(userId: String, folder: SyncResponseJson.Folder) {
         foldersDao.insertFolder(
             folder = FolderEntity(
@@ -251,6 +259,44 @@ class VaultDiskSourceImpl(
             ),
         )
     }
+
+    override suspend fun saveFolders(userId: String, folders: List<SyncResponseJson.Folder>) {
+        foldersDao.insertFolders(
+            folders = folders.map { folder ->
+                FolderEntity(
+                    id = folder.id,
+                    userId = userId,
+                    name = folder.name,
+                    revisionDate = folder.revisionDate,
+                )
+            },
+        )
+    }
+
+    override suspend fun getFolder(
+        userId: String,
+        folderId: String,
+    ): SyncResponseJson.Folder? =
+        foldersDao
+            .getFolder(userId = userId, folderId = folderId)
+            ?.let { folder ->
+                SyncResponseJson.Folder(
+                    id = folder.id,
+                    name = folder.name,
+                    revisionDate = folder.revisionDate,
+                )
+            }
+
+    override suspend fun getFolders(userId: String): List<SyncResponseJson.Folder> =
+        foldersDao
+            .getAllFolders(userId = userId)
+            .map { folder ->
+                SyncResponseJson.Folder(
+                    id = folder.id,
+                    name = folder.name,
+                    revisionDate = folder.revisionDate,
+                )
+            }
 
     override fun getFoldersFlow(
         userId: String,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FoldersDao.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FoldersDao.kt
@@ -36,6 +36,30 @@ interface FoldersDao {
     ): Flow<List<FolderEntity>>
 
     /**
+     * Retrieves all folders from the database for a given [userId].
+     */
+    @Query("SELECT * FROM folders WHERE user_id = :userId")
+    fun getAllFolders(
+        userId: String,
+    ): List<FolderEntity>
+
+    /**
+     * Retrieves a folder from the database for a given [userId] and [folderId].
+     */
+    @Query("SELECT * FROM folders WHERE user_id = :userId AND id = :folderId LIMIT 1")
+    suspend fun getFolder(
+        userId: String,
+        folderId: String,
+    ): FolderEntity?
+
+    /**
+     * Deletes the stored folders associated with the given [userId] whose IDs are in [folderIds].
+     * This will return the number of rows deleted by this query.
+     */
+    @Query("DELETE FROM folders WHERE user_id = :userId AND id IN (:folderIds)")
+    suspend fun deleteSelectedFolders(userId: String, folderIds: List<String>): Int
+
+    /**
      * Deletes all the stored folders associated with the given [userId]. This will return the
      * number of rows deleted by this query.
      */

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkFolderExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkFolderExtensions.kt
@@ -25,6 +25,16 @@ fun SyncResponseJson.Folder.toEncryptedSdkFolder(): Folder =
     )
 
 /**
+ * Converts a Bitwarden SDK [Folder] object to a corresponding [SyncResponseJson.Folder] object.
+ */
+fun Folder.toEncryptedNetworkFolderResponse(): SyncResponseJson.Folder =
+    SyncResponseJson.Folder(
+        id = id.orEmpty(),
+        name = name,
+        revisionDate = revisionDate,
+    )
+
+/**
  * Converts a Bitwarden SDK [Folder] objects to a corresponding
  * [SyncResponseJson.Folder] object.
  */

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkFolderRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/platform/manager/sdk/repository/SdkFolderRepositoryTest.kt
@@ -1,0 +1,270 @@
+package com.x8bit.bitwarden.data.platform.manager.sdk.repository
+
+import com.bitwarden.network.model.SyncResponseJson
+import com.bitwarden.sdk.FolderRepository
+import com.bitwarden.vault.Folder
+import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedNetworkFolderResponse
+import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkFolder
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SdkFolderRepositoryTest {
+
+    private val vaultDiskSource: VaultDiskSource = mockk()
+
+    private val sdkFolderRepository: FolderRepository = SdkFolderRepository(
+        userId = USER_ID,
+        vaultDiskSource = vaultDiskSource,
+    )
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(
+            SyncResponseJson.Folder::toEncryptedSdkFolder,
+            Folder::toEncryptedNetworkFolderResponse,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(
+            SyncResponseJson.Folder::toEncryptedSdkFolder,
+            Folder::toEncryptedNetworkFolderResponse,
+        )
+    }
+
+    @Test
+    fun `get should return null when not present`() = runTest {
+        val folderId = "folderId"
+        coEvery {
+            vaultDiskSource.getFolder(userId = USER_ID, folderId = folderId)
+        } returns null
+
+        val result = sdkFolderRepository.get(id = folderId)
+
+        assertNull(result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getFolder(userId = USER_ID, folderId = folderId)
+        }
+    }
+
+    @Test
+    fun `get should return an encrypted sdk folder when present`() = runTest {
+        val folderId = "folderId"
+        val expected = mockk<Folder>()
+        val responseFolder = mockk<SyncResponseJson.Folder> {
+            every { toEncryptedSdkFolder() } returns expected
+        }
+        coEvery {
+            vaultDiskSource.getFolder(userId = USER_ID, folderId = folderId)
+        } returns responseFolder
+
+        val result = sdkFolderRepository.get(id = folderId)
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getFolder(userId = USER_ID, folderId = folderId)
+        }
+    }
+
+    @Test
+    fun `has should return false when not present`() = runTest {
+        val folderId = "folderId"
+        coEvery {
+            vaultDiskSource.getFolder(userId = USER_ID, folderId = folderId)
+        } returns null
+
+        val result = sdkFolderRepository.has(id = folderId)
+
+        assertFalse(result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getFolder(userId = USER_ID, folderId = folderId)
+        }
+    }
+
+    @Test
+    fun `has should return true when present`() = runTest {
+        val folderId = "folderId"
+        val responseFolder = mockk<SyncResponseJson.Folder> {
+            every { toEncryptedSdkFolder() } returns mockk<Folder>()
+        }
+        coEvery {
+            vaultDiskSource.getFolder(userId = USER_ID, folderId = folderId)
+        } returns responseFolder
+
+        val result = sdkFolderRepository.has(id = folderId)
+
+        assertTrue(result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getFolder(userId = USER_ID, folderId = folderId)
+        }
+    }
+
+    @Test
+    fun `list should return empty list when nothing present`() = runTest {
+        coEvery { vaultDiskSource.getFolders(userId = USER_ID) } returns emptyList()
+
+        val result = sdkFolderRepository.list()
+
+        assertEquals(emptyList<Folder>(), result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getFolders(userId = USER_ID)
+        }
+    }
+
+    @Test
+    fun `list should return encrypted sdk folder list when present`() = runTest {
+        val expectedFolder = mockk<Folder>()
+        val expected = listOf(expectedFolder)
+        val responseFolder = mockk<SyncResponseJson.Folder> {
+            every { toEncryptedSdkFolder() } returns expectedFolder
+        }
+        coEvery { vaultDiskSource.getFolders(userId = USER_ID) } returns listOf(responseFolder)
+
+        val result = sdkFolderRepository.list()
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) {
+            vaultDiskSource.getFolders(userId = USER_ID)
+        }
+    }
+
+    @Test
+    fun `remove should call deleteFolder on the vaultDiskSource`() = runTest {
+        val folderId = "folderId"
+        coEvery {
+            vaultDiskSource.deleteFolder(userId = USER_ID, folderId = folderId)
+        } just runs
+
+        sdkFolderRepository.remove(id = folderId)
+
+        coVerify(exactly = 1) {
+            vaultDiskSource.deleteFolder(userId = USER_ID, folderId = folderId)
+        }
+    }
+
+    @Test
+    fun `set should do nothing if the ids don't match`() = runTest {
+        val folderId = "folderId"
+        val folder = mockk<Folder> {
+            every { id } returns "differentFolderId"
+        }
+
+        sdkFolderRepository.set(id = folderId, value = folder)
+
+        coVerify(exactly = 0) {
+            vaultDiskSource.saveFolder(userId = any(), folder = any())
+        }
+    }
+
+    @Test
+    fun `set should call saveFolder on vaultDiskSource if ids match`() = runTest {
+        val folderId = "folderId"
+        val responseFolder = mockk<SyncResponseJson.Folder>()
+        val folder = mockk<Folder> {
+            every { id } returns folderId
+            every { toEncryptedNetworkFolderResponse() } returns responseFolder
+        }
+        coEvery {
+            vaultDiskSource.saveFolder(userId = USER_ID, folder = responseFolder)
+        } just runs
+
+        sdkFolderRepository.set(id = folderId, value = folder)
+
+        coVerify(exactly = 1) {
+            vaultDiskSource.saveFolder(userId = USER_ID, folder = responseFolder)
+        }
+    }
+
+    @Test
+    fun `setBulk should skip entries where ids do not match`() = runTest {
+        val folder = mockk<Folder> {
+            every { id } returns "differentId"
+        }
+
+        sdkFolderRepository.setBulk(values = mapOf("folderId" to folder))
+
+        coVerify(exactly = 0) {
+            vaultDiskSource.saveFolders(userId = any(), folders = any())
+        }
+    }
+
+    @Test
+    fun `setBulk should save valid entries via saveFolders`() = runTest {
+        val folderId = "folderId"
+        val responseFolder = mockk<SyncResponseJson.Folder>()
+        val folder = mockk<Folder> {
+            every { id } returns folderId
+            every { toEncryptedNetworkFolderResponse() } returns responseFolder
+        }
+        coEvery {
+            vaultDiskSource.saveFolders(userId = USER_ID, folders = listOf(responseFolder))
+        } just runs
+
+        sdkFolderRepository.setBulk(values = mapOf(folderId to folder))
+
+        coVerify(exactly = 1) {
+            vaultDiskSource.saveFolders(userId = USER_ID, folders = listOf(responseFolder))
+        }
+    }
+
+    @Test
+    fun `setBulk should do nothing for empty map`() = runTest {
+        sdkFolderRepository.setBulk(values = emptyMap())
+
+        coVerify(exactly = 0) {
+            vaultDiskSource.saveFolders(userId = any(), folders = any())
+        }
+    }
+
+    @Test
+    fun `removeBulk should call deleteSelectedFolders`() = runTest {
+        val ids = listOf("id1", "id2")
+        coEvery {
+            vaultDiskSource.deleteSelectedFolders(userId = USER_ID, folderIds = ids)
+        } just runs
+
+        sdkFolderRepository.removeBulk(keys = ids)
+
+        coVerify(exactly = 1) {
+            vaultDiskSource.deleteSelectedFolders(userId = USER_ID, folderIds = ids)
+        }
+    }
+
+    @Test
+    fun `removeBulk should not call deleteSelectedFolders for empty list`() = runTest {
+        sdkFolderRepository.removeBulk(keys = emptyList())
+
+        coVerify(exactly = 0) {
+            vaultDiskSource.deleteSelectedFolders(userId = any(), folderIds = any())
+        }
+    }
+
+    @Test
+    fun `removeAll should call deleteAllFolders`() = runTest {
+        coEvery { vaultDiskSource.deleteAllFolders(userId = USER_ID) } just runs
+
+        sdkFolderRepository.removeAll()
+
+        coVerify(exactly = 1) {
+            vaultDiskSource.deleteAllFolders(userId = USER_ID)
+        }
+    }
+}
+
+private const val USER_ID: String = "userId"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/VaultDiskSourceTest.kt
@@ -246,6 +246,30 @@ class VaultDiskSourceTest {
     }
 
     @Test
+    fun `deleteSelectedFolders should call deleteSelectedFolders`() = runTest {
+        assertFalse(foldersDao.deleteSelectedFoldersCalled)
+        foldersDao.storedFolders.add(FOLDER_ENTITY)
+        assertEquals(1, foldersDao.storedFolders.size)
+
+        vaultDiskSource.deleteSelectedFolders(USER_ID, listOf(FOLDER_1.id))
+
+        assertTrue(foldersDao.deleteSelectedFoldersCalled)
+        assertEquals(emptyList<FolderEntity>(), foldersDao.storedFolders)
+    }
+
+    @Test
+    fun `deleteAllFolders should call deleteAllFolders`() = runTest {
+        assertFalse(foldersDao.deleteFoldersCalled)
+        foldersDao.storedFolders.add(FOLDER_ENTITY)
+        assertEquals(1, foldersDao.storedFolders.size)
+
+        vaultDiskSource.deleteAllFolders(USER_ID)
+
+        assertTrue(foldersDao.deleteFoldersCalled)
+        assertEquals(emptyList<FolderEntity>(), foldersDao.storedFolders)
+    }
+
+    @Test
     fun `saveFolder should call insertFolder`() = runTest {
         assertFalse(foldersDao.insertFolderCalled)
         assertEquals(0, foldersDao.storedFolders.size)
@@ -254,6 +278,31 @@ class VaultDiskSourceTest {
 
         assertTrue(foldersDao.insertFolderCalled)
         assertEquals(listOf(FOLDER_ENTITY), foldersDao.storedFolders)
+    }
+
+    @Test
+    fun `saveFolders should call insertFolders`() = runTest {
+        assertFalse(foldersDao.insertFoldersCalled)
+        assertEquals(0, foldersDao.storedFolders.size)
+
+        vaultDiskSource.saveFolders(USER_ID, listOf(FOLDER_1))
+
+        assertTrue(foldersDao.insertFoldersCalled)
+        assertEquals(1, foldersDao.storedFolders.size)
+        val storedFolderEntity = foldersDao.storedFolders.first()
+        assertEquals(FOLDER_ENTITY, storedFolderEntity)
+    }
+
+    @Test
+    fun `getFolders should return all FoldersDao folders`() = runTest {
+        val folderEntities = listOf(FOLDER_ENTITY)
+        val folders = listOf(FOLDER_1)
+
+        val result1 = vaultDiskSource.getFolders(USER_ID)
+        assertEquals(emptyList<SyncResponseJson.Folder>(), result1)
+        foldersDao.insertFolders(folderEntities)
+        val result2 = vaultDiskSource.getFolders(USER_ID)
+        assertEquals(folders, result2)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeFoldersDao.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/disk/dao/FakeFoldersDao.kt
@@ -11,7 +11,9 @@ class FakeFoldersDao : FoldersDao {
 
     var deleteFolderCalled: Boolean = false
     var deleteFoldersCalled: Boolean = false
+    var deleteSelectedFoldersCalled: Boolean = false
     var insertFolderCalled: Boolean = false
+    var insertFoldersCalled: Boolean = false
 
     private val foldersFlow = bufferedMutableSharedFlow<List<FolderEntity>>(replay = 1)
 
@@ -33,12 +35,33 @@ class FakeFoldersDao : FoldersDao {
         foldersFlow.tryEmit(storedFolders.toList())
     }
 
+    override suspend fun deleteSelectedFolders(
+        userId: String,
+        folderIds: List<String>,
+    ): Int {
+        deleteSelectedFoldersCalled = true
+        val count = storedFolders.count { it.userId == userId && it.id in folderIds }
+        storedFolders.removeAll { it.userId == userId && it.id in folderIds }
+        foldersFlow.tryEmit(storedFolders.toList())
+        return count
+    }
+
     override fun getAllFoldersFlow(userId: String): Flow<List<FolderEntity>> =
         foldersFlow.map { ciphers -> ciphers.filter { it.userId == userId } }
+
+    override suspend fun getFolder(
+        userId: String,
+        folderId: String,
+    ): FolderEntity? = storedFolders.find { it.userId == userId && it.id == folderId }
+
+    override fun getAllFolders(
+        userId: String,
+    ): List<FolderEntity> = storedFolders.filter { it.userId == userId }
 
     override suspend fun insertFolders(folders: List<FolderEntity>) {
         storedFolders.addAll(folders)
         foldersFlow.tryEmit(storedFolders.toList())
+        insertFoldersCalled = true
     }
 
     override suspend fun insertFolder(folder: FolderEntity) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkFolderExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkFolderExtensionsTest.kt
@@ -73,4 +73,14 @@ class VaultSdkFolderExtensionsTest {
             syncFolder,
         )
     }
+
+    @Test
+    fun `toEncryptedNetworkFolderResponse should convert a NetworkFolder to a SdkFolder`() {
+        val sdkFolder = createMockSdkFolder(number = 1)
+        val networkFolder = sdkFolder.toEncryptedNetworkFolderResponse()
+        assertEquals(
+            createMockFolder(number = 1),
+            networkFolder,
+        )
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR adds the `SdkFolderRepository` as an interface for the Bitwarden SDK to interact with the Folders stored on disk. The `SdkFolderRepository` is not yet set on the SDK because the SDK team is not yet ready for it.
