### PR TITLE
PM-33909: bug: Check the column index before querying for 3rd party autofill data

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/autofill/manager/browser/BrowserThirdPartyAutofillManagerImpl.kt
@@ -62,11 +62,13 @@ class BrowserThirdPartyAutofillManagerImpl(
             )
         var thirdPartyEnabled = false
         val isThirdPartyAvailable = cursor
-            ?.let {
+            ?.use {
                 it.moveToFirst()
-                val columnIndex = it.getColumnIndex(THIRD_PARTY_MODE_COLUMN)
-                thirdPartyEnabled = it.getInt(columnIndex) != 0
-                it.close()
+                thirdPartyEnabled = it
+                    .getColumnIndex(THIRD_PARTY_MODE_COLUMN)
+                    .takeUnless { columnIndex -> columnIndex == -1 }
+                    ?.let { columnIndex -> it.getInt(columnIndex) != 0 }
+                    ?: false
                 true
             }
             ?: false


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33909](https://bitwarden.atlassian.net/browse/PM-33909)

## 📔 Objective

This PR updates the `BrowserThirdPartyAutofillManagerImpl` to query for the 3rd party autofill data in a safer manner in order to avoid a rare crash seen in Crashlytics.


[PM-33909]: https://bitwarden.atlassian.net/browse/PM-33909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ