### PR TITLE
llm: Add test constants placement rule to testing skill

### DIFF
--- a/.claude/skills/testing-android-code/SKILL.md
+++ b/.claude/skills/testing-android-code/SKILL.md
@@ -284,6 +284,10 @@ module/src/testFixtures/kotlin/com/bitwarden/.../
 └── model/*Util.kt
 ```
 
+### Test Constants Placement
+
+Declare test constants as top-level `private const val` at the **bottom** of the file, after the class closing brace. Do NOT use `companion object` for test constants.
+
 ### Test Naming
 
 - Classes: `*Test.kt`, `*ScreenTest.kt`, `*ViewModelTest.kt`


### PR DESCRIPTION
## 🎟️ Tracking

LLM tooling improvement — no Jira ticket.

## 📔 Objective

Add a "Test Constants Placement" section to the `testing-android-code` skill documenting the convention: declare test constants as top-level `private const val` at the bottom of the file, not inside `companion object`.