### PR TITLE
chore: Update RootNavScreen to enforce state-based navigation

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/auth/AuthNavigation.kt
@@ -82,7 +82,7 @@ fun NavGraphBuilder.authGraph(
                 navController.navigateToMasterPasswordGuidance()
             },
             onNavigateToPreventAccountLockout = {
-                navController.navigateToPreventAccountLockout()
+                navController.navigateToPreventAccountLockout(isPasswordReset = false)
             },
             onNavigateToLogin = { emailAddress ->
                 navController.navigateToLogin(
@@ -172,11 +172,14 @@ fun NavGraphBuilder.authGraph(
             onNavigateToGeneratePassword = { navController.navigateToMasterPasswordGenerator() },
         )
         preventAccountLockoutDestination(
+            isPasswordReset = false,
             onNavigateBack = { navController.popBackStack() },
         )
         masterPasswordGeneratorDestination(
             onNavigateBack = { navController.popBackStack() },
-            onNavigateToPreventLockout = { navController.navigateToPreventAccountLockout() },
+            onNavigateToPreventLockout = {
+                navController.navigateToPreventAccountLockout(isPasswordReset = false)
+            },
             onNavigateBackWithPassword = {
                 navController.popUpToCompleteRegistration()
             },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/preventaccountlockout/PreventAccountLockoutNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/preventaccountlockout/PreventAccountLockoutNavigation.kt
@@ -10,24 +10,51 @@ import kotlinx.serialization.Serializable
  * The type-safe route for the prevent account lockout screen.
  */
 @Serializable
-data object PreventAccountLockoutRoute
+sealed class PreventAccountLockoutRoute {
+    /**
+     * The type-safe route for the prevent account lockout screen.
+     */
+    @Serializable
+    data object Standard : PreventAccountLockoutRoute()
+
+    /**
+     * The type-safe route for the password reset prevent account lockout screen.
+     */
+    @Serializable
+    data object PasswordReset : PreventAccountLockoutRoute()
+}
 
 /**
  * Navigate to prevent account lockout screen.
  */
-fun NavController.navigateToPreventAccountLockout(navOptions: NavOptions? = null) {
-    this.navigate(route = PreventAccountLockoutRoute, navOptions = navOptions)
+fun NavController.navigateToPreventAccountLockout(
+    isPasswordReset: Boolean,
+    navOptions: NavOptions? = null,
+) {
+    this.navigate(
+        route = if (isPasswordReset) {
+            PreventAccountLockoutRoute.PasswordReset
+        } else {
+            PreventAccountLockoutRoute.Standard
+        },
+        navOptions = navOptions,
+    )
 }
 
 /**
  * Add the prevent account lockout screen to the nav graph.
  */
 fun NavGraphBuilder.preventAccountLockoutDestination(
+    isPasswordReset: Boolean,
     onNavigateBack: () -> Unit,
 ) {
-    composableWithSlideTransitions<PreventAccountLockoutRoute> {
-        PreventAccountLockoutScreen(
-            onNavigateBack = onNavigateBack,
-        )
+    if (isPasswordReset) {
+        composableWithSlideTransitions<PreventAccountLockoutRoute.PasswordReset> {
+            PreventAccountLockoutScreen(onNavigateBack = onNavigateBack)
+        }
+    } else {
+        composableWithSlideTransitions<PreventAccountLockoutRoute.Standard> {
+            PreventAccountLockoutScreen(onNavigateBack = onNavigateBack)
+        }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/auth/feature/resetpassword/ResetPasswordNavigation.kt
@@ -2,15 +2,44 @@ package com.x8bit.bitwarden.ui.auth.feature.resetpassword
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import com.x8bit.bitwarden.ui.auth.feature.preventaccountlockout.navigateToPreventAccountLockout
+import com.x8bit.bitwarden.ui.auth.feature.preventaccountlockout.preventAccountLockoutDestination
 import kotlinx.serialization.Serializable
+
+/**
+ * The type-safe route for the reset password graph.
+ */
+@Serializable
+data object ResetPasswordGraphRoute
 
 /**
  * The type-safe route for the reset password screen.
  */
 @Serializable
 data object ResetPasswordRoute
+
+/**
+ * Add password reset destinations to the nav graph.
+ */
+fun NavGraphBuilder.passwordResetGraph(navController: NavHostController) {
+    navigation<ResetPasswordGraphRoute>(
+        startDestination = ResetPasswordRoute,
+    ) {
+        resetPasswordDestination(
+            onNavigateToPreventAccountLockOut = {
+                navController.navigateToPreventAccountLockout(isPasswordReset = true)
+            },
+        )
+        preventAccountLockoutDestination(
+            isPasswordReset = true,
+            onNavigateBack = { navController.popBackStack() },
+        )
+    }
+}
 
 /**
  * Add the Reset Password screen to the nav graph.
@@ -24,10 +53,10 @@ fun NavGraphBuilder.resetPasswordDestination(
 }
 
 /**
- * Navigate to the Reset Password screen.
+ * Navigate to the Reset Password graph.
  */
-fun NavController.navigateToResetPasswordScreen(
+fun NavController.navigateToResetPasswordGraph(
     navOptions: NavOptions? = null,
 ) {
-    this.navigate(route = ResetPasswordRoute, navOptions = navOptions)
+    this.navigate(route = ResetPasswordGraphRoute, navOptions = navOptions)
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreen.kt
@@ -34,13 +34,12 @@ import com.x8bit.bitwarden.ui.auth.feature.auth.authGraph
 import com.x8bit.bitwarden.ui.auth.feature.auth.navigateToAuthGraph
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.navigateToCompleteRegistration
 import com.x8bit.bitwarden.ui.auth.feature.expiredregistrationlink.navigateToExpiredRegistrationLinkScreen
-import com.x8bit.bitwarden.ui.auth.feature.preventaccountlockout.navigateToPreventAccountLockout
 import com.x8bit.bitwarden.ui.auth.feature.removepassword.RemovePasswordRoute
 import com.x8bit.bitwarden.ui.auth.feature.removepassword.navigateToRemovePassword
 import com.x8bit.bitwarden.ui.auth.feature.removepassword.removePasswordDestination
-import com.x8bit.bitwarden.ui.auth.feature.resetpassword.ResetPasswordRoute
-import com.x8bit.bitwarden.ui.auth.feature.resetpassword.navigateToResetPasswordScreen
-import com.x8bit.bitwarden.ui.auth.feature.resetpassword.resetPasswordDestination
+import com.x8bit.bitwarden.ui.auth.feature.resetpassword.ResetPasswordGraphRoute
+import com.x8bit.bitwarden.ui.auth.feature.resetpassword.navigateToResetPasswordGraph
+import com.x8bit.bitwarden.ui.auth.feature.resetpassword.passwordResetGraph
 import com.x8bit.bitwarden.ui.auth.feature.setpassword.SetPasswordRoute
 import com.x8bit.bitwarden.ui.auth.feature.setpassword.navigateToSetPassword
 import com.x8bit.bitwarden.ui.auth.feature.trusteddevice.TrustedDeviceGraphRoute
@@ -107,11 +106,7 @@ fun RootNavScreen(
         splashDestination()
         authGraph(navController)
         removePasswordDestination()
-        resetPasswordDestination(
-            onNavigateToPreventAccountLockOut = {
-                navController.navigateToPreventAccountLockout()
-            },
-        )
+        passwordResetGraph(navController)
         trustedDeviceGraph(navController)
         vaultUnlockDestination()
         vaultUnlockedGraph(navController)
@@ -130,7 +125,7 @@ fun RootNavScreen(
         RootNavState.ExpiredRegistrationLink,
             -> AuthGraphRoute
 
-        RootNavState.ResetPassword -> ResetPasswordRoute
+        RootNavState.ResetPassword -> ResetPasswordGraphRoute
         RootNavState.SetPassword -> SetPasswordRoute
         RootNavState.RemovePassword -> RemovePasswordRoute
         RootNavState.Splash -> SplashRoute
@@ -215,7 +210,7 @@ fun RootNavScreen(
 
             RootNavState.RemovePassword -> navController.navigateToRemovePassword(rootNavOptions)
             RootNavState.ResetPassword -> {
-                navController.navigateToResetPasswordScreen(rootNavOptions)
+                navController.navigateToResetPasswordGraph(rootNavOptions)
             }
 
             RootNavState.SetPassword -> navController.navigateToSetPassword(rootNavOptions)
@@ -354,7 +349,7 @@ private fun AnimatedContentTransitionScope<NavBackStackEntry>.toEnterTransition(
     } else {
         when (targetState.destination.rootLevelRoute()) {
             MigrateToMyItemsGraphRoute.toObjectNavigationRoute(),
-            ResetPasswordRoute.toObjectNavigationRoute(),
+            ResetPasswordGraphRoute.toObjectNavigationRoute(),
                 -> RootTransitionProviders.Enter.slideUp
 
             else -> when (initialState.destination.rootLevelRoute()) {
@@ -364,7 +359,7 @@ private fun AnimatedContentTransitionScope<NavBackStackEntry>.toEnterTransition(
                 // should stay but due to an issue when combining certain animations,
                 // we are just using a fadeIn instead.
                 MigrateToMyItemsGraphRoute.toObjectNavigationRoute(),
-                ResetPasswordRoute.toObjectNavigationRoute(),
+                ResetPasswordGraphRoute.toObjectNavigationRoute(),
                     -> RootTransitionProviders.Enter.fadeIn
 
                 else -> RootTransitionProviders.Enter.fadeIn
@@ -387,12 +382,12 @@ private fun AnimatedContentTransitionScope<NavBackStackEntry>.toExitTransition()
             // Disable transitions when coming from the splash screen
             SplashRoute.toObjectNavigationRoute() -> RootTransitionProviders.Exit.none
             MigrateToMyItemsGraphRoute.toObjectNavigationRoute(),
-            ResetPasswordRoute.toObjectNavigationRoute(),
+            ResetPasswordGraphRoute.toObjectNavigationRoute(),
                 -> RootTransitionProviders.Exit.slideDown
 
             else -> when (targetRoute) {
                 MigrateToMyItemsGraphRoute.toObjectNavigationRoute(),
-                ResetPasswordRoute.toObjectNavigationRoute(),
+                ResetPasswordGraphRoute.toObjectNavigationRoute(),
                     -> RootTransitionProviders.Exit.stay
 
                 else -> RootTransitionProviders.Exit.fadeOut

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavScreenTest.kt
@@ -11,7 +11,7 @@ import com.x8bit.bitwarden.ui.auth.feature.accountsetup.SetupUnlockRoute
 import com.x8bit.bitwarden.ui.auth.feature.auth.AuthGraphRoute
 import com.x8bit.bitwarden.ui.auth.feature.completeregistration.CompleteRegistrationRoute
 import com.x8bit.bitwarden.ui.auth.feature.expiredregistrationlink.ExpiredRegistrationLinkRoute
-import com.x8bit.bitwarden.ui.auth.feature.resetpassword.ResetPasswordRoute
+import com.x8bit.bitwarden.ui.auth.feature.resetpassword.ResetPasswordGraphRoute
 import com.x8bit.bitwarden.ui.auth.feature.setpassword.SetPasswordRoute
 import com.x8bit.bitwarden.ui.auth.feature.trusteddevice.TrustedDeviceGraphRoute
 import com.x8bit.bitwarden.ui.auth.feature.vaultunlock.VaultUnlockRoute
@@ -165,7 +165,7 @@ class RootNavScreenTest : BitwardenComposeTest() {
         composeTestRule.runOnIdle {
             verify {
                 mockNavHostController.navigate(
-                    route = ResetPasswordRoute,
+                    route = ResetPasswordGraphRoute,
                     navOptions = expectedNavOptions,
                 )
             }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR cleans up a small bit of code where we were mixing event-based navigation into the `RootNavScreen` where only state-based navigation should be allowed.

