### PR TITLE
[PM-36039] Send folder

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSource.kt
@@ -17,6 +17,8 @@ import com.bitwarden.fido.Fido2CredentialAutofillView
 import com.bitwarden.fido.PublicKeyCredentialAuthenticatorAssertionResponse
 import com.bitwarden.fido.PublicKeyCredentialAuthenticatorAttestationResponse
 import com.bitwarden.sdk.Fido2CredentialStore
+import com.bitwarden.sdk.MakeSendFolderFileUniFfiEntry
+import com.bitwarden.sdk.MakeSendFolderFileUniFfiResult
 import com.bitwarden.send.Send
 import com.bitwarden.send.SendView
 import com.bitwarden.vault.Attachment
@@ -277,6 +279,21 @@ interface VaultSdkSource {
         path: String,
         destinationFilePath: String,
     ): Result<File>
+
+    /**
+     * Creates a zip archive from the given folder [files] on disk for the user with the given
+     * [userId]. The SDK reads files directly from disk and writes the resulting zip to
+     * [outputZipPath], returning a [MakeSendFolderFileUniFfiResult] wrapped in a [Result].
+     *
+     * This should only be called after a successful call to [initializeCrypto] for the associated
+     * user.
+     */
+    suspend fun makeSendFolderFile(
+        userId: String,
+        folderName: String,
+        files: List<MakeSendFolderFileUniFfiEntry>,
+        outputZipPath: String,
+    ): Result<MakeSendFolderFileUniFfiResult>
 
     /**
      * Decrypts a [Send] for the user with the given [userId], returning a [SendView] wrapped in a

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/datasource/sdk/VaultSdkSourceImpl.kt
@@ -21,6 +21,8 @@ import com.bitwarden.fido.PublicKeyCredentialAuthenticatorAttestationResponse
 import com.bitwarden.sdk.BitwardenException
 import com.bitwarden.sdk.Fido2CredentialStore
 import com.bitwarden.sdk.VaultClient
+import com.bitwarden.sdk.MakeSendFolderFileUniFfiEntry
+import com.bitwarden.sdk.MakeSendFolderFileUniFfiResult
 import com.bitwarden.send.Send
 import com.bitwarden.send.SendView
 import com.bitwarden.vault.Attachment
@@ -259,6 +261,22 @@ class VaultSdkSourceImpl(
                     encryptedFilePath = destinationFilePath,
                 )
             File(destinationFilePath)
+        }
+
+    override suspend fun makeSendFolderFile(
+        userId: String,
+        folderName: String,
+        files: List<MakeSendFolderFileUniFfiEntry>,
+        outputZipPath: String,
+    ): Result<MakeSendFolderFileUniFfiResult> =
+        runCatchingWithLogs {
+            getClient(userId = userId)
+                .sends()
+                .makeSendFolderFile(
+                    folderName = folderName,
+                    files = files,
+                    destination = outputZipPath,
+                )
         }
 
     override suspend fun encryptAttachment(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManager.kt
@@ -19,6 +19,16 @@ interface SendManager {
     suspend fun createSend(sendView: SendView, fileUri: Uri?): CreateSendResult
 
     /**
+     * Attempt to create a folder send. The folder at [folderUri] will be zipped via the SDK
+     * and uploaded as a file send. [folderName] is the display name of the selected folder.
+     */
+    suspend fun createFolderSend(
+        sendView: SendView,
+        folderUri: Uri,
+        folderName: String,
+    ): CreateSendResult
+
+    /**
      * Attempt to delete a send.
      */
     suspend fun deleteSend(sendId: String): DeleteSendResult

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/SendManagerImpl.kt
@@ -5,6 +5,7 @@ import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.core.data.util.flatMap
+import com.bitwarden.sdk.MakeSendFolderFileUniFfiEntry
 import com.bitwarden.data.manager.file.FileManager
 import com.bitwarden.network.model.CreateFileSendResponse
 import com.bitwarden.network.model.CreateSendJsonResponse
@@ -90,6 +91,125 @@ class SendManagerImpl(
 
                     is CreateSendJsonResponse.Success -> {
                         // Save the send immediately, regardless of whether the decrypt succeeds
+                        vaultDiskSource.saveSend(userId = userId, send = createSendResponse.send)
+                        createSendResponse
+                    }
+                }
+            }
+            .flatMap { createSendSuccessResponse ->
+                vaultSdkSource.decryptSend(
+                    userId = userId,
+                    send = createSendSuccessResponse.send.toEncryptedSdkSend(),
+                )
+            }
+            .fold(
+                onFailure = { CreateSendResult.Error(message = null, error = it) },
+                onSuccess = {
+                    reviewPromptManager.registerCreateSendAction()
+                    CreateSendResult.Success(sendView = it)
+                },
+            )
+    }
+
+    @Suppress("LongMethod")
+    override suspend fun createFolderSend(
+        sendView: SendView,
+        folderUri: Uri,
+        folderName: String,
+    ): CreateSendResult {
+        val userId = activeUserId
+            ?: return CreateSendResult.Error(message = null, error = NoActiveUserException())
+
+        val zipFile = fileManager.createTempFileInCache(
+            prefix = "send_folder_",
+            suffix = ".zip",
+        )
+        return fileManager
+            .writeFolderFilesToCache(folderUri)
+            .flatMap { diskEntries ->
+                val sdkEntries = diskEntries.map { entry ->
+                    MakeSendFolderFileUniFfiEntry(
+                        path = entry.relativePath,
+                        source = entry.diskPath,
+                    )
+                }
+                vaultSdkSource
+                    .makeSendFolderFile(
+                        userId = userId,
+                        folderName = folderName,
+                        files = sdkEntries,
+                        outputZipPath = zipFile.absolutePath,
+                    )
+                    .also {
+                        // Clean up individual temp files now that the zip is written.
+                        fileManager.delete(
+                            *diskEntries
+                                .map { java.io.File(it.diskPath) }
+                                .toTypedArray(),
+                        )
+                    }
+            }
+            .flatMap { folderResult ->
+                val folderSendView = sendView.copy(
+                    file = folderResult.file,
+                )
+
+                vaultSdkSource
+                    .encryptSend(userId = userId, sendView = folderSendView)
+                    .flatMap { send ->
+                        vaultSdkSource
+                            .encryptFile(
+                                userId = userId,
+                                send = send,
+                                path = zipFile.absolutePath,
+                                destinationFilePath = zipFile.absolutePath,
+                            )
+                            .flatMap { encryptedFile ->
+                                sendsService
+                                    .createFileSend(
+                                        body = send.toEncryptedNetworkSend(
+                                            fileLength = encryptedFile.length(),
+                                        ),
+                                    )
+                                    .flatMap { sendFileResponse ->
+                                        when (sendFileResponse) {
+                                            is CreateFileSendResponse.Invalid -> {
+                                                CreateSendJsonResponse
+                                                    .Invalid(
+                                                        message = sendFileResponse.message,
+                                                        validationErrors = sendFileResponse
+                                                            .validationErrors,
+                                                    )
+                                                    .asSuccess()
+                                            }
+
+                                            is CreateFileSendResponse.Success -> {
+                                                sendsService
+                                                    .uploadFile(
+                                                        sendFileResponse = sendFileResponse
+                                                            .createFileJsonResponse,
+                                                        encryptedFile = encryptedFile,
+                                                    )
+                                                    .map { CreateSendJsonResponse.Success(it) }
+                                            }
+                                        }
+                                    }
+                            }
+                    }
+            }
+            .also {
+                fileManager.delete(zipFile)
+            }
+            .map { createSendResponse ->
+                when (createSendResponse) {
+                    is CreateSendJsonResponse.Invalid -> {
+                        return CreateSendResult.Error(
+                            message = createSendResponse.firstValidationErrorMessage,
+                            error = null,
+                        )
+                    }
+
+                    is CreateSendJsonResponse.Success -> {
                         vaultDiskSource.saveSend(userId = userId, send = createSendResponse.send)
                         createSendResponse
                     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -122,6 +122,7 @@ fun SendScreen(
 
     SendDialogs(
         dialogState = state.dialogState,
+        isSendFolderEnabled = state.isSendFolderEnabled,
         onAddSendSelected = { viewModel.trySendAction(SendAction.AddSendSelected(it)) },
         onDismissRequest = { viewModel.trySendAction(SendAction.DismissDialog) },
     )
@@ -211,6 +212,7 @@ fun SendScreen(
 @Composable
 private fun SendDialogs(
     dialogState: SendState.DialogState?,
+    isSendFolderEnabled: Boolean,
     onAddSendSelected: (SendItemType) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -230,12 +232,14 @@ private fun SendDialogs(
             title = stringResource(id = BitwardenString.type),
             onDismissRequest = onDismissRequest,
         ) {
-            SendItemType.entries.forEach {
-                BitwardenBasicDialogRow(
-                    text = it.selectionText(),
-                    onClick = { onAddSendSelected(it) },
-                )
-            }
+            SendItemType.entries
+                .filter { it != SendItemType.FOLDER || isSendFolderEnabled }
+                .forEach {
+                    BitwardenBasicDialogRow(
+                        text = it.selectionText(),
+                        onClick = { onAddSendSelected(it) },
+                    )
+                }
         }
 
         null -> Unit

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -304,7 +304,7 @@ class SendViewModel @Inject constructor(
     }
 
     private fun handleAddSendSelected(action: SendAction.AddSendSelected) {
-        if (action.sendType == SendItemType.FILE) {
+        if (action.sendType == SendItemType.FILE || action.sendType == SendItemType.FOLDER) {
             if (state.policyDisablesSend) {
                 mutableStateFlow.update {
                     it.copy(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendViewModel.kt
@@ -16,8 +16,10 @@ import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
+import com.bitwarden.core.data.manager.model.FlagKey
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
 import com.x8bit.bitwarden.data.platform.manager.clipboard.BitwardenClipboardManager
 import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManager
@@ -59,6 +61,7 @@ class SendViewModel @Inject constructor(
     private val environmentRepo: EnvironmentRepository,
     private val vaultRepo: VaultRepository,
     private val networkConnectionManager: NetworkConnectionManager,
+    featureFlagManager: FeatureFlagManager,
 ) : BaseViewModel<SendState, SendEvent, SendAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
@@ -71,6 +74,8 @@ class SendViewModel @Inject constructor(
                 .any(),
             isRefreshing = false,
             isPremiumUser = authRepo.userStateFlow.value?.activeAccount?.isPremium == true,
+            isSendFolderEnabled = featureFlagManager
+                .getFeatureFlag(key = FlagKey.SendFolder),
         ),
 ) {
 
@@ -475,6 +480,7 @@ data class SendState(
     val policyDisablesSend: Boolean,
     val isRefreshing: Boolean,
     val isPremiumUser: Boolean,
+    val isSendFolderEnabled: Boolean,
 ) : Parcelable {
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendContent.kt
@@ -129,6 +129,14 @@ fun AddEditSendContent(
                 )
             }
 
+            is AddEditSendState.ViewState.Content.SendType.Folder -> {
+                FolderTypeContent(
+                    folderType = type,
+                    addSendHandlers = addSendHandlers,
+                    isAddMode = isAddMode,
+                )
+            }
+
             is AddEditSendState.ViewState.Content.SendType.Text -> {
                 TextTypeContent(
                     textType = type,
@@ -369,6 +377,86 @@ private fun ColumnScope.FileTypeContent(
                 style = BitwardenTheme.typography.bodyMedium,
             )
         }
+    }
+}
+
+@Composable
+private fun ColumnScope.FolderTypeContent(
+    folderType: AddEditSendState.ViewState.Content.SendType.Folder,
+    addSendHandlers: AddEditSendHandlers,
+    isAddMode: Boolean,
+) {
+    Spacer(modifier = Modifier.height(height = 8.dp))
+    if (isAddMode) {
+        folderType.name?.let { folderName ->
+            Box(
+                contentAlignment = Alignment.CenterStart,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin()
+                    .defaultMinSize(minHeight = 60.dp)
+                    .cardStyle(cardStyle = CardStyle.Full, paddingHorizontal = 16.dp),
+            ) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = folderName,
+                        color = BitwardenTheme.colorScheme.text.primary,
+                        style = BitwardenTheme.typography.bodyLarge,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(tag = "SendCurrentFolderNameLabel"),
+                    )
+                    if (folderType.fileCount != null && folderType.totalSizeBytes != null) {
+                        Spacer(modifier = Modifier.height(height = 4.dp))
+                        Text(
+                            text = stringResource(
+                                id = BitwardenString.folder_info,
+                                folderType.fileCount,
+                                formatFileSize(folderType.totalSizeBytes),
+                            ),
+                            color = BitwardenTheme.colorScheme.text.secondary,
+                            style = BitwardenTheme.typography.bodySmall,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(height = 8.dp))
+        }
+        BitwardenOutlinedButton(
+            label = stringResource(id = BitwardenString.choose_folder),
+            onClick = addSendHandlers.onChooseFolderClick,
+            isExternalLink = true,
+            modifier = Modifier
+                .testTag(tag = "SendChooseFolderButton")
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+        Spacer(modifier = Modifier.height(height = 8.dp))
+        Text(
+            text = stringResource(id = BitwardenString.required_max_folder_size),
+            color = BitwardenTheme.colorScheme.text.secondary,
+            style = BitwardenTheme.typography.bodySmall,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin()
+                .padding(horizontal = 16.dp),
+        )
+    }
+}
+
+/**
+ * Formats a file size in bytes to a human-readable string.
+ */
+private fun formatFileSize(bytes: Long): String {
+    val kb = 1024.0
+    val mb = kb * 1024
+    return when {
+        bytes >= mb -> "%.1f MB".format(bytes / mb)
+        bytes >= kb -> "%.1f KB".format(bytes / kb)
+        else -> "$bytes B"
     }
 }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -66,6 +66,11 @@ fun AddEditSendScreen(
             addSendHandlers.onFileChoose(it)
         }
     }
+    val folderChooserLauncher = intentManager.getActivityResultLauncher { activityResult ->
+        intentManager.getFolderDataFromActivityResult(activityResult)?.let {
+            addSendHandlers.onFolderChoose(it)
+        }
+    }
 
     val snackbarHostState = rememberBitwardenSnackbarHostState()
     BackHandler(
@@ -82,6 +87,12 @@ fun AddEditSendScreen(
             is AddEditSendEvent.ShowChooserSheet -> {
                 fileChooserLauncher.launch(
                     intentManager.createFileChooserIntent(event.withCameraOption),
+                )
+            }
+
+            is AddEditSendEvent.ShowFolderChooser -> {
+                folderChooserLauncher.launch(
+                    intentManager.createFolderChooserIntent(),
                 )
             }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -17,6 +17,7 @@ import com.bitwarden.ui.platform.base.util.isValidEmail
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.bitwarden.ui.platform.model.FileData
+import com.bitwarden.ui.platform.model.FolderData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
@@ -138,6 +139,15 @@ class AddEditSendViewModel @Inject constructor(
                             )
                         }
 
+                        SendItemType.FOLDER -> {
+                            AddEditSendState.ViewState.Content.SendType.Folder(
+                                uri = null,
+                                name = null,
+                                fileCount = null,
+                                totalSizeBytes = null,
+                            )
+                        }
+
                         SendItemType.TEXT -> {
                             AddEditSendState.ViewState.Content.SendType.Text(
                                 input = "",
@@ -197,6 +207,8 @@ class AddEditSendViewModel @Inject constructor(
         AddEditSendAction.DismissDialogClick -> handleDismissDialogClick()
         is AddEditSendAction.SaveClick -> handleSaveClick()
         is AddEditSendAction.ChooseFileClick -> handleChooseFileClick(action)
+        AddEditSendAction.ChooseFolderClick -> handleChooseFolderClick()
+        is AddEditSendAction.FolderChoose -> handleFolderChoose(action)
         is AddEditSendAction.NameChange -> handleNameChange(action)
         is AddEditSendAction.MaxAccessCountChange -> handleMaxAccessCountChange(action)
         is AddEditSendAction.TextChange -> handleTextChange(action)
@@ -750,6 +762,44 @@ class AddEditSendViewModel @Inject constructor(
                         return@onContent
                     }
                 }
+
+            (content.selectedType as? AddEditSendState.ViewState.Content.SendType.Folder)
+                ?.let { folderType ->
+                    if (!state.isPremium) {
+                        mutableStateFlow.update {
+                            it.copy(
+                                dialogState = AddEditSendState.DialogState.Error(
+                                    title = BitwardenString.send.asText(),
+                                    message = BitwardenString.send_file_premium_required.asText(),
+                                ),
+                            )
+                        }
+                        return@onContent
+                    }
+                    if (folderType.uri == null) {
+                        mutableStateFlow.update {
+                            it.copy(
+                                dialogState = AddEditSendState.DialogState.Error(
+                                    title = BitwardenString.an_error_has_occurred.asText(),
+                                    message = BitwardenString.choose_folder.asText(),
+                                ),
+                            )
+                        }
+                        return@onContent
+                    }
+                    if ((folderType.totalSizeBytes ?: 0) > MAX_FILE_SIZE_BYTES) {
+                        mutableStateFlow.update {
+                            it.copy(
+                                dialogState = AddEditSendState.DialogState.Error(
+                                    title = BitwardenString.an_error_has_occurred.asText(),
+                                    message = BitwardenString.max_file_size.asText(),
+                                ),
+                            )
+                        }
+                        return@onContent
+                    }
+                }
+
             if (!networkConnectionManager.isNetworkConnected) {
                 mutableStateFlow.update {
                     it.copy(
@@ -771,12 +821,23 @@ class AddEditSendViewModel @Inject constructor(
             viewModelScope.launch {
                 when (val addSendType = state.addEditSendType) {
                     AddEditSendType.AddItem -> {
-                        val fileType = content
-                            .selectedType as? AddEditSendState.ViewState.Content.SendType.File
-                        val result = vaultRepo.createSend(
-                            sendView = content.toSendView(clock),
-                            fileUri = fileType?.uri,
-                        )
+                        val folderType = content
+                            .selectedType as? AddEditSendState.ViewState.Content.SendType.Folder
+                        val result = if (folderType != null) {
+                            vaultRepo.createFolderSend(
+                                sendView = content.toSendView(clock),
+                                folderUri = requireNotNull(folderType.uri),
+                                folderName = requireNotNull(folderType.name),
+                            )
+                        } else {
+                            val fileType = content
+                                .selectedType
+                                as? AddEditSendState.ViewState.Content.SendType.File
+                            vaultRepo.createSend(
+                                sendView = content.toSendView(clock),
+                                fileUri = fileType?.uri,
+                            )
+                        }
                         sendAction(AddEditSendAction.Internal.CreateSendResultReceive(result))
                     }
 
@@ -816,6 +877,21 @@ class AddEditSendViewModel @Inject constructor(
 
     private fun handleChooseFileClick(action: AddEditSendAction.ChooseFileClick) {
         sendEvent(AddEditSendEvent.ShowChooserSheet(action.isCameraPermissionGranted))
+    }
+
+    private fun handleChooseFolderClick() {
+        sendEvent(AddEditSendEvent.ShowFolderChooser)
+    }
+
+    private fun handleFolderChoose(action: AddEditSendAction.FolderChoose) {
+        updateFolderContent {
+            it.copy(
+                uri = action.folderData.uri,
+                name = action.folderData.folderName,
+                fileCount = action.folderData.fileCount,
+                totalSizeBytes = action.folderData.totalSizeBytes,
+            )
+        }
     }
 
     private fun handleMaxAccessCountChange(action: AddEditSendAction.MaxAccessCountChange) {
@@ -905,6 +981,17 @@ class AddEditSendViewModel @Inject constructor(
                 ?.let { currentContent.copy(selectedType = block(it)) }
         }
     }
+
+    private inline fun updateFolderContent(
+        crossinline block: (
+            AddEditSendState.ViewState.Content.SendType.Folder,
+        ) -> AddEditSendState.ViewState.Content.SendType.Folder,
+    ) {
+        updateContent { currentContent ->
+            (currentContent.selectedType as? AddEditSendState.ViewState.Content.SendType.Folder)
+                ?.let { currentContent.copy(selectedType = block(it)) }
+        }
+    }
 }
 
 /**
@@ -930,11 +1017,13 @@ data class AddEditSendState(
         get() = when (addEditSendType) {
             AddEditSendType.AddItem -> when (sendType) {
                 SendItemType.FILE -> BitwardenString.add_file_send.asText()
+                SendItemType.FOLDER -> BitwardenString.add_folder_send.asText()
                 SendItemType.TEXT -> BitwardenString.add_text_send.asText()
             }
 
             is AddEditSendType.EditItem -> when (sendType) {
                 SendItemType.FILE -> BitwardenString.edit_file_send.asText()
+                SendItemType.FOLDER -> BitwardenString.edit_folder_send.asText()
                 SendItemType.TEXT -> BitwardenString.edit_text_send.asText()
             }
         }
@@ -1021,6 +1110,17 @@ data class AddEditSendState(
                 ) : SendType()
 
                 /**
+                 * Sending a folder (zipped as a file).
+                 */
+                @Parcelize
+                data class Folder(
+                    val uri: Uri?,
+                    val name: String?,
+                    val fileCount: Int?,
+                    val totalSizeBytes: Long?,
+                ) : SendType()
+
+                /**
                  * Sending text.
                  */
                 @Parcelize
@@ -1094,6 +1194,11 @@ sealed class AddEditSendEvent {
      * Show file chooser sheet.
      */
     data class ShowChooserSheet(val withCameraOption: Boolean) : AddEditSendEvent()
+
+    /**
+     * Show folder chooser.
+     */
+    data object ShowFolderChooser : AddEditSendEvent()
 
     /**
      * Show share sheet.
@@ -1198,6 +1303,16 @@ sealed class AddEditSendAction {
     data class ChooseFileClick(
         val isCameraPermissionGranted: Boolean,
     ) : AddEditSendAction()
+
+    /**
+     * User clicked the choose folder button.
+     */
+    data object ChooseFolderClick : AddEditSendAction()
+
+    /**
+     * User has chosen a folder.
+     */
+    data class FolderChoose(val folderData: FolderData) : AddEditSendAction()
 
     /**
      * User toggled the "hide text by default" toggle.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -884,6 +884,19 @@ class AddEditSendViewModel @Inject constructor(
     }
 
     private fun handleFolderChoose(action: AddEditSendAction.FolderChoose) {
+        if (action.folderData.fileCount <= 0) {
+            mutableStateFlow.update {
+                it.copy(
+                    dialogState = AddEditSendState.DialogState.Error(
+                        title = BitwardenString.an_error_has_occurred.asText(),
+                        message = BitwardenString
+                            .the_selected_folder_is_empty
+                            .asText(),
+                    ),
+                )
+            }
+            return
+        }
         updateFolderContent {
             it.copy(
                 uri = action.folderData.uri,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/handlers/AddEditSendHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/handlers/AddEditSendHandlers.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.tools.feature.send.addedit.handlers
 
 import com.bitwarden.ui.platform.model.FileData
+import com.bitwarden.ui.platform.model.FolderData
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendAction
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendViewModel
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.model.AuthEmail
@@ -15,6 +16,8 @@ data class AddEditSendHandlers(
     val onNameChange: (String) -> Unit,
     val onChooseFileClick: (hasPermission: Boolean) -> Unit,
     val onFileChoose: (FileData) -> Unit,
+    val onChooseFolderClick: () -> Unit,
+    val onFolderChoose: (FolderData) -> Unit,
     val onTextChange: (String) -> Unit,
     val onIsHideByDefaultToggle: (Boolean) -> Unit,
     val onMaxAccessCountChange: (Int) -> Unit,
@@ -47,6 +50,12 @@ data class AddEditSendHandlers(
                     viewModel.trySendAction(AddEditSendAction.ChooseFileClick(it))
                 },
                 onFileChoose = { viewModel.trySendAction(AddEditSendAction.FileChoose(it)) },
+                onChooseFolderClick = {
+                    viewModel.trySendAction(AddEditSendAction.ChooseFolderClick)
+                },
+                onFolderChoose = {
+                    viewModel.trySendAction(AddEditSendAction.FolderChoose(it))
+                },
                 onTextChange = { viewModel.trySendAction(AddEditSendAction.TextChange(it)) },
                 onIsHideByDefaultToggle = {
                     viewModel.trySendAction(AddEditSendAction.HideByDefaultToggle(it))

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/util/AddEditSendStateExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/util/AddEditSendStateExtensions.kt
@@ -59,17 +59,31 @@ fun AddEditSendState.ViewState.Content.toSendView(
 private fun AddEditSendState.ViewState.Content.SendType.toSendType(): SendType =
     when (this) {
         is AddEditSendState.ViewState.Content.SendType.File -> SendType.FILE
+        is AddEditSendState.ViewState.Content.SendType.Folder -> SendType.FILE
         is AddEditSendState.ViewState.Content.SendType.Text -> SendType.TEXT
     }
 
 private fun AddEditSendState.ViewState.Content.toSendFileView(): SendFileView? =
-    (this.selectedType as? AddEditSendState.ViewState.Content.SendType.File)?.let {
-        SendFileView(
-            id = null,
-            fileName = it.name.orEmpty(),
-            size = null,
-            sizeName = null,
-        )
+    when (val type = this.selectedType) {
+        is AddEditSendState.ViewState.Content.SendType.File -> {
+            SendFileView(
+                id = null,
+                fileName = type.name.orEmpty(),
+                size = null,
+                sizeName = null,
+            )
+        }
+
+        is AddEditSendState.ViewState.Content.SendType.Folder -> {
+            SendFileView(
+                id = null,
+                fileName = "${type.name.orEmpty()}.zip",
+                size = null,
+                sizeName = null,
+            )
+        }
+
+        else -> null
     }
 
 private fun AddEditSendState.ViewState.Content.toSendTextView(): SendTextView? =

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/model/SendItemType.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/model/SendItemType.kt
@@ -8,5 +8,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class SendItemType {
     FILE,
+    FOLDER,
     TEXT,
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SentItemTypeExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/util/SentItemTypeExtensions.kt
@@ -11,5 +11,6 @@ import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
 val SendItemType.selectionText: Text
     get() = when (this) {
         SendItemType.FILE -> BitwardenString.file.asText()
+        SendItemType.FOLDER -> BitwardenString.folder.asText()
         SendItemType.TEXT -> BitwardenString.text.asText()
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/viewsend/ViewSendViewModel.kt
@@ -253,7 +253,9 @@ data class ViewSendState(
      */
     val screenDisplayName: Text
         get() = when (sendType) {
-            SendItemType.FILE -> BitwardenString.view_file_send.asText()
+            SendItemType.FILE,
+            SendItemType.FOLDER,
+            -> BitwardenString.view_file_send.asText()
             SendItemType.TEXT -> BitwardenString.view_text_send.asText()
         }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -889,7 +889,9 @@ class VaultItemListingViewModel @Inject constructor(
 
             is VaultItemListingState.ItemListingType.Send -> {
                 when (val sendType = itemListingType.toSendItemType()) {
-                    SendItemType.FILE -> {
+                    SendItemType.FILE,
+                    SendItemType.FOLDER,
+                    -> {
                         if (state.isPremium) {
                             sendEvent(VaultItemListingEvent.NavigateToAddSendItem(sendType))
                         } else {

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -38,6 +38,7 @@ sealed class FlagKey<out T : Any> {
                 ArchiveItems,
                 SendEmailVerification,
                 MobilePremiumUpgrade,
+                SendFolder,
             )
         }
     }
@@ -113,6 +114,14 @@ sealed class FlagKey<out T : Any> {
      */
     data object MobilePremiumUpgrade : FlagKey<Boolean>() {
         override val keyName: String = "PM-31697-premium-upgrade-path"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for the Send Folder feature.
+     */
+    data object SendFolder : FlagKey<Boolean>() {
+        override val keyName: String = "innovation-sprint-2026-send-folder"
         override val defaultValue: Boolean = false
     }
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(project(":network"))
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.documentfile)
     implementation(libs.androidx.security.crypto)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.google.hilt.android)

--- a/data/src/main/kotlin/com/bitwarden/data/manager/file/FileManager.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/file/FileManager.kt
@@ -3,6 +3,7 @@ package com.bitwarden.data.manager.file
 import android.net.Uri
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.data.manager.model.DownloadResult
+import com.bitwarden.data.manager.model.FolderDiskEntry
 import com.bitwarden.data.manager.model.ZipFileResult
 import java.io.File
 
@@ -26,6 +27,12 @@ interface FileManager {
      * Deletes [files] from disk.
      */
     suspend fun delete(vararg files: File)
+
+    /**
+     * Creates a temporary file in the private cache directory with the given [prefix] and
+     * [suffix]. Returns the created [File].
+     */
+    suspend fun createTempFileInCache(prefix: String, suffix: String): File
 
     /**
      * Downloads a file temporarily to cache from [url]. A successful [DownloadResult] will contain
@@ -61,4 +68,11 @@ interface FileManager {
      * reference.
      */
     suspend fun writeUriToCache(fileUri: Uri): Result<File>
+
+    /**
+     * Streams all files from a folder tree identified by [folderUri] (a tree URI from
+     * `ACTION_OPEN_DOCUMENT_TREE`) to temporary files in the cache directory. Returns a flat
+     * list of [FolderDiskEntry] mapping relative paths to their on-disk locations.
+     */
+    suspend fun writeFolderFilesToCache(folderUri: Uri): Result<List<FolderDiskEntry>>
 }

--- a/data/src/main/kotlin/com/bitwarden/data/manager/file/FileManagerImpl.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/file/FileManagerImpl.kt
@@ -7,7 +7,9 @@ import android.net.Uri
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.util.sdkAgnosticTransferTo
+import androidx.documentfile.provider.DocumentFile
 import com.bitwarden.data.manager.model.DownloadResult
+import com.bitwarden.data.manager.model.FolderDiskEntry
 import com.bitwarden.data.manager.model.ZipFileResult
 import com.bitwarden.network.service.DownloadService
 import kotlinx.coroutines.withContext
@@ -46,6 +48,13 @@ internal class FileManagerImpl(
         withContext(dispatcherManager.io) {
             files.forEach { it.delete() }
         }
+    }
+
+    override suspend fun createTempFileInCache(
+        prefix: String,
+        suffix: String,
+    ): File = withContext(dispatcherManager.io) {
+        File.createTempFile(prefix, suffix, context.cacheDir)
     }
 
     @Suppress("NestedBlockDepth")
@@ -194,6 +203,71 @@ internal class FileManagerImpl(
                 File(context.filesDir, tempFileName)
             }
         }
+
+    override suspend fun writeFolderFilesToCache(
+        folderUri: Uri,
+    ): Result<List<FolderDiskEntry>> =
+        runCatching {
+            withContext(dispatcherManager.io) {
+                val rootDocument = DocumentFile.fromTreeUri(context, folderUri)
+                    ?: throw IllegalStateException("Cannot access folder")
+                val entries = mutableListOf<FolderDiskEntry>()
+                streamDocumentTreeToCache(
+                    document = rootDocument,
+                    parentPath = "",
+                    entries = entries,
+                )
+                entries
+            }
+        }
+
+    private fun streamDocumentTreeToCache(
+        document: DocumentFile,
+        parentPath: String,
+        entries: MutableList<FolderDiskEntry>,
+    ) {
+        document.listFiles().forEach { child ->
+            val childPath = if (parentPath.isEmpty()) {
+                child.name.orEmpty()
+            } else {
+                "$parentPath/${child.name.orEmpty()}"
+            }
+            if (child.isDirectory) {
+                streamDocumentTreeToCache(
+                    document = child,
+                    parentPath = childPath,
+                    entries = entries,
+                )
+            } else {
+                val tempFile = File.createTempFile(
+                    "send_folder_file_",
+                    null,
+                    context.cacheDir,
+                )
+                context
+                    .contentResolver
+                    .openInputStream(child.uri)
+                    ?.use { inputStream ->
+                        FileOutputStream(tempFile).use { outputStream ->
+                            val buffer = ByteArray(BUFFER_SIZE)
+                            var length: Int
+                            while (
+                                inputStream.read(buffer).also { length = it } != -1
+                            ) {
+                                outputStream.write(buffer, 0, length)
+                            }
+                        }
+                    }
+                    ?: throw IllegalStateException("Cannot read file: $childPath")
+                entries.add(
+                    FolderDiskEntry(
+                        relativePath = childPath,
+                        diskPath = tempFile.absolutePath,
+                    ),
+                )
+            }
+        }
+    }
 }
 
 /**

--- a/data/src/main/kotlin/com/bitwarden/data/manager/model/FolderFileEntry.kt
+++ b/data/src/main/kotlin/com/bitwarden/data/manager/model/FolderFileEntry.kt
@@ -1,0 +1,10 @@
+package com.bitwarden.data.manager.model
+
+/**
+ * Represents a single file entry within a folder, with its [relativePath] from the folder root
+ * and its absolute [diskPath] on the local file system.
+ */
+data class FolderDiskEntry(
+    val relativePath: String,
+    val diskPath: String,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-mani
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
+androidx-documentfile = { module = "androidx.documentfile:documentfile", version = "1.0.1" }
 #noinspection CredentialDependency - Used for Passkey support, which is not available below Android 14
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidxCredentials" }
 androidx-credentials-providerevents = { module = "androidx.credentials.providerevents:providerevents", version.ref = "androidxCredentialsProviderEvents" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ androidxBrowser = "1.9.0"
 androidxCamera = "1.5.3"
 androidxComposeBom = "2026.03.00"
 androidxCore = "1.18.0"
+androidxDocumentFile = "1.1.0"
 androidxCredentials = "1.6.0-rc02"
 androidxCredentialsProviderEvents = "1.0.0-alpha05"
 androidxHiltNavigationCompose = "1.3.0"
@@ -84,7 +85,7 @@ androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-mani
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
-androidx-documentfile = { module = "androidx.documentfile:documentfile", version = "1.0.1" }
+androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "androidxDocumentFile" }
 #noinspection CredentialDependency - Used for Passkey support, which is not available below Android 14
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "androidxCredentials" }
 androidx-credentials-providerevents = { module = "androidx.credentials.providerevents:providerevents", version.ref = "androidxCredentialsProviderEvents" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.credentials)
+    implementation(libs.androidx.documentfile)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.bumptech.glide)
     implementation(libs.kotlinx.serialization)

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
@@ -32,6 +32,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.ArchiveItems,
     FlagKey.SendEmailVerification,
     FlagKey.MobilePremiumUpgrade,
+    FlagKey.SendFolder,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -85,4 +86,5 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.ArchiveItems -> stringResource(BitwardenString.archive_items)
     FlagKey.SendEmailVerification -> stringResource(BitwardenString.send_email_verification)
     FlagKey.MobilePremiumUpgrade -> stringResource(BitwardenString.mobile_premium_upgrade)
+    FlagKey.SendFolder -> stringResource(BitwardenString.send_folder)
 }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManager.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManager.kt
@@ -12,6 +12,7 @@ import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
 import com.bitwarden.ui.platform.model.FileData
+import com.bitwarden.ui.platform.model.FolderData
 import java.time.Clock
 
 /**
@@ -98,6 +99,16 @@ interface IntentManager {
      * Creates an intent to use when selecting to save an item with [fileName] to disk.
      */
     fun createDocumentIntent(fileName: String): Intent
+
+    /**
+     * Creates an intent for choosing a folder from the device.
+     */
+    fun createFolderChooserIntent(): Intent
+
+    /**
+     * Processes the [activityResult] and attempts to get the relevant folder data from it.
+     */
+    fun getFolderDataFromActivityResult(activityResult: ActivityResult): FolderData?
 
     @Suppress("UndocumentedPublicClass")
     @OmitFromCoverage

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImpl.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/manager/IntentManagerImpl.kt
@@ -30,7 +30,9 @@ import com.bitwarden.core.data.manager.util.deviceData
 import com.bitwarden.core.data.manager.util.fileProviderAuthority
 import com.bitwarden.core.util.isBuildVersionAtLeast
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
+import androidx.documentfile.provider.DocumentFile
 import com.bitwarden.ui.platform.model.FileData
+import com.bitwarden.ui.platform.model.FolderData
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.util.getLocalFileData
 import timber.log.Timber
@@ -229,6 +231,49 @@ internal class IntentManagerImpl(
             addCategory(Intent.CATEGORY_OPENABLE)
             putExtra(Intent.EXTRA_TITLE, fileName)
         }
+
+    override fun createFolderChooserIntent(): Intent =
+        Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+
+    override fun getFolderDataFromActivityResult(
+        activityResult: ActivityResult,
+    ): FolderData? {
+        if (activityResult.resultCode != Activity.RESULT_OK) return null
+        val treeUri = activityResult.data?.data ?: return null
+        val rootDocument = DocumentFile.fromTreeUri(activity, treeUri) ?: return null
+        var fileCount = 0
+        var totalSize = 0L
+        countFilesRecursively(rootDocument) { count, size ->
+            fileCount = count
+            totalSize = size
+        }
+        return FolderData(
+            folderName = rootDocument.name ?: "folder",
+            uri = treeUri,
+            fileCount = fileCount,
+            totalSizeBytes = totalSize,
+        )
+    }
+
+    private fun countFilesRecursively(
+        document: DocumentFile,
+        onResult: (fileCount: Int, totalSize: Long) -> Unit,
+    ) {
+        var count = 0
+        var size = 0L
+        fun traverse(doc: DocumentFile) {
+            doc.listFiles().forEach { child ->
+                if (child.isDirectory) {
+                    traverse(child)
+                } else {
+                    count++
+                    size += child.length()
+                }
+            }
+        }
+        traverse(document)
+        onResult(count, size)
+    }
 
     private fun createPlayStoreIntent(packageName: String): Intent {
         val playStoreUri = "https://play.google.com/store/apps/details"

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/model/FolderData.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/model/FolderData.kt
@@ -1,0 +1,16 @@
+package com.bitwarden.ui.platform.model
+
+import android.net.Uri
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Represents metadata about a selected folder.
+ */
+@Parcelize
+data class FolderData(
+    val folderName: String,
+    val uri: Uri,
+    val fileCount: Int,
+    val totalSizeBytes: Long,
+) : Parcelable

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -486,6 +486,7 @@ Scanning will happen automatically.</string>
     <string name="add_folder_send">New folder Send</string>
     <string name="edit_folder_send">Edit folder Send</string>
     <string name="choose_folder">Choose folder</string>
+    <string name="the_selected_folder_is_empty">The selected folder is empty. Please choose a folder that contains files.</string>
     <string name="folder_info">%1$d files, %2$s</string>
     <string name="required_max_folder_size">Maximum total size: 100 MB.</string>
     <string name="add_text_send">New text Send</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -483,6 +483,11 @@ Scanning will happen automatically.</string>
     <string name="edit_file_send">Edit file Send</string>
     <string name="edit_text_send">Edit text Send</string>
     <string name="add_file_send">New file Send</string>
+    <string name="add_folder_send">New folder Send</string>
+    <string name="edit_folder_send">Edit folder Send</string>
+    <string name="choose_folder">Choose folder</string>
+    <string name="folder_info">%1$d files, %2$s</string>
+    <string name="required_max_folder_size">Maximum total size: 100 MB.</string>
     <string name="add_text_send">New text Send</string>
     <string name="are_you_sure_delete_send">Are you sure you want to delete this Send?</string>
     <string name="send_deleted">Send deleted</string>

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -46,6 +46,7 @@
     <string name="trigger_cookie_acquisition">Trigger cookie acquisition</string>
     <string name="clear_sso_cookies">Clear SSO cookies</string>
     <string name="mobile_premium_upgrade">Mobile Premium Upgrade</string>
+    <string name="send_folder">Send Folder</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36039

## 📔 Objective

Add folder support to Bitwarden Send, allowing users to select an entire folder from their computer with a single click.
The folder (including all its files and subfolders) will be automatically compressed into a single encrypted package (zip) and uploaded just like a regular file Send.
Uses SDK WASM implementation for the compression.
Uses storage compression (basically zero, no compression algorithm at all)

Behind `innovation-sprint-2026-send-folder` feature flag.

CI expected to fail until [SDK PR](https://github.com/bitwarden/sdk-internal/pull/881) is merged.

## 📸 Screenshots

https://github.com/user-attachments/assets/5fd49ddd-0d92-4821-a0ac-ac7ebde7cce1

Create new send type:
<img width="843" height="668" alt="image" src="https://github.com/user-attachments/assets/d637c609-988e-4512-973e-c49c00b07b8f" />

Folder send:
<img width="851" height="468" alt="image" src="https://github.com/user-attachments/assets/268c6bf7-6a7b-4818-a961-90bb79bffc7e" />

Folder selected:
<img width="789" height="242" alt="image" src="https://github.com/user-attachments/assets/f2f343b7-e646-4092-814a-3455ed081646" />

Empty folder:
<img width="502" height="207" alt="image" src="https://github.com/user-attachments/assets/5126742b-fa3a-4478-a809-f5de647c56c4" />
