### PR TITLE
chore: Remove unused how_to_manage_my_vault string

### DIFF
--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -512,7 +512,6 @@ Scanning will happen automatically.</string>
     <string name="leave_organization_button">Leave %1$s</string>
     <string name="leave_organization_warning">By declining, your personal items will stay in your account, but you’ll lose access to shared items and organization features. <annotation link="learnMore">Learn more</annotation></string>
     <string name="contact_your_admin_to_regain_access">Contact your admin to regain access.</string>
-    <string name="how_to_manage_my_vault">How to manage My vault</string>
     <string name="fido2_authenticate_web_authn">Authenticate WebAuthn</string>
     <string name="fido2_return_to_app">Return to app</string>
     <string name="reset_password_auto_enroll_invite_warning">This organization has an enterprise policy that will automatically enroll you in password reset. Enrollment will allow organization administrators to change your master password.</string>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the unused `how_to_manage_my_vault` string from the primary resources file.
