### PR TITLE
[PM-33519] feat: Rewire upgrade CTAs to use conditional routing

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
@@ -86,12 +86,14 @@ fun SavedStateHandle.toSearchArgs(): SearchArgs {
 /**
  * Add search destinations to the nav graph.
  */
+@Suppress("LongParameterList")
 fun NavGraphBuilder.searchDestination(
     onNavigateBack: () -> Unit,
     onNavigateToAddEditSend: (route: AddEditSendRoute) -> Unit,
     onNavigateToViewSend: (route: ViewSendRoute) -> Unit,
     onNavigateToEditCipher: (args: VaultAddEditArgs) -> Unit,
     onNavigateToViewCipher: (args: VaultItemArgs) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     composableWithSlideTransitions<SearchRoute> {
         SearchScreen(
@@ -100,6 +102,7 @@ fun NavGraphBuilder.searchDestination(
             onNavigateToViewSend = onNavigateToViewSend,
             onNavigateToEditCipher = onNavigateToEditCipher,
             onNavigateToViewCipher = onNavigateToViewCipher,
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreen.kt
@@ -58,6 +58,7 @@ fun SearchScreen(
     onNavigateToViewSend: (route: ViewSendRoute) -> Unit,
     onNavigateToEditCipher: (args: VaultAddEditArgs) -> Unit,
     onNavigateToViewCipher: (args: VaultItemArgs) -> Unit,
+    onNavigateToPlan: () -> Unit,
     intentManager: IntentManager = LocalIntentManager.current,
     viewModel: SearchViewModel = hiltViewModel(),
     appResumeStateManager: AppResumeStateManager = LocalAppResumeStateManager.current,
@@ -111,6 +112,7 @@ fun SearchScreen(
             }
 
             is SearchEvent.NavigateToUrl -> intentManager.launchUri(event.url.toUri())
+            SearchEvent.NavigateToPlanModal -> onNavigateToPlan()
             is SearchEvent.ShowShareSheet -> intentManager.shareText(event.content)
             is SearchEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.data)
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -25,6 +25,7 @@ import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.LoginUriView
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManager
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
@@ -101,6 +102,7 @@ class SearchViewModel @Inject constructor(
     private val vaultRepo: VaultRepository,
     private val authRepo: AuthRepository,
     private val environmentRepo: EnvironmentRepository,
+    private val premiumStateManager: PremiumStateManager,
     settingsRepo: SettingsRepository,
     snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     specialCircumstanceManager: SpecialCircumstanceManager,
@@ -318,9 +320,16 @@ class SearchViewModel @Inject constructor(
 
     private fun handleUpgradeToPremiumClick() {
         mutableStateFlow.update { it.copy(dialogState = null) }
-        val baseUrl = environmentRepo.environment.environmentUrlData.baseWebVaultUrlOrDefault
-        val url = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
-        sendEvent(SearchEvent.NavigateToUrl(url = url))
+        if (premiumStateManager.isInAppUpgradeAvailable()) {
+            sendEvent(SearchEvent.NavigateToPlanModal)
+        } else {
+            val baseUrl = environmentRepo
+                .environment
+                .environmentUrlData
+                .baseWebVaultUrlOrDefault
+            val url = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
+            sendEvent(SearchEvent.NavigateToUrl(url = url))
+        }
     }
 
     private fun handleOverflowItemClick(action: SearchAction.OverflowOptionClick) {
@@ -1574,6 +1583,11 @@ sealed class SearchEvent {
     data class NavigateToUrl(
         val url: String,
     ) : SearchEvent()
+
+    /**
+     * Navigates to the in-app plan modal for premium upgrade.
+     */
+    data object NavigateToPlanModal : SearchEvent()
 
     /**
      * Shares the [content] with share sheet.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -106,6 +106,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
                     parentFolderName = it,
                 )
             },
+            onNavigateToPlan = { navController.navigateToPlanModal() },
         )
         vaultUnlockedNavBarDestination(
             onNavigateToExportVault = { navController.navigateToExportVault() },
@@ -189,6 +190,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
                     showOnlyCollections = showOnlyCollections,
                 )
             },
+            onNavigateToPlan = { navController.navigateToPlanModal() },
         )
         vaultMoveToOrganizationDestination(
             onNavigateBack = { navController.popBackStack() },
@@ -209,6 +211,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
                 )
             },
             onNavigateToPreviewAttachment = { navController.navigateToPreviewAttachment(it) },
+            onNavigateToPlan = { navController.navigateToPlanModal() },
         )
         cardScanDestination(
             onNavigateBack = { navController.popBackStack() },
@@ -232,6 +235,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
             onNavigateBack = { navController.popBackStack() },
             onNavigateUpToSearchOrRoot = { navController.navigateUpToSearchOrVaultUnlockedRoot() },
             onNavigateToGeneratorModal = { navController.navigateToGeneratorModal(mode = it) },
+            onNavigateToPlan = { navController.navigateToPlanModal() },
         )
         viewSendDestination(
             onNavigateBack = { navController.popBackStack() },
@@ -259,6 +263,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
             onNavigateToViewSend = { navController.navigateToViewSend(it) },
             onNavigateToEditCipher = { navController.navigateToVaultAddEdit(it) },
             onNavigateToViewCipher = { navController.navigateToVaultItem(it) },
+            onNavigateToPlan = { navController.navigateToPlanModal() },
         )
         attachmentDestination(
             onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlockednavbar/VaultUnlockedNavBarScreen.kt
@@ -212,6 +212,7 @@ private fun VaultUnlockedNavBarScaffold(
                 onNavigateToAddEditSend = onNavigateToAddEditSend,
                 onNavigateToViewSend = onNavigateToViewSend,
                 onNavigateToSearchSend = onNavigateToSearchSend,
+                onNavigateToPlan = onNavigateToPlan,
             )
             generatorGraph(
                 onNavigateToPasswordHistory = { navigateToPasswordHistory() },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendGraphNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendGraphNavigation.kt
@@ -26,6 +26,7 @@ fun NavGraphBuilder.sendGraph(
     onNavigateToAddEditSend: (route: AddEditSendRoute) -> Unit,
     onNavigateToViewSend: (ViewSendRoute) -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     navigation<SendGraphRoute>(
         startDestination = SendRoute,
@@ -46,6 +47,7 @@ fun NavGraphBuilder.sendGraph(
             onNavigateToAddEditSendItem = onNavigateToAddEditSend,
             onNavigateToViewSendItem = onNavigateToViewSend,
             onNavigateToSearchSend = onNavigateToSearchSend,
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendNavigation.kt
@@ -59,12 +59,14 @@ fun NavGraphBuilder.addEditSendDestination(
     onNavigateBack: () -> Unit,
     onNavigateUpToSearchOrRoot: () -> Unit,
     onNavigateToGeneratorModal: (GeneratorMode.Modal) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     composableWithSlideTransitions<AddEditSendRoute> {
         AddEditSendScreen(
             onNavigateBack = onNavigateBack,
             onNavigateUpToSearchOrRoot = onNavigateUpToSearchOrRoot,
             onNavigateToGeneratorModal = onNavigateToGeneratorModal,
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreen.kt
@@ -57,6 +57,7 @@ fun AddEditSendScreen(
     onNavigateBack: () -> Unit,
     onNavigateUpToSearchOrRoot: () -> Unit,
     onNavigateToGeneratorModal: (GeneratorMode.Modal) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val addSendHandlers = remember(viewModel) { AddEditSendHandlers.create(viewModel) }
@@ -98,6 +99,8 @@ fun AddEditSendScreen(
             is AddEditSendEvent.NavigateToPremium -> {
                 intentManager.launchUri(uri = event.uri.toUri())
             }
+
+            AddEditSendEvent.NavigateToPlanModal -> onNavigateToPlan()
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModel.kt
@@ -22,6 +22,7 @@ import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PolicyManager
@@ -90,6 +91,7 @@ class AddEditSendViewModel @Inject constructor(
     private val networkConnectionManager: NetworkConnectionManager,
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     private val featureFlagManager: FeatureFlagManager,
+    private val premiumStateManager: PremiumStateManager,
 ) : BaseViewModel<AddEditSendState, AddEditSendEvent, AddEditSendAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE] ?: run {
@@ -648,15 +650,19 @@ class AddEditSendViewModel @Inject constructor(
     }
 
     private fun handleUpgradeToPremiumClick() {
-        val baseUrl = environmentRepo
-            .environment
-            .environmentUrlData
-            .baseWebVaultUrlOrDefault
-        sendEvent(
-            AddEditSendEvent.NavigateToPremium(
-                uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium",
-            ),
-        )
+        if (premiumStateManager.isInAppUpgradeAvailable()) {
+            sendEvent(AddEditSendEvent.NavigateToPlanModal)
+        } else {
+            val baseUrl = environmentRepo
+                .environment
+                .environmentUrlData
+                .baseWebVaultUrlOrDefault
+            sendEvent(
+                AddEditSendEvent.NavigateToPremium(
+                    uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium",
+                ),
+            )
+        }
     }
 
     @Suppress("LongMethod")
@@ -1113,6 +1119,11 @@ sealed class AddEditSendEvent {
      * Navigate to the Premium upgrade page.
      */
     data class NavigateToPremium(val uri: String) : AddEditSendEvent()
+
+    /**
+     * Navigates to the in-app plan modal for premium upgrade.
+     */
+    data object NavigateToPlanModal : AddEditSendEvent()
 }
 
 /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditNavigation.kt
@@ -77,6 +77,7 @@ fun NavGraphBuilder.vaultAddEditDestination(
     onNavigateToGeneratorModal: (GeneratorMode.Modal) -> Unit,
     onNavigateToAttachments: (cipherId: String) -> Unit,
     onNavigateToMoveToOrganization: (cipherId: String, showOnlyCollections: Boolean) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     composableWithSlideTransitions<VaultAddEditRoute> {
         VaultAddEditScreen(
@@ -87,6 +88,7 @@ fun NavGraphBuilder.vaultAddEditDestination(
             onNavigateToGeneratorModal = onNavigateToGeneratorModal,
             onNavigateToAttachments = onNavigateToAttachments,
             onNavigateToMoveToOrganization = onNavigateToMoveToOrganization,
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -113,6 +113,7 @@ fun VaultAddEditScreen(
     onNavigateToGeneratorModal: (GeneratorMode.Modal) -> Unit,
     onNavigateToAttachments: (cipherId: String) -> Unit,
     onNavigateToMoveToOrganization: (cipherId: String, showOnlyCollections: Boolean) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val userVerificationHandlers = remember(viewModel) {
@@ -210,6 +211,8 @@ fun VaultAddEditScreen(
             VaultAddEditEvent.NavigateToAppSettings -> {
                 intentManager.startAppSettingsActivity()
             }
+
+            VaultAddEditEvent.NavigateToPlanModal -> onNavigateToPlan()
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -33,6 +33,7 @@ import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePinResult
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManager
 import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
 import com.x8bit.bitwarden.data.credentials.model.Fido2RegisterCredentialResult
@@ -141,6 +142,7 @@ class VaultAddEditViewModel @Inject constructor(
     private val networkConnectionManager: NetworkConnectionManager,
     private val firstTimeActionManager: FirstTimeActionManager,
     private val environmentRepository: EnvironmentRepository,
+    private val premiumStateManager: PremiumStateManager,
 ) : BaseViewModel<VaultAddEditState, VaultAddEditEvent, VaultAddEditAction>(
     // We load the state from the savedStateHandle for testing purposes.
     initialState = savedStateHandle[KEY_STATE]
@@ -652,12 +654,19 @@ class VaultAddEditViewModel @Inject constructor(
     }
 
     private fun handleUpgradeToPremiumClick() {
-        val baseUrl = environmentRepository.environment.environmentUrlData.baseWebVaultUrlOrDefault
-        sendEvent(
-            VaultAddEditEvent.NavigateToPremium(
-                uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium",
-            ),
-        )
+        if (premiumStateManager.isInAppUpgradeAvailable()) {
+            sendEvent(VaultAddEditEvent.NavigateToPlanModal)
+        } else {
+            val baseUrl = environmentRepository
+                .environment
+                .environmentUrlData
+                .baseWebVaultUrlOrDefault
+            sendEvent(
+                VaultAddEditEvent.NavigateToPremium(
+                    uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium",
+                ),
+            )
+        }
     }
 
     private fun handleConfirmDeleteClick() {
@@ -3196,6 +3205,11 @@ sealed class VaultAddEditEvent {
     data class NavigateToPremium(
         val uri: String,
     ) : VaultAddEditEvent()
+
+    /**
+     * Navigates to the in-app plan modal for premium upgrade.
+     */
+    data object NavigateToPlanModal : VaultAddEditEvent()
 
     /**
      * Navigates to the collections screen.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemNavigation.kt
@@ -47,6 +47,7 @@ fun NavGraphBuilder.vaultItemDestination(
     onNavigateToAttachments: (vaultItemId: String) -> Unit,
     onNavigateToPasswordHistory: (vaultItemId: String) -> Unit,
     onNavigateToPreviewAttachment: (route: PreviewAttachmentRoute) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     composableWithSlideTransitions<VaultItemRoute> {
         VaultItemScreen(
@@ -56,6 +57,7 @@ fun NavGraphBuilder.vaultItemDestination(
             onNavigateToAttachments = onNavigateToAttachments,
             onNavigateToPasswordHistory = onNavigateToPasswordHistory,
             onNavigateToPreviewAttachment = onNavigateToPreviewAttachment,
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreen.kt
@@ -65,6 +65,7 @@ fun VaultItemScreen(
     onNavigateToAttachments: (vaultItemId: String) -> Unit,
     onNavigateToPasswordHistory: (vaultItemId: String) -> Unit,
     onNavigateToPreviewAttachment: (route: PreviewAttachmentRoute) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val fileChooserLauncher = intentManager.getActivityResultLauncher { activityResult ->
@@ -99,6 +100,8 @@ fun VaultItemScreen(
             }
 
             is VaultItemEvent.NavigateToUri -> intentManager.launchUri(event.uri.toUri())
+
+            VaultItemEvent.NavigateToPlanModal -> onNavigateToPlan()
 
             is VaultItemEvent.NavigateToAttachments -> onNavigateToAttachments(event.itemId)
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -25,6 +25,7 @@ import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
@@ -82,6 +83,7 @@ class VaultItemViewModel @Inject constructor(
     private val environmentRepository: EnvironmentRepository,
     private val settingsRepository: SettingsRepository,
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
+    private val premiumStateManager: PremiumStateManager,
     featureFlagManager: FeatureFlagManager,
 ) : BaseViewModel<VaultItemState, VaultItemEvent, VaultItemAction>(
     // We load the state from the savedStateHandle for testing purposes.
@@ -744,9 +746,16 @@ class VaultItemViewModel @Inject constructor(
 
     private fun handleUpgradeToPremiumClick() {
         updateDialogState(dialog = null)
-        val baseUrl = environmentRepository.environment.environmentUrlData.baseWebVaultUrlOrDefault
-        val uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
-        sendEvent(VaultItemEvent.NavigateToUri(uri = uri))
+        if (premiumStateManager.isInAppUpgradeAvailable()) {
+            sendEvent(VaultItemEvent.NavigateToPlanModal)
+        } else {
+            val baseUrl = environmentRepository
+                .environment
+                .environmentUrlData
+                .baseWebVaultUrlOrDefault
+            val uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
+            sendEvent(VaultItemEvent.NavigateToUri(uri = uri))
+        }
     }
 
     private fun handlePasswordVisibilityClicked(
@@ -1975,6 +1984,11 @@ sealed class VaultItemEvent {
     data class NavigateToUri(
         val uri: String,
     ) : VaultItemEvent()
+
+    /**
+     * Navigates to the in-app plan modal for premium upgrade.
+     */
+    data object NavigateToPlanModal : VaultItemEvent()
 
     /**
      * Navigates to the attachments screen.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
@@ -148,6 +148,7 @@ fun NavGraphBuilder.vaultItemListingDestination(
     onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     internalVaultItemListingDestination<VaultItemListingRoute.CipherItemListing>(
         onNavigateBack = onNavigateBack,
@@ -159,6 +160,7 @@ fun NavGraphBuilder.vaultItemListingDestination(
         onNavigateToVaultEditItemScreen = onNavigateToVaultEditItemScreen,
         onNavigateToSearch = { onNavigateToSearchVault(it as SearchType.Vault) },
         onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
+        onNavigateToPlan = onNavigateToPlan,
     )
 }
 
@@ -173,6 +175,7 @@ fun NavGraphBuilder.vaultItemListingDestinationAsRoot(
     onNavigateToVaultAddItemScreen: (args: VaultAddEditArgs) -> Unit,
     onNavigateToAddFolderScreen: (selectedFolderId: String?) -> Unit,
     onNavigateToSearchVault: (searchType: SearchType.Vault) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     composableWithStayTransitions<VaultItemListingRoute.AsRoot> {
         VaultItemListingScreen(
@@ -185,6 +188,7 @@ fun NavGraphBuilder.vaultItemListingDestinationAsRoot(
             onNavigateToVaultItemListing = {},
             onNavigateToAddEditSendItem = {},
             onNavigateToViewSendItem = {},
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }
@@ -197,6 +201,7 @@ fun NavGraphBuilder.sendItemListingDestination(
     onNavigateToAddEditSendItem: (route: AddEditSendRoute) -> Unit,
     onNavigateToViewSendItem: (route: ViewSendRoute) -> Unit,
     onNavigateToSearchSend: (searchType: SearchType.Sends) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     internalVaultItemListingDestination<VaultItemListingRoute.SendItemListing>(
         onNavigateBack = onNavigateBack,
@@ -208,6 +213,7 @@ fun NavGraphBuilder.sendItemListingDestination(
         onNavigateToVaultEditItemScreen = { },
         onNavigateToVaultItemListing = { },
         onNavigateToSearch = { onNavigateToSearchSend(it as SearchType.Sends) },
+        onNavigateToPlan = onNavigateToPlan,
     )
 }
 
@@ -225,6 +231,7 @@ private inline fun <reified T : VaultItemListingRoute> NavGraphBuilder.internalV
     noinline onNavigateToAddEditSendItem: (route: AddEditSendRoute) -> Unit,
     noinline onNavigateToViewSendItem: (route: ViewSendRoute) -> Unit,
     noinline onNavigateToSearch: (searchType: SearchType) -> Unit,
+    noinline onNavigateToPlan: () -> Unit,
 ) {
     composableWithPushTransitions<T> {
         VaultItemListingScreen(
@@ -237,6 +244,7 @@ private inline fun <reified T : VaultItemListingRoute> NavGraphBuilder.internalV
             onNavigateToVaultItemListing = onNavigateToVaultItemListing,
             onNavigateToSearch = onNavigateToSearch,
             onNavigateToAddFolder = onNavigateToAddFolderScreen,
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreen.kt
@@ -85,6 +85,7 @@ fun VaultItemListingScreen(
     onNavigateToAddEditSendItem: (route: AddEditSendRoute) -> Unit,
     onNavigateToViewSendItem: (route: ViewSendRoute) -> Unit,
     onNavigateToSearch: (searchType: SearchType) -> Unit,
+    onNavigateToPlan: () -> Unit,
     intentManager: IntentManager = LocalIntentManager.current,
     exitManager: ExitManager = LocalExitManager.current,
     credentialProviderCompletionManager: CredentialProviderCompletionManager =
@@ -144,6 +145,8 @@ fun VaultItemListingScreen(
             is VaultItemListingEvent.NavigateToUrl -> {
                 intentManager.launchUri(event.url.toUri())
             }
+
+            VaultItemListingEvent.NavigateToPlanModal -> onNavigateToPlan()
 
             is VaultItemListingEvent.NavigateToAddSendItem -> {
                 onNavigateToAddEditSendItem(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -45,6 +45,7 @@ import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySele
 import com.x8bit.bitwarden.data.autofill.manager.AutofillSelectionManager
 import com.x8bit.bitwarden.data.autofill.model.AutofillSelectionData
 import com.x8bit.bitwarden.data.autofill.util.isActiveWithFido2Credentials
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.credentials.manager.BitwardenCredentialManager
 import com.x8bit.bitwarden.data.credentials.manager.OriginManager
 import com.x8bit.bitwarden.data.credentials.model.CreateCredentialRequest
@@ -151,6 +152,7 @@ class VaultItemListingViewModel @Inject constructor(
     private val networkConnectionManager: NetworkConnectionManager,
     private val relyingPartyParser: RelyingPartyParser,
     private val toastManager: ToastManager,
+    private val premiumStateManager: PremiumStateManager,
     snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     featureFlagManager: FeatureFlagManager,
 ) : BaseViewModel<VaultItemListingState, VaultItemListingEvent, VaultItemListingsAction>(
@@ -671,9 +673,16 @@ class VaultItemListingViewModel @Inject constructor(
 
     private fun handleUpgradeToPremiumClick() {
         clearDialogState()
-        val baseUrl = environmentRepository.environment.environmentUrlData.baseWebVaultUrlOrDefault
-        val url = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
-        sendEvent(VaultItemListingEvent.NavigateToUrl(url = url))
+        if (premiumStateManager.isInAppUpgradeAvailable()) {
+            sendEvent(VaultItemListingEvent.NavigateToPlanModal)
+        } else {
+            val baseUrl = environmentRepository
+                .environment
+                .environmentUrlData
+                .baseWebVaultUrlOrDefault
+            val url = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
+            sendEvent(VaultItemListingEvent.NavigateToUrl(url = url))
+        }
     }
 
     private fun handleRemoveSendPasswordClick(
@@ -3500,6 +3509,11 @@ sealed class VaultItemListingEvent {
     data class NavigateToUrl(
         val url: String,
     ) : VaultItemListingEvent()
+
+    /**
+     * Navigates to the in-app plan modal for premium upgrade.
+     */
+    data object NavigateToPlanModal : VaultItemListingEvent()
 
     /**
      * Navigates to the SearchScreen with the given type filter.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultGraphNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultGraphNavigation.kt
@@ -63,6 +63,7 @@ fun NavGraphBuilder.vaultGraph(
             onNavigateToVaultEditItemScreen = onNavigateToVaultEditItemScreen,
             onNavigateToVaultItemListing = { navController.navigateToVaultItemListing(it) },
             onNavigateToAddFolderScreen = onNavigateToAddFolderScreen,
+            onNavigateToPlan = onNavigateToPlan,
         )
 
         vaultVerificationCodeDestination(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -400,9 +400,16 @@ class VaultViewModel @Inject constructor(
 
     private fun handleUpgradeToPremiumClick() {
         mutableStateFlow.update { it.copy(dialog = null) }
-        val baseUrl = environmentRepository.environment.environmentUrlData.baseWebVaultUrlOrDefault
-        val url = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
-        sendEvent(VaultEvent.NavigateToUrl(url = url))
+        if (premiumStateManager.isInAppUpgradeAvailable()) {
+            sendEvent(VaultEvent.NavigateToUpgradePremium)
+        } else {
+            val baseUrl = environmentRepository
+                .environment
+                .environmentUrlData
+                .baseWebVaultUrlOrDefault
+            val url = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
+            sendEvent(VaultEvent.NavigateToUrl(url = url))
+        }
     }
 
     private fun handleDismissActionCardClick(action: VaultAction.DismissActionCardClick) {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchScreenTest.kt
@@ -73,6 +73,7 @@ class SearchScreenTest : BitwardenComposeTest() {
     private var onNavigateToViewSendRoute: ViewSendRoute? = null
     private var onNavigateToEditCipherArgs: VaultAddEditArgs? = null
     private var onNavigateToViewCipherArgs: VaultItemArgs? = null
+    private var onNavigateToPlanCalled = false
 
     @Before
     fun setup() {
@@ -87,6 +88,7 @@ class SearchScreenTest : BitwardenComposeTest() {
                 onNavigateToViewSend = { onNavigateToViewSendRoute = it },
                 onNavigateToEditCipher = { onNavigateToEditCipherArgs = it },
                 onNavigateToViewCipher = { onNavigateToViewCipherArgs = it },
+                onNavigateToPlan = { onNavigateToPlanCalled = true },
             )
         }
     }
@@ -151,6 +153,12 @@ class SearchScreenTest : BitwardenComposeTest() {
         verify(exactly = 1) {
             intentManager.launchUri(url.toUri())
         }
+    }
+
+    @Test
+    fun `NavigateToPlanModal should call onNavigateToPlan`() {
+        mutableEventFlow.tryEmit(SearchEvent.NavigateToPlanModal)
+        assertTrue(onNavigateToPlanCalled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -26,6 +26,7 @@ import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.LoginUriView
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
 import com.x8bit.bitwarden.data.autofill.accessibility.manager.AccessibilitySelectionManager
@@ -161,6 +162,9 @@ class SearchViewModelTest : BaseViewModelTest() {
         every {
             getSnackbarDataFlow(relay = any(), relays = anyVararg())
         } returns mutableSnackbarDataFlow
+    }
+    private val premiumStateManager: PremiumStateManager = mockk {
+        every { isInAppUpgradeAvailable() } returns false
     }
     private val mutableArchiveItemsFlow = MutableStateFlow(true)
     private val featureFlagManager: FeatureFlagManager = mockk {
@@ -301,20 +305,35 @@ class SearchViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `UpgradeToPremiumClick should emit NavigateToUrl`() = runTest {
-        val viewModel = createViewModel(initialState = null)
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(SearchAction.UpgradeToPremiumClick)
-            assertEquals(
-                SearchEvent.NavigateToUrl(
-                    url = "https://vault.bitwarden.com/#/" +
-                        "settings/subscription/premium" +
-                        "?callToAction=upgradeToPremium",
-                ),
-                awaitItem(),
-            )
+    fun `UpgradeToPremiumClick should emit NavigateToUrl when in-app upgrade not available`() =
+        runTest {
+            val viewModel = createViewModel(initialState = null)
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(SearchAction.UpgradeToPremiumClick)
+                assertEquals(
+                    SearchEvent.NavigateToUrl(
+                        url = "https://vault.bitwarden.com/#/" +
+                            "settings/subscription/premium" +
+                            "?callToAction=upgradeToPremium",
+                    ),
+                    awaitItem(),
+                )
+            }
         }
-    }
+
+    @Test
+    fun `UpgradeToPremiumClick should emit NavigateToPlanModal when in-app upgrade available`() =
+        runTest {
+            every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+            val viewModel = createViewModel(initialState = null)
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(SearchAction.UpgradeToPremiumClick)
+                assertEquals(
+                    SearchEvent.NavigateToPlanModal,
+                    awaitItem(),
+                )
+            }
+        }
 
     @Test
     fun `ArchiveClick without Premium should show ArchiveRequiresPremium dialog`() = runTest {
@@ -2013,6 +2032,7 @@ class SearchViewModelTest : BaseViewModelTest() {
         accessibilitySelectionManager = accessibilitySelectionManager,
         autofillSelectionManager = autofillSelectionManager,
         organizationEventManager = organizationEventManager,
+        premiumStateManager = premiumStateManager,
         snackbarRelayManager = snackbarRelayManager,
         featureFlagManager = featureFlagManager,
     )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendScreenTest.kt
@@ -58,6 +58,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
     private var navgatedGeneratorMode: GeneratorMode.Modal? = null
     private var onNavigateBackCalled = false
     private var onNavigateUpToSearchOrRootCalled = false
+    private var onNavigateToPlanCalled = false
 
     private val exitManager: ExitManager = mockk(relaxed = true) {
         every { exitApplication() } just runs
@@ -87,6 +88,7 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
                 onNavigateToGeneratorModal = { mode ->
                     navgatedGeneratorMode = mode
                 },
+                onNavigateToPlan = { onNavigateToPlanCalled = true },
             )
         }
     }
@@ -112,6 +114,12 @@ class AddEditSendScreenTest : BitwardenComposeTest() {
         )
 
         assertEquals(mode, navgatedGeneratorMode)
+    }
+
+    @Test
+    fun `on NavigateToPlanModal event should call onNavigateToPlan`() {
+        mutableEventFlow.tryEmit(AddEditSendEvent.NavigateToPlanModal)
+        assertTrue(onNavigateToPlanCalled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/addedit/AddEditSendViewModelTest.kt
@@ -19,6 +19,7 @@ import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.auth.repository.model.PolicyInformation
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
@@ -109,6 +110,9 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
         every { sendSnackbarData(data = any(), relay = any()) } just runs
     }
 
+    private val premiumStateManager: PremiumStateManager = mockk {
+        every { isInAppUpgradeAvailable() } returns false
+    }
     private val mutableSendEmailVerificationFeatureFlagFlow = MutableStateFlow(false)
     private val featureFlagManager: FeatureFlagManager = mockk {
         every {
@@ -1458,20 +1462,33 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
-    fun `UpgradeToPremiumClick should send NavigateToPremium event`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(AddEditSendAction.UpgradeToPremiumClick)
-            val event = awaitItem()
-            assertEquals(
-                AddEditSendEvent.NavigateToPremium(
-                    uri = "https://vault.bitwarden.com/#/settings/subscription/premium?callToAction=upgradeToPremium",
-                ),
-                event,
-            )
+    fun `UpgradeToPremiumClick should send NavigateToPremium when in-app upgrade not available`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(AddEditSendAction.UpgradeToPremiumClick)
+                assertEquals(
+                    AddEditSendEvent.NavigateToPremium(
+                        uri = "https://vault.bitwarden.com/#/settings/subscription/premium?callToAction=upgradeToPremium",
+                    ),
+                    awaitItem(),
+                )
+            }
         }
-    }
+
+    @Test
+    fun `UpgradeToPremiumClick should send NavigateToPlanModal when in-app upgrade available`() =
+        runTest {
+            every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(AddEditSendAction.UpgradeToPremiumClick)
+                assertEquals(
+                    AddEditSendEvent.NavigateToPlanModal,
+                    awaitItem(),
+                )
+            }
+        }
 
     //endregion Authentication Tests
 
@@ -1499,6 +1516,7 @@ class AddEditSendViewModelTest : BaseViewModelTest() {
         snackbarRelayManager = snackbarRelayManager,
         generatorRepository = generatorRepository,
         featureFlagManager = featureFlagManager,
+        premiumStateManager = premiumStateManager,
     )
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -98,6 +98,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
     private var onNavigateToAttachmentsId: String? = null
     private var onNavigateToCardScanScreenCalled = false
     private var onNavigateToMoveToOrganizationId: String? = null
+    private var onNavigateToPlanCalled = false
 
     private val mutableEventFlow = bufferedMutableSharedFlow<VaultAddEditEvent>()
     private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE_LOGIN)
@@ -140,6 +141,7 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
                 onNavigateToAttachments = { onNavigateToAttachmentsId = it },
                 onNavigateToMoveToOrganization = { id, _ -> onNavigateToMoveToOrganizationId = id },
                 onNavigateToCardScanScreen = { onNavigateToCardScanScreenCalled = true },
+                onNavigateToPlan = { onNavigateToPlanCalled = true },
                 viewModel = viewModel,
             )
         }
@@ -273,6 +275,12 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             ),
         )
         assertEquals(GeneratorMode.Modal.Username(website), onNavigateToGeneratorModalType)
+    }
+
+    @Test
+    fun `on NavigateToPlanModal event should invoke onNavigateToPlan`() {
+        mutableEventFlow.tryEmit(VaultAddEditEvent.NavigateToPlanModal)
+        assertTrue(onNavigateToPlanCalled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -34,6 +34,7 @@ import com.bitwarden.vault.FolderView
 import com.bitwarden.vault.UriMatchType
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.ValidatePasswordResult
@@ -226,6 +227,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         every { show(message = any(), duration = any()) } just runs
     }
     private val environmentRepository = FakeEnvironmentRepository()
+    private val premiumStateManager: PremiumStateManager = mockk {
+        every { isInAppUpgradeAvailable() } returns false
+    }
     private val mutableArchiveItemsFlow = MutableStateFlow(true)
     private val mutableCardScannerFlow = MutableStateFlow(false)
     private val mutableCardScanResultFlow =
@@ -552,20 +556,35 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `UpgradeToPremiumClick should emit NavigateToPremium`() = runTest {
-        val viewModel = createAddVaultItemViewModel()
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(VaultAddEditAction.Common.UpgradeToPremiumClick)
-            assertEquals(
-                VaultAddEditEvent.NavigateToPremium(
-                    uri = "https://vault.bitwarden.com/#/" +
-                        "settings/subscription/premium" +
-                        "?callToAction=upgradeToPremium",
-                ),
-                awaitItem(),
-            )
+    fun `UpgradeToPremiumClick should emit NavigateToPremium when in-app upgrade not available`() =
+        runTest {
+            val viewModel = createAddVaultItemViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultAddEditAction.Common.UpgradeToPremiumClick)
+                assertEquals(
+                    VaultAddEditEvent.NavigateToPremium(
+                        uri = "https://vault.bitwarden.com/#/" +
+                            "settings/subscription/premium" +
+                            "?callToAction=upgradeToPremium",
+                    ),
+                    awaitItem(),
+                )
+            }
         }
-    }
+
+    @Test
+    fun `UpgradeToPremiumClick should emit NavigateToPlanModal when in-app upgrade available`() =
+        runTest {
+            every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+            val viewModel = createAddVaultItemViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultAddEditAction.Common.UpgradeToPremiumClick)
+                assertEquals(
+                    VaultAddEditEvent.NavigateToPlanModal,
+                    awaitItem(),
+                )
+            }
+        }
 
     @Test
     fun `snackbar relay emission should send ShowSnackbar`() = runTest {
@@ -5539,6 +5558,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             networkConnectionManager = networkConnectionManager,
             firstTimeActionManager = firstTimeActionManager,
             environmentRepository = environmentRepository,
+            premiumStateManager = premiumStateManager,
         )
 
     private fun createVaultData(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -71,6 +71,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
     private var onNavigateToAttachmentsId: String? = null
     private var onNavigateToPasswordHistoryId: String? = null
     private var onNavigateToPreviewAttachment: PreviewAttachmentRoute? = null
+    private var onNavigateToPlanCalled = false
 
     private val intentManager = mockk<IntentManager>(relaxed = true)
 
@@ -96,6 +97,7 @@ class VaultItemScreenTest : BitwardenComposeTest() {
                 onNavigateToAttachments = { onNavigateToAttachmentsId = it },
                 onNavigateToPasswordHistory = { onNavigateToPasswordHistoryId = it },
                 onNavigateToPreviewAttachment = { onNavigateToPreviewAttachment = it },
+                onNavigateToPlan = { onNavigateToPlanCalled = true },
             )
         }
     }
@@ -197,6 +199,12 @@ class VaultItemScreenTest : BitwardenComposeTest() {
         verify(exactly = 1) {
             intentManager.launchUri(uri)
         }
+    }
+
+    @Test
+    fun `NavigateToPlanModal event should invoke onNavigateToPlan`() {
+        mutableEventFlow.tryEmit(VaultItemEvent.NavigateToPlanModal)
+        assertTrue(onNavigateToPlanCalled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModelTest.kt
@@ -26,6 +26,7 @@ import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.auth.repository.model.BreachCountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.model.createMockOrganization
@@ -132,6 +133,9 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         } returns mutableSnackbarDataFlow
         every { sendSnackbarData(data = any(), relay = any()) } just runs
     }
+    private val premiumStateManager: PremiumStateManager = mockk {
+        every { isInAppUpgradeAvailable() } returns false
+    }
     private val mutableArchiveItemsFlow = MutableStateFlow(true)
     private val featureFlagManager: FeatureFlagManager = mockk {
         every { getFeatureFlag(FlagKey.ArchiveItems) } answers { mutableArchiveItemsFlow.value }
@@ -232,20 +236,40 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         }
 
         @Test
-        fun `UpgradeToPremiumClick should emit NavigateToPremium`() = runTest {
-            val viewModel = createViewModel(state = null)
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(VaultItemAction.Common.UpgradeToPremiumClick)
-                assertEquals(
-                    VaultItemEvent.NavigateToUri(
-                        uri = "https://vault.bitwarden.com/#/" +
-                            "settings/subscription/premium" +
-                            "?callToAction=upgradeToPremium",
-                    ),
-                    awaitItem(),
-                )
+        fun `UpgradeToPremiumClick should emit NavigateToUri when in-app upgrade not available`() =
+            runTest {
+                val viewModel = createViewModel(state = null)
+                viewModel.eventFlow.test {
+                    viewModel.trySendAction(
+                        VaultItemAction.Common.UpgradeToPremiumClick,
+                    )
+                    assertEquals(
+                        VaultItemEvent.NavigateToUri(
+                            uri = "https://vault.bitwarden.com/#/" +
+                                "settings/subscription/premium" +
+                                "?callToAction=upgradeToPremium",
+                        ),
+                        awaitItem(),
+                    )
+                }
             }
-        }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `UpgradeToPremiumClick should emit NavigateToPlanModal when in-app upgrade available`() =
+            runTest {
+                every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+                val viewModel = createViewModel(state = null)
+                viewModel.eventFlow.test {
+                    viewModel.trySendAction(
+                        VaultItemAction.Common.UpgradeToPremiumClick,
+                    )
+                    assertEquals(
+                        VaultItemEvent.NavigateToPlanModal,
+                        awaitItem(),
+                    )
+                }
+            }
 
         @Test
         fun `ArchiveClick without Premium should show ArchiveRequiresPremium dialog`() = runTest {
@@ -2963,6 +2987,7 @@ class VaultItemViewModelTest : BaseViewModelTest() {
         environmentRepository = environmentRepository,
         settingsRepository = settingsRepository,
         snackbarRelayManager = snackbarRelayManager,
+        premiumStateManager = premiumStateManager,
         featureFlagManager = featureFlagManager,
     )
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingScreenTest.kt
@@ -100,6 +100,7 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
     private var onNavigateToVaultItemListingScreenType: VaultItemListingType? = null
     private var onNavigateToAddFolderCalled = false
     private var onNavigateToAddFolderParentFolderName: String? = null
+    private var onNavigateToPlanCalled: Boolean = false
 
     private val exitManager: ExitManager = mockk {
         every { exitApplication() } just runs
@@ -146,6 +147,7 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
                     onNavigateToAddFolderCalled = true
                     onNavigateToAddFolderParentFolderName = folderName
                 },
+                onNavigateToPlan = { onNavigateToPlanCalled = true },
             )
         }
     }
@@ -633,6 +635,12 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
         verify(exactly = 1) {
             intentManager.launchUri(url.toUri())
         }
+    }
+
+    @Test
+    fun `NavigateToPlanModal event should invoke onNavigateToPlan`() {
+        mutableEventFlow.tryEmit(VaultItemListingEvent.NavigateToPlanModal)
+        assertTrue(onNavigateToPlanCalled)
     }
 
     @Test
@@ -1588,6 +1596,7 @@ class VaultItemListingScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
     }
 
+    @Suppress("LongMethod")
     @Test
     fun `on send item overflow option click should emit the appropriate action`() {
         val number = 1

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -46,6 +46,7 @@ import com.bitwarden.vault.CipherRepromptType
 import com.bitwarden.vault.CipherType
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.SwitchAccountResult
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
@@ -297,6 +298,9 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         every { parse(any<BeginGetPublicKeyCredentialOption>()) } returns DEFAULT_RELYING_PARTY_ID
         every { parse(any<GetPublicKeyCredentialOption>()) } returns DEFAULT_RELYING_PARTY_ID
         every { parse(any<CreatePublicKeyCredentialRequest>()) } returns DEFAULT_RELYING_PARTY_ID
+    }
+    private val premiumStateManager: PremiumStateManager = mockk {
+        every { isInAppUpgradeAvailable() } returns false
     }
     private val mutableArchiveItemsFlow = MutableStateFlow(true)
     private val featureFlagManager: FeatureFlagManager = mockk {
@@ -1057,20 +1061,35 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `UpgradeToPremiumClick should emit NavigateToUrl`() = runTest {
-        val viewModel = createVaultItemListingViewModel()
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
-            assertEquals(
-                VaultItemListingEvent.NavigateToUrl(
-                    url = "https://vault.bitwarden.com/#/" +
-                        "settings/subscription/premium" +
-                        "?callToAction=upgradeToPremium",
-                ),
-                awaitItem(),
-            )
+    fun `UpgradeToPremiumClick should emit NavigateToUrl when in-app upgrade not available`() =
+        runTest {
+            val viewModel = createVaultItemListingViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
+                assertEquals(
+                    VaultItemListingEvent.NavigateToUrl(
+                        url = "https://vault.bitwarden.com/#/" +
+                            "settings/subscription/premium" +
+                            "?callToAction=upgradeToPremium",
+                    ),
+                    awaitItem(),
+                )
+            }
         }
-    }
+
+    @Test
+    fun `UpgradeToPremiumClick should emit NavigateToPlanModal when in-app upgrade available`() =
+        runTest {
+            every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+            val viewModel = createVaultItemListingViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
+                assertEquals(
+                    VaultItemListingEvent.NavigateToPlanModal,
+                    awaitItem(),
+                )
+            }
+        }
 
     @Test
     fun `ArchiveClick without Premium should show ArchiveRequiresPremium dialog`() = runTest {
@@ -6178,6 +6197,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             privilegedAppRepository = privilegedAppRepository,
             snackbarRelayManager = snackbarRelayManager,
             toastManager = toastManager,
+            premiumStateManager = premiumStateManager,
             relyingPartyParser = relyingPartyParser,
             featureFlagManager = featureFlagManager,
         )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -240,6 +240,7 @@ class VaultViewModelTest : BaseViewModelTest() {
         every {
             isPremiumUpgradeBannerEligibleFlow
         } returns mutablePremiumUpgradeBannerEligibleFlow
+        every { isInAppUpgradeAvailable() } returns false
         every { dismissPremiumUpgradeBanner() } just runs
     }
 
@@ -832,20 +833,36 @@ class VaultViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `UpgradeToPremiumClick should emit NavigateToUrl`() = runTest {
-        val viewModel = createViewModel()
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(VaultAction.UpgradeToPremiumClick)
-            assertEquals(
-                VaultEvent.NavigateToUrl(
-                    url = "https://vault.bitwarden.com/#/" +
-                        "settings/subscription/premium" +
-                        "?callToAction=upgradeToPremium",
-                ),
-                awaitItem(),
-            )
+    fun `UpgradeToPremiumClick should emit NavigateToUrl when in-app upgrade not available`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultAction.UpgradeToPremiumClick)
+                assertEquals(
+                    VaultEvent.NavigateToUrl(
+                        url = "https://vault.bitwarden.com/#/" +
+                            "settings/subscription/premium" +
+                            "?callToAction=upgradeToPremium",
+                    ),
+                    awaitItem(),
+                )
+            }
         }
-    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `UpgradeToPremiumClick should emit NavigateToUpgradePremium when in-app upgrade available`() =
+        runTest {
+            every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultAction.UpgradeToPremiumClick)
+                assertEquals(
+                    VaultEvent.NavigateToUpgradePremium,
+                    awaitItem(),
+                )
+            }
+        }
 
     @Test
     fun `ArchiveClick without Premium should show ArchiveRequiresPremium dialog`() = runTest {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33519

## 📔 Objective

Rewire all existing premium upgrade CTAs across the app to conditionally route to either the in-app PlanScreen (modal) or the external web vault URL based on `isInAppUpgradeAvailableFlow`.

**Stacked on PM-33518 PR** (upgrade available flow)

### Changes

- Inject `PremiumStateManager` into ViewModels that have upgrade CTAs: VaultViewModel, VaultItemViewModel, VaultItemListingViewModel, VaultAddEditViewModel, AddEditSendViewModel, SearchViewModel
- Add `NavigateToPlanModal` event and `onNavigateToPlan` callback to affected screens and navigation graphs
- Conditionally route: if in-app upgrade available → navigate to PlanScreen modal; otherwise → launch web vault URL as before
- Thread `onNavigateToPlan` through VaultUnlockedNavigation, VaultGraphNavigation, SendGraphNavigation, and all affected screen destinations
- Full test coverage for conditional routing in all affected ViewModels and Screens