### PR TITLE
chore: Attachment UI tweaks

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsContent.kt
@@ -1,6 +1,7 @@
 package com.x8bit.bitwarden.ui.vault.feature.attachments
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -305,7 +306,7 @@ private fun AttachmentListEntry(
             .defaultMinSize(minHeight = 60.dp)
             .cardStyle(
                 cardStyle = cardStyle,
-                paddingStart = 16.dp,
+                padding = PaddingValues(start = 16.dp),
                 onClick = { onItemClick(attachmentItem) },
             )
             .testTag("AttachmentRow"),
@@ -314,7 +315,7 @@ private fun AttachmentListEntry(
         Text(
             text = attachmentItem.title,
             color = BitwardenTheme.colorScheme.text.primary,
-            style = BitwardenTheme.typography.bodyMedium,
+            style = BitwardenTheme.typography.bodyLarge,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier
@@ -326,8 +327,8 @@ private fun AttachmentListEntry(
 
         Text(
             text = attachmentItem.displaySize,
-            color = BitwardenTheme.colorScheme.text.primary,
-            style = BitwardenTheme.typography.labelSmall,
+            color = BitwardenTheme.colorScheme.text.secondary,
+            style = BitwardenTheme.typography.bodyMedium,
             modifier = Modifier
                 .testTag("AttachmentSizeLabel"),
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/component/VaultItemAttachment.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/component/VaultItemAttachment.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.vault.feature.item.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -50,7 +51,7 @@ fun VaultItemAttachment(
             .defaultMinSize(minHeight = 60.dp)
             .cardStyle(
                 cardStyle = cardStyle,
-                paddingStart = 16.dp,
+                padding = PaddingValues(start = 16.dp),
                 onClick = {
                     if (!attachmentItem.isDownloadAllowed) {
                         shouldShowPremiumWarningDialog = true
@@ -73,7 +74,7 @@ fun VaultItemAttachment(
             Text(
                 text = attachmentItem.title,
                 color = BitwardenTheme.colorScheme.text.primary,
-                style = BitwardenTheme.typography.bodyMedium,
+                style = BitwardenTheme.typography.bodyLarge,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
@@ -88,8 +89,8 @@ fun VaultItemAttachment(
             ) {
                 Text(
                     text = attachmentItem.displaySize,
-                    color = BitwardenTheme.colorScheme.text.primary,
-                    style = BitwardenTheme.typography.labelSmall,
+                    color = BitwardenTheme.colorScheme.text.secondary,
+                    style = BitwardenTheme.typography.bodyMedium,
                     modifier = Modifier
                         .testTag("AttachmentSizeLabel"),
                 )


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR updates some minor details on the attachments row items to be in line with the current UI standards.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/8b9a6d36-4677-4a58-9efd-1c127a1e597d" /> | <img width="350" src="https://github.com/user-attachments/assets/13960243-1b03-41e6-a854-2094a6933db8" /> |
| <img width="350" src="https://github.com/user-attachments/assets/63b225dd-a301-4244-bfa9-55baae5d2278" /> | <img width="350" src="https://github.com/user-attachments/assets/07bb11e4-8bbc-44a2-bc03-cadcc9a5d15b" /> |
