### PR TITLE
llm: Codify when-branch brace rule in implementation and review skills

### DIFF
--- a/.claude/skills/implementing-android-code/SKILL.md
+++ b/.claude/skills/implementing-android-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementing-android-code
-version: 0.1.2
+version: 0.1.3
 description: This skill should be used when implementing Android code in Bitwarden. Covers critical patterns, gotchas, and anti-patterns unique to this codebase. Triggered by "How do I implement a ViewModel?", "Create a new screen", "Add navigation", "Write a repository", "BaseViewModel pattern", "State-Action-Event", "type-safe navigation", "@Serializable route", "SavedStateHandle persistence", "process death recovery", "handleAction", "sendAction", "Hilt module", "Repository pattern", "implementing a screen", "adding a data source", "handling navigation", "encrypted storage", "security patterns", "Clock injection", "DataState", or any questions about implementing features, screens, ViewModels, data sources, or navigation in the Bitwarden Android app.
 ---
 
@@ -437,6 +437,42 @@ val FIXED_CLOCK = Clock.fixed(
 
 ---
 
+### I. Kotlin Style Rules
+
+Project-specific style conventions enforced in code review. These supplement (not replace) `docs/STYLE_AND_BEST_PRACTICES.md`.
+
+**`when` branches with wrapped right-hand side require curly braces.**
+
+When a `when` branch's expression is too long to fit on the same line as the arrow and is wrapped to the next line, wrap the body in `{ }`. A bare `->` followed by an indented expression on its own line is rejected in review.
+
+❌ **Wrong** — wrapped body without braces:
+```kotlin
+when (type) {
+    VaultItemCipherType.LOGIN -> VaultAddEditState.ViewState.Content.ItemType.Login()
+    VaultItemCipherType.BANK_ACCOUNT ->
+        VaultAddEditState.ViewState.Content.ItemType.BankAccount()
+    VaultItemCipherType.DRIVERS_LICENSE ->
+        VaultAddEditState.ViewState.Content.ItemType.DriversLicense()
+}
+```
+
+✅ **Right** — wrapped body with braces:
+```kotlin
+when (type) {
+    VaultItemCipherType.LOGIN -> VaultAddEditState.ViewState.Content.ItemType.Login()
+    VaultItemCipherType.BANK_ACCOUNT -> {
+        VaultAddEditState.ViewState.Content.ItemType.BankAccount()
+    }
+    VaultItemCipherType.DRIVERS_LICENSE -> {
+        VaultAddEditState.ViewState.Content.ItemType.DriversLicense()
+    }
+}
+```
+
+Single-line branches (body fits on the same line as `->`) do **not** need braces.
+
+---
+
 ## Bitwarden-Specific Anti-Patterns
 
 **General anti-patterns are documented in CLAUDE.md.** This section covers violations specific to Bitwarden's State-Action-Event, navigation, and data layer patterns:
@@ -478,4 +514,3 @@ For build, test, and codebase discovery commands, use the **`build-test-verify`*
 When pointing to specific code, use: `file_path:line_number`
 
 Example: `ui/src/main/kotlin/com/bitwarden/ui/platform/base/BaseViewModel.kt` (see `handleAction` method)
-

--- a/.claude/skills/reviewing-changes/SKILL.md
+++ b/.claude/skills/reviewing-changes/SKILL.md
@@ -68,7 +68,8 @@ Load reference files only when needed for specific questions:
 - **Security questions (comprehensive)** → `docs/ARCHITECTURE.md#security` (full zero-knowledge architecture)
 - **Testing questions** → `reference/testing-patterns.md` (unit tests, mocking, null safety)
 - **UI questions** → `reference/ui-patterns.md` (Compose patterns, theming)
-- **Style questions** → `docs/STYLE_AND_BEST_PRACTICES.md`
+- **Style questions (project-specific)** → `reference/style-patterns.md` (Kotlin rules enforced in review)
+- **Style questions (general)** → `docs/STYLE_AND_BEST_PRACTICES.md`
 
 ## Core Principles
 

--- a/.claude/skills/reviewing-changes/reference/style-patterns.md
+++ b/.claude/skills/reviewing-changes/reference/style-patterns.md
@@ -1,0 +1,32 @@
+# Style Patterns Quick Reference
+
+Project-specific Kotlin style rules to catch during code review. These supplement (not replace) `docs/STYLE_AND_BEST_PRACTICES.md`.
+
+## `when` branches with wrapped right-hand side require curly braces
+
+When a `when` branch's expression is too long to fit on the same line as `->` and is wrapped to its own line, the body must be wrapped in `{ }`. A bare `->` followed by an indented expression on the next line should be flagged.
+
+**Flag this:**
+
+```kotlin
+when (type) {
+    VaultItemCipherType.LOGIN -> VaultAddEditState.ViewState.Content.ItemType.Login()
+    VaultItemCipherType.BANK_ACCOUNT ->
+        VaultAddEditState.ViewState.Content.ItemType.BankAccount()
+}
+```
+
+**Accept this:**
+
+```kotlin
+when (type) {
+    VaultItemCipherType.LOGIN -> VaultAddEditState.ViewState.Content.ItemType.Login()
+    VaultItemCipherType.BANK_ACCOUNT -> {
+        VaultAddEditState.ViewState.Content.ItemType.BankAccount()
+    }
+}
+```
+
+Single-line branches (body fits alongside `->`) do **not** require braces.
+
+**Suggested classification:** SUGGESTED (style consistency, not correctness).


### PR DESCRIPTION
## 🎟️ Tracking

Recurring style feedback from PR review on #6828 ([comment](https://github.com/bitwarden/android/pull/6828#discussion_r3157515767)). No Jira ticket — Claude tooling change.

## 📔 Objective

Encode the team's `when`-branch brace convention into the Claude skills so it is followed at authoring time and flagged during review:

- **`implementing-android-code` SKILL.md** — adds section _I. Kotlin Style Rules_ with do/don't examples; bumps version to 0.1.3
- **`reviewing-changes` SKILL.md** — adds a new reference pointer for project-specific style questions
- **`reviewing-changes/reference/style-patterns.md`** — new file holding the rule with flag/accept examples and a SUGGESTED severity classification

The rule: when a `when` branch's right-hand side wraps to its own line, wrap the body in `{ }`. Single-line branches do not require braces.

Future Kotlin style rules surfaced in review can join `style-patterns.md` rather than scatter across checklists.