### PR TITLE
BWA-228: bug: Update identity custom field keys to use index

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemIdentityContent.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -316,10 +315,10 @@ fun VaultItemIdentityContent(
                         .animateItem(),
                 )
             }
-            items(
+            itemsIndexed(
                 items = customFields,
-                key = { "customField_$it" },
-            ) { customField ->
+                key = { index, _ -> "customField_$index" },
+            ) { _, customField ->
                 Spacer(modifier = Modifier.height(height = 8.dp))
                 CustomField(
                     customField = customField,


### PR DESCRIPTION
## 🎟️ Tracking

[BWA-228](https://bitwarden.atlassian.net/browse/BWA-228)

## 📔 Objective

This PR updates the identity screen to use the custom field index as part of it's unique key. This is the same as the other cipher types and ensure that they are unique even if their contents are identical.


[BWA-228]: https://bitwarden.atlassian.net/browse/BWA-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ