### PR TITLE
Add missing Password Manager Locale for Play Store

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -417,7 +417,7 @@ platform :android do
     version_code = options[:versionCode]
 
     auth_locales = ["en-US"]
-    pw_manager_locales = ["ca", "cs-CZ", "da-DK", "de-DE", "en-US", "es-ES", "et", "fr-FR", "hr", "hu-HU", "id", "it-IT", "iw-IL", "ja-JP", "nl-NL", "pl-PL", "pt-BR", "pt-PT", "ro", "ru-RU", "sk", "sv-SE", "tr-TR", "uk", "vi", "zh-CN", "zh-TW"]
+    pw_manager_locales = ["ca", "cs-CZ", "da-DK", "de-DE", "en-US", "es-ES", "et", "fi-FI", "fr-FR", "hr", "hu-HU", "id", "it-IT", "iw-IL", "ja-JP", "nl-NL", "pl-PL", "pt-BR", "pt-PT", "ro", "ru-RU", "sk", "sv-SE", "tr-TR", "uk", "vi", "zh-CN", "zh-TW"]
     if options[:packageName] == "com.bitwarden.authenticator"
       locales = auth_locales
     elsif options[:packageName] == "com.x8bit.bitwarden" || options[:packageName] == "com.x8bit.bitwarden.beta"


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When reviewing our latest submission I realized that we are missing a locale from the list for the Password Manager in the Play Store. This PR adds it.
