### PR TITLE
PM-35925: bug: Update 'hexToColor' function to handle default names

### DIFF
--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StringExtensions.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StringExtensions.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.core.graphics.toColorInt
+import timber.log.Timber
 import java.net.URI
 import java.net.URISyntaxException
 import java.text.Normalizer
@@ -169,11 +170,16 @@ fun String.toAnnotatedString(): AnnotatedString = AnnotatedString(text = this)
  * Supported formats:
  * - "rrggbb" / "#rrggbb"
  * - "aarrggbb" / "#aarrggbb"
+ * Support for some default color names per the [toColorInt] function.
  */
-fun String.hexToColor(): Color = if (startsWith("#")) {
-    Color(toColorInt())
-} else {
-    Color("#$this".toColorInt())
+fun String.hexToColor(): Color {
+    val colorString = if (Regex("^[0-9A-Fa-f]+$").matches(this)) "#$this" else this
+    return try {
+        Color(colorString.toColorInt())
+    } catch (e: IllegalArgumentException) {
+        Timber.e(e, "Failed to parse color: $this")
+        Color.Black
+    }
 }
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35925](https://bitwarden.atlassian.net/browse/PM-35925)

## 📔 Objective

This PR updates the `hexToColor()` function to support default names (like teal).

Previously we assumed that the string value would always be a valid hex value with or without the `#`. We now only add the `#` prefix if the value is all digits, otherwise we let the text pass as is. This change allows the default name values such as `teal` to be parsed correctly. If an unsupported value is passed in, we will log the error and default to the color black.


[PM-35925]: https://bitwarden.atlassian.net/browse/PM-35925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ