### PR TITLE
PM-33913: bug: Remove org event to avoid duplicate entry

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEvent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/OrganizationEvent.kt
@@ -135,22 +135,10 @@ sealed class OrganizationEvent {
      * folder as required by the organization's personal vault ownership policy.
      */
     data class ItemOrganizationAccepted(
-        override val cipherId: String? = null,
         override val organizationId: String,
     ) : OrganizationEvent() {
+        override val cipherId: String? = null
         override val type: OrganizationEventType
             get() = OrganizationEventType.ORGANIZATION_ITEM_ORGANIZATION_ACCEPTED
-    }
-
-    /**
-     * Tracks when a user chooses to leave an organization instead of migrating their personal
-     * ciphers to their organization's My Items folder.
-     */
-    data class ItemOrganizationDeclined(
-        override val cipherId: String? = null,
-        override val organizationId: String,
-    ) : OrganizationEvent() {
-        override val type: OrganizationEventType
-            get() = OrganizationEventType.ORGANIZATION_ITEM_ORGANIZATION_DECLINED
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/leaveorganization/LeaveOrganizationViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/leaveorganization/LeaveOrganizationViewModel.kt
@@ -13,8 +13,6 @@ import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.RevokeFromOrganizationResult
-import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
-import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.vault.manager.VaultMigrationManager
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,7 +32,6 @@ private const val KEY_STATE = "state"
 class LeaveOrganizationViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
-    private val organizationEventManager: OrganizationEventManager,
     private val vaultMigrationManager: VaultMigrationManager,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<LeaveOrganizationState, LeaveOrganizationEvent, LeaveOrganizationAction>(
@@ -109,11 +106,6 @@ class LeaveOrganizationViewModel @Inject constructor(
                     relay = SnackbarRelay.LEFT_ORGANIZATION,
                     data = BitwardenSnackbarData(
                         message = BitwardenString.you_left_the_organization.asText(),
-                    ),
-                )
-                organizationEventManager.trackEvent(
-                    event = OrganizationEvent.ItemOrganizationDeclined(
-                        organizationId = state.organizationId,
                     ),
                 )
                 mutableStateFlow.update {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/leaveorganization/LeaveOrganizationViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/leaveorganization/LeaveOrganizationViewModelTest.kt
@@ -15,9 +15,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.RevokeFromOrganizationResu
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.VaultUnlockType
 import com.x8bit.bitwarden.data.auth.repository.model.createMockOrganization
-import com.x8bit.bitwarden.data.platform.manager.event.OrganizationEventManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
-import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.vault.manager.VaultMigrationManager
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import io.mockk.coEvery
@@ -45,10 +43,6 @@ class LeaveOrganizationViewModelTest : BaseViewModelTest() {
 
     private val mockSnackbarRelayManager: SnackbarRelayManager<SnackbarRelay> = mockk {
         every { sendSnackbarData(data = any(), relay = any()) } just runs
-    }
-
-    private val mockOrganizationEventManager: OrganizationEventManager = mockk {
-        every { trackEvent(any()) } just runs
     }
 
     private val mockVaultMigrationManager: VaultMigrationManager = mockk {
@@ -138,11 +132,6 @@ class LeaveOrganizationViewModelTest : BaseViewModelTest() {
                         message = BitwardenString.you_left_the_organization.asText(),
                     ),
                 )
-                mockOrganizationEventManager.trackEvent(
-                    event = OrganizationEvent.ItemOrganizationDeclined(
-                        organizationId = ORGANIZATION_ID,
-                    ),
-                )
                 mockVaultMigrationManager.clearMigrationState()
             }
 
@@ -169,7 +158,8 @@ class LeaveOrganizationViewModelTest : BaseViewModelTest() {
                         message = BitwardenString.generic_error_message.asText(),
                         error = null,
                     ),
-                ), awaitItem(),
+                ),
+                awaitItem(),
             )
 
             // Dismiss the dialog
@@ -203,7 +193,8 @@ class LeaveOrganizationViewModelTest : BaseViewModelTest() {
                         message = BitwardenString.internet_connection_required_message.asText(),
                         error = error,
                     ),
-                ), awaitItem(),
+                ),
+                awaitItem(),
             )
 
             // Dismiss the dialog and clear migration
@@ -238,15 +229,8 @@ class LeaveOrganizationViewModelTest : BaseViewModelTest() {
             organizationName = "Saved Organization",
             dialogState = null,
         )
-        val savedStateHandle = SavedStateHandle(mapOf("state" to savedState))
 
-        val viewModel = LeaveOrganizationViewModel(
-            authRepository = mockAuthRepository,
-            snackbarRelayManager = mockSnackbarRelayManager,
-            organizationEventManager = mockOrganizationEventManager,
-            vaultMigrationManager = mockVaultMigrationManager,
-            savedStateHandle = savedStateHandle,
-        )
+        val viewModel = createViewModel(state = savedState)
 
         assertEquals(savedState, viewModel.stateFlow.value)
     }
@@ -257,7 +241,6 @@ class LeaveOrganizationViewModelTest : BaseViewModelTest() {
         return LeaveOrganizationViewModel(
             authRepository = mockAuthRepository,
             snackbarRelayManager = mockSnackbarRelayManager,
-            organizationEventManager = mockOrganizationEventManager,
             vaultMigrationManager = mockVaultMigrationManager,
             savedStateHandle = SavedStateHandle(mapOf("state" to state)),
         )

--- a/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventType.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/OrganizationEventType.kt
@@ -129,9 +129,6 @@ enum class OrganizationEventType {
 
     @SerialName("1618")
     ORGANIZATION_ITEM_ORGANIZATION_ACCEPTED,
-
-    @SerialName("1619")
-    ORGANIZATION_ITEM_ORGANIZATION_DECLINED,
 }
 
 @Keep


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33913](https://bitwarden.atlassian.net/browse/PM-33913)

## 📔 Objective

This PR removes an org event entry from the app to avoid duplicate entries. This is because the cloud logs these events for us.


[PM-33913]: https://bitwarden.atlassian.net/browse/PM-33913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ