### PR TITLE
PM-29763: bug: Handle invalid URI crash

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/URIExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/util/URIExtensions.kt
@@ -60,7 +60,9 @@ fun URI.addSchemeToUriIfNecessary(): URI {
         // provided that scheme does not exist already.
         !uriString.hasHttpProtocol()
     ) {
-        URI("https://$uriString")
+        "https://$uriString"
+            .toUriOrNull()
+            ?: this
     } else {
         this
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/util/UriExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/util/UriExtensionsTest.kt
@@ -356,4 +356,13 @@ class UriExtensionsTest {
             uriWithCustomScheme.addSchemeToUriIfNecessary(),
         )
     }
+
+    @Test
+    fun `addSchemeToUriIfNecessary should return the original URI for invalid URI`() {
+        val invalidUri = URI("turn:198.51.100.1:5349[Password1234][]")
+        assertEquals(
+            invalidUri,
+            invalidUri.addSchemeToUriIfNecessary(),
+        )
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29763](https://bitwarden.atlassian.net/browse/PM-29763)

## 📔 Objective

This PR resolves a crash that occurs when the user has an invalid Uri on a login cipher.


[PM-29763]: https://bitwarden.atlassian.net/browse/PM-29763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ