### PR TITLE
PM-35654: bug: User switch should not occur on soft-logout

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerImpl.kt
@@ -57,7 +57,6 @@ class UserLogoutManagerImpl(
         val ableToSwitchToNewAccount = switchUserIfAvailable(
             currentUserId = userId,
             isSecurityStamp = isSecurityStamp,
-            removeCurrentUserFromAccounts = true,
         )
 
         if (!ableToSwitchToNewAccount) {
@@ -85,12 +84,6 @@ class UserLogoutManagerImpl(
         val pinProtectedUserKey = authDiskSource.getPinProtectedUserKey(userId = userId)
         val pinProtectedUserKeyEnvelope = authDiskSource.getPinProtectedUserKeyEnvelope(
             userId = userId,
-        )
-
-        switchUserIfAvailable(
-            currentUserId = userId,
-            removeCurrentUserFromAccounts = false,
-            isSecurityStamp = isSecurityStamp,
         )
 
         clearData(userId = userId)
@@ -135,7 +128,6 @@ class UserLogoutManagerImpl(
 
     private fun switchUserIfAvailable(
         currentUserId: String,
-        removeCurrentUserFromAccounts: Boolean,
         isSecurityStamp: Boolean,
     ): Boolean {
         val currentUserState = authDiskSource.userState ?: return false
@@ -143,8 +135,7 @@ class UserLogoutManagerImpl(
         val currentAccountsMap = currentUserState.accounts
 
         // Remove the active user from the accounts map
-        val updatedAccounts = currentAccountsMap
-            .filterKeys { it != currentUserId }
+        val updatedAccounts = currentAccountsMap.filterKeys { it != currentUserId }
 
         // Check if there is a new active user
         return if (updatedAccounts.isNotEmpty()) {
@@ -163,11 +154,7 @@ class UserLogoutManagerImpl(
             // Update the user information and emit an updated token
             authDiskSource.userState = currentUserState.copy(
                 activeUserId = updatedActiveUserId,
-                accounts = if (removeCurrentUserFromAccounts) {
-                    updatedAccounts
-                } else {
-                    currentAccountsMap
-                },
+                accounts = updatedAccounts,
             )
             true
         } else {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/auth/manager/UserLogoutManagerTest.kt
@@ -145,7 +145,6 @@ class UserLogoutManagerTest {
         val pinProtectedUserKeyEnvelope = "pinProtectedUserKeyEnvelope"
         val encryptedPin = "encryptedPin"
 
-        every { authDiskSource.userState } returns MULTI_USER_STATE
         every {
             settingsDiskSource.getVaultTimeoutInMinutes(userId = userId)
         } returns vaultTimeoutInMinutes
@@ -186,7 +185,6 @@ class UserLogoutManagerTest {
                 userId = userId,
                 vaultTimeoutAction = vaultTimeoutAction,
             )
-            toastManager.show(messageId = BitwardenString.account_switched_automatically)
             settingsDiskSource.storeVaultTimeoutInMinutes(
                 userId = userId,
                 vaultTimeoutInMinutes = vaultTimeoutInMinutes,
@@ -208,7 +206,7 @@ class UserLogoutManagerTest {
     }
 
     @Test
-    fun `softLogout should switch active user but keep previous user in accounts list`() {
+    fun `softLogout should clear user data but keep the user in accounts list`() {
         val userId = USER_ID_1
         val vaultTimeoutInMinutes = 360
         val vaultTimeoutAction = VaultTimeoutAction.LOGOUT
@@ -216,7 +214,6 @@ class UserLogoutManagerTest {
         val pinProtectedUserKeyEnvelope = "pinProtectedUserKeyEnvelope"
         val encryptedPin = "encryptedPin"
 
-        every { authDiskSource.userState } returns MULTI_USER_STATE
         every {
             settingsDiskSource.getVaultTimeoutInMinutes(userId = userId)
         } returns vaultTimeoutInMinutes
@@ -247,11 +244,6 @@ class UserLogoutManagerTest {
         userLogoutManager.softLogout(userId = userId, reason = LogoutReason.Timeout)
 
         verify(exactly = 1) {
-            authDiskSource.userState = UserStateJson(
-                activeUserId = USER_ID_2,
-                accounts = MULTI_USER_STATE.accounts,
-            )
-            toastManager.show(messageId = BitwardenString.account_switched_automatically)
             settingsDiskSource.storeVaultTimeoutInMinutes(
                 userId = userId,
                 vaultTimeoutInMinutes = vaultTimeoutInMinutes,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35654](https://bitwarden.atlassian.net/browse/PM-35654)

## 📔 Objective

This PR updates the soft-logout flow to not switch the active user. This allows the user to be able to re-login much easier.


[PM-35654]: https://bitwarden.atlassian.net/browse/PM-35654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ