### PR TITLE
PM-32814: Chore: Parsing lists safely

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/network/di/PlatformNetworkModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/datasource/network/di/PlatformNetworkModule.kt
@@ -19,6 +19,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
 import java.time.Clock
 import javax.inject.Singleton
 
@@ -77,7 +78,9 @@ object PlatformNetworkModule {
     @Singleton
     fun provideBitwardenServiceClient(
         serviceClientConfig: BitwardenServiceClientConfig,
+        json: Json,
     ): BitwardenServiceClient = bitwardenServiceClient(
         config = serviceClientConfig,
+        json = json,
     )
 }

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/network/di/PlatformNetworkModule.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/platform/datasource/network/di/PlatformNetworkModule.kt
@@ -20,6 +20,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
 import java.net.Socket
 import java.security.Principal
 import java.security.PrivateKey
@@ -86,8 +87,10 @@ object PlatformNetworkModule {
     @Singleton
     fun provideBitwardenServiceClient(
         serviceClientConfig: BitwardenServiceClientConfig,
+        json: Json,
     ): BitwardenServiceClient = bitwardenServiceClient(
         config = serviceClientConfig,
+        json = json,
     )
 
     @Provides

--- a/core/src/main/kotlin/com/bitwarden/core/data/serializer/SafeListSerializer.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/serializer/SafeListSerializer.kt
@@ -1,0 +1,35 @@
+package com.bitwarden.core.data.serializer
+
+import com.bitwarden.core.data.util.decodeFromJsonElementOrNull
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonArray
+
+/**
+ * A [KSerializer] for parsing lists of items and allows for the individual items in the array
+ * to fail when deserialize without returning an error. If any number of items fail to be parsed,
+ * they are removed from the list.
+ */
+class SafeListSerializer<T>(
+    private val innerSerializer: KSerializer<T>,
+) : KSerializer<List<T>> {
+    private val listSerializer: KSerializer<List<T>> = ListSerializer(innerSerializer)
+    override val descriptor: SerialDescriptor = listSerializer.descriptor
+
+    override fun serialize(
+        encoder: Encoder,
+        value: List<T>,
+    ): Unit = listSerializer.serialize(encoder, value)
+
+    override fun deserialize(
+        decoder: Decoder,
+    ): List<T> = with(decoder as JsonDecoder) {
+        decodeJsonElement()
+            .jsonArray
+            .mapNotNull { json.decodeFromJsonElementOrNull(innerSerializer, it) }
+    }
+}

--- a/core/src/main/kotlin/com/bitwarden/core/data/util/JsonExtensions.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/util/JsonExtensions.kt
@@ -1,7 +1,25 @@
 package com.bitwarden.core.data.util
 
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Attempts to decode the given JSON [element] into the given type [T]. If there is an error in
+ * processing the JSON or deserializing it to an instance of [T], `null` will be returned.
+ */
+fun <T> Json.decodeFromJsonElementOrNull(
+    deserializer: DeserializationStrategy<T>,
+    element: JsonElement,
+): T? =
+    try {
+        decodeFromJsonElement(deserializer = deserializer, element = element)
+    } catch (_: SerializationException) {
+        null
+    } catch (_: IllegalArgumentException) {
+        null
+    }
 
 /**
  * Attempts to decode the given JSON [string] into the given type [T]. If there is an error in

--- a/core/src/main/kotlin/com/bitwarden/core/di/CoreModule.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/di/CoreModule.kt
@@ -3,6 +3,7 @@ package com.bitwarden.core.di
 import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.serializer.BigDecimalSerializer
 import com.bitwarden.core.data.serializer.InstantSerializer
+import com.bitwarden.core.data.serializer.SafeListSerializer
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -36,6 +37,7 @@ object CoreModule {
         serializersModule = SerializersModule {
             contextual(InstantSerializer())
             contextual(BigDecimalSerializer())
+            contextual(List::class) { args -> SafeListSerializer(args.first()) }
         }
 
         // Respect model default property values.

--- a/core/src/test/kotlin/com/bitwarden/core/data/serializer/SafeListSerializerTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/serializer/SafeListSerializerTest.kt
@@ -1,0 +1,77 @@
+package com.bitwarden.core.data.serializer
+
+import com.bitwarden.core.di.CoreModule
+import io.mockk.mockk
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SafeListSerializerTest {
+    private val json = CoreModule.providesJson(buildInfoManager = mockk(relaxed = true))
+
+    @Test
+    fun `deserializes JSON successfully with invalid items`() {
+        assertEquals(
+            TestClass(data = listOf(TestClass.InnerTestClass(string = "test"))),
+            json.decodeFromString<TestClass>(
+                """
+                {
+                  "data": [
+                    { "string": "test" },
+                    { "string": null }
+                  ]
+                }
+                """,
+            ),
+        )
+    }
+
+    @Test
+    fun `deserializes JSON successfully with null list`() {
+        assertEquals(
+            TestClass(data = null),
+            json.decodeFromString<TestClass>(
+                """
+                {
+                  "data": null
+                }
+                """,
+            ),
+        )
+    }
+
+    @Test
+    fun `serialized JSON successfully`() {
+        assertEquals(
+            buildJsonObject {
+                putJsonArray(key = "data") {
+                    addJsonObject {
+                        put(key = "string", value = "test")
+                    }
+                }
+            },
+            json.encodeToJsonElement(
+                serializer = TestClass.serializer(),
+                value = TestClass(data = listOf(TestClass.InnerTestClass(string = "test"))),
+            ),
+        )
+    }
+}
+
+@Serializable
+private data class TestClass(
+    @Serializable(with = SafeListSerializer::class)
+    @SerialName("data")
+    val data: List<InnerTestClass>?,
+) {
+    @Serializable
+    data class InnerTestClass(
+        @SerialName("string")
+        val string: String,
+    )
+}

--- a/core/src/test/kotlin/com/bitwarden/core/data/util/JsonExtensionsTest.kt
+++ b/core/src/test/kotlin/com/bitwarden/core/data/util/JsonExtensionsTest.kt
@@ -3,12 +3,37 @@ package com.bitwarden.core.data.util
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class JsonExtensionsTest {
     private val json = Json
+
+    @Test
+    fun `decodeFromJsonElementOrNull for valid JSON but an incorrect model should return null`() {
+        assertNull(
+            json.decodeFromJsonElementOrNull(
+                deserializer = TestData.serializer(),
+                element = buildJsonObject {},
+            ),
+        )
+    }
+
+    @Test
+    fun `decodeFromJsonElementOrNull for valid JSON and a correct model should parse correctly`() {
+        assertEquals(
+            TestData(data = "test"),
+            json.decodeFromJsonElementOrNull(
+                deserializer = TestData.serializer(),
+                element = buildJsonObject {
+                    put(key = "data", value = "test")
+                },
+            ),
+        )
+    }
 
     @Test
     fun `decodeFromStringOrNull for invalid JSON should return null`() {

--- a/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClient.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClient.kt
@@ -24,6 +24,7 @@ import com.bitwarden.network.service.OrganizationService
 import com.bitwarden.network.service.PushService
 import com.bitwarden.network.service.SendsService
 import com.bitwarden.network.service.SyncService
+import kotlinx.serialization.json.Json
 
 /**
  * Provides access to Bitwarden services.
@@ -176,4 +177,8 @@ interface BitwardenServiceClient {
  */
 fun bitwardenServiceClient(
     config: BitwardenServiceClientConfig,
-): BitwardenServiceClient = BitwardenServiceClientImpl(config)
+    json: Json,
+): BitwardenServiceClient = BitwardenServiceClientImpl(
+    bitwardenServiceClientConfig = config,
+    clientJson = json,
+)

--- a/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClientImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/BitwardenServiceClientImpl.kt
@@ -1,8 +1,6 @@
 package com.bitwarden.network
 
 import com.bitwarden.annotation.OmitFromCoverage
-import com.bitwarden.core.data.serializer.BigDecimalSerializer
-import com.bitwarden.core.data.serializer.InstantSerializer
 import com.bitwarden.network.interceptor.AuthTokenManager
 import com.bitwarden.network.interceptor.BaseUrlInterceptors
 import com.bitwarden.network.interceptor.CookieInterceptor
@@ -45,8 +43,6 @@ import com.bitwarden.network.service.PushServiceImpl
 import com.bitwarden.network.service.SendsServiceImpl
 import com.bitwarden.network.service.SyncServiceImpl
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.contextual
 import retrofit2.create
 
 /**
@@ -55,6 +51,7 @@ import retrofit2.create
 @OmitFromCoverage
 internal class BitwardenServiceClientImpl(
     private val bitwardenServiceClientConfig: BitwardenServiceClientConfig,
+    private val clientJson: Json,
 ) : BitwardenServiceClient {
 
     private val authTokenManager: AuthTokenManager = AuthTokenManager(
@@ -64,23 +61,7 @@ internal class BitwardenServiceClientImpl(
     override val tokenProvider: TokenProvider = authTokenManager
 
     override val cookieProvider: CookieProvider = bitwardenServiceClientConfig.cookieProvider
-    private val clientJson = Json {
 
-        // If there are keys returned by the server not modeled by a serializable class,
-        // ignore them.
-        // This makes additive server changes non-breaking.
-        ignoreUnknownKeys = true
-
-        // We allow for nullable values to have keys missing in the JSON response.
-        explicitNulls = false
-        serializersModule = SerializersModule {
-            contextual(InstantSerializer())
-            contextual(BigDecimalSerializer())
-        }
-
-        // Respect model default property values.
-        coerceInputValues = true
-    }
     private val retrofits: Retrofits by lazy {
         RetrofitsImpl(
             authTokenManager = authTokenManager,

--- a/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/SyncResponseJson.kt
@@ -36,6 +36,7 @@ data class SyncResponseJson(
     @JsonNames("Profile")
     val profile: Profile,
 
+    @Contextual
     @SerialName("ciphers")
     val ciphers: List<Cipher>?,
 

--- a/network/src/test/kotlin/com/bitwarden/network/service/SyncServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/SyncServiceTest.kt
@@ -310,7 +310,7 @@ private const val SYNC_SUCCESS_JSON = """
         "mockCollectionId-1"
       ],
       "name": "mockName-1",
-      "id": "mockId-1"
+      "id": "mockId-1",
       "fields": [
         {
           "linkedId": 100,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32814](https://bitwarden.atlassian.net/browse/PM-32814)

## 📔 Objective

This PR updates the way we parse lists of ciphers to ensure that the app continues to function even if an unsupported cipher type is received and we cannot parse it.


[PM-32814]: https://bitwarden.atlassian.net/browse/PM-32814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ