### PR TITLE
[PM-34168] Add future CalyxOS Chromium key to FIDO2 privilege community list

### DIFF
--- a/app/src/main/assets/fido2_privileged_community.json
+++ b/app/src/main/assets/fido2_privileged_community.json
@@ -43,6 +43,18 @@
     {
       "type": "android",
       "info": {
+        "package_name": "org.calyxos.chromium",
+        "signatures": [
+          {
+            "build": "release",
+            "cert_fingerprint_sha256": "CB:33:EE:73:84:2F:2F:BD:C3:E3:52:5F:D1:C3:74:07:41:82:6F:33:84:9B:C9:6F:95:4D:76:18:17:D3:00:EB"
+          }
+        ]
+      }
+    },
+    {
+      "type": "android",
+      "info": {
         "package_name": "org.cromite.cromite",
         "signatures": [
           {


### PR DESCRIPTION
We should now be migrating to org.calyxos.chromium, instead of using the default Chromium package name, we're also using HSMs for signing our builds now, including this key, see https://calyxos.org/news/2026/02/10/calyxos-hsm-signing/

## 📔 Objective

Prepare Bitwarden for compatibility with our Chromium builds as soon as they're out

