### PR TITLE
PM-33907: bug: Handle exceptions thrown when querying the AutofillManager

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/AutofillActivityManagerImpl.kt
@@ -8,6 +8,7 @@ import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserThirdPartyAutofi
 import com.x8bit.bitwarden.data.autofill.model.browser.BrowserThirdPartyAutofillStatus
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
 
 /**
  * Primary implementation of [AutofillActivityManager].
@@ -20,10 +21,34 @@ class AutofillActivityManagerImpl(
     lifecycleScope: LifecycleCoroutineScope,
     browserThirdPartyAutofillEnabledManager: BrowserThirdPartyAutofillEnabledManager,
 ) : AutofillActivityManager {
-    private val isAutofillEnabledAndSupported: Boolean
-        get() = autofillManager.isEnabled &&
-            autofillManager.hasEnabledAutofillServices() &&
+    private val autofillManagerIsEnabled: Boolean
+        get() = try {
+            autofillManager.isEnabled
+        } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+            Timber.e(e, "autofillManager.isEnabled failed")
+            false
+        }
+
+    private val autofillManagerHasEnabledAutofillServices: Boolean
+        get() = try {
+            autofillManager.hasEnabledAutofillServices()
+        } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+            Timber.e(e, "autofillManager.hasEnabledAutofillServices() failed")
+            false
+        }
+
+    private val autofillManagerIsAutofillSupported: Boolean
+        get() = try {
             autofillManager.isAutofillSupported
+        } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+            Timber.e(e, "autofillManager.isAutofillSupported() failed")
+            false
+        }
+
+    private val isAutofillEnabledAndSupported: Boolean
+        get() = autofillManagerIsEnabled &&
+            autofillManagerHasEnabledAutofillServices &&
+            autofillManagerIsAutofillSupported
 
     private val browserAutofillStatus: BrowserThirdPartyAutofillStatus
         get() = BrowserThirdPartyAutofillStatus(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33907](https://bitwarden.atlassian.net/browse/PM-33907)

## 📔 Objective

This PR updates the `AutofillActivityManagerImpl` to handle exceptions thrown from the system `AutofillManager`.


[PM-33907]: https://bitwarden.atlassian.net/browse/PM-33907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ