### PR TITLE
chore: Remove MaxLineLength suppression guidance from testing skill

### DIFF
--- a/.claude/skills/testing-android-code/SKILL.md
+++ b/.claude/skills/testing-android-code/SKILL.md
@@ -245,8 +245,6 @@ fun `test exception`() {
 
 Common testing mistakes in Bitwarden. **For complete details and examples:** See `references/critical-gotchas.md`
 
-> **⛔ STOP — `@Suppress("MaxLineLength")`**: Do NOT add this annotation unless the `fun` declaration line **actually exceeds 100 characters**. Count the characters first. Do not copy it from nearby tests. Detekt will tell you if it's needed — when in doubt, leave it off.
-
 **Core Patterns:**
 - **assertCoroutineThrows + runTest** - Never wrap in `runTest`; call directly
 - **Static mock cleanup** - Always `unmockkStatic()` in `@After`


### PR DESCRIPTION
## 🎟️ Tracking

No ticket — repo tooling cleanup for the `.claude/` Claude Code skill files.

## 📔 Objective

The `testing-android-code` skill contained a prominent STOP block instructing agents when to add `@Suppress(\"MaxLineLength\")`. In practice this primed agents to reach for the annotation reflexively even on lines well under the 100-char limit.

Detekt already runs as a pre-commit hook and flags any line that genuinely exceeds the limit, so in-skill guidance about the suppression is redundant and net-harmful. Removing the block lets detekt serve as the single source of truth.