### PR TITLE
[PM-35700] fix(about): localize Version label with parameterized string resource (#6824)

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/about/AboutViewModel.kt
@@ -9,6 +9,7 @@ import com.bitwarden.data.repository.ServerConfigRepository
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
 import com.bitwarden.core.data.manager.util.deviceData
 import com.bitwarden.ui.platform.base.BaseViewModel
+import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.bitwarden.ui.util.concat
@@ -47,7 +48,7 @@ class AboutViewModel @Inject constructor(
     initialState = savedStateHandle[KEY_STATE] ?: run {
         val serverData = serverConfigRepository.serverConfigStateFlow.value?.serverData
         AboutState(
-            version = "Version: ${buildInfoManager.versionData}".asText(),
+            version = BitwardenString.version_x.asText(buildInfoManager.versionData),
             sdkVersion = "\uD83E\uDD80 SDK: ${buildInfoManager.sdkData}".asText(),
             serverData = StringBuilder()
                 .append("\uD83C\uDF29 Server:")

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1077,6 +1077,7 @@ Do you want to switch to this account?</string>
     <string name="security">Security</string>
     <string name="too_many_failed_biometric_attempts">Too many failed biometrics attempts.</string>
     <string name="version">Version</string>
+    <string name="version_x" comment="%1$s is the version string (e.g. 2025.1.0 (1234)).">Version: %1$s</string>
     <string name="learn_more_about_how_to_use_bitwarden_authenticator_on_the_help_center">Learn more about how to use Bitwarden Authenticator on the Help Center.</string>
     <string name="key">Key</string>
     <string name="create_verification_code">Create Verification code</string>


### PR DESCRIPTION
Closes #6824 (PM-35678).

## Problem

On the About screen, the "Version: ..." line was built as an interpolated string:

```kotlin
version = "Version: ${buildInfoManager.versionData}".asText()
```

"Version:" was not a string resource, so Crowdin could not translate it and the label appeared in English regardless of the app's locale.

## Change

- Add `version_x` to the `:ui` module's `values/strings.xml`, following the existing `created` (`"Created: %1$s"`) and `default_text` (`"Default (%1$s)"`) patterns for "Label: ${value}" layouts.
- Use `BitwardenString.version_x.asText(buildInfoManager.versionData)` in `AboutViewModel`.
- Include a `comment` attribute explaining `%1$s` for translators.

Displayed text is unchanged in English ("Version: 2026.4.0 (21434)"). Other locales can now translate the label (including word order or punctuation changes they prefer).

## Why a parameterized string instead of concatenation

The repo consistently uses parameterized strings (`Created: %1$s`, `Default (%1$s)`, `Search %1$s`) rather than concatenation with a hardcoded separator. This keeps locale-specific punctuation and word order in the translator's hands — some languages may want a non-breaking space before the colon, or the value before the label.

## Testing

I did not run `./gradlew app:testStandardDebugUnitTest` locally — no Android SDK in this environment. The change is self-contained: one Kotlin import, one call-site swap, one string-resource addition.

- `AboutViewModelTest.DEFAULT_ABOUT_STATE` is a static `AboutState` fixture passed through `SavedStateHandle`, so it doesn't exercise the initial-state computation path this change touches.
- `AboutScreen.kt` preview (line 332) and `AboutScreenTest.kt` (line 278) build the version string themselves for display-only verification and don't reference `BitwardenString.version_x`, so they don't need updating.

Happy to update tests or adjust if there's a convention I missed.