### PR TITLE
Create sdk-breaking-change-check workflow

### DIFF
--- a/.github/workflows/sdk-breaking-change-check.yml
+++ b/.github/workflows/sdk-breaking-change-check.yml
@@ -16,8 +16,8 @@ on:
         description: "Workflow run ID containing SDK artifacts"
         required: true
         type: string
-      sdk_package_version:
-        description: "SDK Maven package version to test against"
+      artifact_name:
+        description: "SDK artifact identifier (Maven package version)"
         required: true
         type: string
 
@@ -48,7 +48,7 @@ jobs:
           # Always use .dev package - this workflow only runs on PRs, and PR builds
           # publish to sdk-android.dev (main branch publishes to sdk-android)
           _SDK_PACKAGE: "com.bitwarden:sdk-android.dev"
-          _SDK_VERSION: ${{ inputs.sdk_package_version }}
+          _SDK_VERSION: ${{ inputs.artifact_name }}
         run: |
           ./scripts/update-sdk-version.sh "$_SDK_PACKAGE" "$_SDK_VERSION"
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27825

## 📔 Objective

Adds a new `sdk-breaking-change-check.yml` workflow, the analog of https://github.com/bitwarden/clients/blob/main/.github/workflows/sdk-breaking-change-check.yml on `clients`.

This workflow will be triggered via `workflow_dispatch` after the Android package is generated in `build-android.yml` in `sdk-internal`: https://github.com/bitwarden/sdk-internal/pull/892.
