### PR TITLE
[PM-33514] feat: Add premium upgrade banner visibility logic

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -487,6 +487,10 @@ private fun ActionCard(
     modifier: Modifier = Modifier,
 ) {
     when (actionCardState) {
+        VaultState.ActionCardState.UpgradePremium -> {
+            // UI implementation in PM-33515.
+        }
+
         VaultState.ActionCardState.IntroducingArchive -> {
             BitwardenActionCard(
                 cardTitle = stringResource(id = BitwardenString.introducing_archive),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -33,6 +33,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.UpdateKdfMinimumsResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserAutofillDialogManager
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.platform.manager.CredentialExchangeRegistryManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
@@ -107,6 +108,7 @@ class VaultViewModel @Inject constructor(
     private val organizationEventManager: OrganizationEventManager,
     private val clock: Clock,
     private val policyManager: PolicyManager,
+    private val premiumStateManager: PremiumStateManager,
     private val settingsRepository: SettingsRepository,
     private val vaultRepository: VaultRepository,
     private val firstTimeActionManager: FirstTimeActionManager,
@@ -237,6 +239,16 @@ class VaultViewModel @Inject constructor(
         settingsRepository
             .getIntroducingArchiveActionCardDismissedFlow()
             .map { VaultAction.Internal.IntroducingArchiveActionCardDismissedFlowReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        premiumStateManager
+            .isPremiumUpgradeBannerEligibleFlow
+            .map {
+                VaultAction.Internal.PremiumUpgradeBannerEligibilityReceive(
+                    isEligible = it,
+                )
+            }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -385,6 +397,10 @@ class VaultViewModel @Inject constructor(
 
     private fun handleDismissActionCardClick(action: VaultAction.DismissActionCardClick) {
         when (action.actionCard) {
+            VaultState.ActionCardState.UpgradePremium -> {
+                premiumStateManager.dismissPremiumUpgradeBanner()
+            }
+
             VaultState.ActionCardState.IntroducingArchive -> {
                 settingsRepository.dismissIntroducingArchiveActionCard()
             }
@@ -393,9 +409,15 @@ class VaultViewModel @Inject constructor(
 
     private fun handleActionCardClick(action: VaultAction.ActionCardClick) {
         when (action.actionCard) {
+            VaultState.ActionCardState.UpgradePremium -> {
+                // Navigation to Plan screen wired in PM-33515/PM-33516.
+            }
+
             VaultState.ActionCardState.IntroducingArchive -> {
                 settingsRepository.dismissIntroducingArchiveActionCard()
-                sendEvent(VaultEvent.NavigateToItemListing(VaultItemListingType.Archive))
+                sendEvent(
+                    VaultEvent.NavigateToItemListing(VaultItemListingType.Archive),
+                )
             }
         }
     }
@@ -956,6 +978,10 @@ class VaultViewModel @Inject constructor(
             is VaultAction.Internal.IntroducingArchiveActionCardDismissedFlowReceive -> {
                 handleIntroducingArchiveActionCardDismissedFlowReceive(action)
             }
+
+            is VaultAction.Internal.PremiumUpgradeBannerEligibilityReceive -> {
+                handlePremiumUpgradeBannerEligibilityReceive(action)
+            }
         }
     }
 
@@ -1065,6 +1091,14 @@ class VaultViewModel @Inject constructor(
     ) {
         mutableStateFlow.update {
             it.copy(isIntroducingArchiveActionCardDismissed = action.isDismissed)
+        }
+    }
+
+    private fun handlePremiumUpgradeBannerEligibilityReceive(
+        action: VaultAction.Internal.PremiumUpgradeBannerEligibilityReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(isPremiumUpgradeBannerEligible = action.isEligible)
         }
     }
 
@@ -1481,6 +1515,7 @@ data class VaultState(
     val hasShownDecryptionFailureAlert: Boolean,
     val restrictItemTypesPolicyOrgIds: List<String>,
     val isIntroducingArchiveActionCardDismissed: Boolean,
+    val isPremiumUpgradeBannerEligible: Boolean = false,
 ) : Parcelable {
 
     /**
@@ -1488,9 +1523,13 @@ data class VaultState(
      */
     val actionCard: ActionCardState?
         get() = (viewState as? ViewState.Content)?.let {
-            ActionCardState.IntroducingArchive.takeIf {
-                isPremium && !isIntroducingArchiveActionCardDismissed && isArchiveEnabled
-            }
+            ActionCardState.UpgradePremium
+                .takeIf { isPremiumUpgradeBannerEligible }
+                ?: ActionCardState.IntroducingArchive.takeIf {
+                    isPremium &&
+                        !isIntroducingArchiveActionCardDismissed &&
+                        isArchiveEnabled
+                }
         }
 
     /**
@@ -1807,6 +1846,11 @@ data class VaultState(
      * Represents an action card to be displayed.
      */
     sealed class ActionCardState {
+        /**
+         * Indicates that the user is eligible for a premium upgrade.
+         */
+        data object UpgradePremium : ActionCardState()
+
         /**
          * Indicates that the archive feature is ready for use.
          */
@@ -2363,6 +2407,14 @@ sealed class VaultAction {
          */
         data class IntroducingArchiveActionCardDismissedFlowReceive(
             val isDismissed: Boolean,
+        ) : Internal()
+
+        /**
+         * Indicates that the premium upgrade banner eligibility has been
+         * updated.
+         */
+        data class PremiumUpgradeBannerEligibilityReceive(
+            val isEligible: Boolean,
         ) : Internal()
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -30,10 +30,11 @@ import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.createMockOrganization
 import com.x8bit.bitwarden.data.autofill.manager.browser.BrowserAutofillDialogManager
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.platform.manager.CredentialExchangeRegistryManager
-import com.x8bit.bitwarden.data.platform.manager.GmsManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
+import com.x8bit.bitwarden.data.platform.manager.GmsManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.ReviewPromptManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
@@ -93,6 +94,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -228,6 +230,14 @@ class VaultViewModelTest : BaseViewModelTest() {
         every { getFeatureFlag(FlagKey.ArchiveItems) } returns mutableArchiveItemsFlagFlow.value
     }
 
+    private val mutablePremiumUpgradeBannerEligibleFlow = MutableStateFlow(false)
+    private val premiumStateManager: PremiumStateManager = mockk {
+        every {
+            isPremiumUpgradeBannerEligibleFlow
+        } returns mutablePremiumUpgradeBannerEligibleFlow
+        every { dismissPremiumUpgradeBanner() } just runs
+    }
+
     @AfterEach
     fun tearDown() {
         unmockkStatic(FlightRecorderDataSet::toSnackbarData)
@@ -311,6 +321,83 @@ class VaultViewModelTest : BaseViewModelTest() {
                 settingsRepository.dismissIntroducingArchiveActionCard()
             }
         }
+
+    @Test
+    fun `PremiumUpgradeBannerEligibleFlow updates should update state`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_STATE, awaitItem())
+                mutablePremiumUpgradeBannerEligibleFlow.value = true
+                assertEquals(
+                    DEFAULT_STATE.copy(
+                        isPremiumUpgradeBannerEligible = true,
+                    ),
+                    awaitItem(),
+                )
+                mutablePremiumUpgradeBannerEligibleFlow.value = false
+                assertEquals(DEFAULT_STATE, awaitItem())
+            }
+        }
+
+    @Test
+    fun `DismissActionCardClick with UpgradePremium should call dismissPremiumUpgradeBanner`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.trySendAction(
+                VaultAction.DismissActionCardClick(
+                    VaultState.ActionCardState.UpgradePremium,
+                ),
+            )
+
+            verify(exactly = 1) {
+                premiumStateManager.dismissPremiumUpgradeBanner()
+            }
+        }
+
+    @Test
+    fun `actionCard should return UpgradePremium when eligible and content is showing`() {
+        val contentViewState = DEFAULT_CONTENT_VIEW_STATE
+        val state = createMockVaultState(viewState = contentViewState).copy(
+            isPremiumUpgradeBannerEligible = true,
+        )
+
+        assertEquals(
+            VaultState.ActionCardState.UpgradePremium,
+            state.actionCard,
+        )
+    }
+
+    @Test
+    fun `actionCard should return IntroducingArchive when not eligible for premium upgrade`() {
+        val contentViewState = DEFAULT_CONTENT_VIEW_STATE
+        val state = createMockVaultState(viewState = contentViewState).copy(
+            isPremiumUpgradeBannerEligible = false,
+            isPremium = true,
+            isArchiveEnabled = true,
+            isIntroducingArchiveActionCardDismissed = false,
+        )
+
+        assertEquals(
+            VaultState.ActionCardState.IntroducingArchive,
+            state.actionCard,
+        )
+    }
+
+    @Test
+    fun `actionCard should return null when not eligible for either card`() {
+        val contentViewState = DEFAULT_CONTENT_VIEW_STATE
+        val state = createMockVaultState(viewState = contentViewState).copy(
+            isPremiumUpgradeBannerEligible = false,
+            isPremium = false,
+            isArchiveEnabled = true,
+            isIntroducingArchiveActionCardDismissed = false,
+        )
+
+        assertNull(state.actionCard)
+    }
 
     @Test
     fun `UserState updates with a null value should do nothing`() {
@@ -3723,6 +3810,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             environmentRepository = environmentRepository,
             clipboardManager = clipboardManager,
             policyManager = policyManager,
+            premiumStateManager = premiumStateManager,
             clock = clock,
             settingsRepository = settingsRepository,
             vaultRepository = vaultRepository,
@@ -3858,4 +3946,25 @@ private fun createMockVaultState(
         restrictItemTypesPolicyOrgIds = emptyList(),
         isArchiveEnabled = true,
         isIntroducingArchiveActionCardDismissed = false,
+        isPremiumUpgradeBannerEligible = false,
     )
+
+private val DEFAULT_CONTENT_VIEW_STATE = VaultState.ViewState.Content(
+    itemTypesCount = 0,
+    loginItemsCount = 0,
+    cardItemsCount = 0,
+    identityItemsCount = 0,
+    secureNoteItemsCount = 0,
+    sshKeyItemsCount = 0,
+    totpItemsCount = 0,
+    favoriteItems = emptyList(),
+    folderItems = emptyList(),
+    noFolderItems = emptyList(),
+    collectionItems = emptyList(),
+    trashItemsCount = 0,
+    archivedItemsCount = null,
+    archiveEnabled = false,
+    archiveSubText = null,
+    archiveEndIcon = null,
+    showCardGroup = true,
+)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33514

## 📔 Objective

Add premium upgrade banner visibility logic to `VaultViewModel` so the vault screen knows when to show the premium upgrade banner.

**Changes:**
- Inject `PremiumStateManager` into `VaultViewModel` and subscribe to `isPremiumUpgradeBannerEligibleFlow`
- Add `isPremiumUpgradeBannerEligible` state field to `VaultState`
- Add `ActionCardState.UpgradePremium` to the sealed class with higher priority than `IntroducingArchive` in the `actionCard` computed property
- Handle dismiss action via `premiumStateManager.dismissPremiumUpgradeBanner()`
- Add exhaustive `when` branch in `VaultContent.kt` (placeholder for PM-33515 UI rendering)
- Add 5 unit tests covering flow subscription, dismiss delegation, and all action card priority scenarios

All banner eligibility logic (premium status, billing support, feature flag, account age, vault items, dismissal) is encapsulated in `PremiumStateManager` — the ViewModel simply consumes the boolean flow.