### PR TITLE
[PM-33946] feat: Add dynamic pricing and fix checkout flow

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -23,12 +23,11 @@ import com.x8bit.bitwarden.data.auth.repository.util.getSsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.getWebAuthResult
 import com.x8bit.bitwarden.data.auth.util.getCompleteRegistrationDataIntentOrNull
 import com.x8bit.bitwarden.data.auth.util.getPasswordlessRequestDataIntentOrNull
-import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
-import com.x8bit.bitwarden.data.billing.util.getPremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.util.getAutofillSaveItemOrNull
 import com.x8bit.bitwarden.data.autofill.util.getAutofillSelectionDataOrNull
+import com.x8bit.bitwarden.data.billing.util.getPremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.credentials.manager.CredentialProviderRequestManager
 import com.x8bit.bitwarden.data.credentials.manager.model.CredentialProviderRequest
 import com.x8bit.bitwarden.data.platform.manager.AppResumeManager
@@ -251,11 +250,9 @@ class MainViewModel @Inject constructor(
     }
 
     private fun handlePremiumCheckoutResult(action: MainAction.PremiumCheckoutResult) {
-        val callbackResult = action.authResult.getPremiumCheckoutCallbackResult()
-        specialCircumstanceManager.specialCircumstance =
-            SpecialCircumstance.PremiumCheckoutResult(
-                isSuccess = callbackResult is PremiumCheckoutCallbackResult.Success,
-            )
+        specialCircumstanceManager.specialCircumstance = SpecialCircumstance.PremiumCheckoutResult(
+            callbackResult = action.authResult.getPremiumCheckoutCallbackResult(),
+        )
     }
 
     private fun handleAppResumeDataUpdated(action: MainAction.ResumeScreenDataReceived) {
@@ -408,10 +405,9 @@ class MainViewModel @Inject constructor(
             }
 
             hasPremiumCheckoutCallback -> {
-                val callbackResult = intent.data.getPremiumCheckoutCallbackResult()
                 specialCircumstanceManager.specialCircumstance =
                     SpecialCircumstance.PremiumCheckoutResult(
-                        isSuccess = callbackResult is PremiumCheckoutCallbackResult.Success,
+                        callbackResult = intent.data.getPremiumCheckoutCallbackResult(),
                     )
             }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -250,7 +250,7 @@ class MainViewModel @Inject constructor(
     }
 
     private fun handlePremiumCheckoutResult(action: MainAction.PremiumCheckoutResult) {
-        specialCircumstanceManager.specialCircumstance = SpecialCircumstance.PremiumCheckoutResult(
+        specialCircumstanceManager.specialCircumstance = SpecialCircumstance.PremiumCheckout(
             callbackResult = action.authResult.getPremiumCheckoutCallbackResult(),
         )
     }
@@ -406,7 +406,7 @@ class MainViewModel @Inject constructor(
 
             hasPremiumCheckoutCallback -> {
                 specialCircumstanceManager.specialCircumstance =
-                    SpecialCircumstance.PremiumCheckoutResult(
+                    SpecialCircumstance.PremiumCheckout(
                         callbackResult = intent.data.getPremiumCheckoutCallbackResult(),
                     )
             }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/MainViewModel.kt
@@ -23,6 +23,8 @@ import com.x8bit.bitwarden.data.auth.repository.util.getSsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.getWebAuthResult
 import com.x8bit.bitwarden.data.auth.util.getCompleteRegistrationDataIntentOrNull
 import com.x8bit.bitwarden.data.auth.util.getPasswordlessRequestDataIntentOrNull
+import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
+import com.x8bit.bitwarden.data.billing.util.getPremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.util.getAutofillSaveItemOrNull
@@ -198,7 +200,7 @@ class MainViewModel @Inject constructor(
             is MainAction.SsoResult -> handleSsoResult(action)
             is MainAction.WebAuthnResult -> handleWebAuthnResult(action)
             is MainAction.CookieAcquisitionResult -> handleCookieAcquisitionResult(action)
-            is MainAction.PremiumCheckoutResult -> handlePremiumCheckoutResult()
+            is MainAction.PremiumCheckoutResult -> handlePremiumCheckoutResult(action)
             is MainAction.Internal -> handleInternalAction(action)
         }
     }
@@ -248,9 +250,12 @@ class MainViewModel @Inject constructor(
         )
     }
 
-    private fun handlePremiumCheckoutResult() {
+    private fun handlePremiumCheckoutResult(action: MainAction.PremiumCheckoutResult) {
+        val callbackResult = action.authResult.getPremiumCheckoutCallbackResult()
         specialCircumstanceManager.specialCircumstance =
-            SpecialCircumstance.PremiumCheckoutResult
+            SpecialCircumstance.PremiumCheckoutResult(
+                isSuccess = callbackResult is PremiumCheckoutCallbackResult.Success,
+            )
     }
 
     private fun handleAppResumeDataUpdated(action: MainAction.ResumeScreenDataReceived) {
@@ -403,8 +408,11 @@ class MainViewModel @Inject constructor(
             }
 
             hasPremiumCheckoutCallback -> {
+                val callbackResult = intent.data.getPremiumCheckoutCallbackResult()
                 specialCircumstanceManager.specialCircumstance =
-                    SpecialCircumstance.PremiumCheckoutResult
+                    SpecialCircumstance.PremiumCheckoutResult(
+                        isSuccess = callbackResult is PremiumCheckoutCallbackResult.Success,
+                    )
             }
 
             hasGeneratorShortcut -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -61,11 +61,12 @@ class PremiumStateManagerImpl(
                         ?: flowOf(false)
                 },
             vaultRepository.vaultDataStateFlow,
-        ) { userState,
-            isInAppBillingSupported,
-            featureFlagEnabled,
-            isDismissed,
-            vaultDataState,
+        ) {
+                userState,
+                isInAppBillingSupported,
+                featureFlagEnabled,
+                isDismissed,
+                vaultDataState,
             ->
             val activeAccount = userState?.activeAccount
                 ?: return@combine false

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepository.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.billing.repository
 
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.CustomerPortalResult
+import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -23,4 +24,9 @@ interface BillingRepository {
      * Retrieves the Stripe customer portal URL for managing the Premium subscription.
      */
     suspend fun getPortalUrl(): CustomerPortalResult
+
+    /**
+     * Retrieves the premium plan pricing information.
+     */
+    suspend fun getPremiumPlanPricing(): PremiumPlanPricingResult
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
@@ -4,7 +4,10 @@ import com.bitwarden.network.service.BillingService
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManager
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.CustomerPortalResult
+import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import kotlinx.coroutines.flow.StateFlow
+import java.text.NumberFormat
+import java.util.Locale
 
 /**
  * The default implementation of [BillingRepository].
@@ -32,4 +35,24 @@ class BillingRepositoryImpl(
                 onSuccess = { CustomerPortalResult.Success(url = it.url) },
                 onFailure = { CustomerPortalResult.Error(error = it) },
             )
+
+    override suspend fun getPremiumPlanPricing(): PremiumPlanPricingResult =
+        billingService
+            .getPremiumPlan()
+            .fold(
+                onSuccess = {
+                    val monthlyPrice = it.seat.price / MONTHS_PER_YEAR
+                    val formatted = NumberFormat
+                        .getCurrencyInstance(Locale.US)
+                        .format(monthlyPrice)
+                    PremiumPlanPricingResult.Success(
+                        monthlyRate = formatted,
+                    )
+                },
+                onFailure = {
+                    PremiumPlanPricingResult.Error(error = it)
+                },
+            )
 }
+
+private const val MONTHS_PER_YEAR = 12

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
@@ -6,8 +6,6 @@ import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.CustomerPortalResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import kotlinx.coroutines.flow.StateFlow
-import java.text.NumberFormat
-import java.util.Locale
 
 /**
  * The default implementation of [BillingRepository].
@@ -41,12 +39,8 @@ class BillingRepositoryImpl(
             .getPremiumPlan()
             .fold(
                 onSuccess = {
-                    val monthlyPrice = it.seat.price / MONTHS_PER_YEAR
-                    val formatted = NumberFormat
-                        .getCurrencyInstance(Locale.US)
-                        .format(monthlyPrice)
                     PremiumPlanPricingResult.Success(
-                        monthlyRate = formatted,
+                        annualPrice = it.seat.price,
                     )
                 },
                 onFailure = {
@@ -54,5 +48,3 @@ class BillingRepositoryImpl(
                 },
             )
 }
-
-private const val MONTHS_PER_YEAR = 12

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumPlanPricingResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumPlanPricingResult.kt
@@ -10,10 +10,10 @@ sealed class PremiumPlanPricingResult {
     /**
      * The premium plan pricing was successfully retrieved.
      *
-     * @property monthlyRate The formatted monthly rate (e.g. "$1.67").
+     * @property annualPrice The annual price in the plan's currency.
      */
     data class Success(
-        val monthlyRate: String,
+        val annualPrice: Double,
     ) : PremiumPlanPricingResult()
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumPlanPricingResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumPlanPricingResult.kt
@@ -1,0 +1,28 @@
+package com.x8bit.bitwarden.data.billing.repository.model
+
+import com.x8bit.bitwarden.data.platform.util.userFriendlyMessage
+
+/**
+ * Models the result of retrieving premium plan pricing.
+ */
+sealed class PremiumPlanPricingResult {
+
+    /**
+     * The premium plan pricing was successfully retrieved.
+     *
+     * @property monthlyRate The formatted monthly rate (e.g. "$1.67").
+     */
+    data class Success(
+        val monthlyRate: String,
+    ) : PremiumPlanPricingResult()
+
+    /**
+     * An error occurred while retrieving the premium plan pricing.
+     * The optional [errorMessage] may be displayed directly in the UI
+     * when present.
+     */
+    data class Error(
+        val error: Throwable,
+        val errorMessage: String? = error.userFriendlyMessage,
+    ) : PremiumPlanPricingResult()
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/util/PremiumCheckoutUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/util/PremiumCheckoutUtils.kt
@@ -1,0 +1,66 @@
+package com.x8bit.bitwarden.data.billing.util
+
+import android.net.Uri
+import android.os.Parcelable
+import androidx.browser.auth.AuthTabIntent
+import com.bitwarden.annotation.OmitFromCoverage
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Query parameter name used by Stripe to indicate the checkout outcome.
+ */
+private const val RESULT_PARAM = "result"
+
+/**
+ * Query parameter value indicating a successful checkout.
+ */
+private const val RESULT_SUCCESS = "success"
+
+/**
+ * Retrieves a [PremiumCheckoutCallbackResult] from an
+ * [AuthTabIntent.AuthResult].
+ *
+ * - [PremiumCheckoutCallbackResult.Success]: The user completed payment.
+ * - [PremiumCheckoutCallbackResult.Canceled]: The user left without paying.
+ */
+@OmitFromCoverage
+fun AuthTabIntent.AuthResult.getPremiumCheckoutCallbackResult():
+    PremiumCheckoutCallbackResult =
+    when (resultCode) {
+        AuthTabIntent.RESULT_OK -> resultUri.getPremiumCheckoutCallbackResult()
+        else -> PremiumCheckoutCallbackResult.Canceled
+    }
+
+/**
+ * Retrieves a [PremiumCheckoutCallbackResult] from a redirect [Uri].
+ *
+ * Examines the `result` query parameter: `?result=success` maps to
+ * [PremiumCheckoutCallbackResult.Success], anything else maps to
+ * [PremiumCheckoutCallbackResult.Canceled].
+ */
+fun Uri?.getPremiumCheckoutCallbackResult(): PremiumCheckoutCallbackResult {
+    val resultParam = this?.getQueryParameter(RESULT_PARAM)
+    return if (resultParam.equals(RESULT_SUCCESS, ignoreCase = true)) {
+        PremiumCheckoutCallbackResult.Success
+    } else {
+        PremiumCheckoutCallbackResult.Canceled
+    }
+}
+
+/**
+ * Represents the result of a premium checkout callback from Stripe.
+ */
+sealed class PremiumCheckoutCallbackResult : Parcelable {
+
+    /**
+     * The user completed payment successfully.
+     */
+    @Parcelize
+    data object Success : PremiumCheckoutCallbackResult()
+
+    /**
+     * The user canceled or left checkout without completing payment.
+     */
+    @Parcelize
+    data object Canceled : PremiumCheckoutCallbackResult()
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/util/PremiumCheckoutUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/util/PremiumCheckoutUtils.kt
@@ -24,8 +24,7 @@ private const val RESULT_SUCCESS = "success"
  * - [PremiumCheckoutCallbackResult.Canceled]: The user left without paying.
  */
 @OmitFromCoverage
-fun AuthTabIntent.AuthResult.getPremiumCheckoutCallbackResult():
-    PremiumCheckoutCallbackResult =
+fun AuthTabIntent.AuthResult.getPremiumCheckoutCallbackResult(): PremiumCheckoutCallbackResult =
     when (resultCode) {
         AuthTabIntent.RESULT_OK -> resultUri.getPremiumCheckoutCallbackResult()
         else -> PremiumCheckoutCallbackResult.Canceled

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
@@ -137,9 +137,14 @@ sealed class SpecialCircumstance : Parcelable {
     /**
      * The app was launched via a Premium checkout callback deep link,
      * indicating the user is returning from a Stripe checkout session.
+     *
+     * @property isSuccess `true` if the checkout completed successfully, `false` if the user
+     * canceled or closed the checkout without completing payment.
      */
     @Parcelize
-    data object PremiumCheckoutResult : SpecialCircumstance()
+    data class PremiumCheckoutResult(
+        val isSuccess: Boolean,
+    ) : SpecialCircumstance()
 
     /**
      * The app was launched to select an account to export credentials from.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
@@ -5,6 +5,7 @@ import androidx.credentials.CredentialManager
 import com.bitwarden.cxf.model.ImportCredentialsRequestData
 import com.bitwarden.ui.platform.manager.share.model.ShareData
 import com.bitwarden.ui.platform.model.TotpData
+import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.autofill.model.AutofillSaveItem
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
@@ -137,13 +138,10 @@ sealed class SpecialCircumstance : Parcelable {
     /**
      * The app was launched via a Premium checkout callback deep link,
      * indicating the user is returning from a Stripe checkout session.
-     *
-     * @property isSuccess `true` if the checkout completed successfully, `false` if the user
-     * canceled or closed the checkout without completing payment.
      */
     @Parcelize
     data class PremiumCheckoutResult(
-        val isSuccess: Boolean,
+        val callbackResult: PremiumCheckoutCallbackResult,
     ) : SpecialCircumstance()
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/SpecialCircumstance.kt
@@ -140,7 +140,7 @@ sealed class SpecialCircumstance : Parcelable {
      * indicating the user is returning from a Stripe checkout session.
      */
     @Parcelize
-    data class PremiumCheckoutResult(
+    data class PremiumCheckout(
         val callbackResult: PremiumCheckoutCallbackResult,
     ) : SpecialCircumstance()
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -156,6 +156,20 @@ private fun FreeDialogs(
             )
         }
 
+        is PlanState.DialogState.PendingUpgrade -> {
+            BitwardenTwoButtonDialog(
+                title = stringResource(id = BitwardenString.upgrade_pending),
+                message = stringResource(
+                    id = BitwardenString.upgrade_pending_message,
+                ),
+                confirmButtonText = stringResource(id = BitwardenString.sync_now),
+                dismissButtonText = stringResource(id = BitwardenString.continue_text),
+                onConfirmClick = handlers.onSyncClick,
+                onDismissClick = handlers.onContinueClick,
+                onDismissRequest = handlers.onContinueClick,
+            )
+        }
+
         is PlanState.DialogState.Loading -> {
             BitwardenLoadingDialog(text = dialogState.message())
         }
@@ -301,7 +315,11 @@ private fun PlanScreenFreeAccount_preview() {
     BitwardenTheme {
         BitwardenScaffold {
             FreeContent(
-                viewState = PlanState.ViewState.Free(rate = "$1.67"),
+                viewState = PlanState.ViewState.Free(
+                    rate = "$1.67",
+                    checkoutUrl = null,
+                    isAwaitingPremiumStatus = false,
+                ),
                 isDialogShowing = false,
                 handlers = PlanHandlers(
                     onBackClick = {},
@@ -312,6 +330,8 @@ private fun PlanScreenFreeAccount_preview() {
                     onClosePricingErrorClick = {},
                     onCancelWaiting = {},
                     onGoBackClick = {},
+                    onSyncClick = {},
+                    onContinueClick = {},
                 ),
             )
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -243,11 +243,16 @@ private fun PremiumDetailsCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .cardStyle(cardStyle = CardStyle.Full),
+            .cardStyle(
+                cardStyle = CardStyle.Full,
+                // Override bottom padding to account for custom
+                // `BitwardenContentBlock` vertical padding, below.
+                paddingBottom = 0.dp,
+            ),
     ) {
         Column(
             modifier = Modifier
-                .padding(bottom = 12.dp)
+                .padding(bottom = 16.dp)
                 .standardHorizontalMargin(),
         ) {
             PriceRow(
@@ -264,9 +269,7 @@ private fun PremiumDetailsCard(
             )
         }
 
-        BitwardenHorizontalDivider(
-            modifier = Modifier.padding(start = 16.dp),
-        )
+        BitwardenHorizontalDivider()
 
         val features = listOf(
             BitwardenString.built_in_authenticator,
@@ -282,7 +285,7 @@ private fun PremiumDetailsCard(
                 ),
                 headerTextStyle = BitwardenTheme.typography.titleMedium,
                 showDivider = index != features.lastIndex,
-                modifier = Modifier.padding(vertical = 6.dp),
+                modifier = Modifier.padding(vertical = 8.dp),
             )
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -54,7 +54,6 @@ import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
 /**
  * The screen for the plan -- shows upgrade flow for free users.
  */
-@Suppress("LongMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlanScreen(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -247,10 +247,7 @@ private fun PremiumDetailsCard(
     ) {
         Column(
             modifier = Modifier
-                .padding(
-                    top = 16.dp,
-                    bottom = 12.dp,
-                )
+                .padding(bottom = 12.dp)
                 .standardHorizontalMargin(),
         ) {
             PriceRow(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -41,6 +41,8 @@ import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.ui.platform.components.divider.BitwardenHorizontalDivider
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
+import com.bitwarden.ui.platform.components.snackbar.BitwardenSnackbarHost
+import com.bitwarden.ui.platform.components.snackbar.model.rememberBitwardenSnackbarHostState
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
@@ -64,6 +66,7 @@ fun PlanScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val handlers = remember(viewModel) { PlanHandlers.create(viewModel) }
+    val snackbarHostState = rememberBitwardenSnackbarHostState()
 
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
@@ -76,6 +79,7 @@ fun PlanScreen(
             }
 
             PlanEvent.NavigateBack -> onNavigateBack()
+            is PlanEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)
         }
     }
 
@@ -89,6 +93,9 @@ fun PlanScreen(
         modifier = Modifier
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection),
+        snackbarHost = {
+            BitwardenSnackbarHost(bitwardenHostState = snackbarHostState)
+        },
         topBar = {
             BitwardenTopAppBar(
                 title = stringResource(id = BitwardenString.upgrade_to_premium),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -54,6 +54,7 @@ import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
 /**
  * The screen for the plan -- shows upgrade flow for free users.
  */
+@Suppress("LongMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlanScreen(
@@ -126,6 +127,18 @@ private fun FreeDialogs(
                 confirmButtonText = stringResource(id = BitwardenString.try_again),
                 dismissButtonText = stringResource(id = BitwardenString.close),
                 onConfirmClick = handlers.onRetryClick,
+                onDismissClick = handlers.onDismissError,
+                onDismissRequest = handlers.onDismissError,
+            )
+        }
+
+        is PlanState.DialogState.GetPricingError -> {
+            BitwardenTwoButtonDialog(
+                title = dialogState.title(),
+                message = dialogState.message(),
+                confirmButtonText = stringResource(BitwardenString.try_again),
+                dismissButtonText = stringResource(BitwardenString.okay),
+                onConfirmClick = handlers.onRetryPricingClick,
                 onDismissClick = handlers.onDismissError,
                 onDismissRequest = handlers.onDismissError,
             )
@@ -297,6 +310,7 @@ private fun PlanScreenFreeAccount_preview() {
                     onRetryClick = {},
                     onCancelWaiting = {},
                     onGoBackClick = {},
+                    onRetryPricingClick = {},
                 ),
             )
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -137,10 +137,10 @@ private fun FreeDialogs(
                 title = dialogState.title(),
                 message = dialogState.message(),
                 confirmButtonText = stringResource(BitwardenString.try_again),
-                dismissButtonText = stringResource(BitwardenString.okay),
+                dismissButtonText = stringResource(BitwardenString.close),
                 onConfirmClick = handlers.onRetryPricingClick,
-                onDismissClick = handlers.onDismissError,
-                onDismissRequest = handlers.onDismissError,
+                onDismissClick = handlers.onClosePricingErrorClick,
+                onDismissRequest = handlers.onClosePricingErrorClick,
             )
         }
 
@@ -301,16 +301,17 @@ private fun PlanScreenFreeAccount_preview() {
     BitwardenTheme {
         BitwardenScaffold {
             FreeContent(
-                viewState = PlanState.ViewState.Free(rate = "$1.65"),
+                viewState = PlanState.ViewState.Free(rate = "$1.67"),
                 isDialogShowing = false,
                 handlers = PlanHandlers(
                     onBackClick = {},
                     onUpgradeNowClick = {},
                     onDismissError = {},
                     onRetryClick = {},
+                    onRetryPricingClick = {},
+                    onClosePricingErrorClick = {},
                     onCancelWaiting = {},
                     onGoBackClick = {},
-                    onRetryPricingClick = {},
                 ),
             )
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -20,8 +20,11 @@ import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -36,36 +39,32 @@ private const val PLACEHOLDER_RATE = "--"
 /**
  * The callback URL for the premium checkout custom tab.
  */
-const val PREMIUM_CHECKOUT_CALLBACK_URL = "bitwarden://premium-upgrade-callback"
+const val PREMIUM_CHECKOUT_CALLBACK_URL = "bitwarden://premium-checkout-result"
 
 /**
  * View model for the plan screen, handling the free-user upgrade flow.
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class PlanViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val billingRepository: BillingRepository,
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
-    authRepository: AuthRepository,
-    specialCircumstanceManager: SpecialCircumstanceManager,
+    private val authRepository: AuthRepository,
+    private val specialCircumstanceManager: SpecialCircumstanceManager,
+    private val vaultRepository: VaultRepository,
+    settingsRepository: SettingsRepository,
 ) : BaseViewModel<PlanState, PlanEvent, PlanAction>(
-    initialState = savedStateHandle[KEY_STATE] ?: run {
-        val planMode = savedStateHandle.toPlanArgs().planMode
-        val dialogState = when (specialCircumstanceManager.specialCircumstance) {
-            is SpecialCircumstance.PremiumCheckoutResult -> {
-                specialCircumstanceManager.specialCircumstance = null
-                PlanState.DialogState.WaitingForPayment
-            }
-
-            else -> null
-        }
-        PlanState(
-            planMode = planMode,
-            viewState = PlanState.ViewState.Free(rate = PLACEHOLDER_RATE),
-            dialogState = dialogState,
-        )
-    },
+    initialState = savedStateHandle[KEY_STATE]
+        ?: PlanState(
+            planMode = savedStateHandle.toPlanArgs().planMode,
+            viewState = PlanState.ViewState.Free(
+                rate = PLACEHOLDER_RATE,
+                checkoutUrl = null,
+                isAwaitingPremiumStatus = false,
+            ),
+            dialogState = null,
+        ),
 ) {
     init {
         stateFlow
@@ -78,10 +77,24 @@ class PlanViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
+        specialCircumstanceManager
+            .specialCircumstanceStateFlow
+            .map { PlanAction.Internal.SpecialCircumstanceReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        settingsRepository
+            .vaultLastSyncStateFlow
+            .drop(count = 1)
+            .map { PlanAction.Internal.SyncCompleteReceive }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
         viewModelScope.launch {
-            val result = billingRepository.getPremiumPlanPricing()
             sendAction(
-                PlanAction.Internal.PricingResultReceive(result),
+                PlanAction.Internal.PricingResultReceive(
+                    result = billingRepository.getPremiumPlanPricing(),
+                ),
             )
         }
     }
@@ -105,12 +118,22 @@ class PlanViewModel @Inject constructor(
 
             is PlanAction.CancelWaiting -> handleCancelWaiting()
             is PlanAction.GoBackClick -> handleGoBackClick()
+            is PlanAction.SyncClick -> handleSyncClick()
+            is PlanAction.ContinueClick -> handleContinueClick()
             is PlanAction.Internal.CheckoutUrlReceive -> {
                 handleCheckoutUrlReceive(action)
             }
 
             is PlanAction.Internal.UserStateUpdateReceive -> {
                 handleUserStateUpdateReceive(action)
+            }
+
+            is PlanAction.Internal.SpecialCircumstanceReceive -> {
+                handleSpecialCircumstanceReceive(action)
+            }
+
+            is PlanAction.Internal.SyncCompleteReceive -> {
+                handleSyncCompleteReceive()
             }
 
             is PlanAction.Internal.PricingResultReceive -> {
@@ -132,9 +155,10 @@ class PlanViewModel @Inject constructor(
             )
         }
         viewModelScope.launch {
-            val result = billingRepository.getCheckoutSessionUrl()
             sendAction(
-                PlanAction.Internal.CheckoutUrlReceive(result),
+                PlanAction.Internal.CheckoutUrlReceive(
+                    result = billingRepository.getCheckoutSessionUrl(),
+                ),
             )
         }
     }
@@ -154,6 +178,22 @@ class PlanViewModel @Inject constructor(
 
     private fun handleCancelWaiting() {
         mutableStateFlow.update { it.copy(dialogState = null) }
+    }
+
+    private fun handleSyncClick() {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.Loading(
+                    message = BitwardenString.syncing.asText(),
+                ),
+            )
+        }
+        vaultRepository.sync(forced = true)
+    }
+
+    private fun handleContinueClick() {
+        mutableStateFlow.update { it.copy(dialogState = null) }
+        sendEvent(PlanEvent.NavigateBack)
     }
 
     private fun handleGoBackClick() {
@@ -190,7 +230,7 @@ class PlanViewModel @Inject constructor(
                             viewState = freeState.copy(
                                 checkoutUrl = result.url,
                             ),
-                            dialogState = PlanState.DialogState.WaitingForPayment,
+                            dialogState = null,
                         )
                     }
                 }
@@ -207,18 +247,94 @@ class PlanViewModel @Inject constructor(
     private fun handleUserStateUpdateReceive(
         action: PlanAction.Internal.UserStateUpdateReceive,
     ) {
-        if (state.dialogState !is PlanState.DialogState.WaitingForPayment) return
+        onFreeContent { freeState ->
+            if (!freeState.isAwaitingPremiumStatus) return@onFreeContent
 
-        val isPremium = action.userState?.activeAccount?.isPremium == true
-        if (isPremium) {
-            snackbarRelayManager.sendSnackbarData(
-                data = BitwardenSnackbarData(
-                    message = BitwardenString.upgraded_to_premium.asText(),
-                ),
-                relay = SnackbarRelay.PREMIUM_UPGRADED,
-            )
-            sendEvent(PlanEvent.NavigateBack)
+            val isPremium = action.userState?.activeAccount?.isPremium == true
+            if (isPremium) {
+                handlePremiumUpgradeSuccess()
+            }
         }
+    }
+
+    private fun handleSpecialCircumstanceReceive(
+        action: PlanAction.Internal.SpecialCircumstanceReceive,
+    ) {
+        val checkoutResult = action.specialCircumstance
+            as? SpecialCircumstance.PremiumCheckoutResult ?: return
+        specialCircumstanceManager.specialCircumstance = null
+
+        if (!checkoutResult.isSuccess) {
+            // User canceled checkout — show "Payment not received yet" dialog.
+            onFreeContent { freeState ->
+                mutableStateFlow.update {
+                    it.copy(
+                        viewState = freeState.copy(
+                            isAwaitingPremiumStatus = true,
+                        ),
+                        dialogState = PlanState.DialogState.WaitingForPayment,
+                    )
+                }
+            }
+            return
+        }
+
+        // Success — check if already premium, otherwise trigger background sync.
+        val isPremium = authRepository
+            .userStateFlow
+            .value
+            ?.activeAccount
+            ?.isPremium == true
+        if (isPremium) {
+            handlePremiumUpgradeSuccess()
+        } else {
+            onFreeContent { freeState ->
+                mutableStateFlow.update {
+                    it.copy(
+                        viewState = freeState.copy(
+                            isAwaitingPremiumStatus = true,
+                        ),
+                        dialogState = PlanState.DialogState.Loading(
+                            message = BitwardenString.syncing.asText(),
+                        ),
+                    )
+                }
+            }
+            vaultRepository.sync(forced = true)
+        }
+    }
+
+    private fun handleSyncCompleteReceive() {
+        onFreeContent { freeState ->
+            if (!freeState.isAwaitingPremiumStatus) return@onFreeContent
+
+            val isPremium = authRepository
+                .userStateFlow
+                .value
+                ?.activeAccount
+                ?.isPremium == true
+            if (isPremium) {
+                handlePremiumUpgradeSuccess()
+            } else {
+                // Sync completed but premium not yet provisioned —
+                // prompt the user to retry or continue as free.
+                mutableStateFlow.update {
+                    it.copy(
+                        dialogState = PlanState.DialogState.PendingUpgrade,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun handlePremiumUpgradeSuccess() {
+        snackbarRelayManager.sendSnackbarData(
+            data = BitwardenSnackbarData(
+                message = BitwardenString.upgraded_to_premium.asText(),
+            ),
+            relay = SnackbarRelay.PREMIUM_UPGRADED,
+        )
+        sendEvent(PlanEvent.NavigateBack)
     }
 
     private inline fun onFreeContent(
@@ -332,7 +448,8 @@ data class PlanState(
         @Parcelize
         data class Free(
             override val rate: String,
-            val checkoutUrl: String? = null,
+            val checkoutUrl: String?,
+            val isAwaitingPremiumStatus: Boolean,
         ) : ViewState()
     }
 
@@ -365,10 +482,18 @@ data class PlanState(
         ) : DialogState()
 
         /**
-         * Waiting dialog shown after the browser has been launched for checkout.
+         * Waiting dialog shown when the user returns from checkout
+         * without completing payment.
          */
         @Parcelize
         data object WaitingForPayment : DialogState()
+
+        /**
+         * Dialog shown after a successful checkout when premium
+         * status has not yet been provisioned by the server.
+         */
+        @Parcelize
+        data object PendingUpgrade : DialogState()
     }
 }
 
@@ -438,6 +563,16 @@ sealed class PlanAction {
     data object GoBackClick : PlanAction()
 
     /**
+     * The user clicked sync on the pending upgrade dialog.
+     */
+    data object SyncClick : PlanAction()
+
+    /**
+     * The user chose to continue without waiting for upgrade.
+     */
+    data object ContinueClick : PlanAction()
+
+    /**
      * Models actions the view model sends itself.
      */
     sealed class Internal : PlanAction() {
@@ -456,6 +591,18 @@ sealed class PlanAction {
         data class UserStateUpdateReceive(
             val userState: UserState?,
         ) : Internal()
+
+        /**
+         * A special circumstance update has been received.
+         */
+        data class SpecialCircumstanceReceive(
+            val specialCircumstance: SpecialCircumstance?,
+        ) : Internal()
+
+        /**
+         * A vault sync has completed.
+         */
+        data object SyncCompleteReceive : Internal()
 
         /**
          * A pricing result has been received from the repository.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -62,7 +62,9 @@ class PlanViewModel @Inject constructor(
                 checkoutUrl = null,
                 isAwaitingPremiumStatus = false,
             ),
-            dialogState = null,
+            dialogState = PlanState.DialogState.Loading(
+                message = BitwardenString.loading.asText(),
+            ),
         ),
 ) {
     init {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -2,8 +2,6 @@ package com.x8bit.bitwarden.ui.platform.feature.premium.plan
 
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
-import java.text.NumberFormat
-import java.util.Locale
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -19,9 +17,9 @@ import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
+import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -31,6 +29,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import java.text.NumberFormat
+import java.util.Locale
 import javax.inject.Inject
 
 private const val KEY_STATE = "state"

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -377,7 +377,7 @@ class PlanViewModel @Inject constructor(
                     mutableStateFlow.update {
                         it.copy(
                             dialogState = PlanState.DialogState.GetPricingError(
-                                title = BitwardenString.an_error_has_occurred.asText(),
+                                title = BitwardenString.pricing_unavailable.asText(),
                                 message = result.errorMessage?.asText()
                                     ?: BitwardenString.generic_error_message.asText(),
                             ),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -20,6 +20,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
@@ -255,7 +256,7 @@ class PlanViewModel @Inject constructor(
             as? SpecialCircumstance.PremiumCheckoutResult ?: return
         specialCircumstanceManager.specialCircumstance = null
 
-        if (!checkoutResult.isSuccess) {
+        if (checkoutResult.callbackResult is PremiumCheckoutCallbackResult.Canceled) {
             // User canceled checkout — show "Payment not received yet" dialog.
             onFreeContent { freeState ->
                 mutableStateFlow.update {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -255,7 +255,7 @@ class PlanViewModel @Inject constructor(
         action: PlanAction.Internal.SpecialCircumstanceReceive,
     ) {
         val checkoutResult = action.specialCircumstance
-            as? SpecialCircumstance.PremiumCheckoutResult ?: return
+            as? SpecialCircumstance.PremiumCheckout ?: return
         specialCircumstanceManager.specialCircumstance = null
 
         if (checkoutResult.callbackResult is PremiumCheckoutCallbackResult.Canceled) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -17,6 +17,7 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
+import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
@@ -30,6 +31,7 @@ import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 private const val KEY_STATE = "state"
+private const val PLACEHOLDER_RATE = "--"
 
 /**
  * The callback URL for the premium checkout custom tab.
@@ -37,14 +39,9 @@ private const val KEY_STATE = "state"
 const val PREMIUM_CHECKOUT_CALLBACK_URL = "bitwarden://premium-upgrade-callback"
 
 /**
- * Placeholder rate until dynamic pricing is available.
- * TODO: [PM-33946] Replace with dynamic pricing from GET /api/plans/premium.
- */
-private const val PLACEHOLDER_RATE = "$1.65"
-
-/**
  * View model for the plan screen, handling the free-user upgrade flow.
  */
+@Suppress("TooManyFunctions")
 @HiltViewModel
 class PlanViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -80,6 +77,13 @@ class PlanViewModel @Inject constructor(
             .map { PlanAction.Internal.UserStateUpdateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            val result = billingRepository.getPremiumPlanPricing()
+            sendAction(
+                PlanAction.Internal.PricingResultReceive(result),
+            )
+        }
     }
 
     override fun handleAction(action: PlanAction) {
@@ -91,6 +95,10 @@ class PlanViewModel @Inject constructor(
 
             is PlanAction.DismissError -> handleDismissError()
             is PlanAction.RetryClick -> handleRetryClick()
+            is PlanAction.RetryPricingClick -> {
+                handleRetryPricingClick()
+            }
+
             is PlanAction.CancelWaiting -> handleCancelWaiting()
             is PlanAction.GoBackClick -> handleGoBackClick()
             is PlanAction.Internal.CheckoutUrlReceive -> {
@@ -99,6 +107,10 @@ class PlanViewModel @Inject constructor(
 
             is PlanAction.Internal.UserStateUpdateReceive -> {
                 handleUserStateUpdateReceive(action)
+            }
+
+            is PlanAction.Internal.PricingResultReceive -> {
+                handlePricingResultReceive(action)
             }
         }
     }
@@ -206,6 +218,49 @@ class PlanViewModel @Inject constructor(
         (state.viewState as? PlanState.ViewState.Free)
             ?.let(block)
     }
+
+    private fun handlePricingResultReceive(
+        action: PlanAction.Internal.PricingResultReceive,
+    ) {
+        mutableStateFlow.update {
+            when (val result = action.result) {
+                is PremiumPlanPricingResult.Success -> {
+                    it.copy(
+                        viewState = PlanState.ViewState.Free(
+                            rate = result.monthlyRate,
+                        ),
+                    )
+                }
+
+                is PremiumPlanPricingResult.Error -> {
+                    it.copy(
+                        dialogState = PlanState.DialogState.GetPricingError(
+                            title = BitwardenString.an_error_has_occurred.asText(),
+                            message = result.errorMessage?.asText()
+                                ?: BitwardenString.generic_error_message.asText(),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun handleRetryPricingClick() {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.Loading(
+                    message = BitwardenString.loading.asText(),
+                ),
+            )
+        }
+        viewModelScope.launch {
+            sendAction(
+                PlanAction.Internal.PricingResultReceive(
+                    result = billingRepository.getPremiumPlanPricing(),
+                ),
+            )
+        }
+    }
 }
 
 /**
@@ -283,15 +338,22 @@ data class PlanState(
         ) : DialogState()
 
         /**
-         * Error dialog shown when the checkout session could not
-         * be loaded.
+         * Error dialog shown when the checkout session could not be loaded.
          */
         @Parcelize
         data object CheckoutError : DialogState()
 
         /**
-         * Waiting dialog shown after the browser has been launched
-         * for checkout.
+         * Error dialog shown when pricing information cannot be retrieved.
+         */
+        @Parcelize
+        data class GetPricingError(
+            val title: Text,
+            val message: Text,
+        ) : DialogState()
+
+        /**
+         * Waiting dialog shown after the browser has been launched for checkout.
          */
         @Parcelize
         data object WaitingForPayment : DialogState()
@@ -344,6 +406,11 @@ sealed class PlanAction {
     data object RetryClick : PlanAction()
 
     /**
+     * The user clicked retry on the pricing error screen.
+     */
+    data object RetryPricingClick : PlanAction()
+
+    /**
      * The user dismissed the waiting for payment dialog.
      */
     data object CancelWaiting : PlanAction()
@@ -371,6 +438,13 @@ sealed class PlanAction {
          */
         data class UserStateUpdateReceive(
             val userState: UserState?,
+        ) : Internal()
+
+        /**
+         * A pricing result has been received from the repository.
+         */
+        data class PricingResultReceive(
+            val result: PremiumPlanPricingResult,
         ) : Internal()
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -2,6 +2,8 @@ package com.x8bit.bitwarden.ui.platform.feature.premium.plan
 
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
+import java.text.NumberFormat
+import java.util.Locale
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -34,6 +36,7 @@ import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 private const val KEY_STATE = "state"
+private const val MONTHS_PER_YEAR = 12
 private const val PLACEHOLDER_RATE = "--"
 
 /**
@@ -125,7 +128,7 @@ class PlanViewModel @Inject constructor(
             }
 
             is PlanAction.Internal.SyncCompleteReceive -> {
-                handleSyncCompleteReceive(action)
+                handleSyncCompleteReceive()
             }
 
             is PlanAction.Internal.PricingResultReceive -> {
@@ -244,7 +247,7 @@ class PlanViewModel @Inject constructor(
 
             val isPremium = action.userState?.activeAccount?.isPremium == true
             if (isPremium) {
-                handlePremiumUpgradeSuccess()
+                onPremiumUpgradeSuccess()
             }
         }
     }
@@ -278,7 +281,7 @@ class PlanViewModel @Inject constructor(
             ?.activeAccount
             ?.isPremium == true
         if (isPremium) {
-            handlePremiumUpgradeSuccess()
+            onPremiumUpgradeSuccess()
         } else {
             onFreeContent { freeState ->
                 mutableStateFlow.update {
@@ -303,9 +306,7 @@ class PlanViewModel @Inject constructor(
         }
     }
 
-    private fun handleSyncCompleteReceive(
-        action: PlanAction.Internal.SyncCompleteReceive,
-    ) {
+    private fun handleSyncCompleteReceive() {
         onFreeContent { freeState ->
             if (!freeState.isAwaitingPremiumStatus) return@onFreeContent
 
@@ -315,7 +316,7 @@ class PlanViewModel @Inject constructor(
                 ?.activeAccount
                 ?.isPremium == true
             if (isPremium) {
-                handlePremiumUpgradeSuccess()
+                onPremiumUpgradeSuccess()
             } else {
                 // Sync completed but premium not yet provisioned —
                 // prompt the user to retry or continue as free.
@@ -328,7 +329,7 @@ class PlanViewModel @Inject constructor(
         }
     }
 
-    private fun handlePremiumUpgradeSuccess() {
+    private fun onPremiumUpgradeSuccess() {
         snackbarRelayManager.sendSnackbarData(
             data = BitwardenSnackbarData(
                 message = BitwardenString.upgraded_to_premium.asText(),
@@ -351,9 +352,12 @@ class PlanViewModel @Inject constructor(
         onFreeContent { freeState ->
             when (val result = action.result) {
                 is PremiumPlanPricingResult.Success -> {
+                    val formattedRate = NumberFormat
+                        .getCurrencyInstance(Locale.US)
+                        .format(result.annualPrice / MONTHS_PER_YEAR)
                     mutableStateFlow.update {
                         it.copy(
-                            viewState = freeState.copy(rate = result.monthlyRate),
+                            viewState = freeState.copy(rate = formattedRate),
                             dialogState = null,
                         )
                     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -20,11 +20,10 @@ import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -53,7 +52,6 @@ class PlanViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val specialCircumstanceManager: SpecialCircumstanceManager,
     private val vaultRepository: VaultRepository,
-    settingsRepository: SettingsRepository,
 ) : BaseViewModel<PlanState, PlanEvent, PlanAction>(
     initialState = savedStateHandle[KEY_STATE]
         ?: PlanState(
@@ -80,13 +78,6 @@ class PlanViewModel @Inject constructor(
         specialCircumstanceManager
             .specialCircumstanceStateFlow
             .map { PlanAction.Internal.SpecialCircumstanceReceive(it) }
-            .onEach(::sendAction)
-            .launchIn(viewModelScope)
-
-        settingsRepository
-            .vaultLastSyncStateFlow
-            .drop(count = 1)
-            .map { PlanAction.Internal.SyncCompleteReceive }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -133,7 +124,7 @@ class PlanViewModel @Inject constructor(
             }
 
             is PlanAction.Internal.SyncCompleteReceive -> {
-                handleSyncCompleteReceive()
+                handleSyncCompleteReceive(action)
             }
 
             is PlanAction.Internal.PricingResultReceive -> {
@@ -188,7 +179,7 @@ class PlanViewModel @Inject constructor(
                 ),
             )
         }
-        vaultRepository.sync(forced = true)
+        triggerSync()
     }
 
     private fun handleContinueClick() {
@@ -300,11 +291,20 @@ class PlanViewModel @Inject constructor(
                     )
                 }
             }
-            vaultRepository.sync(forced = true)
+            triggerSync()
         }
     }
 
-    private fun handleSyncCompleteReceive() {
+    private fun triggerSync() {
+        viewModelScope.launch {
+            val result = vaultRepository.syncForResult(forced = true)
+            sendAction(PlanAction.Internal.SyncCompleteReceive(result))
+        }
+    }
+
+    private fun handleSyncCompleteReceive(
+        action: PlanAction.Internal.SyncCompleteReceive,
+    ) {
         onFreeContent { freeState ->
             if (!freeState.isAwaitingPremiumStatus) return@onFreeContent
 
@@ -602,7 +602,9 @@ sealed class PlanAction {
         /**
          * A vault sync has completed.
          */
-        data object SyncCompleteReceive : Internal()
+        data class SyncCompleteReceive(
+            val result: SyncVaultDataResult,
+        ) : Internal()
 
         /**
          * A pricing result has been received from the repository.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.viewModelScope
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
-import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
@@ -25,7 +24,6 @@ import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
-import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -47,12 +45,11 @@ const val PREMIUM_CHECKOUT_CALLBACK_URL = "bitwarden://premium-checkout-result"
 /**
  * View model for the plan screen, handling the free-user upgrade flow.
  */
-@Suppress("TooManyFunctions", "LongParameterList")
+@Suppress("TooManyFunctions")
 @HiltViewModel
 class PlanViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val billingRepository: BillingRepository,
-    private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     private val authRepository: AuthRepository,
     private val specialCircumstanceManager: SpecialCircumstanceManager,
     private val vaultRepository: VaultRepository,
@@ -179,7 +176,7 @@ class PlanViewModel @Inject constructor(
         mutableStateFlow.update {
             it.copy(
                 dialogState = PlanState.DialogState.Loading(
-                    message = BitwardenString.syncing.asText(),
+                    message = BitwardenString.confirming_your_upgrade.asText(),
                 ),
             )
         }
@@ -290,7 +287,7 @@ class PlanViewModel @Inject constructor(
                             isAwaitingPremiumStatus = true,
                         ),
                         dialogState = PlanState.DialogState.Loading(
-                            message = BitwardenString.syncing.asText(),
+                            message = BitwardenString.confirming_your_upgrade.asText(),
                         ),
                     )
                 }
@@ -330,13 +327,24 @@ class PlanViewModel @Inject constructor(
     }
 
     private fun onPremiumUpgradeSuccess() {
-        snackbarRelayManager.sendSnackbarData(
-            data = BitwardenSnackbarData(
-                message = BitwardenString.upgraded_to_premium.asText(),
+        onFreeContent { freeState ->
+            mutableStateFlow.update {
+                it.copy(
+                    viewState = freeState.copy(
+                        isAwaitingPremiumStatus = false,
+                    ),
+                    dialogState = null,
+                )
+            }
+        }
+        sendEvent(
+            PlanEvent.ShowSnackbar(
+                data = BitwardenSnackbarData(
+                    message = BitwardenString.upgraded_to_premium.asText(),
+                ),
             ),
-            relay = SnackbarRelay.PREMIUM_UPGRADED,
         )
-        sendEvent(PlanEvent.NavigateBack)
+        // TODO: transition to Premium ViewState (PM-33517)
     }
 
     private inline fun onFreeContent(
@@ -520,6 +528,13 @@ sealed class PlanEvent {
      * Navigate back to the previous screen.
      */
     data object NavigateBack : PlanEvent()
+
+    /**
+     * Show a snackbar with the given [data].
+     */
+    data class ShowSnackbar(
+        val data: BitwardenSnackbarData,
+    ) : PlanEvent()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -94,6 +94,10 @@ class PlanViewModel @Inject constructor(
             }
 
             is PlanAction.DismissError -> handleDismissError()
+            is PlanAction.ClosePricingErrorClick -> {
+                handleClosePricingErrorClick()
+            }
+
             is PlanAction.RetryClick -> handleRetryClick()
             is PlanAction.RetryPricingClick -> {
                 handleRetryPricingClick()
@@ -141,6 +145,11 @@ class PlanViewModel @Inject constructor(
 
     private fun handleDismissError() {
         mutableStateFlow.update { it.copy(dialogState = null) }
+    }
+
+    private fun handleClosePricingErrorClick() {
+        mutableStateFlow.update { it.copy(dialogState = null) }
+        sendEvent(PlanEvent.NavigateBack)
     }
 
     private fun handleCancelWaiting() {
@@ -222,24 +231,27 @@ class PlanViewModel @Inject constructor(
     private fun handlePricingResultReceive(
         action: PlanAction.Internal.PricingResultReceive,
     ) {
-        mutableStateFlow.update {
+        onFreeContent { freeState ->
             when (val result = action.result) {
                 is PremiumPlanPricingResult.Success -> {
-                    it.copy(
-                        viewState = PlanState.ViewState.Free(
-                            rate = result.monthlyRate,
-                        ),
-                    )
+                    mutableStateFlow.update {
+                        it.copy(
+                            viewState = freeState.copy(rate = result.monthlyRate),
+                            dialogState = null,
+                        )
+                    }
                 }
 
                 is PremiumPlanPricingResult.Error -> {
-                    it.copy(
-                        dialogState = PlanState.DialogState.GetPricingError(
-                            title = BitwardenString.an_error_has_occurred.asText(),
-                            message = result.errorMessage?.asText()
-                                ?: BitwardenString.generic_error_message.asText(),
-                        ),
-                    )
+                    mutableStateFlow.update {
+                        it.copy(
+                            dialogState = PlanState.DialogState.GetPricingError(
+                                title = BitwardenString.an_error_has_occurred.asText(),
+                                message = result.errorMessage?.asText()
+                                    ?: BitwardenString.generic_error_message.asText(),
+                            ),
+                        )
+                    }
                 }
             }
         }
@@ -409,6 +421,11 @@ sealed class PlanAction {
      * The user clicked retry on the pricing error screen.
      */
     data object RetryPricingClick : PlanAction()
+
+    /**
+     * The user clicked the close button on the pricing error dialog.
+     */
+    data object ClosePricingErrorClick : PlanAction()
 
     /**
      * The user dismissed the waiting for payment dialog.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
@@ -16,6 +16,8 @@ data class PlanHandlers(
     val onClosePricingErrorClick: () -> Unit,
     val onCancelWaiting: () -> Unit,
     val onGoBackClick: () -> Unit,
+    val onSyncClick: () -> Unit,
+    val onContinueClick: () -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -34,6 +36,8 @@ data class PlanHandlers(
             },
             onCancelWaiting = { viewModel.trySendAction(PlanAction.CancelWaiting) },
             onGoBackClick = { viewModel.trySendAction(PlanAction.GoBackClick) },
+            onSyncClick = { viewModel.trySendAction(PlanAction.SyncClick) },
+            onContinueClick = { viewModel.trySendAction(PlanAction.ContinueClick) },
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
@@ -12,6 +12,7 @@ data class PlanHandlers(
     val onUpgradeNowClick: () -> Unit,
     val onDismissError: () -> Unit,
     val onRetryClick: () -> Unit,
+    val onRetryPricingClick: () -> Unit,
     val onCancelWaiting: () -> Unit,
     val onGoBackClick: () -> Unit,
 ) {
@@ -26,6 +27,7 @@ data class PlanHandlers(
             onUpgradeNowClick = { viewModel.trySendAction(PlanAction.UpgradeNowClick) },
             onDismissError = { viewModel.trySendAction(PlanAction.DismissError) },
             onRetryClick = { viewModel.trySendAction(PlanAction.RetryClick) },
+            onRetryPricingClick = { viewModel.trySendAction(PlanAction.RetryPricingClick) },
             onCancelWaiting = { viewModel.trySendAction(PlanAction.CancelWaiting) },
             onGoBackClick = { viewModel.trySendAction(PlanAction.GoBackClick) },
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
@@ -13,6 +13,7 @@ data class PlanHandlers(
     val onDismissError: () -> Unit,
     val onRetryClick: () -> Unit,
     val onRetryPricingClick: () -> Unit,
+    val onClosePricingErrorClick: () -> Unit,
     val onCancelWaiting: () -> Unit,
     val onGoBackClick: () -> Unit,
 ) {
@@ -28,6 +29,9 @@ data class PlanHandlers(
             onDismissError = { viewModel.trySendAction(PlanAction.DismissError) },
             onRetryClick = { viewModel.trySendAction(PlanAction.RetryClick) },
             onRetryPricingClick = { viewModel.trySendAction(PlanAction.RetryPricingClick) },
+            onClosePricingErrorClick = {
+                viewModel.trySendAction(PlanAction.ClosePricingErrorClick)
+            },
             onCancelWaiting = { viewModel.trySendAction(PlanAction.CancelWaiting) },
             onGoBackClick = { viewModel.trySendAction(PlanAction.GoBackClick) },
         )

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -208,7 +208,7 @@ class RootNavViewModel @Inject constructor(
 
                     SpecialCircumstance.AccountSecurityShortcut,
                     SpecialCircumstance.GeneratorShortcut,
-                    SpecialCircumstance.PremiumCheckoutResult,
+                    is SpecialCircumstance.PremiumCheckoutResult,
                     SpecialCircumstance.VaultShortcut,
                     SpecialCircumstance.SendShortcut,
                     is SpecialCircumstance.SearchShortcut,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/rootnav/RootNavViewModel.kt
@@ -208,7 +208,7 @@ class RootNavViewModel @Inject constructor(
 
                     SpecialCircumstance.AccountSecurityShortcut,
                     SpecialCircumstance.GeneratorShortcut,
-                    is SpecialCircumstance.PremiumCheckoutResult,
+                    is SpecialCircumstance.PremiumCheckout,
                     SpecialCircumstance.VaultShortcut,
                     SpecialCircumstance.SendShortcut,
                     is SpecialCircumstance.SearchShortcut,
@@ -284,7 +284,7 @@ class RootNavViewModel @Inject constructor(
         when (specialCircumstance) {
             is SpecialCircumstance.AccountSecurityShortcut,
             is SpecialCircumstance.GeneratorShortcut,
-            is SpecialCircumstance.PremiumCheckoutResult,
+            is SpecialCircumstance.PremiumCheckout,
             is SpecialCircumstance.SearchShortcut,
             is SpecialCircumstance.SendShortcut,
             is SpecialCircumstance.ShareNewSend,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtils.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtils.kt
@@ -25,4 +25,4 @@ val Intent.isAccountSecurityShortcut: Boolean
  * checkout session, `false` otherwise.
  */
 val Intent.isPremiumCheckoutCallback: Boolean
-    get() = dataString?.equals("bitwarden://premium-upgrade-callback") == true
+    get() = dataString?.startsWith("bitwarden://premium-checkout-result") == true

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -883,7 +883,7 @@ class MainViewModelTest : BaseViewModelTest() {
             MainAction.ReceiveFirstIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(
+            SpecialCircumstance.PremiumCheckout(
                 callbackResult = PremiumCheckoutCallbackResult.Success,
             ),
             specialCircumstanceManager.specialCircumstance,
@@ -906,7 +906,7 @@ class MainViewModelTest : BaseViewModelTest() {
             MainAction.ReceiveFirstIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(
+            SpecialCircumstance.PremiumCheckout(
                 callbackResult = PremiumCheckoutCallbackResult.Canceled,
             ),
             specialCircumstanceManager.specialCircumstance,
@@ -929,7 +929,7 @@ class MainViewModelTest : BaseViewModelTest() {
             MainAction.ReceiveNewIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(
+            SpecialCircumstance.PremiumCheckout(
                 callbackResult = PremiumCheckoutCallbackResult.Success,
             ),
             specialCircumstanceManager.specialCircumstance,
@@ -952,7 +952,7 @@ class MainViewModelTest : BaseViewModelTest() {
             MainAction.ReceiveNewIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(
+            SpecialCircumstance.PremiumCheckout(
                 callbackResult = PremiumCheckoutCallbackResult.Canceled,
             ),
             specialCircumstanceManager.specialCircumstance,
@@ -1265,7 +1265,7 @@ class MainViewModelTest : BaseViewModelTest() {
         )
 
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(
+            SpecialCircumstance.PremiumCheckout(
                 callbackResult = PremiumCheckoutCallbackResult.Success,
             ),
             specialCircumstanceManager.specialCircumstance,
@@ -1285,7 +1285,7 @@ class MainViewModelTest : BaseViewModelTest() {
         )
 
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(
+            SpecialCircumstance.PremiumCheckout(
                 callbackResult = PremiumCheckoutCallbackResult.Canceled,
             ),
             specialCircumstanceManager.specialCircumstance,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -1,8 +1,11 @@
 package com.x8bit.bitwarden
 
 import android.content.Intent
+import android.net.Uri
 import androidx.browser.auth.AuthTabIntent
 import androidx.credentials.GetPublicKeyCredentialOption
+import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
+import com.x8bit.bitwarden.data.billing.util.getPremiumCheckoutCallbackResult
 import androidx.credentials.provider.BiometricPromptResult
 import androidx.credentials.provider.ProviderCreateCredentialRequest
 import androidx.credentials.provider.ProviderGetCredentialRequest
@@ -196,6 +199,7 @@ class MainViewModelTest : BaseViewModelTest() {
             AuthTabIntent.AuthResult::getDuoCallbackTokenResult,
             AuthTabIntent.AuthResult::getSsoCallbackResult,
             AuthTabIntent.AuthResult::getWebAuthResult,
+            AuthTabIntent.AuthResult::getPremiumCheckoutCallbackResult,
         )
         mockkStatic(
             Intent::isMyVaultShortcut,
@@ -228,6 +232,7 @@ class MainViewModelTest : BaseViewModelTest() {
             AuthTabIntent.AuthResult::getDuoCallbackTokenResult,
             AuthTabIntent.AuthResult::getSsoCallbackResult,
             AuthTabIntent.AuthResult::getWebAuthResult,
+            AuthTabIntent.AuthResult::getPremiumCheckoutCallbackResult,
         )
         unmockkStatic(
             Intent::isMyVaultShortcut,
@@ -864,34 +869,84 @@ class MainViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `on ReceiveFirstIntent with Premium checkout callback should set special circumstance to PremiumCheckoutResult`() {
+    fun `on ReceiveFirstIntent with Premium checkout success callback should set PremiumCheckoutResult with isSuccess true`() {
         val viewModel = createViewModel()
+        val mockUri = mockk<Uri> {
+            every { getQueryParameter("result") } returns "success"
+        }
         val mockIntent = createMockIntent(
             mockIsPremiumCheckoutCallback = true,
+            mockDataUri = mockUri,
         )
 
         viewModel.trySendAction(
             MainAction.ReceiveFirstIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult,
+            SpecialCircumstance.PremiumCheckoutResult(isSuccess = true),
             specialCircumstanceManager.specialCircumstance,
         )
     }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `on ReceiveNewIntent with Premium checkout callback should set special circumstance to PremiumCheckoutResult`() {
+    fun `on ReceiveFirstIntent with Premium checkout canceled callback should set PremiumCheckoutResult with isSuccess false`() {
         val viewModel = createViewModel()
+        val mockUri = mockk<Uri> {
+            every { getQueryParameter("result") } returns "canceled"
+        }
         val mockIntent = createMockIntent(
             mockIsPremiumCheckoutCallback = true,
+            mockDataUri = mockUri,
+        )
+
+        viewModel.trySendAction(
+            MainAction.ReceiveFirstIntent(intent = mockIntent),
+        )
+        assertEquals(
+            SpecialCircumstance.PremiumCheckoutResult(isSuccess = false),
+            specialCircumstanceManager.specialCircumstance,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveNewIntent with Premium checkout success callback should set PremiumCheckoutResult with isSuccess true`() {
+        val viewModel = createViewModel()
+        val mockUri = mockk<Uri> {
+            every { getQueryParameter("result") } returns "success"
+        }
+        val mockIntent = createMockIntent(
+            mockIsPremiumCheckoutCallback = true,
+            mockDataUri = mockUri,
         )
 
         viewModel.trySendAction(
             MainAction.ReceiveNewIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult,
+            SpecialCircumstance.PremiumCheckoutResult(isSuccess = true),
+            specialCircumstanceManager.specialCircumstance,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on ReceiveNewIntent with Premium checkout canceled callback should set PremiumCheckoutResult with isSuccess false`() {
+        val viewModel = createViewModel()
+        val mockUri = mockk<Uri> {
+            every { getQueryParameter("result") } returns "canceled"
+        }
+        val mockIntent = createMockIntent(
+            mockIsPremiumCheckoutCallback = true,
+            mockDataUri = mockUri,
+        )
+
+        viewModel.trySendAction(
+            MainAction.ReceiveNewIntent(intent = mockIntent),
+        )
+        assertEquals(
+            SpecialCircumstance.PremiumCheckoutResult(isSuccess = false),
             specialCircumstanceManager.specialCircumstance,
         )
     }
@@ -1189,9 +1244,12 @@ class MainViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `on PremiumCheckoutResult should set PremiumCheckoutResult special circumstance`() {
-        val authResult = mockk<AuthTabIntent.AuthResult>()
+    fun `on PremiumCheckoutResult with RESULT_OK should set PremiumCheckoutResult with isSuccess true`() {
+        val authResult = mockk<AuthTabIntent.AuthResult> {
+            every { getPremiumCheckoutCallbackResult() } returns PremiumCheckoutCallbackResult.Success
+        }
         val viewModel = createViewModel()
 
         viewModel.trySendAction(
@@ -1199,7 +1257,25 @@ class MainViewModelTest : BaseViewModelTest() {
         )
 
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult,
+            SpecialCircumstance.PremiumCheckoutResult(isSuccess = true),
+            specialCircumstanceManager.specialCircumstance,
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `on PremiumCheckoutResult with RESULT_CANCELED should set PremiumCheckoutResult with isSuccess false`() {
+        val authResult = mockk<AuthTabIntent.AuthResult> {
+            every { getPremiumCheckoutCallbackResult() } returns PremiumCheckoutCallbackResult.Canceled
+        }
+        val viewModel = createViewModel()
+
+        viewModel.trySendAction(
+            MainAction.PremiumCheckoutResult(authResult = authResult),
+        )
+
+        assertEquals(
+            SpecialCircumstance.PremiumCheckoutResult(isSuccess = false),
             specialCircumstanceManager.specialCircumstance,
         )
     }
@@ -1319,6 +1395,7 @@ private fun createMockIntent(
     mockIsPremiumCheckoutCallback: Boolean = false,
     mockIsAddTotpLoginItemFromAuthenticator: Boolean = false,
     mockProviderImportCredentialsRequest: ProviderImportCredentialsRequest? = null,
+    mockDataUri: Uri? = null,
 ): Intent = mockk<Intent> {
     every { getTotpDataOrNull() } returns mockTotpData
     every { getPasswordlessRequestDataIntentOrNull() } returns mockPasswordlessRequestData
@@ -1331,6 +1408,7 @@ private fun createMockIntent(
     every { isPremiumCheckoutCallback } returns mockIsPremiumCheckoutCallback
     every { isAddTotpLoginItemFromAuthenticator() } returns mockIsAddTotpLoginItemFromAuthenticator
     every { getProviderImportCredentialsRequest() } returns mockProviderImportCredentialsRequest
+    every { data } returns mockDataUri
 }
 
 private val FIXED_CLOCK: Clock = Clock.fixed(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/MainViewModelTest.kt
@@ -883,7 +883,9 @@ class MainViewModelTest : BaseViewModelTest() {
             MainAction.ReceiveFirstIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(isSuccess = true),
+            SpecialCircumstance.PremiumCheckoutResult(
+                callbackResult = PremiumCheckoutCallbackResult.Success,
+            ),
             specialCircumstanceManager.specialCircumstance,
         )
     }
@@ -904,7 +906,9 @@ class MainViewModelTest : BaseViewModelTest() {
             MainAction.ReceiveFirstIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(isSuccess = false),
+            SpecialCircumstance.PremiumCheckoutResult(
+                callbackResult = PremiumCheckoutCallbackResult.Canceled,
+            ),
             specialCircumstanceManager.specialCircumstance,
         )
     }
@@ -925,7 +929,9 @@ class MainViewModelTest : BaseViewModelTest() {
             MainAction.ReceiveNewIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(isSuccess = true),
+            SpecialCircumstance.PremiumCheckoutResult(
+                callbackResult = PremiumCheckoutCallbackResult.Success,
+            ),
             specialCircumstanceManager.specialCircumstance,
         )
     }
@@ -946,7 +952,9 @@ class MainViewModelTest : BaseViewModelTest() {
             MainAction.ReceiveNewIntent(intent = mockIntent),
         )
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(isSuccess = false),
+            SpecialCircumstance.PremiumCheckoutResult(
+                callbackResult = PremiumCheckoutCallbackResult.Canceled,
+            ),
             specialCircumstanceManager.specialCircumstance,
         )
     }
@@ -1257,7 +1265,9 @@ class MainViewModelTest : BaseViewModelTest() {
         )
 
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(isSuccess = true),
+            SpecialCircumstance.PremiumCheckoutResult(
+                callbackResult = PremiumCheckoutCallbackResult.Success,
+            ),
             specialCircumstanceManager.specialCircumstance,
         )
     }
@@ -1275,7 +1285,9 @@ class MainViewModelTest : BaseViewModelTest() {
         )
 
         assertEquals(
-            SpecialCircumstance.PremiumCheckoutResult(isSuccess = false),
+            SpecialCircumstance.PremiumCheckoutResult(
+                callbackResult = PremiumCheckoutCallbackResult.Canceled,
+            ),
             specialCircumstanceManager.specialCircumstance,
         )
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
@@ -4,10 +4,12 @@ import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
 import com.bitwarden.network.model.CheckoutSessionResponseJson
 import com.bitwarden.network.model.PortalUrlResponseJson
+import com.bitwarden.network.model.PremiumPlanResponseJson
 import com.bitwarden.network.service.BillingService
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManager
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.CustomerPortalResult
+import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -101,4 +103,54 @@ class BillingRepositoryTest {
                 result,
             )
         }
+
+    @Test
+    fun `getPremiumPlanPricing when service returns success should return formatted pricing`() =
+        runTest {
+            coEvery {
+                billingService.getPremiumPlan()
+            } returns PremiumPlanResponseJson(
+                name = "Premium",
+                legacyYear = null,
+                isAvailable = true,
+                seat = PremiumPlanResponseJson.PurchasableJson(
+                    stripePriceId = "premium-annually-2026",
+                    price = ANNUAL_PRICE,
+                    provided = 0,
+                ),
+                storage = PremiumPlanResponseJson.PurchasableJson(
+                    stripePriceId = "personal-storage-gb-annually",
+                    price = 4.00,
+                    provided = 5,
+                ),
+            ).asSuccess()
+
+            val result = repository.getPremiumPlanPricing()
+
+            assertEquals(
+                PremiumPlanPricingResult.Success(
+                    monthlyRate = EXPECTED_MONTHLY_RATE,
+                ),
+                result,
+            )
+        }
+
+    @Test
+    fun `getPremiumPlanPricing when service returns failure should return Error`() =
+        runTest {
+            val exception = RuntimeException("Network error")
+            coEvery {
+                billingService.getPremiumPlan()
+            } returns exception.asFailure()
+
+            val result = repository.getPremiumPlanPricing()
+
+            assertEquals(
+                PremiumPlanPricingResult.Error(error = exception),
+                result,
+            )
+        }
 }
+
+private const val ANNUAL_PRICE = 19.99
+private const val EXPECTED_MONTHLY_RATE = "$1.67"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
@@ -129,7 +129,7 @@ class BillingRepositoryTest {
 
             assertEquals(
                 PremiumPlanPricingResult.Success(
-                    monthlyRate = EXPECTED_MONTHLY_RATE,
+                    annualPrice = ANNUAL_PRICE,
                 ),
                 result,
             )
@@ -153,4 +153,3 @@ class BillingRepositoryTest {
 }
 
 private const val ANNUAL_PRICE = 19.99
-private const val EXPECTED_MONTHLY_RATE = "$1.67"

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/util/PremiumCheckoutUtilsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/util/PremiumCheckoutUtilsTest.kt
@@ -30,7 +30,6 @@ class PremiumCheckoutUtilsTest {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `getPremiumCheckoutCallbackResult should return Success for case insensitive SUCCESS`() {
         val uri = mockk<Uri> {
@@ -42,7 +41,6 @@ class PremiumCheckoutUtilsTest {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `getPremiumCheckoutCallbackResult should return Canceled when result param is missing`() {
         val uri = mockk<Uri> {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/util/PremiumCheckoutUtilsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/util/PremiumCheckoutUtilsTest.kt
@@ -1,0 +1,65 @@
+package com.x8bit.bitwarden.data.billing.util
+
+import android.net.Uri
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PremiumCheckoutUtilsTest {
+
+    @Test
+    fun `getPremiumCheckoutCallbackResult should return Success for result success`() {
+        val uri = mockk<Uri> {
+            every { getQueryParameter("result") } returns "success"
+        }
+        assertEquals(
+            PremiumCheckoutCallbackResult.Success,
+            uri.getPremiumCheckoutCallbackResult(),
+        )
+    }
+
+    @Test
+    fun `getPremiumCheckoutCallbackResult should return Canceled for result canceled`() {
+        val uri = mockk<Uri> {
+            every { getQueryParameter("result") } returns "canceled"
+        }
+        assertEquals(
+            PremiumCheckoutCallbackResult.Canceled,
+            uri.getPremiumCheckoutCallbackResult(),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getPremiumCheckoutCallbackResult should return Success for case insensitive SUCCESS`() {
+        val uri = mockk<Uri> {
+            every { getQueryParameter("result") } returns "SUCCESS"
+        }
+        assertEquals(
+            PremiumCheckoutCallbackResult.Success,
+            uri.getPremiumCheckoutCallbackResult(),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `getPremiumCheckoutCallbackResult should return Canceled when result param is missing`() {
+        val uri = mockk<Uri> {
+            every { getQueryParameter("result") } returns null
+        }
+        assertEquals(
+            PremiumCheckoutCallbackResult.Canceled,
+            uri.getPremiumCheckoutCallbackResult(),
+        )
+    }
+
+    @Test
+    fun `getPremiumCheckoutCallbackResult should return Canceled for null Uri`() {
+        val uri: Uri? = null
+        assertEquals(
+            PremiumCheckoutCallbackResult.Canceled,
+            uri.getPremiumCheckoutCallbackResult(),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.platform.feature.premium.plan
 
 import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.filterToOne
@@ -15,6 +16,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.core.net.toUri
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
+import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -95,6 +97,15 @@ class PlanScreenTest : BitwardenComposeTest() {
                 launcher = premiumCheckoutLauncher,
             )
         }
+    }
+
+    @Test
+    fun `ShowSnackbar event should display snackbar`() {
+        val data = BitwardenSnackbarData("Upgraded to premium".asText())
+        mutableEventFlow.tryEmit(PlanEvent.ShowSnackbar(data))
+        composeTestRule
+            .onNodeWithText("Upgraded to premium")
+            .assertIsDisplayed()
     }
 
     // endregion Events

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -315,6 +315,152 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     // endregion Free content tests
+
+    // region PendingUpgrade dialog tests
+
+    @Test
+    fun `pending upgrade dialog should render when dialogState is PendingUpgrade`() {
+        composeTestRule
+            .onAllNodesWithText("Upgrade pending")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertDoesNotExist()
+
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.PendingUpgrade,
+            )
+        }
+
+        composeTestRule
+            .onAllNodesWithText("Upgrade pending")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertExists()
+    }
+
+    @Test
+    fun `pending upgrade dialog should display sync now button`() {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.PendingUpgrade,
+            )
+        }
+        composeTestRule
+            .onAllNodesWithText("Sync now")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertExists()
+    }
+
+    @Test
+    fun `pending upgrade dialog should display continue button`() {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.PendingUpgrade,
+            )
+        }
+        composeTestRule
+            .onAllNodesWithText("Continue")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertExists()
+    }
+
+    @Test
+    fun `pending upgrade dialog sync now click should send SyncClick action`() {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.PendingUpgrade,
+            )
+        }
+        composeTestRule
+            .onAllNodesWithText("Sync now")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+        verify { viewModel.trySendAction(PlanAction.SyncClick) }
+    }
+
+    @Test
+    fun `pending upgrade dialog continue click should send ContinueClick action`() {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.PendingUpgrade,
+            )
+        }
+        composeTestRule
+            .onAllNodesWithText("Continue")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+        verify { viewModel.trySendAction(PlanAction.ContinueClick) }
+    }
+
+    // endregion PendingUpgrade dialog tests
+
+    // region GetPricingError dialog tests
+
+    @Test
+    fun `get pricing error dialog should render when dialogState is GetPricingError`() {
+        val title = "An error has occurred".asText()
+        val message = "Unable to retrieve pricing.".asText()
+
+        composeTestRule
+            .onAllNodesWithText("An error has occurred")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertDoesNotExist()
+
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.GetPricingError(
+                    title = title,
+                    message = message,
+                ),
+            )
+        }
+
+        composeTestRule
+            .onAllNodesWithText("An error has occurred")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertExists()
+        composeTestRule
+            .onAllNodesWithText("Unable to retrieve pricing.")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .assertExists()
+    }
+
+    @Test
+    fun `get pricing error dialog try again click should send RetryPricingClick action`() {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.GetPricingError(
+                    title = "An error has occurred".asText(),
+                    message = "Unable to retrieve pricing.".asText(),
+                ),
+            )
+        }
+        composeTestRule
+            .onAllNodesWithText("Try again")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+        verify { viewModel.trySendAction(PlanAction.RetryPricingClick) }
+    }
+
+    @Test
+    fun `get pricing error dialog close click should send ClosePricingErrorClick action`() {
+        mutableStateFlow.update {
+            it.copy(
+                dialogState = PlanState.DialogState.GetPricingError(
+                    title = "An error has occurred".asText(),
+                    message = "Unable to retrieve pricing.".asText(),
+                ),
+            )
+        }
+        composeTestRule
+            .onAllNodesWithText("Close")
+            .filterToOne(hasAnyAncestor(isDialog()))
+            .performClick()
+        verify {
+            viewModel.trySendAction(PlanAction.ClosePricingErrorClick)
+        }
+    }
+
+    // endregion GetPricingError dialog tests
 }
 
 private val DEFAULT_FREE_STATE = PlanState(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -321,6 +321,8 @@ private val DEFAULT_FREE_STATE = PlanState(
     planMode = PlanMode.Modal,
     viewState = PlanState.ViewState.Free(
         rate = "$1.65",
+        checkoutUrl = null,
+        isAwaitingPremiumStatus = false,
     ),
     dialogState = null,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -15,11 +15,11 @@ import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
-import java.time.Instant
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -57,11 +57,9 @@ class PlanViewModelTest : BaseViewModelTest() {
             } returns mutableSpecialCircumstanceStateFlow
         }
     private val mockVaultRepository: VaultRepository = mockk {
-        every { sync(any()) } just runs
-    }
-    private val mutableVaultLastSyncStateFlow = MutableStateFlow<Instant?>(null)
-    private val mockSettingsRepository: SettingsRepository = mockk {
-        every { vaultLastSyncStateFlow } returns mutableVaultLastSyncStateFlow
+        coEvery {
+            syncForResult(any())
+        } returns SyncVaultDataResult.Success(itemsAvailable = true)
     }
 
     @BeforeEach
@@ -501,7 +499,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `PremiumCheckoutResult with isSuccess true should show Loading and trigger sync when not premium`() =
+    fun `PremiumCheckoutResult with isSuccess true should trigger sync and show PendingUpgrade when not premium`() =
         runTest {
             val viewModel = createViewModel()
 
@@ -511,6 +509,10 @@ class PlanViewModelTest : BaseViewModelTest() {
                 mutableSpecialCircumstanceStateFlow.value =
                     SpecialCircumstance.PremiumCheckoutResult(isSuccess = true)
 
+                // Loading while sync is in progress.
+                awaitItem()
+
+                // Sync completes without premium — PendingUpgrade shown.
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
                         viewState = PlanState.ViewState.Free(
@@ -518,9 +520,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = true,
                         ),
-                        dialogState = PlanState.DialogState.Loading(
-                            message = BitwardenString.syncing.asText(),
-                        ),
+                        dialogState = PlanState.DialogState.PendingUpgrade,
                     ),
                     awaitItem(),
                 )
@@ -528,7 +528,9 @@ class PlanViewModelTest : BaseViewModelTest() {
 
             verify {
                 mockSpecialCircumstanceManager.specialCircumstance = null
-                mockVaultRepository.sync(forced = true)
+            }
+            coVerify {
+                mockVaultRepository.syncForResult(forced = true)
             }
         }
 
@@ -582,48 +584,6 @@ class PlanViewModelTest : BaseViewModelTest() {
                     ),
                 )
                 expectNoEvents()
-            }
-        }
-
-    @Suppress("MaxLineLength")
-    @Test
-    fun `SyncCompleteReceive during Loading should fall back to WaitingForPayment when not premium`() =
-        runTest {
-            val awaitingFreeState = DEFAULT_FREE_STATE.copy(
-                viewState = PlanState.ViewState.Free(
-                    rate = "$1.67",
-                    checkoutUrl = null,
-                    isAwaitingPremiumStatus = true,
-                ),
-            )
-            val viewModel = createViewModel(
-                initialState = awaitingFreeState.copy(
-                    dialogState = PlanState.DialogState.Loading(
-                        message = BitwardenString.syncing.asText(),
-                    ),
-                ),
-                pricingResult = null,
-            )
-
-            viewModel.stateFlow.test {
-                assertEquals(
-                    awaitingFreeState.copy(
-                        dialogState = PlanState.DialogState.Loading(
-                            message = BitwardenString.syncing.asText(),
-                        ),
-                    ),
-                    awaitItem(),
-                )
-
-                // Simulate sync completion without premium.
-                mutableVaultLastSyncStateFlow.value = Instant.now()
-
-                assertEquals(
-                    awaitingFreeState.copy(
-                        dialogState = PlanState.DialogState.PendingUpgrade,
-                    ),
-                    awaitItem(),
-                )
             }
         }
 
@@ -798,7 +758,6 @@ class PlanViewModelTest : BaseViewModelTest() {
             snackbarRelayManager = mockSnackbarRelayManager,
             specialCircumstanceManager = mockSpecialCircumstanceManager,
             vaultRepository = mockVaultRepository,
-            settingsRepository = mockSettingsRepository,
         )
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -807,6 +807,7 @@ private val DEFAULT_FREE_STATE = PlanState(
     dialogState = null,
 )
 
+private const val ANNUAL_PRICE = 19.99
 private val DEFAULT_PRICING_SUCCESS = PremiumPlanPricingResult.Success(
-    monthlyRate = "$1.67",
+    annualPrice = ANNUAL_PRICE,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -109,7 +109,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(DEFAULT_FREE_STATE, awaitItem())
 
                 mutableSpecialCircumstanceStateFlow.value =
-                    SpecialCircumstance.PremiumCheckoutResult(
+                    SpecialCircumstance.PremiumCheckout(
                         callbackResult = PremiumCheckoutCallbackResult.Canceled,
                     )
 
@@ -145,7 +145,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 mutableSpecialCircumstanceStateFlow.value =
-                    SpecialCircumstance.PremiumCheckoutResult(
+                    SpecialCircumstance.PremiumCheckout(
                         callbackResult = PremiumCheckoutCallbackResult.Success,
                     )
 
@@ -452,7 +452,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 // Simulate returning from checkout canceled (isSuccess = false),
                 // then premium status updates.
                 mutableSpecialCircumstanceStateFlow.value =
-                    SpecialCircumstance.PremiumCheckoutResult(
+                    SpecialCircumstance.PremiumCheckout(
                         callbackResult = PremiumCheckoutCallbackResult.Canceled,
                     )
 
@@ -502,7 +502,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(DEFAULT_FREE_STATE, awaitItem())
 
                 mutableSpecialCircumstanceStateFlow.value =
-                    SpecialCircumstance.PremiumCheckoutResult(
+                    SpecialCircumstance.PremiumCheckout(
                         callbackResult = PremiumCheckoutCallbackResult.Success,
                     )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -44,10 +44,8 @@ class PlanViewModelTest : BaseViewModelTest() {
         MutableStateFlow<SpecialCircumstance?>(null)
     private val mockSpecialCircumstanceManager: SpecialCircumstanceManager =
         mockk(relaxed = true) {
-            every { specialCircumstance } returns null
-            every {
-                specialCircumstanceStateFlow
-            } returns mutableSpecialCircumstanceStateFlow
+            every { specialCircumstance } returns mutableSpecialCircumstanceStateFlow.value
+            every { specialCircumstanceStateFlow } returns mutableSpecialCircumstanceStateFlow
         }
     private val mockVaultRepository: VaultRepository = mockk {
         coEvery {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -12,6 +12,7 @@ import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
+import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
@@ -36,7 +37,9 @@ class PlanViewModelTest : BaseViewModelTest() {
     private val mockAuthRepository: AuthRepository = mockk {
         every { userStateFlow } returns mutableUserStateFlow
     }
-    private val mockBillingRepository: BillingRepository = mockk()
+    private val mockBillingRepository: BillingRepository = mockk {
+        coEvery { getPremiumPlanPricing() } returns DEFAULT_PRICING_SUCCESS
+    }
     private val mockSnackbarRelayManager: SnackbarRelayManager<SnackbarRelay> =
         mockk {
             every { sendSnackbarData(any(), any()) } just runs
@@ -339,8 +342,7 @@ class PlanViewModelTest : BaseViewModelTest() {
         runTest {
             val viewModel = createViewModel(
                 initialState = DEFAULT_FREE_STATE.copy(
-                    dialogState = PlanState.DialogState
-                        .WaitingForPayment,
+                    dialogState = PlanState.DialogState.WaitingForPayment,
                 ),
             )
 
@@ -473,6 +475,63 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     // endregion Free user path
 
+    // region Pricing fetch
+
+    @Test
+    fun `pricing fetch failure should transition to Error ViewState`() =
+        runTest {
+            coEvery {
+                mockBillingRepository.getPremiumPlanPricing()
+            } returns PremiumPlanPricingResult.Error(
+                error = RuntimeException("Network error"),
+            )
+
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_LOADING_STATE.copy(
+                        viewState = PlanState.ViewState.Error,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `RetryPricingClick should transition to Loading then Free on success`() =
+        runTest {
+            coEvery {
+                mockBillingRepository.getPremiumPlanPricing()
+            } returns PremiumPlanPricingResult.Error(
+                error = RuntimeException("Network error"),
+            ) andThen DEFAULT_PRICING_SUCCESS
+
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_LOADING_STATE.copy(
+                        viewState = PlanState.ViewState.Error,
+                    ),
+                    awaitItem(),
+                )
+
+                viewModel.trySendAction(PlanAction.RetryPricingClick)
+
+                assertEquals(
+                    DEFAULT_LOADING_STATE,
+                    awaitItem(),
+                )
+                assertEquals(
+                    DEFAULT_FREE_STATE,
+                    awaitItem(),
+                )
+            }
+        }
+
+    // endregion Pricing fetch
+
     private fun createViewModel(
         initialState: PlanState? = null,
         planMode: PlanMode = PlanMode.Modal,
@@ -519,10 +578,22 @@ private val DEFAULT_USER_STATE = UserState(
     hasPendingAccountAddition = false,
 )
 
+private val DEFAULT_LOADING_STATE = PlanState(
+    planMode = PlanMode.Modal,
+    viewState = PlanState.ViewState.Free(
+        rate = "$1.67",
+    ),
+    dialogState = null,
+)
+
 private val DEFAULT_FREE_STATE = PlanState(
     planMode = PlanMode.Modal,
     viewState = PlanState.ViewState.Free(
-        rate = "$1.65",
+        rate = "$1.67",
     ),
     dialogState = null,
+)
+
+private val DEFAULT_PRICING_SUCCESS = PremiumPlanPricingResult.Success(
+    monthlyRate = "$1.67",
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -156,7 +156,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
                         viewState = PlanState.ViewState.Free(
-                            rate = "$1.65",
+                            rate = "$1.67",
                             checkoutUrl = checkoutUrl,
                         ),
                         dialogState = PlanState.DialogState.WaitingForPayment,
@@ -244,7 +244,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
                         viewState = PlanState.ViewState.Free(
-                            rate = "$1.65",
+                            rate = "$1.67",
                             checkoutUrl = checkoutUrl,
                         ),
                         dialogState = PlanState.DialogState.WaitingForPayment,
@@ -313,7 +313,7 @@ class PlanViewModelTest : BaseViewModelTest() {
         runTest {
             val checkoutUrl = "https://checkout.stripe.com/session123"
             val freeState = PlanState.ViewState.Free(
-                rate = "$1.65",
+                rate = "$1.67",
                 checkoutUrl = checkoutUrl,
             )
             val viewModel = createViewModel(
@@ -478,7 +478,7 @@ class PlanViewModelTest : BaseViewModelTest() {
     // region Pricing fetch
 
     @Test
-    fun `pricing fetch failure should transition to Error ViewState`() =
+    fun `pricing fetch failure should show GetPricingError dialog`() =
         runTest {
             coEvery {
                 mockBillingRepository.getPremiumPlanPricing()
@@ -490,8 +490,15 @@ class PlanViewModelTest : BaseViewModelTest() {
 
             viewModel.stateFlow.test {
                 assertEquals(
-                    DEFAULT_LOADING_STATE.copy(
-                        viewState = PlanState.ViewState.Error,
+                    PlanState(
+                        planMode = PlanMode.Modal,
+                        viewState = PlanState.ViewState.Free(
+                            rate = "--",
+                        ),
+                        dialogState = PlanState.DialogState.GetPricingError(
+                            title = BitwardenString.an_error_has_occurred.asText(),
+                            message = BitwardenString.generic_error_message.asText(),
+                        ),
                     ),
                     awaitItem(),
                 )
@@ -511,8 +518,15 @@ class PlanViewModelTest : BaseViewModelTest() {
 
             viewModel.stateFlow.test {
                 assertEquals(
-                    DEFAULT_LOADING_STATE.copy(
-                        viewState = PlanState.ViewState.Error,
+                    PlanState(
+                        planMode = PlanMode.Modal,
+                        viewState = PlanState.ViewState.Free(
+                            rate = "--",
+                        ),
+                        dialogState = PlanState.DialogState.GetPricingError(
+                            title = BitwardenString.an_error_has_occurred.asText(),
+                            message = BitwardenString.generic_error_message.asText(),
+                        ),
                     ),
                     awaitItem(),
                 )
@@ -520,12 +534,65 @@ class PlanViewModelTest : BaseViewModelTest() {
                 viewModel.trySendAction(PlanAction.RetryPricingClick)
 
                 assertEquals(
-                    DEFAULT_LOADING_STATE,
+                    PlanState(
+                        planMode = PlanMode.Modal,
+                        viewState = PlanState.ViewState.Free(
+                            rate = "--",
+                        ),
+                        dialogState = PlanState.DialogState.Loading(
+                            message = BitwardenString.loading.asText(),
+                        ),
+                    ),
                     awaitItem(),
                 )
                 assertEquals(
                     DEFAULT_FREE_STATE,
                     awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `ClosePricingErrorClick should clear dialog and emit NavigateBack`() =
+        runTest {
+            coEvery {
+                mockBillingRepository.getPremiumPlanPricing()
+            } returns PremiumPlanPricingResult.Error(
+                error = RuntimeException("Network error"),
+            )
+
+            val viewModel = createViewModel()
+
+            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
+                assertEquals(
+                    PlanState(
+                        planMode = PlanMode.Modal,
+                        viewState = PlanState.ViewState.Free(
+                            rate = "--",
+                        ),
+                        dialogState = PlanState.DialogState.GetPricingError(
+                            title = BitwardenString.an_error_has_occurred.asText(),
+                            message = BitwardenString.generic_error_message.asText(),
+                        ),
+                    ),
+                    stateFlow.awaitItem(),
+                )
+
+                viewModel.trySendAction(PlanAction.ClosePricingErrorClick)
+
+                assertEquals(
+                    PlanState(
+                        planMode = PlanMode.Modal,
+                        viewState = PlanState.ViewState.Free(
+                            rate = "--",
+                        ),
+                        dialogState = null,
+                    ),
+                    stateFlow.awaitItem(),
+                )
+                assertEquals(
+                    PlanEvent.NavigateBack,
+                    eventFlow.awaitItem(),
                 )
             }
         }
@@ -576,14 +643,6 @@ private val DEFAULT_USER_STATE = UserState(
     activeUserId = "user-id-1",
     accounts = listOf(DEFAULT_ACCOUNT),
     hasPendingAccountAddition = false,
-)
-
-private val DEFAULT_LOADING_STATE = PlanState(
-    planMode = PlanMode.Modal,
-    viewState = PlanState.ViewState.Free(
-        rate = "$1.67",
-    ),
-    dialogState = null,
 )
 
 private val DEFAULT_FREE_STATE = PlanState(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -640,7 +640,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             isAwaitingPremiumStatus = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
-                            title = BitwardenString.an_error_has_occurred.asText(),
+                            title = BitwardenString.pricing_unavailable.asText(),
                             message = BitwardenString.generic_error_message.asText(),
                         ),
                     ),
@@ -668,7 +668,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             isAwaitingPremiumStatus = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
-                            title = BitwardenString.an_error_has_occurred.asText(),
+                            title = BitwardenString.pricing_unavailable.asText(),
                             message = BitwardenString.generic_error_message.asText(),
                         ),
                     ),
@@ -722,7 +722,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                             isAwaitingPremiumStatus = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
-                            title = BitwardenString.an_error_has_occurred.asText(),
+                            title = BitwardenString.pricing_unavailable.asText(),
                             message = BitwardenString.generic_error_message.asText(),
                         ),
                     ),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -131,7 +131,6 @@ class PlanViewModelTest : BaseViewModelTest() {
             }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `PremiumCheckoutResult with isSuccess true should show snackbar when premium`() =
         runTest {
@@ -405,7 +404,6 @@ class PlanViewModelTest : BaseViewModelTest() {
             }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `premium status flip should show snackbar when in WaitingForPayment`() =
         runTest {
@@ -440,7 +438,6 @@ class PlanViewModelTest : BaseViewModelTest() {
             }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `premium status flip via canceled special circumstance should show snackbar`() =
         runTest {
@@ -531,7 +528,6 @@ class PlanViewModelTest : BaseViewModelTest() {
             }
         }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `UserStateUpdateReceive with premium during Loading should show snackbar`() =
         runTest {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -5,7 +5,6 @@ import app.cash.turbine.test
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.components.snackbar.model.BitwardenSnackbarData
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
-import com.bitwarden.ui.platform.manager.snackbar.SnackbarRelayManager
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
@@ -18,14 +17,11 @@ import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
-import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.awaitCancellation
@@ -44,10 +40,6 @@ class PlanViewModelTest : BaseViewModelTest() {
         every { userStateFlow } returns mutableUserStateFlow
     }
     private val mockBillingRepository: BillingRepository = mockk()
-    private val mockSnackbarRelayManager: SnackbarRelayManager<SnackbarRelay> =
-        mockk {
-            every { sendSnackbarData(any(), any()) } just runs
-        }
     private val mutableSpecialCircumstanceStateFlow =
         MutableStateFlow<SpecialCircumstance?>(null)
     private val mockSpecialCircumstanceManager: SpecialCircumstanceManager =
@@ -143,7 +135,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `PremiumCheckoutResult with isSuccess true should send snackbar and navigate back when premium`() =
+    fun `PremiumCheckoutResult with isSuccess true should show snackbar when premium`() =
         runTest {
             mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
                 accounts = listOf(
@@ -159,17 +151,18 @@ class PlanViewModelTest : BaseViewModelTest() {
                         callbackResult = PremiumCheckoutCallbackResult.Success,
                     )
 
-                assertEquals(PlanEvent.NavigateBack, awaitItem())
+                assertEquals(
+                    PlanEvent.ShowSnackbar(
+                        data = BitwardenSnackbarData(
+                            message = BitwardenString.upgraded_to_premium.asText(),
+                        ),
+                    ),
+                    awaitItem(),
+                )
             }
 
             verify {
                 mockSpecialCircumstanceManager.specialCircumstance = null
-                mockSnackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(
-                        message = BitwardenString.upgraded_to_premium.asText(),
-                    ),
-                    relay = SnackbarRelay.PREMIUM_UPGRADED,
-                )
             }
         }
 
@@ -416,7 +409,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `premium status flip should send snackbar and emit NavigateBack when in WaitingForPayment`() =
+    fun `premium status flip should show snackbar when in WaitingForPayment`() =
         runTest {
             val viewModel = createViewModel(
                 initialState = DEFAULT_FREE_STATE.copy(
@@ -438,22 +431,20 @@ class PlanViewModelTest : BaseViewModelTest() {
                     ),
                 )
 
-                assertEquals(PlanEvent.NavigateBack, awaitItem())
-            }
-
-            verify {
-                mockSnackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(
-                        message = BitwardenString.upgraded_to_premium.asText(),
+                assertEquals(
+                    PlanEvent.ShowSnackbar(
+                        data = BitwardenSnackbarData(
+                            message = BitwardenString.upgraded_to_premium.asText(),
+                        ),
                     ),
-                    relay = SnackbarRelay.PREMIUM_UPGRADED,
+                    awaitItem(),
                 )
             }
         }
 
     @Suppress("MaxLineLength")
     @Test
-    fun `premium status flip via canceled special circumstance should send snackbar and emit NavigateBack`() =
+    fun `premium status flip via canceled special circumstance should show snackbar`() =
         runTest {
             val viewModel = createViewModel()
 
@@ -486,18 +477,19 @@ class PlanViewModelTest : BaseViewModelTest() {
                     ),
                 )
 
+                // State clears dialog and isAwaitingPremiumStatus.
                 assertEquals(
-                    PlanEvent.NavigateBack,
-                    eventFlow.awaitItem(),
+                    DEFAULT_FREE_STATE,
+                    stateFlow.awaitItem(),
                 )
-            }
 
-            verify {
-                mockSnackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(
-                        message = BitwardenString.upgraded_to_premium.asText(),
+                assertEquals(
+                    PlanEvent.ShowSnackbar(
+                        data = BitwardenSnackbarData(
+                            message = BitwardenString.upgraded_to_premium.asText(),
+                        ),
                     ),
-                    relay = SnackbarRelay.PREMIUM_UPGRADED,
+                    eventFlow.awaitItem(),
                 )
             }
         }
@@ -541,8 +533,9 @@ class PlanViewModelTest : BaseViewModelTest() {
             }
         }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `UserStateUpdateReceive with premium during Loading should navigate back with snackbar`() =
+    fun `UserStateUpdateReceive with premium during Loading should show snackbar`() =
         runTest {
             val viewModel = createViewModel(
                 initialState = DEFAULT_FREE_STATE.copy(
@@ -552,7 +545,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                         isAwaitingPremiumStatus = true,
                     ),
                     dialogState = PlanState.DialogState.Loading(
-                        message = BitwardenString.syncing.asText(),
+                        message = BitwardenString.confirming_your_upgrade.asText(),
                     ),
                 ),
                 pricingResult = null,
@@ -565,15 +558,13 @@ class PlanViewModelTest : BaseViewModelTest() {
                     ),
                 )
 
-                assertEquals(PlanEvent.NavigateBack, awaitItem())
-            }
-
-            verify {
-                mockSnackbarRelayManager.sendSnackbarData(
-                    data = BitwardenSnackbarData(
-                        message = BitwardenString.upgraded_to_premium.asText(),
+                assertEquals(
+                    PlanEvent.ShowSnackbar(
+                        data = BitwardenSnackbarData(
+                            message = BitwardenString.upgraded_to_premium.asText(),
+                        ),
                     ),
-                    relay = SnackbarRelay.PREMIUM_UPGRADED,
+                    awaitItem(),
                 )
             }
         }
@@ -762,7 +753,6 @@ class PlanViewModelTest : BaseViewModelTest() {
             savedStateHandle = savedStateHandle,
             authRepository = mockAuthRepository,
             billingRepository = mockBillingRepository,
-            snackbarRelayManager = mockSnackbarRelayManager,
             specialCircumstanceManager = mockSpecialCircumstanceManager,
             vaultRepository = mockVaultRepository,
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -13,6 +13,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
+import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
@@ -118,7 +119,9 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(DEFAULT_FREE_STATE, awaitItem())
 
                 mutableSpecialCircumstanceStateFlow.value =
-                    SpecialCircumstance.PremiumCheckoutResult(isSuccess = false)
+                    SpecialCircumstance.PremiumCheckoutResult(
+                        callbackResult = PremiumCheckoutCallbackResult.Canceled,
+                    )
 
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
@@ -152,7 +155,9 @@ class PlanViewModelTest : BaseViewModelTest() {
 
             viewModel.eventFlow.test {
                 mutableSpecialCircumstanceStateFlow.value =
-                    SpecialCircumstance.PremiumCheckoutResult(isSuccess = true)
+                    SpecialCircumstance.PremiumCheckoutResult(
+                        callbackResult = PremiumCheckoutCallbackResult.Success,
+                    )
 
                 assertEquals(PlanEvent.NavigateBack, awaitItem())
             }
@@ -459,7 +464,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 // then premium status updates.
                 mutableSpecialCircumstanceStateFlow.value =
                     SpecialCircumstance.PremiumCheckoutResult(
-                        isSuccess = false,
+                        callbackResult = PremiumCheckoutCallbackResult.Canceled,
                     )
 
                 assertEquals(
@@ -507,7 +512,9 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(DEFAULT_FREE_STATE, awaitItem())
 
                 mutableSpecialCircumstanceStateFlow.value =
-                    SpecialCircumstance.PremiumCheckoutResult(isSuccess = true)
+                    SpecialCircumstance.PremiumCheckoutResult(
+                        callbackResult = PremiumCheckoutCallbackResult.Success,
+                    )
 
                 // Loading while sync is in progress.
                 awaitItem()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -15,6 +15,9 @@ import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.vault.repository.VaultRepository
+import java.time.Instant
 import com.x8bit.bitwarden.ui.platform.model.SnackbarRelay
 import io.mockk.coEvery
 import io.mockk.every
@@ -24,6 +27,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -31,23 +35,34 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@Suppress("LargeClass")
 class PlanViewModelTest : BaseViewModelTest() {
 
     private val mutableUserStateFlow = MutableStateFlow<UserState?>(DEFAULT_USER_STATE)
     private val mockAuthRepository: AuthRepository = mockk {
         every { userStateFlow } returns mutableUserStateFlow
     }
-    private val mockBillingRepository: BillingRepository = mockk {
-        coEvery { getPremiumPlanPricing() } returns DEFAULT_PRICING_SUCCESS
-    }
+    private val mockBillingRepository: BillingRepository = mockk()
     private val mockSnackbarRelayManager: SnackbarRelayManager<SnackbarRelay> =
         mockk {
             every { sendSnackbarData(any(), any()) } just runs
         }
+    private val mutableSpecialCircumstanceStateFlow =
+        MutableStateFlow<SpecialCircumstance?>(null)
     private val mockSpecialCircumstanceManager: SpecialCircumstanceManager =
         mockk(relaxed = true) {
             every { specialCircumstance } returns null
+            every {
+                specialCircumstanceStateFlow
+            } returns mutableSpecialCircumstanceStateFlow
         }
+    private val mockVaultRepository: VaultRepository = mockk {
+        every { sync(any()) } just runs
+    }
+    private val mutableVaultLastSyncStateFlow = MutableStateFlow<Instant?>(null)
+    private val mockSettingsRepository: SettingsRepository = mockk {
+        every { vaultLastSyncStateFlow } returns mutableVaultLastSyncStateFlow
+    }
 
     @BeforeEach
     fun setup() {
@@ -97,17 +112,23 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `initial state should be WaitingForPayment when PremiumCheckoutResult special circumstance present`() =
+    fun `PremiumCheckoutResult with isSuccess false should show WaitingForPayment when not premium`() =
         runTest {
-            every {
-                mockSpecialCircumstanceManager.specialCircumstance
-            } returns SpecialCircumstance.PremiumCheckoutResult
-
             val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
+                assertEquals(DEFAULT_FREE_STATE, awaitItem())
+
+                mutableSpecialCircumstanceStateFlow.value =
+                    SpecialCircumstance.PremiumCheckoutResult(isSuccess = false)
+
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
+                        viewState = PlanState.ViewState.Free(
+                            rate = "$1.67",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = true,
+                        ),
                         dialogState = PlanState.DialogState.WaitingForPayment,
                     ),
                     awaitItem(),
@@ -116,6 +137,36 @@ class PlanViewModelTest : BaseViewModelTest() {
 
             verify {
                 mockSpecialCircumstanceManager.specialCircumstance = null
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `PremiumCheckoutResult with isSuccess true should send snackbar and navigate back when premium`() =
+        runTest {
+            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                accounts = listOf(
+                    DEFAULT_ACCOUNT.copy(isPremium = true),
+                ),
+            )
+
+            val viewModel = createViewModel()
+
+            viewModel.eventFlow.test {
+                mutableSpecialCircumstanceStateFlow.value =
+                    SpecialCircumstance.PremiumCheckoutResult(isSuccess = true)
+
+                assertEquals(PlanEvent.NavigateBack, awaitItem())
+            }
+
+            verify {
+                mockSpecialCircumstanceManager.specialCircumstance = null
+                mockSnackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(
+                        message = BitwardenString.upgraded_to_premium.asText(),
+                    ),
+                    relay = SnackbarRelay.PREMIUM_UPGRADED,
+                )
             }
         }
 
@@ -131,7 +182,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `UpgradeNowClick should transition to Loading then emit LaunchBrowser and WaitingForPayment on success`() =
+    fun `UpgradeNowClick should transition to Loading then dismiss dialog and emit LaunchBrowser on success`() =
         runTest {
             val checkoutUrl = "https://checkout.stripe.com/session123"
             coEvery {
@@ -158,8 +209,9 @@ class PlanViewModelTest : BaseViewModelTest() {
                         viewState = PlanState.ViewState.Free(
                             rate = "$1.67",
                             checkoutUrl = checkoutUrl,
+                            isAwaitingPremiumStatus = false,
                         ),
-                        dialogState = PlanState.DialogState.WaitingForPayment,
+                        dialogState = null,
                     ),
                     stateFlow.awaitItem(),
                 )
@@ -210,7 +262,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `RetryClick should transition to Loading then emit LaunchBrowser and WaitingForPayment on success`() =
+    fun `RetryClick should transition to Loading then dismiss dialog and emit LaunchBrowser on success`() =
         runTest {
             val checkoutUrl = "https://checkout.stripe.com/session123"
             coEvery {
@@ -221,6 +273,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 initialState = DEFAULT_FREE_STATE.copy(
                     dialogState = PlanState.DialogState.CheckoutError,
                 ),
+                pricingResult = null,
             )
 
             viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
@@ -246,8 +299,9 @@ class PlanViewModelTest : BaseViewModelTest() {
                         viewState = PlanState.ViewState.Free(
                             rate = "$1.67",
                             checkoutUrl = checkoutUrl,
+                            isAwaitingPremiumStatus = false,
                         ),
-                        dialogState = PlanState.DialogState.WaitingForPayment,
+                        dialogState = null,
                     ),
                     stateFlow.awaitItem(),
                 )
@@ -269,6 +323,7 @@ class PlanViewModelTest : BaseViewModelTest() {
             initialState = DEFAULT_FREE_STATE.copy(
                 dialogState = PlanState.DialogState.CheckoutError,
             ),
+            pricingResult = null,
         )
 
         viewModel.stateFlow.test {
@@ -292,6 +347,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 initialState = DEFAULT_FREE_STATE.copy(
                     dialogState = PlanState.DialogState.WaitingForPayment,
                 ),
+                pricingResult = null,
             )
 
             viewModel.stateFlow.test {
@@ -315,12 +371,14 @@ class PlanViewModelTest : BaseViewModelTest() {
             val freeState = PlanState.ViewState.Free(
                 rate = "$1.67",
                 checkoutUrl = checkoutUrl,
+                isAwaitingPremiumStatus = false,
             )
             val viewModel = createViewModel(
                 initialState = DEFAULT_FREE_STATE.copy(
                     viewState = freeState,
                     dialogState = PlanState.DialogState.WaitingForPayment,
                 ),
+                pricingResult = null,
             )
 
             viewModel.eventFlow.test {
@@ -344,6 +402,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 initialState = DEFAULT_FREE_STATE.copy(
                     dialogState = PlanState.DialogState.WaitingForPayment,
                 ),
+                pricingResult = null,
             )
 
             viewModel.eventFlow.test {
@@ -356,29 +415,65 @@ class PlanViewModelTest : BaseViewModelTest() {
     @Test
     fun `premium status flip should send snackbar and emit NavigateBack when in WaitingForPayment`() =
         runTest {
-            val checkoutUrl = "https://checkout.stripe.com/session123"
-            coEvery {
-                mockBillingRepository.getCheckoutSessionUrl()
-            } returns CheckoutSessionResult.Success(url = checkoutUrl)
+            val viewModel = createViewModel(
+                initialState = DEFAULT_FREE_STATE.copy(
+                    viewState = PlanState.ViewState.Free(
+                        rate = "$1.67",
+                        checkoutUrl = null,
+                        isAwaitingPremiumStatus = true,
+                    ),
+                    dialogState = PlanState.DialogState.WaitingForPayment,
+                ),
+                pricingResult = null,
+            )
 
+            viewModel.eventFlow.test {
+                // Simulate premium status flip while WaitingForPayment.
+                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                    accounts = listOf(
+                        DEFAULT_ACCOUNT.copy(isPremium = true),
+                    ),
+                )
+
+                assertEquals(PlanEvent.NavigateBack, awaitItem())
+            }
+
+            verify {
+                mockSnackbarRelayManager.sendSnackbarData(
+                    data = BitwardenSnackbarData(
+                        message = BitwardenString.upgraded_to_premium.asText(),
+                    ),
+                    relay = SnackbarRelay.PREMIUM_UPGRADED,
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `premium status flip via canceled special circumstance should send snackbar and emit NavigateBack`() =
+        runTest {
             val viewModel = createViewModel()
 
             viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 assertEquals(DEFAULT_FREE_STATE, stateFlow.awaitItem())
 
-                viewModel.trySendAction(PlanAction.UpgradeNowClick)
+                // Simulate returning from checkout canceled (isSuccess = false),
+                // then premium status updates.
+                mutableSpecialCircumstanceStateFlow.value =
+                    SpecialCircumstance.PremiumCheckoutResult(
+                        isSuccess = false,
+                    )
 
-                // Consume Loading and WaitingForPayment states.
-                stateFlow.awaitItem()
-                stateFlow.awaitItem()
                 assertEquals(
-                    PlanEvent.LaunchBrowser(
-                        url = checkoutUrl,
-                        authTabData = AuthTabData.CustomScheme(
-                            callbackUrl = PREMIUM_CHECKOUT_CALLBACK_URL,
+                    DEFAULT_FREE_STATE.copy(
+                        viewState = PlanState.ViewState.Free(
+                            rate = "$1.67",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = true,
                         ),
+                        dialogState = PlanState.DialogState.WaitingForPayment,
                     ),
-                    eventFlow.awaitItem(),
+                    stateFlow.awaitItem(),
                 )
 
                 // Simulate premium status flip.
@@ -406,33 +501,62 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `premium status flip should send snackbar and emit NavigateBack via special circumstance`() =
+    fun `PremiumCheckoutResult with isSuccess true should show Loading and trigger sync when not premium`() =
         runTest {
-            every {
-                mockSpecialCircumstanceManager.specialCircumstance
-            } returns SpecialCircumstance.PremiumCheckoutResult
-
             val viewModel = createViewModel()
 
-            viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_FREE_STATE, awaitItem())
+
+                mutableSpecialCircumstanceStateFlow.value =
+                    SpecialCircumstance.PremiumCheckoutResult(isSuccess = true)
+
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
-                        dialogState = PlanState.DialogState.WaitingForPayment,
+                        viewState = PlanState.ViewState.Free(
+                            rate = "$1.67",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = true,
+                        ),
+                        dialogState = PlanState.DialogState.Loading(
+                            message = BitwardenString.syncing.asText(),
+                        ),
                     ),
-                    stateFlow.awaitItem(),
+                    awaitItem(),
                 )
+            }
 
-                // Simulate premium status flip.
+            verify {
+                mockSpecialCircumstanceManager.specialCircumstance = null
+                mockVaultRepository.sync(forced = true)
+            }
+        }
+
+    @Test
+    fun `UserStateUpdateReceive with premium during Loading should navigate back with snackbar`() =
+        runTest {
+            val viewModel = createViewModel(
+                initialState = DEFAULT_FREE_STATE.copy(
+                    viewState = PlanState.ViewState.Free(
+                        rate = "$1.67",
+                        checkoutUrl = null,
+                        isAwaitingPremiumStatus = true,
+                    ),
+                    dialogState = PlanState.DialogState.Loading(
+                        message = BitwardenString.syncing.asText(),
+                    ),
+                ),
+                pricingResult = null,
+            )
+
+            viewModel.eventFlow.test {
                 mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
                     accounts = listOf(
                         DEFAULT_ACCOUNT.copy(isPremium = true),
                     ),
                 )
 
-                assertEquals(
-                    PlanEvent.NavigateBack,
-                    eventFlow.awaitItem(),
-                )
+                assertEquals(PlanEvent.NavigateBack, awaitItem())
             }
 
             verify {
@@ -461,12 +585,57 @@ class PlanViewModelTest : BaseViewModelTest() {
             }
         }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `SyncCompleteReceive during Loading should fall back to WaitingForPayment when not premium`() =
+        runTest {
+            val awaitingFreeState = DEFAULT_FREE_STATE.copy(
+                viewState = PlanState.ViewState.Free(
+                    rate = "$1.67",
+                    checkoutUrl = null,
+                    isAwaitingPremiumStatus = true,
+                ),
+            )
+            val viewModel = createViewModel(
+                initialState = awaitingFreeState.copy(
+                    dialogState = PlanState.DialogState.Loading(
+                        message = BitwardenString.syncing.asText(),
+                    ),
+                ),
+                pricingResult = null,
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    awaitingFreeState.copy(
+                        dialogState = PlanState.DialogState.Loading(
+                            message = BitwardenString.syncing.asText(),
+                        ),
+                    ),
+                    awaitItem(),
+                )
+
+                // Simulate sync completion without premium.
+                mutableVaultLastSyncStateFlow.value = Instant.now()
+
+                assertEquals(
+                    awaitingFreeState.copy(
+                        dialogState = PlanState.DialogState.PendingUpgrade,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
     @Test
     fun `saved state should be restored`() = runTest {
         val savedState = DEFAULT_FREE_STATE.copy(
             dialogState = PlanState.DialogState.CheckoutError,
         )
-        val viewModel = createViewModel(initialState = savedState)
+        val viewModel = createViewModel(
+            initialState = savedState,
+            pricingResult = null,
+        )
 
         viewModel.stateFlow.test {
             assertEquals(savedState, awaitItem())
@@ -480,13 +649,11 @@ class PlanViewModelTest : BaseViewModelTest() {
     @Test
     fun `pricing fetch failure should show GetPricingError dialog`() =
         runTest {
-            coEvery {
-                mockBillingRepository.getPremiumPlanPricing()
-            } returns PremiumPlanPricingResult.Error(
-                error = RuntimeException("Network error"),
+            val viewModel = createViewModel(
+                pricingResult = PremiumPlanPricingResult.Error(
+                    error = RuntimeException("Network error"),
+                ),
             )
-
-            val viewModel = createViewModel()
 
             viewModel.stateFlow.test {
                 assertEquals(
@@ -494,6 +661,8 @@ class PlanViewModelTest : BaseViewModelTest() {
                         planMode = PlanMode.Modal,
                         viewState = PlanState.ViewState.Free(
                             rate = "--",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
                             title = BitwardenString.an_error_has_occurred.asText(),
@@ -508,13 +677,11 @@ class PlanViewModelTest : BaseViewModelTest() {
     @Test
     fun `RetryPricingClick should transition to Loading then Free on success`() =
         runTest {
-            coEvery {
-                mockBillingRepository.getPremiumPlanPricing()
-            } returns PremiumPlanPricingResult.Error(
-                error = RuntimeException("Network error"),
-            ) andThen DEFAULT_PRICING_SUCCESS
-
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(
+                pricingResult = PremiumPlanPricingResult.Error(
+                    error = RuntimeException("Network error"),
+                ),
+            )
 
             viewModel.stateFlow.test {
                 assertEquals(
@@ -522,6 +689,8 @@ class PlanViewModelTest : BaseViewModelTest() {
                         planMode = PlanMode.Modal,
                         viewState = PlanState.ViewState.Free(
                             rate = "--",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
                             title = BitwardenString.an_error_has_occurred.asText(),
@@ -531,6 +700,11 @@ class PlanViewModelTest : BaseViewModelTest() {
                     awaitItem(),
                 )
 
+                // Override mock for retry to return success.
+                coEvery {
+                    mockBillingRepository.getPremiumPlanPricing()
+                } returns DEFAULT_PRICING_SUCCESS
+
                 viewModel.trySendAction(PlanAction.RetryPricingClick)
 
                 assertEquals(
@@ -538,6 +712,8 @@ class PlanViewModelTest : BaseViewModelTest() {
                         planMode = PlanMode.Modal,
                         viewState = PlanState.ViewState.Free(
                             rate = "--",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
                         ),
                         dialogState = PlanState.DialogState.Loading(
                             message = BitwardenString.loading.asText(),
@@ -555,13 +731,11 @@ class PlanViewModelTest : BaseViewModelTest() {
     @Test
     fun `ClosePricingErrorClick should clear dialog and emit NavigateBack`() =
         runTest {
-            coEvery {
-                mockBillingRepository.getPremiumPlanPricing()
-            } returns PremiumPlanPricingResult.Error(
-                error = RuntimeException("Network error"),
+            val viewModel = createViewModel(
+                pricingResult = PremiumPlanPricingResult.Error(
+                    error = RuntimeException("Network error"),
+                ),
             )
-
-            val viewModel = createViewModel()
 
             viewModel.stateEventFlow(backgroundScope) { stateFlow, eventFlow ->
                 assertEquals(
@@ -569,6 +743,8 @@ class PlanViewModelTest : BaseViewModelTest() {
                         planMode = PlanMode.Modal,
                         viewState = PlanState.ViewState.Free(
                             rate = "--",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
                         ),
                         dialogState = PlanState.DialogState.GetPricingError(
                             title = BitwardenString.an_error_has_occurred.asText(),
@@ -585,6 +761,8 @@ class PlanViewModelTest : BaseViewModelTest() {
                         planMode = PlanMode.Modal,
                         viewState = PlanState.ViewState.Free(
                             rate = "--",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
                         ),
                         dialogState = null,
                     ),
@@ -602,7 +780,13 @@ class PlanViewModelTest : BaseViewModelTest() {
     private fun createViewModel(
         initialState: PlanState? = null,
         planMode: PlanMode = PlanMode.Modal,
+        pricingResult: PremiumPlanPricingResult? = DEFAULT_PRICING_SUCCESS,
     ): PlanViewModel {
+        coEvery {
+            mockBillingRepository.getPremiumPlanPricing()
+        } coAnswers {
+            pricingResult ?: awaitCancellation()
+        }
         val savedStateHandle = SavedStateHandle().apply {
             set("state", initialState)
             every { toPlanArgs() } returns PlanArgs(planMode = planMode)
@@ -613,6 +797,8 @@ class PlanViewModelTest : BaseViewModelTest() {
             billingRepository = mockBillingRepository,
             snackbarRelayManager = mockSnackbarRelayManager,
             specialCircumstanceManager = mockSpecialCircumstanceManager,
+            vaultRepository = mockVaultRepository,
+            settingsRepository = mockSettingsRepository,
         )
     }
 }
@@ -649,6 +835,8 @@ private val DEFAULT_FREE_STATE = PlanState(
     planMode = PlanMode.Modal,
     viewState = PlanState.ViewState.Free(
         rate = "$1.67",
+        checkoutUrl = null,
+        isAwaitingPremiumStatus = false,
     ),
     dialogState = null,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -603,6 +603,29 @@ class PlanViewModelTest : BaseViewModelTest() {
     // region Pricing fetch
 
     @Test
+    fun `initial state before pricing fetch resolves should show Loading dialog`() =
+        runTest {
+            val viewModel = createViewModel(pricingResult = null)
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    PlanState(
+                        planMode = PlanMode.Modal,
+                        viewState = PlanState.ViewState.Free(
+                            rate = "--",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
+                        ),
+                        dialogState = PlanState.DialogState.Loading(
+                            message = BitwardenString.loading.asText(),
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
     fun `pricing fetch failure should show GetPricingError dialog`() =
         runTest {
             val viewModel = createViewModel(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtilsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtilsTest.kt
@@ -57,14 +57,25 @@ class ShortcutUtilsTest {
         assertFalse(mockIntent.isPasswordGeneratorShortcut)
     }
 
+    @Suppress("MaxLineLength")
     @Test
-    fun `isPremiumCheckoutCallback should return true when dataString is checkout callback`() {
+    fun `isPremiumCheckoutCallback should return true when dataString is success checkout callback`() {
         val mockIntent = mockk<Intent> {
-            every { dataString } returns "bitwarden://premium-upgrade-callback"
+            every { dataString } returns "bitwarden://premium-checkout-result?result=success"
         }
         assertTrue(mockIntent.isPremiumCheckoutCallback)
     }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `isPremiumCheckoutCallback should return true when dataString is canceled checkout callback`() {
+        val mockIntent = mockk<Intent> {
+            every { dataString } returns "bitwarden://premium-checkout-result?result=canceled"
+        }
+        assertTrue(mockIntent.isPremiumCheckoutCallback)
+    }
+
+    @Suppress("MaxLineLength")
     @Test
     fun `isPremiumCheckoutCallback should return false when dataString is not checkout callback`() {
         val mockIntent = mockk<Intent> {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtilsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/util/ShortcutUtilsTest.kt
@@ -75,7 +75,6 @@ class ShortcutUtilsTest {
         assertTrue(mockIntent.isPremiumCheckoutCallback)
     }
 
-    @Suppress("MaxLineLength")
     @Test
     fun `isPremiumCheckoutCallback should return false when dataString is not checkout callback`() {
         val mockIntent = mockk<Intent> {

--- a/network/src/main/kotlin/com/bitwarden/network/api/AuthenticatedBillingApi.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/api/AuthenticatedBillingApi.kt
@@ -4,7 +4,9 @@ import com.bitwarden.network.model.CheckoutSessionRequestJson
 import com.bitwarden.network.model.CheckoutSessionResponseJson
 import com.bitwarden.network.model.NetworkResult
 import com.bitwarden.network.model.PortalUrlResponseJson
+import com.bitwarden.network.model.PremiumPlanResponseJson
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 /**
@@ -25,4 +27,10 @@ internal interface AuthenticatedBillingApi {
      */
     @POST("/account/billing/vnext/portal-session")
     suspend fun getPortalUrl(): NetworkResult<PortalUrlResponseJson>
+
+    /**
+     * Retrieves the premium plan pricing information.
+     */
+    @GET("/plans/premium")
+    suspend fun getPremiumPlan(): NetworkResult<PremiumPlanResponseJson>
 }

--- a/network/src/main/kotlin/com/bitwarden/network/model/PremiumPlanResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/PremiumPlanResponseJson.kt
@@ -1,0 +1,51 @@
+package com.bitwarden.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response object returned when retrieving the premium plan pricing.
+ *
+ * @property name The display name of the plan.
+ * @property legacyYear The legacy year identifier, if applicable.
+ * @property isAvailable Whether the plan is currently available for purchase.
+ * @property seat The seat pricing information.
+ * @property storage The storage pricing information.
+ */
+@Serializable
+data class PremiumPlanResponseJson(
+    @SerialName("name")
+    val name: String,
+
+    @SerialName("legacyYear")
+    val legacyYear: Int?,
+
+    @SerialName("available")
+    val isAvailable: Boolean,
+
+    @SerialName("seat")
+    val seat: PurchasableJson,
+
+    @SerialName("storage")
+    val storage: PurchasableJson,
+) {
+
+    /**
+     * Purchasable item pricing details within a premium plan.
+     *
+     * @property stripePriceId The Stripe price identifier.
+     * @property price The annual price.
+     * @property provided The number of units provided by default.
+     */
+    @Serializable
+    data class PurchasableJson(
+        @SerialName("stripePriceId")
+        val stripePriceId: String,
+
+        @SerialName("price")
+        val price: Double,
+
+        @SerialName("provided")
+        val provided: Int,
+    )
+}

--- a/network/src/main/kotlin/com/bitwarden/network/service/BillingService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/BillingService.kt
@@ -2,6 +2,7 @@ package com.bitwarden.network.service
 
 import com.bitwarden.network.model.CheckoutSessionResponseJson
 import com.bitwarden.network.model.PortalUrlResponseJson
+import com.bitwarden.network.model.PremiumPlanResponseJson
 
 /**
  * Provides an API for interacting with the billing endpoints.
@@ -17,4 +18,9 @@ interface BillingService {
      * Creates a Stripe customer portal session for managing the Premium subscription.
      */
     suspend fun getPortalUrl(): Result<PortalUrlResponseJson>
+
+    /**
+     * Retrieves the premium plan pricing information.
+     */
+    suspend fun getPremiumPlan(): Result<PremiumPlanResponseJson>
 }

--- a/network/src/main/kotlin/com/bitwarden/network/service/BillingServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/BillingServiceImpl.kt
@@ -4,6 +4,7 @@ import com.bitwarden.network.api.AuthenticatedBillingApi
 import com.bitwarden.network.model.CheckoutSessionRequestJson
 import com.bitwarden.network.model.CheckoutSessionResponseJson
 import com.bitwarden.network.model.PortalUrlResponseJson
+import com.bitwarden.network.model.PremiumPlanResponseJson
 import com.bitwarden.network.util.toResult
 
 private const val PLATFORM = "android"
@@ -25,5 +26,10 @@ internal class BillingServiceImpl(
     override suspend fun getPortalUrl(): Result<PortalUrlResponseJson> =
         authenticatedBillingApi
             .getPortalUrl()
+            .toResult()
+
+    override suspend fun getPremiumPlan(): Result<PremiumPlanResponseJson> =
+        authenticatedBillingApi
+            .getPremiumPlan()
             .toResult()
 }

--- a/network/src/test/kotlin/com/bitwarden/network/service/BillingServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/BillingServiceTest.kt
@@ -5,6 +5,7 @@ import com.bitwarden.network.api.AuthenticatedBillingApi
 import com.bitwarden.network.base.BaseServiceTest
 import com.bitwarden.network.model.CheckoutSessionResponseJson
 import com.bitwarden.network.model.PortalUrlResponseJson
+import com.bitwarden.network.model.PremiumPlanResponseJson
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -56,6 +57,26 @@ class BillingServiceTest : BaseServiceTest() {
         val actual = service.getPortalUrl()
         assertEquals(PORTAL_URL_RESPONSE.asSuccess(), actual)
     }
+
+    @Test
+    fun `getPremiumPlan when response is Failure should return Failure`() =
+        runTest {
+            val response = MockResponse().setResponseCode(400)
+            server.enqueue(response)
+            val actual = service.getPremiumPlan()
+            assertTrue(actual.isFailure)
+        }
+
+    @Test
+    fun `getPremiumPlan when response is Success should return Success`() =
+        runTest {
+            val response = MockResponse()
+                .setBody(PREMIUM_PLAN_RESPONSE_JSON)
+                .setResponseCode(200)
+            server.enqueue(response)
+            val actual = service.getPremiumPlan()
+            assertEquals(PREMIUM_PLAN_RESPONSE.asSuccess(), actual)
+        }
 }
 
 private const val CHECKOUT_SESSION_RESPONSE_JSON = """
@@ -76,4 +97,38 @@ private const val PORTAL_URL_RESPONSE_JSON = """
 
 private val PORTAL_URL_RESPONSE = PortalUrlResponseJson(
     url = "https://billing.stripe.com/p/session/test_portal_456",
+)
+
+private const val PREMIUM_PLAN_RESPONSE_JSON = """
+{
+  "name": "Premium",
+  "legacyYear": null,
+  "available": true,
+  "seat": {
+    "stripePriceId": "premium-annually-2026",
+    "price": 19.99,
+    "provided": 0
+  },
+  "storage": {
+    "stripePriceId": "personal-storage-gb-annually",
+    "price": 4.00,
+    "provided": 5
+  }
+}
+"""
+
+private val PREMIUM_PLAN_RESPONSE = PremiumPlanResponseJson(
+    name = "Premium",
+    legacyYear = null,
+    isAvailable = true,
+    seat = PremiumPlanResponseJson.PurchasableJson(
+        stripePriceId = "premium-annually-2026",
+        price = 19.99,
+        provided = 0,
+    ),
+    storage = PremiumPlanResponseJson.PurchasableJson(
+        stripePriceId = "personal-storage-gb-annually",
+        price = 4.00,
+        provided = 5,
+    ),
 )

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1239,6 +1239,7 @@ Do you want to switch to this account?</string>
     <string name="preview_unavailable">Preview unavailable</string>
     <string name="download_attachment">Download Attachment</string>
     <string name="upgraded_to_premium">Upgraded to premium</string>
+    <string name="confirming_your_upgrade">Confirming your upgrade…</string>
     <string name="upgrade_pending">Upgrade pending</string>
     <string name="upgrade_pending_message">Your upgrade is being processed. You’ll remain on the free plan until it’s complete. Sync now to check, or continue and it will update automatically.</string>
     <string name="unlock_premium_features">Unlock more advanced features with a Premium plan.</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1239,6 +1239,8 @@ Do you want to switch to this account?</string>
     <string name="preview_unavailable">Preview unavailable</string>
     <string name="download_attachment">Download Attachment</string>
     <string name="upgraded_to_premium">Upgraded to premium</string>
+    <string name="upgrade_pending">Upgrade pending</string>
+    <string name="upgrade_pending_message">Your upgrade is being processed. You’ll remain on the free plan until it’s complete. Sync now to check, or continue and it will update automatically.</string>
     <string name="unlock_premium_features">Unlock more advanced features with a Premium plan.</string>
     <string name="per_month">/ month</string>
     <string name="built_in_authenticator">Built-in authenticator</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1263,4 +1263,5 @@ Do you want to switch to this account?</string>
     <string name="next_code_x">Next code, %1$s</string>
     <string name="archive_item">Archive item</string>
     <string name="once_archived_this_item_will_be_excluded">Once archived, this item will be excluded from search results and autofill suggestions.</string>
+    <string name="pricing_unavailable">Pricing unavailable</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33946

## 📔 Objective

Replace the static placeholder rate with dynamic pricing from the plans API, and implement correct checkout result handling for the premium upgrade flow.

**Dynamic pricing:**
- Fetch pricing from `GET /api/plans/premium` on PlanScreen load
- Show loading and error states when pricing is unavailable
- Format the monthly rate from the annual plan price

**Checkout result handling:**
- Correct the callback URL to `bitwarden://premium-checkout-result` to match the server-configured Stripe redirect (PM-34173)
- Parse `?result=success` / `?result=canceled` query parameter via `PremiumCheckoutCallbackResult` sealed class, following the existing `CookieCallbackResult` pattern
- Observe `specialCircumstanceStateFlow` at runtime to detect when the user returns from checkout
- On success: show syncing state, trigger `syncForResult()`, navigate back with snackbar if premium is detected, or show "Upgrade pending" dialog with Sync now / Continue options if not yet provisioned
- On canceled: show "Payment not received yet" dialog per Figma designs
- Track checkout return state via `isAwaitingPremiumStatus` on `ViewState.Free`

## 📸 Screenshots


<video src="https://github.com/user-attachments/assets/1dc09c06-488c-498b-85ab-60e89677f495" />