### PR TITLE
chore: Use private key accessor

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryImpl.kt
@@ -17,6 +17,7 @@ import com.bitwarden.data.datasource.disk.ConfigDiskSource
 import com.bitwarden.data.repository.util.appLinksScheme
 import com.bitwarden.data.repository.util.toEnvironmentUrls
 import com.bitwarden.data.repository.util.toEnvironmentUrlsOrDefault
+import com.bitwarden.network.model.AccountKeysJson
 import com.bitwarden.network.model.CreateAccountKeysResponseJson
 import com.bitwarden.network.model.DeleteAccountResponseJson
 import com.bitwarden.network.model.GetTokenResponseJson
@@ -101,6 +102,7 @@ import com.x8bit.bitwarden.data.auth.repository.util.SsoCallbackResult
 import com.x8bit.bitwarden.data.auth.repository.util.WebAuthResult
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
 import com.x8bit.bitwarden.data.auth.repository.util.policyInformation
+import com.x8bit.bitwarden.data.auth.repository.util.toAccountCryptographicState
 import com.x8bit.bitwarden.data.auth.repository.util.toOrganizations
 import com.x8bit.bitwarden.data.auth.repository.util.toRemovedPasswordUserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
@@ -123,7 +125,6 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.VaultSdkSource
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockError
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
-import com.x8bit.bitwarden.data.vault.repository.util.createWrappedAccountCryptographicState
 import com.x8bit.bitwarden.data.vault.repository.util.toSdkMasterPasswordUnlock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -555,9 +556,6 @@ class AuthRepositoryImpl(
                 errorMessage = null,
                 error = MissingPropertyException("Private Key"),
             )
-        val signingKey = accountKeys?.signatureKeyPair?.wrappedSigningKey
-        val securityState = accountKeys?.securityState?.securityState
-        val signedPublicKey = accountKeys?.publicKeyEncryptionKeyPair?.signedPublicKey
 
         checkForVaultUnlockError(
             onVaultUnlockError = { error ->
@@ -565,11 +563,8 @@ class AuthRepositoryImpl(
             },
         ) {
             unlockVault(
-                accountCryptographicState = createWrappedAccountCryptographicState(
+                accountCryptographicState = accountKeys.toAccountCryptographicState(
                     privateKey = privateKey,
-                    securityState = securityState,
-                    signingKey = signingKey,
-                    signedPublicKey = signedPublicKey,
                 ),
                 accountProfile = profile,
                 initUserCryptoMethod = InitUserCryptoMethod.AuthRequest(
@@ -1698,7 +1693,7 @@ class AuthRepositoryImpl(
                 val isNewKeyConnectorUser =
                     loginResponse.userDecryptionOptions?.hasMasterPassword == false &&
                         loginResponse.key == null &&
-                        loginResponse.privateKey == null
+                        loginResponse.privateKeyOrNull() == null
                 val isNotConfirmed = !userConfirmedKeyConnector
 
                 // If a new KeyConnector user is logging in for the first time,
@@ -1773,7 +1768,7 @@ class AuthRepositoryImpl(
         }
         // We continue to store the private key for backwards compatibility. Key connector
         // conversion still relies on the private key.
-        loginResponse.privateKey?.let {
+        loginResponse.privateKeyOrNull()?.let {
             // Only set the value if it's present, since we may have set it already
             // when we completed the key connector conversion.
             authDiskSource.storePrivateKey(userId = userId, privateKey = it)
@@ -1863,7 +1858,7 @@ class AuthRepositoryImpl(
         loginResponse: GetTokenResponseJson.Success,
     ): VaultUnlockResult? {
         val key = loginResponse.key
-        val privateKey = loginResponse.privateKey
+        val privateKey = loginResponse.privateKeyOrNull()
         return if (loginResponse.userDecryptionOptions?.hasMasterPassword != false) {
             // This user has a master password, so we skip the key-connector logic as it is not
             // setup yet. The user can still unlock the vault with their master password.
@@ -1877,18 +1872,9 @@ class AuthRepositoryImpl(
                 )
                 .map {
                     unlockVault(
-                        accountCryptographicState = createWrappedAccountCryptographicState(
-                            privateKey = privateKey,
-                            securityState = loginResponse.accountKeys
-                                ?.securityState
-                                ?.securityState,
-                            signingKey = loginResponse.accountKeys
-                                ?.signatureKeyPair
-                                ?.wrappedSigningKey,
-                            signedPublicKey = loginResponse.accountKeys
-                                ?.publicKeyEncryptionKeyPair
-                                ?.signedPublicKey,
-                        ),
+                        accountCryptographicState = loginResponse
+                            .accountKeys
+                            .toAccountCryptographicState(privateKey = privateKey),
                         accountProfile = profile,
                         initUserCryptoMethod = InitUserCryptoMethod.KeyConnector(
                             masterKey = it.masterKey,
@@ -1916,17 +1902,8 @@ class AuthRepositoryImpl(
                 .map { keyConnectorResponse ->
                     val accountKeys = loginResponse.accountKeys
                     val result = unlockVault(
-                        accountCryptographicState = createWrappedAccountCryptographicState(
+                        accountCryptographicState = accountKeys.toAccountCryptographicState(
                             privateKey = keyConnectorResponse.keys.private,
-                            securityState = accountKeys
-                                ?.securityState
-                                ?.securityState,
-                            signingKey = accountKeys
-                                ?.signatureKeyPair
-                                ?.wrappedSigningKey,
-                            signedPublicKey = accountKeys
-                                ?.publicKeyEncryptionKeyPair
-                                ?.signedPublicKey,
                         ),
                         accountProfile = profile,
                         initUserCryptoMethod = InitUserCryptoMethod.KeyConnector(
@@ -1984,17 +1961,8 @@ class AuthRepositoryImpl(
         )
 
         return unlockVault(
-            accountCryptographicState = createWrappedAccountCryptographicState(
+            accountCryptographicState = loginResponse.accountKeys.toAccountCryptographicState(
                 privateKey = privateKey,
-                securityState = loginResponse.accountKeys
-                    ?.securityState
-                    ?.securityState,
-                signingKey = loginResponse.accountKeys
-                    ?.signatureKeyPair
-                    ?.wrappedSigningKey,
-                signedPublicKey = loginResponse.accountKeys
-                    ?.publicKeyEncryptionKeyPair
-                    ?.signedPublicKey,
             ),
             accountProfile = profile,
             initUserCryptoMethod = initUserCryptoMethod,
@@ -2017,18 +1985,9 @@ class AuthRepositoryImpl(
         if (privateKey != null && key != null) {
             deviceData?.let { model ->
                 return unlockVault(
-                    accountCryptographicState = createWrappedAccountCryptographicState(
-                        privateKey = privateKey,
-                        securityState = loginResponse.accountKeys
-                            ?.securityState
-                            ?.securityState,
-                        signingKey = loginResponse.accountKeys
-                            ?.signatureKeyPair
-                            ?.wrappedSigningKey,
-                        signedPublicKey = loginResponse.accountKeys
-                            ?.publicKeyEncryptionKeyPair
-                            ?.signedPublicKey,
-                    ),
+                    accountCryptographicState = loginResponse
+                        .accountKeys
+                        .toAccountCryptographicState(privateKey = privateKey),
                     accountProfile = profile,
                     initUserCryptoMethod = InitUserCryptoMethod.AuthRequest(
                         requestPrivateKey = model.privateKey,
@@ -2054,36 +2013,14 @@ class AuthRepositoryImpl(
             .userDecryptionOptions
             ?.trustedDeviceUserDecryptionOptions
             ?.let { options ->
-                loginResponse.accountKeys
-                    ?.let { accountKeys ->
-                        unlockVaultWithTrustedDeviceUserDecryptionOptionsAndStoreKeys(
-                            options = options,
-                            profile = profile,
-                            privateKey = accountKeys
-                                .publicKeyEncryptionKeyPair
-                                .wrappedPrivateKey,
-                            securityState = accountKeys
-                                .securityState
-                                ?.securityState,
-                            signedPublicKey = accountKeys
-                                .publicKeyEncryptionKeyPair
-                                .signedPublicKey,
-                            signingKey = accountKeys
-                                .signatureKeyPair
-                                ?.wrappedSigningKey,
-                        )
-                    }
-                    ?: loginResponse.privateKey
-                        ?.let { privateKey ->
-                            unlockVaultWithTrustedDeviceUserDecryptionOptionsAndStoreKeys(
-                                options = options,
-                                profile = profile,
-                                privateKey = privateKey,
-                                securityState = null,
-                                signedPublicKey = null,
-                                signingKey = null,
-                            )
-                        }
+                loginResponse.privateKeyOrNull()?.let { privateKey ->
+                    unlockVaultWithTrustedDeviceUserDecryptionOptionsAndStoreKeys(
+                        options = options,
+                        profile = profile,
+                        privateKey = privateKey,
+                        accountKeys = loginResponse.accountKeys,
+                    )
+                }
             }
     }
 
@@ -2095,9 +2032,7 @@ class AuthRepositoryImpl(
         options: TrustedDeviceUserDecryptionOptionsJson,
         profile: AccountJson.Profile,
         privateKey: String,
-        securityState: String?,
-        signedPublicKey: String?,
-        signingKey: String?,
+        accountKeys: AccountKeysJson?,
     ): VaultUnlockResult? {
         var vaultUnlockResult: VaultUnlockResult? = null
         val userId = profile.userId
@@ -2114,11 +2049,8 @@ class AuthRepositoryImpl(
                     // For approved requests the key will always be present.
                     val userKey = requireNotNull(request.key)
                     vaultUnlockResult = unlockVault(
-                        accountCryptographicState = createWrappedAccountCryptographicState(
+                        accountCryptographicState = accountKeys.toAccountCryptographicState(
                             privateKey = privateKey,
-                            securityState = securityState,
-                            signingKey = signingKey,
-                            signedPublicKey = signedPublicKey,
                         ),
                         accountProfile = profile,
                         initUserCryptoMethod = InitUserCryptoMethod.AuthRequest(
@@ -2146,11 +2078,8 @@ class AuthRepositoryImpl(
         }
 
         vaultUnlockResult = unlockVault(
-            accountCryptographicState = createWrappedAccountCryptographicState(
+            accountCryptographicState = accountKeys.toAccountCryptographicState(
                 privateKey = privateKey,
-                securityState = securityState,
-                signingKey = signingKey,
-                signedPublicKey = signedPublicKey,
             ),
             accountProfile = profile,
             initUserCryptoMethod = InitUserCryptoMethod.DeviceKey(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/AccountKeysJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/repository/util/AccountKeysJsonExtensions.kt
@@ -1,0 +1,23 @@
+package com.x8bit.bitwarden.data.auth.repository.util
+
+import com.bitwarden.core.WrappedAccountCryptographicState
+import com.bitwarden.network.model.AccountKeysJson
+import com.x8bit.bitwarden.data.vault.repository.util.createWrappedAccountCryptographicState
+
+/**
+ * Creates a [WrappedAccountCryptographicState] based on the available cryptographic parameters.
+ *
+ * Returns [WrappedAccountCryptographicState.V2] if signing key, signed public key, and security
+ * state are all present, otherwise returns [WrappedAccountCryptographicState.V1].
+ *
+ * @receiver The users account keys.
+ * @param privateKey The user's wrapped private key.
+ */
+fun AccountKeysJson?.toAccountCryptographicState(
+    privateKey: String,
+): WrappedAccountCryptographicState = createWrappedAccountCryptographicState(
+    privateKey = privateKey,
+    securityState = this?.securityState?.securityState,
+    signingKey = this?.signatureKeyPair?.wrappedSigningKey,
+    signedPublicKey = this?.publicKeyEncryptionKeyPair?.signedPublicKey,
+)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/repository/AuthenticatorBridgeRepositoryImpl.kt
@@ -10,13 +10,13 @@ import com.bitwarden.core.data.util.flatMap
 import com.bitwarden.data.repository.util.toEnvironmentUrlsOrDefault
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
+import com.x8bit.bitwarden.data.auth.repository.util.toAccountCryptographicState
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.platform.repository.util.sanitizeTotpUri
 import com.x8bit.bitwarden.data.vault.datasource.disk.VaultDiskSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.ScopedVaultSdkSource
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.InitializeCryptoResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
-import com.x8bit.bitwarden.data.vault.repository.util.createWrappedAccountCryptographicState
 import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipher
 import com.x8bit.bitwarden.data.vault.repository.util.toVaultUnlockResult
 
@@ -147,22 +147,13 @@ class AuthenticatorBridgeRepositoryImpl(
             ?: return VaultUnlockResult.InvalidStateError(
                 MissingPropertyException("Private key"),
             )
-        val securityState = authDiskSource
-            .getAccountKeys(userId = userId)
-            ?.securityState
-            ?.securityState
-        val signingKey = accountKeys?.signatureKeyPair?.wrappedSigningKey
-        val signedPublicKey = accountKeys?.publicKeyEncryptionKeyPair?.signedPublicKey
 
         return scopedVaultSdkSource
             .initializeCrypto(
                 userId = userId,
                 request = InitUserCryptoRequest(
-                    accountCryptographicState = createWrappedAccountCryptographicState(
+                    accountCryptographicState = accountKeys.toAccountCryptographicState(
                         privateKey = privateKey,
-                        securityState = securityState,
-                        signingKey = signingKey,
-                        signedPublicKey = signedPublicKey,
                     ),
                     userId = userId,
                     kdfParams = account.profile.toSdkParams(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/manager/VaultLockManagerImpl.kt
@@ -28,6 +28,7 @@ import com.x8bit.bitwarden.data.auth.manager.UserLogoutManager
 import com.x8bit.bitwarden.data.auth.repository.model.LogoutReason
 import com.x8bit.bitwarden.data.auth.repository.model.UpdateKdfMinimumsResult
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
+import com.x8bit.bitwarden.data.auth.repository.util.toAccountCryptographicState
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.auth.repository.util.userAccountTokens
 import com.x8bit.bitwarden.data.auth.repository.util.userSwitchingChangesFlow
@@ -40,7 +41,6 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.InitializeCryptoResul
 import com.x8bit.bitwarden.data.vault.manager.model.VaultStateEvent
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockData
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
-import com.x8bit.bitwarden.data.vault.repository.util.createWrappedAccountCryptographicState
 import com.x8bit.bitwarden.data.vault.repository.util.logTag
 import com.x8bit.bitwarden.data.vault.repository.util.statusFor
 import com.x8bit.bitwarden.data.vault.repository.util.toVaultUnlockResult
@@ -681,16 +681,10 @@ class VaultLockManagerImpl(
             ?: return VaultUnlockResult.InvalidStateError(
                 error = MissingPropertyException("Private key"),
             )
-        val signingKey = accountKeys?.signatureKeyPair?.wrappedSigningKey
-        val securityState = accountKeys?.securityState?.securityState
-        val signedPublicKey = accountKeys?.publicKeyEncryptionKeyPair?.signedPublicKey
         val organizationKeys = authDiskSource.getOrganizationKeys(userId = userId)
         return unlockVault(
-            accountCryptographicState = createWrappedAccountCryptographicState(
+            accountCryptographicState = accountKeys.toAccountCryptographicState(
                 privateKey = privateKey,
-                securityState = securityState,
-                signingKey = signingKey,
-                signedPublicKey = signedPublicKey,
             ),
             userId = userId,
             email = account.profile.email,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/VaultRepositoryImpl.kt
@@ -19,6 +19,7 @@ import com.bitwarden.vault.CipherType
 import com.bitwarden.vault.CipherView
 import com.bitwarden.vault.FolderView
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
+import com.x8bit.bitwarden.data.auth.repository.util.toAccountCryptographicState
 import com.x8bit.bitwarden.data.auth.repository.util.toSdkParams
 import com.x8bit.bitwarden.data.autofill.util.login
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
@@ -41,7 +42,6 @@ import com.x8bit.bitwarden.data.vault.repository.model.GenerateTotpResult
 import com.x8bit.bitwarden.data.vault.repository.model.ImportCredentialsResult
 import com.x8bit.bitwarden.data.vault.repository.model.TotpCodeResult
 import com.x8bit.bitwarden.data.vault.repository.model.VaultUnlockResult
-import com.x8bit.bitwarden.data.vault.repository.util.createWrappedAccountCryptographicState
 import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkCipher
 import com.x8bit.bitwarden.data.vault.repository.util.toEncryptedSdkFolder
 import com.x8bit.bitwarden.data.vault.repository.util.toSdkAccount
@@ -539,17 +539,10 @@ class VaultRepositoryImpl(
             ?: return VaultUnlockResult.InvalidStateError(
                 error = MissingPropertyException("Private key"),
             )
-        val signingKey = accountKeys?.signatureKeyPair?.wrappedSigningKey
-        val securityState = accountKeys?.securityState?.securityState
-        val signedPublicKey = accountKeys?.publicKeyEncryptionKeyPair?.signedPublicKey
-        val organizationKeys = authDiskSource
-            .getOrganizationKeys(userId = userId)
+        val organizationKeys = authDiskSource.getOrganizationKeys(userId = userId)
         return vaultLockManager.unlockVault(
-            accountCryptographicState = createWrappedAccountCryptographicState(
+            accountCryptographicState = accountKeys.toAccountCryptographicState(
                 privateKey = privateKey,
-                securityState = securityState,
-                signingKey = signingKey,
-                signedPublicKey = signedPublicKey,
             ),
             userId = userId,
             email = account.profile.email,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/repository/AuthRepositoryTest.kt
@@ -1977,7 +1977,7 @@ class AuthRepositoryTest {
             coVerify { identityService.preLogin(email = EMAIL) }
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -2092,7 +2092,7 @@ class AuthRepositoryTest {
             coVerify { identityService.preLogin(email = EMAIL) }
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -2445,7 +2445,7 @@ class AuthRepositoryTest {
             coVerify { identityService.preLogin(email = EMAIL) }
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -2826,7 +2826,7 @@ class AuthRepositoryTest {
         coVerify { identityService.preLogin(email = EMAIL) }
         fakeAuthDiskSource.assertPrivateKey(
             userId = USER_ID_1,
-            privateKey = "privateKey",
+            privateKey = "mockWrappedPrivateKey-1",
         )
         fakeAuthDiskSource.assertAccountKeys(
             userId = USER_ID_1,
@@ -3095,7 +3095,7 @@ class AuthRepositoryTest {
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -3221,7 +3221,7 @@ class AuthRepositoryTest {
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -3565,7 +3565,7 @@ class AuthRepositoryTest {
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -3639,7 +3639,10 @@ class AuthRepositoryTest {
             )
             assertEquals(LoginResult.Success, result)
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
-            fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = "privateKey")
+            fakeAuthDiskSource.assertPrivateKey(
+                userId = USER_ID_1,
+                privateKey = "mockWrappedPrivateKey-1",
+            )
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = ACCOUNT_KEYS)
             fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = "key")
             coVerify(exactly = 1) {
@@ -3879,7 +3882,7 @@ class AuthRepositoryTest {
             coEvery {
                 vaultRepository.unlockVault(
                     accountCryptographicState = createWrappedAccountCryptographicState(
-                        privateKey = "privateKey",
+                        privateKey = "mockWrappedPrivateKey-1",
                         securityState = null,
                         signedPublicKey = null,
                         signingKey = null,
@@ -3911,7 +3914,10 @@ class AuthRepositoryTest {
 
             assertEquals(LoginResult.Success, result)
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
-            fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = "privateKey")
+            fakeAuthDiskSource.assertPrivateKey(
+                userId = USER_ID_1,
+                privateKey = "mockWrappedPrivateKey-1",
+            )
             fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = "key")
             coVerify(exactly = 1) {
                 identityService.getToken(
@@ -3930,7 +3936,7 @@ class AuthRepositoryTest {
                 )
                 vaultRepository.unlockVault(
                     accountCryptographicState = createWrappedAccountCryptographicState(
-                        privateKey = "privateKey",
+                        privateKey = "mockWrappedPrivateKey-1",
                         securityState = null,
                         signedPublicKey = null,
                         signingKey = null,
@@ -4387,7 +4393,7 @@ class AuthRepositoryTest {
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -4486,7 +4492,10 @@ class AuthRepositoryTest {
 
             assertEquals(LoginResult.Success, result)
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
-            fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = "privateKey")
+            fakeAuthDiskSource.assertPrivateKey(
+                userId = USER_ID_1,
+                privateKey = "mockWrappedPrivateKey-1",
+            )
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = ACCOUNT_KEYS)
             fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = null)
             fakeAuthDiskSource.assertDeviceKey(userId = USER_ID_1, deviceKey = null)
@@ -4584,7 +4593,10 @@ class AuthRepositoryTest {
 
             assertEquals(LoginResult.Success, result)
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
-            fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = "privateKey")
+            fakeAuthDiskSource.assertPrivateKey(
+                userId = USER_ID_1,
+                privateKey = "mockWrappedPrivateKey-1",
+            )
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = ACCOUNT_KEYS)
             fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = encryptedUserKey)
             fakeAuthDiskSource.assertDeviceKey(userId = USER_ID_1, deviceKey = deviceKey)
@@ -4711,7 +4723,10 @@ class AuthRepositoryTest {
 
             assertEquals(LoginResult.Success, result)
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
-            fakeAuthDiskSource.assertPrivateKey(userId = USER_ID_1, privateKey = "privateKey")
+            fakeAuthDiskSource.assertPrivateKey(
+                userId = USER_ID_1,
+                privateKey = "mockWrappedPrivateKey-1",
+            )
             fakeAuthDiskSource.assertAccountKeys(userId = USER_ID_1, accountKeys = ACCOUNT_KEYS)
             fakeAuthDiskSource.assertUserKey(userId = USER_ID_1, userKey = authRequestKey)
             assertEquals(SINGLE_USER_STATE_1, fakeAuthDiskSource.userState)
@@ -4800,7 +4815,7 @@ class AuthRepositoryTest {
             assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -5012,7 +5027,7 @@ class AuthRepositoryTest {
         assertEquals(AuthState.Authenticated(ACCESS_TOKEN), repository.authStateFlow.value)
         fakeAuthDiskSource.assertPrivateKey(
             userId = USER_ID_1,
-            privateKey = "privateKey",
+            privateKey = "mockWrappedPrivateKey-1",
         )
         fakeAuthDiskSource.assertAccountKeys(
             userId = USER_ID_1,
@@ -7389,7 +7404,7 @@ class AuthRepositoryTest {
             coVerify { identityService.preLogin(email = EMAIL) }
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,
@@ -7468,7 +7483,7 @@ class AuthRepositoryTest {
             coVerify { identityService.preLogin(email = EMAIL) }
             fakeAuthDiskSource.assertPrivateKey(
                 userId = USER_ID_1,
-                privateKey = "privateKey",
+                privateKey = "mockWrappedPrivateKey-1",
             )
             fakeAuthDiskSource.assertAccountKeys(
                 userId = USER_ID_1,


### PR DESCRIPTION
## 🎟️ Tracking

NA

## 📔 Objective

This PR updates the way we access the private key from the login response to ensure we are always attempting to retrieve it from the `accountKeys` before falling back to the legacy `privateKey` property. Additionally, a new `AccountKeysJson.toAccountCryptographicState` extension was added to simplify the transformation to a `WrappedAccountCryptographicState`.
