### PR TITLE
PM-32721: bug: Add sorting to password history

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModel.kt
@@ -139,16 +139,18 @@ class PasswordHistoryViewModel @Inject constructor(
     }
 
     private fun List<PasswordHistoryView>?.toViewState(): PasswordHistoryState.ViewState {
-        val passwords = this?.map { passwordHistoryView ->
-            GeneratedPassword(
-                password = passwordHistoryView.password,
-                date = passwordHistoryView.lastUsedDate.toFormattedDateTimeStyle(
-                    dateStyle = FormatStyle.SHORT,
-                    timeStyle = FormatStyle.SHORT,
-                    clock = clock,
-                ),
-            )
-        }
+        val passwords = this
+            ?.sortedByDescending { it.lastUsedDate }
+            ?.map { passwordHistoryView ->
+                GeneratedPassword(
+                    password = passwordHistoryView.password,
+                    date = passwordHistoryView.lastUsedDate.toFormattedDateTimeStyle(
+                        dateStyle = FormatStyle.SHORT,
+                        timeStyle = FormatStyle.SHORT,
+                        clock = clock,
+                    ),
+                )
+            }
         return if (passwords?.isNotEmpty() == true) {
             PasswordHistoryState.ViewState.Content(passwords)
         } else {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherViewUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/model/CipherViewUtil.kt
@@ -61,6 +61,9 @@ fun createMockCipherView(
     card: CardView? = createMockCardView(number = number).takeIf { cipherType == CipherType.CARD },
     attachments: List<AttachmentView> = listOf(createMockAttachmentView(number = number)),
     isArchived: Boolean = false,
+    passwordHistory: List<PasswordHistoryView> = listOf(
+        createMockPasswordHistoryView(number = number, clock),
+    ),
 ): CipherView =
     CipherView(
         id = "mockId-$number",
@@ -92,7 +95,7 @@ fun createMockCipherView(
         },
         sshKey = sshKey.takeIf { cipherType == CipherType.SSH_KEY },
         favorite = false,
-        passwordHistory = listOf(createMockPasswordHistoryView(number = number, clock)),
+        passwordHistory = passwordHistory,
         permissions = createMockSdkCipherPermissions(),
         reprompt = repromptType,
         secureNote = createMockSecureNoteView().takeIf { cipherType == CipherType.SECURE_NOTE },

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/passwordhistory/PasswordHistoryViewModelTest.kt
@@ -14,6 +14,7 @@ import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardMan
 import com.x8bit.bitwarden.data.platform.repository.model.LocalDataState
 import com.x8bit.bitwarden.data.tools.generator.repository.util.FakeGeneratorRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockPasswordHistoryView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorPasswordHistoryMode
 import io.mockk.every
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.FormatStyle
@@ -182,6 +184,47 @@ class PasswordHistoryViewModelTest : BaseViewModelTest() {
             assertEquals(expectedState, actualState)
         }
     }
+
+    @Test
+    fun `when VaultRepository emits Loaded state the state updates correctly in a sorted order`() =
+        runTest {
+            val cipher = createMockCipherView(
+                number = 1,
+                passwordHistory = listOf(
+                    createMockPasswordHistoryView(number = 1, clock = fixedClock),
+                    createMockPasswordHistoryView(
+                        number = 2,
+                        clock = Clock.offset(fixedClock, Duration.ofMinutes(5)),
+                    ),
+                ),
+            )
+            mutableVaultItemFlow.value = DataState.Loaded(cipher)
+            val viewModel = createViewModel(
+                initialState = createPasswordHistoryState(
+                    passwordHistoryMode = GeneratorPasswordHistoryMode.Item(itemId = "mockId-1"),
+                ),
+            )
+
+            viewModel.stateFlow.test {
+                val expectedState = createPasswordHistoryState(
+                    viewState = PasswordHistoryState.ViewState.Content(
+                        passwords = listOf(
+                            PasswordHistoryState.GeneratedPassword(
+                                password = "mockPassword-2",
+                                date = "10/27/23, 12:05\u202FPM",
+                            ),
+                            PasswordHistoryState.GeneratedPassword(
+                                password = "mockPassword-1",
+                                date = "10/27/23, 12:00\u202FPM",
+                            ),
+                        ),
+                    ),
+                    passwordHistoryMode = GeneratorPasswordHistoryMode.Item(itemId = "mockId-1"),
+                )
+                val actualState = awaitItem()
+                assertEquals(expectedState, actualState)
+            }
+        }
 
     @Test
     fun `when password history updates the state updates correctly`() = runTest {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32721](https://bitwarden.atlassian.net/browse/PM-32721)

## 📔 Objective

This PR adds a sort order by date to the password history screen. The password are displayed, most recent at the top going down to the oldest.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/6ac76cdc-9305-4bb1-b2ae-3ac9100d79f8" /> | <img width="350" src="https://github.com/user-attachments/assets/54b2476a-f85f-4cfb-8007-82349186dd4d" /> |


[PM-32721]: https://bitwarden.atlassian.net/browse/PM-32721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ