### PR TITLE
PM-34115: bug: Consistent visual length of TOTP codes

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeItem.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/verificationcode/VerificationCodeItem.kt
@@ -106,7 +106,9 @@ fun VaultVerificationCodeItem(
 
         if (!hideAuthCode) {
             Text(
-                text = authCode.chunked(3).joinToString(" "),
+                text = authCode
+                    .chunked(size = 3) { it.padEnd(length = 3, padChar = ' ') }
+                    .joinToString(separator = " "),
                 style = BitwardenTheme.typography.sensitiveInfoSmall,
                 color = BitwardenTheme.colorScheme.text.primary,
             )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/VaultVerificationCodeItem.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/VaultVerificationCodeItem.kt
@@ -154,7 +154,9 @@ fun VaultVerificationCodeItem(
 
         Text(
             modifier = Modifier.testTag(tag = "AuthCode"),
-            text = authCode.chunked(size = 3).joinToString(separator = " "),
+            text = authCode
+                .chunked(size = 3) { it.padEnd(length = 3, padChar = ' ') }
+                .joinToString(separator = " "),
             style = BitwardenTheme.typography.sensitiveInfoSmall,
             color = BitwardenTheme.colorScheme.text.primary,
         )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34115](https://bitwarden.atlassian.net/browse/PM-34115)

## 📔 Objective

This PR forces the UI to display TOTP codes in chunks of 3 characters to ensure that they have a consistent length.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/1b0e9796-b17d-4d51-9fd9-b6a26c5eb527" /> | <img width="350" src="https://github.com/user-attachments/assets/11f480b5-86f9-4937-a01f-5b074d5b74b6" /> |
| <img width="350" src="https://github.com/user-attachments/assets/d4f0c1b1-b985-4054-ab55-07b58b851b6a" /> | <img width="350" src="https://github.com/user-attachments/assets/2ffaa4bc-4fb5-4a06-852b-706291e83a34" /> |


[PM-34115]: https://bitwarden.atlassian.net/browse/PM-34115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ