### PR TITLE
PM-29871: bug: Add more accessibility callouts for external links

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendListItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendListItem.kt
@@ -73,6 +73,10 @@ fun SendListItem(
             ),
             SelectionItemData(
                 text = stringResource(id = BitwardenString.share_link),
+                contentDescription = stringResource(
+                    id = BitwardenString.external_link_format,
+                    formatArgs = arrayOf(stringResource(id = BitwardenString.share_link)),
+                ),
                 onClick = onShareClick,
             ),
             SelectionItemData(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -151,6 +151,7 @@ fun AddEditSendScreen(
                                 .takeIf { !state.policyDisablesSend },
                             OverflowMenuItemData(
                                 text = stringResource(id = BitwardenString.share_link),
+                                isExternalLink = true,
                                 onClick = {
                                     viewModel.trySendAction(AddEditSendAction.ShareLinkClick)
                                 },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendScreen.kt
@@ -250,6 +250,7 @@ private fun ViewStateContent(
             label = stringResource(id = BitwardenString.share),
             onClick = onShareClick,
             icon = rememberVectorPainter(id = BitwardenDrawable.ic_share_small),
+            isExternalLink = true,
             cardStyle = CardStyle.Bottom,
             cardInsets = PaddingValues(top = 6.dp, bottom = 16.dp, start = 16.dp, end = 16.dp),
             modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/importitems/ImportItemsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/importitems/ImportItemsScreen.kt
@@ -168,6 +168,7 @@ private fun ImportItemsContent(
             BitwardenTextRow(
                 text = stringResource(BitwardenString.import_from_another_app),
                 onClick = onImportFromAnotherAppClick,
+                isExternalLink = true,
                 cardStyle = CardStyle.Bottom,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
@@ -66,7 +66,8 @@ sealed class ListingItemOverflowAction : Parcelable {
         @Parcelize
         data class ShareUrlClick(val sendUrl: String) : SendAction() {
             override val title: Text get() = BitwardenString.share_link.asText()
-            override val contentDescription: Text get() = title
+            override val contentDescription: Text
+                get() = BitwardenString.external_link_format.asText(title)
         }
 
         /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/SaveManualCodeButtons.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/manualcodeentry/SaveManualCodeButtons.kt
@@ -58,6 +58,7 @@ fun SaveManualCodeButtons(
             Column(modifier = modifier) {
                 BitwardenFilledButton(
                     label = stringResource(id = BitwardenString.save_to_bitwarden),
+                    isExternalLink = true,
                     onClick = onSaveToBitwardenClick,
                     modifier = Modifier.fillMaxWidth(),
                 )

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/row/BitwardenTextRow.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/row/BitwardenTextRow.kt
@@ -15,6 +15,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
@@ -26,6 +28,7 @@ import com.bitwarden.ui.platform.components.button.BitwardenHelpIconButton
 import com.bitwarden.ui.platform.components.button.model.BitwardenHelpButtonData
 import com.bitwarden.ui.platform.components.divider.BitwardenHorizontalDivider
 import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 
 /**
@@ -42,6 +45,7 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
  * and it's contents will be dimmed.
  * @param clickable An optional override for whether the row is clickable or not. Defaults to
  * [isEnabled].
+ * @param isExternalLink Indicates the row is an whether the text is an external link or not.
  * @param withDivider Indicates if a divider should be drawn on the bottom of the row, defaults
  * to `false`.
  * @param helpData The data required to display a help button.
@@ -58,6 +62,7 @@ fun BitwardenTextRow(
     textTestTag: String? = null,
     isEnabled: Boolean = true,
     clickable: Boolean = isEnabled,
+    isExternalLink: Boolean = false,
     withDivider: Boolean = false,
     helpData: BitwardenHelpButtonData? = null,
     content: (@Composable () -> Unit)? = null,
@@ -85,6 +90,11 @@ fun BitwardenTextRow(
                     .weight(1f),
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
+                    val formattedContentDescription = if (isExternalLink) {
+                        stringResource(id = BitwardenString.external_link_format, text)
+                    } else {
+                        text
+                    }
                     Text(
                         text = text,
                         style = BitwardenTheme.typography.bodyLarge,
@@ -93,7 +103,9 @@ fun BitwardenTextRow(
                         } else {
                             BitwardenTheme.colorScheme.filledButton.foregroundDisabled
                         },
-                        modifier = Modifier.nullableTestTag(tag = textTestTag),
+                        modifier = Modifier
+                            .semantics { contentDescription = formattedContentDescription }
+                            .nullableTestTag(tag = textTestTag),
                     )
                     helpData?.let { HelpButton(helpData = it) }
                 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29871](https://bitwarden.atlassian.net/browse/PM-29871)
[PM-PM-33942](https://bitwarden.atlassian.net/browse/PM-PM-33942)
[PM-PM-33943](https://bitwarden.atlassian.net/browse/PM-PM-33943)
[PM-PM-33944](https://bitwarden.atlassian.net/browse/PM-PM-33944)

## 📔 Objective

This PR adds even more external link callouts for accessibility.

* Share link
* Import from another app
* Save to Bitwarden


[PM-29871]: https://bitwarden.atlassian.net/browse/PM-29871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ