### PR TITLE
PM-34872, PM-34873, PM-34874, PM-34875: feat: Add feature flags for Encryption v2 Registration

### DIFF
--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -40,6 +40,10 @@ sealed class FlagKey<out T : Any> {
                 CardScanner,
                 MobilePremiumUpgrade,
                 AttachmentUpdates,
+                V2EncryptionJitPassword,
+                V2EncryptionKeyConnector,
+                V2EncryptionPassword,
+                V2EncryptionTde,
             )
         }
     }
@@ -131,6 +135,38 @@ sealed class FlagKey<out T : Any> {
      */
     data object AttachmentUpdates : FlagKey<Boolean>() {
         override val keyName: String = "pm-34224-mobile-attachment-updates"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for Encryption V2 pertaining to JIT Password.
+     */
+    data object V2EncryptionJitPassword : FlagKey<Boolean>() {
+        override val keyName: String = "enable-account-encryption-v2-jit-password-registration"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for Encryption V2 pertaining to Key Connector.
+     */
+    data object V2EncryptionKeyConnector : FlagKey<Boolean>() {
+        override val keyName: String = "enable-account-encryption-v2-key-connector-registration"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for Encryption V2 pertaining to Password.
+     */
+    data object V2EncryptionPassword : FlagKey<Boolean>() {
+        override val keyName: String = "pm-27278-v2-password-registration"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Data object holding the feature flag key for Encryption V2 pertaining to TDE.
+     */
+    data object V2EncryptionTde : FlagKey<Boolean>() {
+        override val keyName: String = "pm-27279-v2-registration-tde-jit"
         override val defaultValue: Boolean = false
     }
 

--- a/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/manager/model/FlagKeyTest.kt
@@ -44,6 +44,22 @@ class FlagKeyTest {
             FlagKey.AttachmentUpdates.keyName,
             "pm-34224-mobile-attachment-updates",
         )
+        assertEquals(
+            FlagKey.V2EncryptionJitPassword.keyName,
+            "enable-account-encryption-v2-jit-password-registration",
+        )
+        assertEquals(
+            FlagKey.V2EncryptionKeyConnector.keyName,
+            "enable-account-encryption-v2-key-connector-registration",
+        )
+        assertEquals(
+            FlagKey.V2EncryptionPassword.keyName,
+            "pm-27278-v2-password-registration",
+        )
+        assertEquals(
+            FlagKey.V2EncryptionTde.keyName,
+            "pm-27279-v2-registration-tde-jit",
+        )
     }
 
     @Test
@@ -59,6 +75,10 @@ class FlagKeyTest {
                 FlagKey.SendEmailVerification,
                 FlagKey.MobilePremiumUpgrade,
                 FlagKey.AttachmentUpdates,
+                FlagKey.V2EncryptionJitPassword,
+                FlagKey.V2EncryptionKeyConnector,
+                FlagKey.V2EncryptionPassword,
+                FlagKey.V2EncryptionTde,
             ).all {
                 !it.defaultValue
             },

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
@@ -34,6 +34,10 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.SendEmailVerification,
     FlagKey.MobilePremiumUpgrade,
     FlagKey.AttachmentUpdates,
+    FlagKey.V2EncryptionJitPassword,
+    FlagKey.V2EncryptionKeyConnector,
+    FlagKey.V2EncryptionPassword,
+    FlagKey.V2EncryptionTde,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -89,4 +93,8 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.SendEmailVerification -> stringResource(BitwardenString.send_email_verification)
     FlagKey.MobilePremiumUpgrade -> stringResource(BitwardenString.mobile_premium_upgrade)
     FlagKey.AttachmentUpdates -> stringResource(BitwardenString.attachment_updates)
+    FlagKey.V2EncryptionJitPassword -> stringResource(BitwardenString.v2_encryption_jit_password)
+    FlagKey.V2EncryptionKeyConnector -> stringResource(BitwardenString.v2_encryption_key_connector)
+    FlagKey.V2EncryptionPassword -> stringResource(BitwardenString.v2_encryption_password)
+    FlagKey.V2EncryptionTde -> stringResource(BitwardenString.v2_encryption_tde)
 }

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -47,6 +47,10 @@
     <string name="clear_sso_cookies">Clear SSO cookies</string>
     <string name="mobile_premium_upgrade">Mobile Premium Upgrade</string>
     <string name="attachment_updates">Attachment Updates</string>
+    <string name="v2_encryption_tde">V2 Encryption - TDE</string>
+    <string name="v2_encryption_key_connector">V2 Encryption - Key Connector</string>
+    <string name="v2_encryption_jit_password">V2 Encryption - JIT Password</string>
+    <string name="v2_encryption_password">V2 Encryption - Password</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34872](https://bitwarden.atlassian.net/browse/PM-34872)
[PM-34873](https://bitwarden.atlassian.net/browse/PM-34873)
[PM-34874](https://bitwarden.atlassian.net/browse/PM-34874)
[PM-34875](https://bitwarden.atlassian.net/browse/PM-34875)

## 📔 Objective

This PR adds the 4 feature flags needed for the Encryption v2 Registration feature.

## 📸 Screenshots

<img width="350" src="https://github.com/user-attachments/assets/bdc4ec1c-116c-403c-9be1-cdb5d799a6d4" />


[PM-34872]: https://bitwarden.atlassian.net/browse/PM-34872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-34873]: https://bitwarden.atlassian.net/browse/PM-34873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-34874]: https://bitwarden.atlassian.net/browse/PM-34874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-34875]: https://bitwarden.atlassian.net/browse/PM-34875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ