### PR TITLE
[PM-33513] feat: Add checkout callback deep link handling

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -46,6 +46,7 @@ import com.x8bit.bitwarden.ui.platform.model.FeatureFlagsState
 import com.x8bit.bitwarden.ui.platform.util.isAccountSecurityShortcut
 import com.x8bit.bitwarden.ui.platform.util.isMyVaultShortcut
 import com.x8bit.bitwarden.ui.platform.util.isPasswordGeneratorShortcut
+import com.x8bit.bitwarden.ui.platform.util.isPremiumCheckoutCallback
 import com.x8bit.bitwarden.ui.vault.util.getTotpDataOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
@@ -333,6 +334,7 @@ class MainViewModel @Inject constructor(
         val hasGeneratorShortcut = intent.isPasswordGeneratorShortcut
         val hasVaultShortcut = intent.isMyVaultShortcut
         val hasAccountSecurityShortcut = intent.isAccountSecurityShortcut
+        val hasPremiumCheckoutCallback = intent.isPremiumCheckoutCallback
         val completeRegistrationData = intent.getCompleteRegistrationDataIntentOrNull()
         val importCredentialsRequest = intent.getProviderImportCredentialsRequest()
         val credentialProviderRequest =
@@ -392,6 +394,11 @@ class MainViewModel @Inject constructor(
                         // Send task when this is not the first intent.
                         shouldFinishWhenComplete = isFirstIntent,
                     )
+            }
+
+            hasPremiumCheckoutCallback -> {
+                specialCircumstanceManager.specialCircumstance =
+                    SpecialCircumstance.PremiumCheckoutResult
             }
 
             hasGeneratorShortcut -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
@@ -135,6 +135,13 @@ sealed class SpecialCircumstance : Parcelable {
     data object VerificationCodeShortcut : SpecialCircumstance()
 
     /**
+     * The app was launched via a premium checkout callback deep link,
+     * indicating the user is returning from a Stripe checkout session.
+     */
+    @Parcelize
+    data object PremiumCheckoutResult : SpecialCircumstance()
+
+    /**
      * The app was launched to select an account to export credentials from.
      */
     @Parcelize

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -208,6 +208,7 @@ class RootNavViewModel @Inject constructor(
 
                     SpecialCircumstance.AccountSecurityShortcut,
                     SpecialCircumstance.GeneratorShortcut,
+                    SpecialCircumstance.PremiumCheckoutResult,
                     SpecialCircumstance.VaultShortcut,
                     SpecialCircumstance.SendShortcut,
                     is SpecialCircumstance.SearchShortcut,
@@ -283,6 +284,7 @@ class RootNavViewModel @Inject constructor(
         when (specialCircumstance) {
             is SpecialCircumstance.AccountSecurityShortcut,
             is SpecialCircumstance.GeneratorShortcut,
+            is SpecialCircumstance.PremiumCheckoutResult,
             is SpecialCircumstance.SearchShortcut,
             is SpecialCircumstance.SendShortcut,
             is SpecialCircumstance.ShareNewSend,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtils.kt
@@ -19,3 +19,10 @@ val Intent.isPasswordGeneratorShortcut: Boolean
  */
 val Intent.isAccountSecurityShortcut: Boolean
     get() = dataString?.equals("bitwarden://settings/account_security") == true
+
+/**
+ * Returns `true` if the [Intent] is a deep link callback from a premium
+ * checkout session, `false` otherwise.
+ */
+val Intent.isPremiumCheckoutCallback: Boolean
+    get() = dataString?.equals("bitwarden://premium-upgrade-callback") == true

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -71,6 +71,7 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.appearance.model.AppLang
 import com.x8bit.bitwarden.ui.platform.util.isAccountSecurityShortcut
 import com.x8bit.bitwarden.ui.platform.util.isMyVaultShortcut
 import com.x8bit.bitwarden.ui.platform.util.isPasswordGeneratorShortcut
+import com.x8bit.bitwarden.ui.platform.util.isPremiumCheckoutCallback
 import com.x8bit.bitwarden.ui.vault.util.getTotpDataOrNull
 import io.mockk.coEvery
 import io.mockk.every
@@ -200,6 +201,7 @@ class MainViewModelTest : BaseViewModelTest() {
             Intent::isMyVaultShortcut,
             Intent::isPasswordGeneratorShortcut,
             Intent::isAccountSecurityShortcut,
+            Intent::isPremiumCheckoutCallback,
         )
         mockkObject(
             ProviderCreateCredentialRequest.Companion,
@@ -231,6 +233,7 @@ class MainViewModelTest : BaseViewModelTest() {
             Intent::isMyVaultShortcut,
             Intent::isPasswordGeneratorShortcut,
             Intent::isAccountSecurityShortcut,
+            Intent::isPremiumCheckoutCallback,
         )
         unmockkObject(
             ProviderCreateCredentialRequest.Companion,
@@ -861,6 +864,40 @@ class MainViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `on ReceiveFirstIntent with premium checkout callback should set special circumstance to PremiumCheckoutResult`() {
+        val viewModel = createViewModel()
+        val mockIntent = createMockIntent(
+            mockIsPremiumCheckoutCallback = true,
+        )
+
+        viewModel.trySendAction(
+            MainAction.ReceiveFirstIntent(intent = mockIntent),
+        )
+        assertEquals(
+            SpecialCircumstance.PremiumCheckoutResult,
+            specialCircumstanceManager.specialCircumstance,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveNewIntent with premium checkout callback should set special circumstance to PremiumCheckoutResult`() {
+        val viewModel = createViewModel()
+        val mockIntent = createMockIntent(
+            mockIsPremiumCheckoutCallback = true,
+        )
+
+        viewModel.trySendAction(
+            MainAction.ReceiveNewIntent(intent = mockIntent),
+        )
+        assertEquals(
+            SpecialCircumstance.PremiumCheckoutResult,
+            specialCircumstanceManager.specialCircumstance,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `on ReceiveNewIntent with a password generator deeplink data should set the special circumstance to GeneratorShortcut`() {
         val viewModel = createViewModel()
         val mockIntent = createMockIntent(mockIsPasswordGeneratorShortcut = true)
@@ -1264,6 +1301,7 @@ private fun createMockIntent(
     mockIsMyVaultShortcut: Boolean = false,
     mockIsPasswordGeneratorShortcut: Boolean = false,
     mockIsAccountSecurityShortcut: Boolean = false,
+    mockIsPremiumCheckoutCallback: Boolean = false,
     mockIsAddTotpLoginItemFromAuthenticator: Boolean = false,
     mockProviderImportCredentialsRequest: ProviderImportCredentialsRequest? = null,
 ): Intent = mockk<Intent> {
@@ -1275,6 +1313,7 @@ private fun createMockIntent(
     every { isMyVaultShortcut } returns mockIsMyVaultShortcut
     every { isPasswordGeneratorShortcut } returns mockIsPasswordGeneratorShortcut
     every { isAccountSecurityShortcut } returns mockIsAccountSecurityShortcut
+    every { isPremiumCheckoutCallback } returns mockIsPremiumCheckoutCallback
     every { isAddTotpLoginItemFromAuthenticator() } returns mockIsAddTotpLoginItemFromAuthenticator
     every { getProviderImportCredentialsRequest() } returns mockProviderImportCredentialsRequest
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtilsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtilsTest.kt
@@ -56,4 +56,28 @@ class ShortcutUtilsTest {
         }
         assertFalse(mockIntent.isPasswordGeneratorShortcut)
     }
+
+    @Test
+    fun `isPremiumCheckoutCallback should return true when dataString is checkout callback`() {
+        val mockIntent = mockk<Intent> {
+            every { dataString } returns "bitwarden://premium-upgrade-callback"
+        }
+        assertTrue(mockIntent.isPremiumCheckoutCallback)
+    }
+
+    @Test
+    fun `isPremiumCheckoutCallback should return false when dataString is not checkout callback`() {
+        val mockIntent = mockk<Intent> {
+            every { dataString } returns "bitwarden://some_other_callback"
+        }
+        assertFalse(mockIntent.isPremiumCheckoutCallback)
+    }
+
+    @Test
+    fun `isPremiumCheckoutCallback should return false when dataString is null`() {
+        val mockIntent = mockk<Intent> {
+            every { dataString } returns null
+        }
+        assertFalse(mockIntent.isPremiumCheckoutCallback)
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33513

## 📔 Objective

Add deep link handling for Stripe checkout callbacks so the app can detect when a user returns from a Stripe payment flow.

- Add `isPremiumCheckoutCallback` Intent extension property in `ShortcutUtils.kt` for the `bitwarden://premium-upgrade-callback` deep link
- Add `PremiumCheckoutResult` data object to the `SpecialCircumstance` sealed class
- Handle checkout callback URI in `MainViewModel.handleIntent()`, setting the special circumstance
- Add exhaustiveness branches in `RootNavViewModel.kt` for the new sealed class member
- Unit tests for intent parsing (`ShortcutUtilsTest`) and ViewModel handling (`MainViewModelTest`)