### PR TITLE
PM-34193: bug: Unlock vault from Never-Lock should be on io thread

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -98,6 +98,7 @@ class VaultLockManagerImpl(
     context: Context,
 ) : VaultLockManager {
     private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
+    private val ioScope = CoroutineScope(dispatcherManager.io)
 
     /**
      * This [Map] tracks all active timeout [Job]s that are running and their associated data using
@@ -478,7 +479,7 @@ class VaultLockManagerImpl(
                     .map { userId -> vaultTimeoutChangesForUserFlow(userId = userId) }
                     .merge()
             }
-            .launchIn(unconfinedScope)
+            .launchIn(ioScope)
     }
 
     private fun observeUserLogoutResults() {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34193](https://bitwarden.atlassian.net/browse/PM-34193)

## 📔 Objective

This PR addresses a bug with `Never` timeout value. We are now observing changes to the timeout type via the `io` dispatcher to ensure that the SDK cannot deadlock when calling back. This was a problem when we used the `unconfined` dispatcher. We are going to continue to investigate why this is happening, since using the `unconfined` dispatcher should not be a problem here.


[PM-34193]: https://bitwarden.atlassian.net/browse/PM-34193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ