### PR TITLE
BWA-224: bug: Add sort order for Authenticator items

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreen.kt
@@ -629,6 +629,7 @@ private fun EmptyListingContentPreview() {
 @Composable
 @Preview(showBackground = true)
 private fun ContentPreview() {
+    val email = "longemailaddress+verification+codes@email.com"
     BitwardenTheme {
         ItemListingContent(
             state = ItemListingState.ViewState.Content(
@@ -652,9 +653,7 @@ private fun ContentPreview() {
                     sections = persistentListOf(
                         SharedCodesDisplayState.SharedCodesAccountSection(
                             id = "id",
-                            label =
-                                "longemailaddress+verification+codes@email.com | Bitawrden.eu (1)"
-                                    .asText(),
+                            label = "$email | Bitawrden.eu (1)".asText(),
                             codes = persistentListOf(
                                 VerificationCodeDisplayItem(
                                     id = "",
@@ -670,6 +669,7 @@ private fun ContentPreview() {
                                 ),
                             ),
                             isExpanded = true,
+                            sortKey = email,
                         ),
                     ),
                 ),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingViewModel.kt
@@ -23,6 +23,7 @@ import com.bitwarden.authenticator.ui.authenticator.feature.util.toSharedCodesDi
 import com.bitwarden.authenticator.ui.platform.components.listitem.model.SharedCodesDisplayState
 import com.bitwarden.authenticator.ui.platform.components.listitem.model.VaultDropdownMenuAction
 import com.bitwarden.authenticator.ui.platform.components.listitem.model.VerificationCodeDisplayItem
+import com.bitwarden.authenticator.ui.platform.components.listitem.model.util.sortAlphabetically
 import com.bitwarden.authenticator.ui.platform.model.SnackbarRelay
 import com.bitwarden.authenticatorbridge.manager.AuthenticatorBridgeManager
 import com.bitwarden.core.data.repository.model.DataState
@@ -509,6 +510,7 @@ class ItemListingViewModel @Inject constructor(
                             showOverflow = true,
                         )
                     }
+                    .sortAlphabetically()
                     .toImmutableList(),
                 itemList = localItems
                     .filter { it.source is AuthenticatorItem.Source.Local && !it.source.isFavorite }
@@ -521,6 +523,7 @@ class ItemListingViewModel @Inject constructor(
                             showOverflow = true,
                         )
                     }
+                    .sortAlphabetically()
                     .toImmutableList(),
                 sharedItems = sharedItemsState,
                 actionCard = action.sharedCodesState.toActionCard(),

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/SharedVerificationCodesStateExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/SharedVerificationCodesStateExtensions.kt
@@ -4,6 +4,7 @@ import com.bitwarden.authenticator.data.authenticator.repository.model.Authentic
 import com.bitwarden.authenticator.data.authenticator.repository.model.SharedVerificationCodesState
 import com.bitwarden.authenticator.ui.platform.components.listitem.model.SharedCodesDisplayState
 import com.bitwarden.authenticator.ui.platform.components.listitem.model.VerificationCodeDisplayItem
+import com.bitwarden.authenticator.ui.platform.components.listitem.model.util.sortAlphabetically
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import kotlinx.collections.immutable.toImmutableList
@@ -41,12 +42,14 @@ fun SharedVerificationCodesState.Success.toSharedCodesDisplayState(
                     it.key.environmentLabel,
                     it.value.size,
                 ),
-                codes = it.value.toImmutableList(),
+                codes = it.value.sortAlphabetically().toImmutableList(),
                 isExpanded = currentSections
                     .find { section -> section.id == it.key.userId }
                     ?.isExpanded
                     ?: true,
+                sortKey = it.key.email,
             )
         }
+        .sortAlphabetically()
         .let { SharedCodesDisplayState.Codes(it.toImmutableList()) }
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/SharedCodesDisplayState.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/SharedCodesDisplayState.kt
@@ -33,6 +33,7 @@ sealed class SharedCodesDisplayState : Parcelable {
         val label: Text,
         val codes: ImmutableList<VerificationCodeDisplayItem>,
         val isExpanded: Boolean,
+        val sortKey: String,
     ) : Parcelable
 
     /**

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/util/SharedCodesDisplayStateExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/util/SharedCodesDisplayStateExtensions.kt
@@ -1,0 +1,15 @@
+package com.bitwarden.authenticator.ui.platform.components.listitem.model.util
+
+import com.bitwarden.authenticator.ui.platform.components.listitem.model.SharedCodesDisplayState.SharedCodesAccountSection
+import com.bitwarden.core.data.repository.util.SpecialCharWithPrecedenceComparator
+
+/**
+ * Sorts the data in alphabetical order by name. Using lexicographical sorting but giving
+ * precedence to special characters over letters and digits.
+ */
+fun List<SharedCodesAccountSection>.sortAlphabetically(): List<SharedCodesAccountSection> =
+    this.sortedWith(
+        comparator = { item1, item2 ->
+            SpecialCharWithPrecedenceComparator.compare(item1.sortKey, item2.sortKey)
+        },
+    )

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/util/VerificationCodeDisplayItemExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/util/VerificationCodeDisplayItemExtensions.kt
@@ -1,0 +1,15 @@
+package com.bitwarden.authenticator.ui.platform.components.listitem.model.util
+
+import com.bitwarden.authenticator.ui.platform.components.listitem.model.VerificationCodeDisplayItem
+import com.bitwarden.core.data.repository.util.SpecialCharWithPrecedenceComparator
+
+/**
+ * Sorts the data in alphabetical order by name. Using lexicographical sorting but giving
+ * precedence to special characters over letters and digits.
+ */
+fun List<VerificationCodeDisplayItem>.sortAlphabetically(): List<VerificationCodeDisplayItem> =
+    this.sortedWith(
+        comparator = { item1, item2 ->
+            SpecialCharWithPrecedenceComparator.compare(item1.title, item2.title)
+        },
+    )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/itemlisting/ItemListingScreenTest.kt
@@ -570,6 +570,7 @@ private val SHARED_ACCOUNTS_SECTION = SharedCodesDisplayState.SharedCodesAccount
         ),
     ),
     isExpanded = true,
+    sortKey = "test@test.com",
 )
 
 private val DEFAULT_STATE = ItemListingState(

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModelTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/search/ItemSearchViewModelTest.kt
@@ -410,6 +410,7 @@ private val SHARED_DISPLAY_ITEMS = SharedCodesDisplayState.Codes(
                 ),
             ),
             isExpanded = true,
+            sortKey = "mockEmail-2",
         ),
     ),
 )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/SharedVerificationCodesStateTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/util/SharedVerificationCodesStateTest.kt
@@ -64,29 +64,6 @@ class SharedVerificationCodesStateTest {
                 SharedCodesDisplayState.SharedCodesAccountSection(
                     id = "user1",
                     label = BitwardenString.shared_accounts_header.asText(
-                        "John@test.com",
-                        "bitwarden.com",
-                        1,
-                    ),
-                    codes = persistentListOf(
-                        VerificationCodeDisplayItem(
-                            authCode = "123456",
-                            periodSeconds = 30,
-                            timeLeftSeconds = 10,
-                            id = "123",
-                            title = "--",
-                            subtitle = null,
-                            favorite = false,
-                            showOverflow = false,
-                            alertThresholdSeconds = ALERT_THRESHOLD,
-                            showMoveToBitwarden = false,
-                        ),
-                    ),
-                    isExpanded = true,
-                ),
-                SharedCodesDisplayState.SharedCodesAccountSection(
-                    id = "user1",
-                    label = BitwardenString.shared_accounts_header.asText(
                         "Jane@test.com",
                         "bitwarden.eu",
                         1,
@@ -106,6 +83,31 @@ class SharedVerificationCodesStateTest {
                         ),
                     ),
                     isExpanded = true,
+                    sortKey = "Jane@test.com",
+                ),
+                SharedCodesDisplayState.SharedCodesAccountSection(
+                    id = "user1",
+                    label = BitwardenString.shared_accounts_header.asText(
+                        "John@test.com",
+                        "bitwarden.com",
+                        1,
+                    ),
+                    codes = persistentListOf(
+                        VerificationCodeDisplayItem(
+                            authCode = "123456",
+                            periodSeconds = 30,
+                            timeLeftSeconds = 10,
+                            id = "123",
+                            title = "--",
+                            subtitle = null,
+                            favorite = false,
+                            showOverflow = false,
+                            alertThresholdSeconds = ALERT_THRESHOLD,
+                            showMoveToBitwarden = false,
+                        ),
+                    ),
+                    isExpanded = true,
+                    sortKey = "John@test.com",
                 ),
             ),
         )
@@ -156,29 +158,6 @@ class SharedVerificationCodesStateTest {
                 SharedCodesDisplayState.SharedCodesAccountSection(
                     id = "user1",
                     label = BitwardenString.shared_accounts_header.asText(
-                        "John@test.com",
-                        "bitwarden.com",
-                        1,
-                    ),
-                    codes = persistentListOf(
-                        VerificationCodeDisplayItem(
-                            authCode = "123456",
-                            periodSeconds = 30,
-                            timeLeftSeconds = 10,
-                            id = "123",
-                            title = "--",
-                            subtitle = null,
-                            favorite = false,
-                            showOverflow = false,
-                            alertThresholdSeconds = ALERT_THRESHOLD,
-                            showMoveToBitwarden = false,
-                        ),
-                    ),
-                    isExpanded = false,
-                ),
-                SharedCodesDisplayState.SharedCodesAccountSection(
-                    id = "user1",
-                    label = BitwardenString.shared_accounts_header.asText(
                         "Jane@test.com",
                         "bitwarden.eu",
                         1,
@@ -198,6 +177,31 @@ class SharedVerificationCodesStateTest {
                         ),
                     ),
                     isExpanded = false,
+                    sortKey = "Jane@test.com",
+                ),
+                SharedCodesDisplayState.SharedCodesAccountSection(
+                    id = "user1",
+                    label = BitwardenString.shared_accounts_header.asText(
+                        "John@test.com",
+                        "bitwarden.com",
+                        1,
+                    ),
+                    codes = persistentListOf(
+                        VerificationCodeDisplayItem(
+                            authCode = "123456",
+                            periodSeconds = 30,
+                            timeLeftSeconds = 10,
+                            id = "123",
+                            title = "--",
+                            subtitle = null,
+                            favorite = false,
+                            showOverflow = false,
+                            alertThresholdSeconds = ALERT_THRESHOLD,
+                            showMoveToBitwarden = false,
+                        ),
+                    ),
+                    isExpanded = false,
+                    sortKey = "John@test.com",
                 ),
             ),
         )

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/util/SharedCodesAccountSectionExtensionsTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/util/SharedCodesAccountSectionExtensionsTest.kt
@@ -1,0 +1,67 @@
+package com.bitwarden.authenticator.ui.platform.components.listitem.model.util
+
+import com.bitwarden.authenticator.ui.platform.components.listitem.model.SharedCodesDisplayState
+import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.util.asText
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SharedCodesAccountSectionExtensionsTest {
+    @Test
+    fun `toSortAlphabetically should sort ciphers by sortKey`() {
+        val codes = persistentListOf(
+            SharedCodesDisplayState.SharedCodesAccountSection(
+                id = "user1",
+                label = BitwardenString.shared_accounts_header.asText(
+                    "John@test.com",
+                    "bitwarden.com",
+                    1,
+                ),
+                codes = persistentListOf(),
+                isExpanded = true,
+                sortKey = "John@test.com",
+            ),
+            SharedCodesDisplayState.SharedCodesAccountSection(
+                id = "user1",
+                label = BitwardenString.shared_accounts_header.asText(
+                    "Jane@test.com",
+                    "bitwarden.eu",
+                    1,
+                ),
+                codes = persistentListOf(),
+                isExpanded = true,
+                sortKey = "Jane@test.com",
+            ),
+        )
+        val expected = persistentListOf(
+            SharedCodesDisplayState.SharedCodesAccountSection(
+                id = "user1",
+                label = BitwardenString.shared_accounts_header.asText(
+                    "Jane@test.com",
+                    "bitwarden.eu",
+                    1,
+                ),
+                codes = persistentListOf(),
+                isExpanded = true,
+                sortKey = "Jane@test.com",
+            ),
+            SharedCodesDisplayState.SharedCodesAccountSection(
+                id = "user1",
+                label = BitwardenString.shared_accounts_header.asText(
+                    "John@test.com",
+                    "bitwarden.com",
+                    1,
+                ),
+                codes = persistentListOf(),
+                isExpanded = true,
+                sortKey = "John@test.com",
+            ),
+        )
+
+        assertEquals(
+            expected,
+            codes.sortAlphabetically(),
+        )
+    }
+}

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/util/VerificationCodeDisplayItemExtensionsTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/platform/components/listitem/model/util/VerificationCodeDisplayItemExtensionsTest.kt
@@ -1,0 +1,93 @@
+package com.bitwarden.authenticator.ui.platform.components.listitem.model.util
+
+import com.bitwarden.authenticator.ui.platform.components.listitem.model.VerificationCodeDisplayItem
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class VerificationCodeDisplayItemExtensionsTest {
+    @Test
+    fun `toSortAlphabetically should sort ciphers by title`() {
+        val codes = persistentListOf(
+            VerificationCodeDisplayItem(
+                authCode = "123456",
+                periodSeconds = 30,
+                timeLeftSeconds = 10,
+                id = "123",
+                title = "Bitwarden",
+                subtitle = null,
+                favorite = false,
+                showOverflow = false,
+                alertThresholdSeconds = 7,
+                showMoveToBitwarden = false,
+            ),
+            VerificationCodeDisplayItem(
+                authCode = "123456",
+                periodSeconds = 30,
+                timeLeftSeconds = 10,
+                id = "7643",
+                title = "--",
+                subtitle = null,
+                favorite = false,
+                showOverflow = false,
+                alertThresholdSeconds = 7,
+                showMoveToBitwarden = false,
+            ),
+            VerificationCodeDisplayItem(
+                authCode = "123456",
+                periodSeconds = 30,
+                timeLeftSeconds = 10,
+                id = "84345",
+                title = "bitwarden",
+                subtitle = null,
+                favorite = false,
+                showOverflow = false,
+                alertThresholdSeconds = 7,
+                showMoveToBitwarden = false,
+            ),
+        )
+        val expected = persistentListOf(
+            VerificationCodeDisplayItem(
+                authCode = "123456",
+                periodSeconds = 30,
+                timeLeftSeconds = 10,
+                id = "7643",
+                title = "--",
+                subtitle = null,
+                favorite = false,
+                showOverflow = false,
+                alertThresholdSeconds = 7,
+                showMoveToBitwarden = false,
+            ),
+            VerificationCodeDisplayItem(
+                authCode = "123456",
+                periodSeconds = 30,
+                timeLeftSeconds = 10,
+                id = "84345",
+                title = "bitwarden",
+                subtitle = null,
+                favorite = false,
+                showOverflow = false,
+                alertThresholdSeconds = 7,
+                showMoveToBitwarden = false,
+            ),
+            VerificationCodeDisplayItem(
+                authCode = "123456",
+                periodSeconds = 30,
+                timeLeftSeconds = 10,
+                id = "123",
+                title = "Bitwarden",
+                subtitle = null,
+                favorite = false,
+                showOverflow = false,
+                alertThresholdSeconds = 7,
+                showMoveToBitwarden = false,
+            ),
+        )
+
+        assertEquals(
+            expected,
+            codes.sortAlphabetically(),
+        )
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-224](https://bitwarden.atlassian.net/browse/BWA-224)

## 📔 Objective

This PR adds sorting to the authenticator to match the logic in the PasswordManager. We sort alphabetically.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/de82dac5-307b-4ce1-8151-08bd339d3218" /> | <img width="350" src="https://github.com/user-attachments/assets/c9cc6bf3-0101-4d82-b55d-93e3fd32f3e9" /> |


[BWA-224]: https://bitwarden.atlassian.net/browse/BWA-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ