### PR TITLE
chore: Update AttachmentsState to use immutable list

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
@@ -20,6 +20,7 @@ import com.x8bit.bitwarden.data.vault.repository.model.CreateAttachmentResult
 import com.x8bit.bitwarden.data.vault.repository.model.DeleteAttachmentResult
 import com.x8bit.bitwarden.ui.vault.feature.attachments.util.toViewState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -389,7 +390,7 @@ data class AttachmentsState(
         data class Content(
             @IgnoredOnParcel
             val originalCipher: CipherView? = null,
-            val attachments: List<AttachmentItem>,
+            val attachments: ImmutableList<AttachmentItem>,
             val newAttachment: NewAttachment?,
         ) : ViewState()
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/util/CipherViewExtensions.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.vault.feature.attachments.util
 
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.ui.vault.feature.attachments.AttachmentsState
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * Converts the [CipherView] into a [AttachmentsState.ViewState.Content].
@@ -19,6 +20,7 @@ fun CipherView.toViewState(): AttachmentsState.ViewState.Content =
                     title = it.fileName.orEmpty(),
                     displaySize = it.sizeName.orEmpty(),
                 )
-            },
+            }
+            .toImmutableList(),
         newAttachment = null,
     )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
@@ -24,6 +24,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import org.junit.Assert.assertTrue
@@ -264,14 +265,14 @@ private val DEFAULT_STATE: AttachmentsState = AttachmentsState(
 private val DEFAULT_CONTENT_WITHOUT_ATTACHMENTS: AttachmentsState.ViewState.Content =
     AttachmentsState.ViewState.Content(
         originalCipher = createMockCipherView(number = 1),
-        attachments = emptyList(),
+        attachments = persistentListOf(),
         newAttachment = null,
     )
 
 private val DEFAULT_CONTENT_WITH_ATTACHMENTS: AttachmentsState.ViewState.Content =
     AttachmentsState.ViewState.Content(
         originalCipher = createMockCipherView(number = 1),
-        attachments = listOf(
+        attachments = persistentListOf(
             AttachmentsState.AttachmentItem(
                 id = "cipherId-1234",
                 title = "cool_file.png",

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
@@ -27,6 +27,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -750,7 +751,7 @@ private val DEFAULT_ATTACHMENT_ITEM: AttachmentsState.AttachmentItem =
 private val DEFAULT_CONTENT_WITH_ATTACHMENTS: AttachmentsState.ViewState.Content =
     AttachmentsState.ViewState.Content(
         originalCipher = createMockCipherView(number = 1),
-        attachments = listOf(DEFAULT_ATTACHMENT_ITEM),
+        attachments = persistentListOf(DEFAULT_ATTACHMENT_ITEM),
         newAttachment = null,
     )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/util/CipherViewExtensionsTest.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.ui.vault.feature.attachments.util
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockAttachmentView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
 import com.x8bit.bitwarden.ui.vault.feature.attachments.AttachmentsState
+import kotlinx.collections.immutable.persistentListOf
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 
@@ -17,7 +18,7 @@ class CipherViewExtensionsTest {
         assertEquals(
             AttachmentsState.ViewState.Content(
                 originalCipher = cipherView,
-                attachments = listOf(
+                attachments = persistentListOf(
                     AttachmentsState.AttachmentItem(
                         id = "mockId-1",
                         title = "mockFileName-1",
@@ -41,7 +42,7 @@ class CipherViewExtensionsTest {
         assertEquals(
             AttachmentsState.ViewState.Content(
                 originalCipher = cipherView,
-                attachments = emptyList(),
+                attachments = persistentListOf(),
                 newAttachment = null,
             ),
             result,
@@ -63,7 +64,7 @@ class CipherViewExtensionsTest {
         assertEquals(
             AttachmentsState.ViewState.Content(
                 originalCipher = cipherView,
-                attachments = emptyList(),
+                attachments = persistentListOf(),
                 newAttachment = null,
             ),
             result,


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates the `AttachmentsState` to use `ImmutableList` for improved performance.
