### PR TITLE
llm: Add AI review label prompt to PR creation skill

### DIFF
--- a/.claude/skills/creating-android-pull-request/SKILL.md
+++ b/.claude/skills/creating-android-pull-request/SKILL.md
@@ -58,6 +58,21 @@ gh pr create --draft --title "[PM-XXXXX] feat: Short summary" --body "<fill in f
 
 ---
 
+## AI Review Label
+
+Before running `gh pr create`, **always** use the `AskUserQuestion` tool to ask whether to add an AI review label:
+
+- **Question**: "Would you like to add an AI review label to this PR?"
+- **Options**: `ai-review-vnext`, `ai-review`, `No label`
+
+If the user selects a label, include it via the `--label` flag:
+
+```bash
+gh pr create --draft --label "ai-review-vnext" --title "..." --body "..."
+```
+
+---
+
 ## Base Branch
 
 - Default target: `main`


### PR DESCRIPTION
## 🎟️ Tracking

Internal tooling improvement — no Jira ticket.

## 📔 Objective

Adds an `AskUserQuestion` step to the PR creation skill that prompts the user to select `ai-review-vnext`, `ai-review`, or no label before creating a PR. This ensures AI code review is always offered as an option during the PR workflow.

## 📸 Screenshots

<img width="365" src="https://github.com/user-attachments/assets/ab559623-fce4-479e-a4fb-8021751c7c11" />
