### PR TITLE
PM-32721: bug: Sort password history before persisting

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
@@ -163,13 +163,16 @@ private fun VaultAddEditState.ViewState.Content.toPasswordHistory(
     )
 
     return listOf(
-        common.originalCipher?.passwordHistory.orEmpty(),
         newPasswordHistory,
+        common.originalCipher?.passwordHistory.orEmpty(),
         newHiddenFieldHistory,
     )
         .flatten()
+        // Ensure that they are in the correct order before saving.
+        .sortedByDescending { it.lastUsedDate }
+        // Only persist the 5 most recent items.
+        .take(5)
         .ifEmpty { null }
-        ?.takeLast(5)
 }
 
 private fun getPasswordHistory(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
@@ -18,8 +18,8 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkFido2Cre
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditState
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
-import com.x8bit.bitwarden.ui.vault.model.VaultCollection
 import com.x8bit.bitwarden.ui.vault.model.VaultCardExpirationMonth
+import com.x8bit.bitwarden.ui.vault.model.VaultCollection
 import com.x8bit.bitwarden.ui.vault.model.VaultIdentityTitle
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -202,11 +202,11 @@ class VaultAddItemStateExtensionsTest {
                 ),
                 passwordHistory = listOf(
                     PasswordHistoryView(
-                        password = "old_password",
+                        password = "password",
                         lastUsedDate = FIXED_CLOCK.instant(),
                     ),
                     PasswordHistoryView(
-                        password = "password",
+                        password = "old_password",
                         lastUsedDate = FIXED_CLOCK.instant(),
                     ),
                     PasswordHistoryView(
@@ -1104,11 +1104,11 @@ class VaultAddItemStateExtensionsTest {
                 fields = emptyList(),
                 passwordHistory = listOf(
                     PasswordHistoryView(
-                        password = "old_password",
+                        password = "password",
                         lastUsedDate = FIXED_CLOCK.instant(),
                     ),
                     PasswordHistoryView(
-                        password = "password",
+                        password = "old_password",
                         lastUsedDate = FIXED_CLOCK.instant(),
                     ),
                     PasswordHistoryView(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32721](https://bitwarden.atlassian.net/browse/PM-32721)

## 📔 Objective

This PR updates the logic for how we persist the password history. We now ensure that it is saved in sorted order so that other client that do not sort the list before displaying the data still display everything in the correct order.


[PM-32721]: https://bitwarden.atlassian.net/browse/PM-32721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ