### PR TITLE
[PM-33518] feat: Add isInAppUpgradeAvailableFlow to PremiumStateManager

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -17,6 +17,11 @@ interface PremiumStateManager {
     val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean>
 
     /**
+     * Emits `true` when the in-app upgrade flow is available, or `false` otherwise.
+     */
+    val isInAppUpgradeAvailableFlow: StateFlow<Boolean>
+
+    /**
      * Marks the Premium upgrade banner as dismissed for the current user.
      */
     fun dismissPremiumUpgradeBanner()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -3,10 +3,7 @@ package com.x8bit.bitwarden.data.billing.manager
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Manages the consolidated eligibility state for the Premium upgrade banner.
- *
- * Combines multiple upstream signals (Premium status, billing support, feature flag,
- * banner dismissal, account age, and vault item count) into a single observable flow.
+ * Manages Premium upgrade state for the active user.
  */
 interface PremiumStateManager {
 
@@ -17,9 +14,9 @@ interface PremiumStateManager {
     val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean>
 
     /**
-     * Emits `true` when the in-app upgrade flow is available, or `false` otherwise.
+     * Returns `true` when the in-app upgrade flow is available, or `false` otherwise.
      */
-    val isInAppUpgradeAvailableFlow: StateFlow<Boolean>
+    fun isInAppUpgradeAvailable(): Boolean
 
     /**
      * Marks the Premium upgrade banner as dismissed for the current user.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -90,6 +90,19 @@ class PremiumStateManagerImpl(
                 initialValue = false,
             )
 
+    override val isInAppUpgradeAvailableFlow: StateFlow<Boolean> =
+        combine(
+            billingRepository.isInAppBillingSupportedFlow,
+            featureFlagManager.getFeatureFlagFlow(FlagKey.MobilePremiumUpgrade),
+        ) { isInAppBillingSupported, featureFlagEnabled ->
+            isInAppBillingSupported && featureFlagEnabled
+        }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = false,
+            )
+
     override fun dismissPremiumUpgradeBanner() {
         val activeUserId = authDiskSource.userState?.activeUserId ?: return
         settingsDiskSource.storePremiumUpgradeBannerDismissed(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -27,17 +27,15 @@ import java.time.Instant
 
 /**
  * Default implementation of [PremiumStateManager].
- *
- * Combines five upstream flows into a single eligibility signal using [combine].
  */
 @Suppress("LongParameterList")
 class PremiumStateManagerImpl(
     private val authDiskSource: AuthDiskSource,
     authRepository: AuthRepository,
-    billingRepository: BillingRepository,
+    private val billingRepository: BillingRepository,
     private val settingsDiskSource: SettingsDiskSource,
     vaultRepository: VaultRepository,
-    featureFlagManager: FeatureFlagManager,
+    private val featureFlagManager: FeatureFlagManager,
     private val clock: Clock,
     dispatcherManager: DispatcherManager,
 ) : PremiumStateManager {
@@ -90,18 +88,9 @@ class PremiumStateManagerImpl(
                 initialValue = false,
             )
 
-    override val isInAppUpgradeAvailableFlow: StateFlow<Boolean> =
-        combine(
-            billingRepository.isInAppBillingSupportedFlow,
-            featureFlagManager.getFeatureFlagFlow(FlagKey.MobilePremiumUpgrade),
-        ) { isInAppBillingSupported, featureFlagEnabled ->
-            isInAppBillingSupported && featureFlagEnabled
-        }
-            .stateIn(
-                scope = unconfinedScope,
-                started = SharingStarted.Eagerly,
-                initialValue = false,
-            )
+    override fun isInAppUpgradeAvailable(): Boolean =
+        billingRepository.isInAppBillingSupportedFlow.value &&
+            featureFlagManager.getFeatureFlag(FlagKey.MobilePremiumUpgrade)
 
     override fun dismissPremiumUpgradeBanner() {
         val activeUserId = authDiskSource.userState?.activeUserId ?: return

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
@@ -66,6 +66,9 @@ class PremiumStateManagerImplTest {
         every {
             getFeatureFlagFlow(FlagKey.MobilePremiumUpgrade)
         } returns mutableMobilePremiumUpgradeFlagFlow
+        every {
+            getFeatureFlag(FlagKey.MobilePremiumUpgrade)
+        } answers { mutableMobilePremiumUpgradeFlagFlow.value }
     }
 
     private val dispatcherManager = FakeDispatcherManager()
@@ -331,44 +334,32 @@ class PremiumStateManagerImplTest {
     }
 
     @Test
-    fun `isInAppUpgradeAvailableFlow should emit true when billing supported and flag enabled`() =
-        runTest {
-            val manager = createManager()
-            manager.isInAppUpgradeAvailableFlow.test {
-                assertTrue(awaitItem())
-            }
-        }
+    fun `isInAppUpgradeAvailable should return true when billing supported and flag enabled`() {
+        val manager = createManager()
+        assertTrue(manager.isInAppUpgradeAvailable())
+    }
 
     @Test
-    fun `isInAppUpgradeAvailableFlow should emit false when billing not supported`() =
-        runTest {
-            mutableIsInAppBillingSupportedFlow.value = false
-            val manager = createManager()
-            manager.isInAppUpgradeAvailableFlow.test {
-                assertFalse(awaitItem())
-            }
-        }
+    fun `isInAppUpgradeAvailable should return false when billing not supported`() {
+        mutableIsInAppBillingSupportedFlow.value = false
+        val manager = createManager()
+        assertFalse(manager.isInAppUpgradeAvailable())
+    }
 
     @Test
-    fun `isInAppUpgradeAvailableFlow should emit false when feature flag disabled`() =
-        runTest {
-            mutableMobilePremiumUpgradeFlagFlow.value = false
-            val manager = createManager()
-            manager.isInAppUpgradeAvailableFlow.test {
-                assertFalse(awaitItem())
-            }
-        }
+    fun `isInAppUpgradeAvailable should return false when feature flag disabled`() {
+        mutableMobilePremiumUpgradeFlagFlow.value = false
+        val manager = createManager()
+        assertFalse(manager.isInAppUpgradeAvailable())
+    }
 
     @Test
-    fun `isInAppUpgradeAvailableFlow should emit false when both conditions are false`() =
-        runTest {
-            mutableIsInAppBillingSupportedFlow.value = false
-            mutableMobilePremiumUpgradeFlagFlow.value = false
-            val manager = createManager()
-            manager.isInAppUpgradeAvailableFlow.test {
-                assertFalse(awaitItem())
-            }
-        }
+    fun `isInAppUpgradeAvailable should return false when both conditions are false`() {
+        mutableIsInAppBillingSupportedFlow.value = false
+        mutableMobilePremiumUpgradeFlagFlow.value = false
+        val manager = createManager()
+        assertFalse(manager.isInAppUpgradeAvailable())
+    }
 
     @Test
     fun `dismissPremiumUpgradeBanner should store dismissed state for active user`() {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
@@ -331,6 +331,46 @@ class PremiumStateManagerImplTest {
     }
 
     @Test
+    fun `isInAppUpgradeAvailableFlow should emit true when billing supported and flag enabled`() =
+        runTest {
+            val manager = createManager()
+            manager.isInAppUpgradeAvailableFlow.test {
+                assertTrue(awaitItem())
+            }
+        }
+
+    @Test
+    fun `isInAppUpgradeAvailableFlow should emit false when billing not supported`() =
+        runTest {
+            mutableIsInAppBillingSupportedFlow.value = false
+            val manager = createManager()
+            manager.isInAppUpgradeAvailableFlow.test {
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `isInAppUpgradeAvailableFlow should emit false when feature flag disabled`() =
+        runTest {
+            mutableMobilePremiumUpgradeFlagFlow.value = false
+            val manager = createManager()
+            manager.isInAppUpgradeAvailableFlow.test {
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
+    fun `isInAppUpgradeAvailableFlow should emit false when both conditions are false`() =
+        runTest {
+            mutableIsInAppBillingSupportedFlow.value = false
+            mutableMobilePremiumUpgradeFlagFlow.value = false
+            val manager = createManager()
+            manager.isInAppUpgradeAvailableFlow.test {
+                assertFalse(awaitItem())
+            }
+        }
+
+    @Test
     fun `dismissPremiumUpgradeBanner should store dismissed state for active user`() {
         val manager = createManager()
         manager.dismissPremiumUpgradeBanner()


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33518

## 📔 Objective

Add a consolidated `isInAppUpgradeAvailableFlow` to `PremiumStateManager` that combines `isInAppBillingSupportedFlow` and the `MobilePremiumUpgrade` feature flag into a single observable signal.

**Stacked on PM-33517 PR** (settings/premium management)

### Changes

- Add `isInAppUpgradeAvailableFlow: StateFlow<Boolean>` to `PremiumStateManager` interface
- Implement in `PremiumStateManagerImpl` by combining billing support and feature flag flows
- Add unit tests for the new flow covering all flag/billing combinations