### PR TITLE
bug: Move string to correct resource file

### DIFF
--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1258,4 +1258,6 @@ Do you want to switch to this account?</string>
     <string name="show_next_code">Show next code</string>
     <string name="see_upcoming_codes_in_the_list">See upcoming codes in the list</string>
     <string name="next_code_x">Next code, %1$s</string>
+    <string name="archive_item">Archive item</string>
+    <string name="once_archived_this_item_will_be_excluded">Once archived, this item will be excluded from search results and autofill suggestions.</string>
 </resources>

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -42,8 +42,6 @@
     <string name="avoid_logout_on_kdf_change">Avoid logout on KDF change</string>
     <string name="migrate_my_vault_to_my_items">Migrate My Vault to My Items</string>
     <string name="archive_items">Archive Items</string>
-    <string name="archive_item">Archive item</string>
-    <string name="once_archived_this_item_will_be_excluded">Once archived, this item will be excluded from search results and autofill suggestions.</string>
     <string name="send_email_verification">Send Email Verification</string>
     <string name="trigger_cookie_acquisition">Trigger cookie acquisition</string>
     <string name="clear_sso_cookies">Clear SSO cookies</string>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR moves to archive related strings to the primary strings file to ensure they get localized correctly.
