### PR TITLE
[PM-34124] refactor: Generalize CameraPreview analyzer parameter

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/qrcodescan/QrCodeScanScreen.kt
@@ -92,7 +92,7 @@ fun QrCodeScanScreen(
                 cameraErrorReceive = {
                     viewModel.trySendAction(QrCodeScanAction.CameraSetupErrorReceive)
                 },
-                qrCodeAnalyzer = qrCodeAnalyzer,
+                analyzer = qrCodeAnalyzer,
                 modifier = Modifier.fillMaxSize(),
             )
             when (rememberWindowSize()) {

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/qrcodescan/QrCodeScanScreen.kt
@@ -107,7 +107,7 @@ fun QrCodeScanScreen(
                 cameraErrorReceive = {
                     viewModel.trySendAction(QrCodeScanAction.CameraSetupErrorReceive)
                 },
-                qrCodeAnalyzer = qrCodeAnalyzer,
+                analyzer = qrCodeAnalyzer,
                 modifier = Modifier.fillMaxSize(),
             )
 

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/camera/CameraPreview.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/camera/CameraPreview.kt
@@ -18,14 +18,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import com.bitwarden.ui.platform.feature.qrcodescan.util.QrCodeAnalyzer
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.util.concurrent.Executors
 
 /**
  * A composable for displaying the camera preview.
  *
- * @param qrCodeAnalyzer The [QrCodeAnalyzer].
+ * @param analyzer The [ImageAnalysis.Analyzer] to use for image analysis.
  * @param cameraErrorReceive A callback invoked when an error occurs.
  * @param modifier The [Modifier] for this composable.
  * @param context The local context.
@@ -33,7 +32,7 @@ import java.util.concurrent.Executors
  */
 @Composable
 fun CameraPreview(
-    qrCodeAnalyzer: QrCodeAnalyzer,
+    analyzer: ImageAnalysis.Analyzer,
     cameraErrorReceive: (Exception) -> Unit,
     modifier: Modifier = Modifier,
     context: Context = LocalContext.current,
@@ -43,7 +42,7 @@ fun CameraPreview(
     if ("robolectric" == Build.FINGERPRINT) return
     val surfaceRequests = remember { MutableStateFlow<SurfaceRequest?>(null) }
     val preview = rememberPreview { surfaceRequests.value = it }
-    val imageAnalyzer = rememberImageAnalyzer(qrCodeAnalyzer = qrCodeAnalyzer)
+    val imageAnalyzer = rememberImageAnalyzer(analyzer = analyzer)
     LaunchedEffect(Unit) {
         try {
             val provider = ProcessCameraProvider.awaitInstance(context = context)
@@ -72,12 +71,12 @@ fun CameraPreview(
 
 @Composable
 private fun rememberImageAnalyzer(
-    qrCodeAnalyzer: QrCodeAnalyzer,
-): ImageAnalysis = remember(qrCodeAnalyzer) {
+    analyzer: ImageAnalysis.Analyzer,
+): ImageAnalysis = remember(analyzer) {
     ImageAnalysis.Builder()
         .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
         .build()
-        .apply { setAnalyzer(Executors.newSingleThreadExecutor(), qrCodeAnalyzer) }
+        .apply { setAnalyzer(Executors.newSingleThreadExecutor(), analyzer) }
 }
 
 @Composable


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34124

## 📔 Objective

Generalizes the `CameraPreview` composable to accept any `ImageAnalysis.Analyzer` instead of the QR-code-specific `QrCodeAnalyzer`. This prepares the component for reuse by the upcoming card scanner feature while maintaining full backward compatibility with existing QR code scanning call sites.