### PR TITLE
[PM-32810] feat: Add Add/Edit support for Bank Account item type

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditBankAccountItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditBankAccountItems.kt
@@ -5,10 +5,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
@@ -98,13 +94,10 @@ fun LazyListScope.vaultAddEditBankAccountItems(
     }
 
     item {
-        var showAccountNumber by rememberSaveable { mutableStateOf(value = false) }
         BitwardenPasswordField(
             label = stringResource(id = BitwardenString.account_number),
             value = bankAccountState.accountNumber,
             onValueChange = bankAccountHandlers.onAccountNumberTextChange,
-            showPassword = showAccountNumber,
-            showPasswordChange = { showAccountNumber = it },
             showPasswordTestTag = "ShowAccountNumberButton",
             passwordFieldTestTag = "AccountNumberEntry",
             cardStyle = CardStyle.Middle(),
@@ -141,13 +134,10 @@ fun LazyListScope.vaultAddEditBankAccountItems(
     }
 
     item {
-        var showPin by rememberSaveable { mutableStateOf(value = false) }
         BitwardenPasswordField(
             label = stringResource(id = BitwardenString.pin),
             value = bankAccountState.pin,
             onValueChange = bankAccountHandlers.onPinTextChange,
-            showPassword = showPin,
-            showPasswordChange = { showPin = it },
             keyboardType = KeyboardType.NumberPassword,
             showPasswordTestTag = "ShowPinButton",
             passwordFieldTestTag = "PinEntry",
@@ -172,13 +162,10 @@ fun LazyListScope.vaultAddEditBankAccountItems(
     }
 
     item {
-        var showIban by rememberSaveable { mutableStateOf(value = false) }
         BitwardenPasswordField(
             label = stringResource(id = BitwardenString.iban),
             value = bankAccountState.iban,
             onValueChange = bankAccountHandlers.onIbanTextChange,
-            showPassword = showIban,
-            showPasswordChange = { showIban = it },
             showPasswordTestTag = "ShowIbanButton",
             passwordFieldTestTag = "IbanEntry",
             cardStyle = CardStyle.Middle(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditBankAccountItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditBankAccountItems.kt
@@ -1,0 +1,203 @@
+package com.x8bit.bitwarden.ui.vault.feature.addedit
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
+import com.bitwarden.ui.platform.components.dropdown.BitwardenMultiSelectButton
+import com.bitwarden.ui.platform.components.field.BitwardenPasswordField
+import com.bitwarden.ui.platform.components.field.BitwardenTextField
+import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
+import com.bitwarden.ui.platform.components.model.CardStyle
+import com.bitwarden.ui.platform.resource.BitwardenString
+import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditBankAccountTypeHandlers
+import com.x8bit.bitwarden.ui.vault.model.VaultBankAccountType
+import com.x8bit.bitwarden.ui.vault.util.longName
+import kotlinx.collections.immutable.toImmutableList
+
+/**
+ * The UI for adding and editing a bank account cipher.
+ */
+@Suppress("LongMethod")
+fun LazyListScope.vaultAddEditBankAccountItems(
+    bankAccountState: VaultAddEditState.ViewState.Content.ItemType.BankAccount,
+    bankAccountHandlers: VaultAddEditBankAccountTypeHandlers,
+) {
+    item {
+        Spacer(modifier = Modifier.height(16.dp))
+        BitwardenListHeaderText(
+            label = stringResource(id = BitwardenString.account_details),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin()
+                .padding(horizontal = 16.dp),
+        )
+    }
+
+    item {
+        Spacer(modifier = Modifier.height(8.dp))
+        BitwardenTextField(
+            label = stringResource(id = BitwardenString.bank_name),
+            value = bankAccountState.bankName,
+            onValueChange = bankAccountHandlers.onBankNameTextChange,
+            textFieldTestTag = "BankNameEntry",
+            cardStyle = CardStyle.Top(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        BitwardenTextField(
+            label = stringResource(id = BitwardenString.name_on_account),
+            value = bankAccountState.nameOnAccount,
+            onValueChange = bankAccountHandlers.onNameOnAccountTextChange,
+            textFieldTestTag = "NameOnAccountEntry",
+            cardStyle = CardStyle.Middle(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        val resources = LocalResources.current
+        BitwardenMultiSelectButton(
+            label = stringResource(id = BitwardenString.account_type),
+            options = VaultBankAccountType
+                .entries
+                .map { it.longName() }
+                .toImmutableList(),
+            selectedOption = bankAccountState.accountType.longName(),
+            onOptionSelected = { selectedString ->
+                bankAccountHandlers.onAccountTypeSelect(
+                    VaultBankAccountType
+                        .entries
+                        .first { it.longName.toString(resources) == selectedString },
+                )
+            },
+            cardStyle = CardStyle.Middle(),
+            modifier = Modifier
+                .testTag("AccountTypePicker")
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        var showAccountNumber by rememberSaveable { mutableStateOf(value = false) }
+        BitwardenPasswordField(
+            label = stringResource(id = BitwardenString.account_number),
+            value = bankAccountState.accountNumber,
+            onValueChange = bankAccountHandlers.onAccountNumberTextChange,
+            showPassword = showAccountNumber,
+            showPasswordChange = { showAccountNumber = it },
+            showPasswordTestTag = "ShowAccountNumberButton",
+            passwordFieldTestTag = "AccountNumberEntry",
+            cardStyle = CardStyle.Middle(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        BitwardenTextField(
+            label = stringResource(id = BitwardenString.routing_number),
+            value = bankAccountState.routingNumber,
+            onValueChange = bankAccountHandlers.onRoutingNumberTextChange,
+            textFieldTestTag = "RoutingNumberEntry",
+            cardStyle = CardStyle.Middle(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        BitwardenTextField(
+            label = stringResource(id = BitwardenString.branch_number),
+            value = bankAccountState.branchNumber,
+            onValueChange = bankAccountHandlers.onBranchNumberTextChange,
+            textFieldTestTag = "BranchNumberEntry",
+            cardStyle = CardStyle.Middle(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        var showPin by rememberSaveable { mutableStateOf(value = false) }
+        BitwardenPasswordField(
+            label = stringResource(id = BitwardenString.pin),
+            value = bankAccountState.pin,
+            onValueChange = bankAccountHandlers.onPinTextChange,
+            showPassword = showPin,
+            showPasswordChange = { showPin = it },
+            keyboardType = KeyboardType.NumberPassword,
+            showPasswordTestTag = "ShowPinButton",
+            passwordFieldTestTag = "PinEntry",
+            cardStyle = CardStyle.Middle(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        BitwardenTextField(
+            label = stringResource(id = BitwardenString.swift_code),
+            value = bankAccountState.swiftCode,
+            onValueChange = bankAccountHandlers.onSwiftCodeTextChange,
+            textFieldTestTag = "SwiftCodeEntry",
+            cardStyle = CardStyle.Middle(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        var showIban by rememberSaveable { mutableStateOf(value = false) }
+        BitwardenPasswordField(
+            label = stringResource(id = BitwardenString.iban),
+            value = bankAccountState.iban,
+            onValueChange = bankAccountHandlers.onIbanTextChange,
+            showPassword = showIban,
+            showPasswordChange = { showIban = it },
+            showPasswordTestTag = "ShowIbanButton",
+            passwordFieldTestTag = "IbanEntry",
+            cardStyle = CardStyle.Middle(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+
+    item {
+        BitwardenTextField(
+            label = stringResource(id = BitwardenString.bank_contact_phone),
+            value = bankAccountState.bankContactPhone,
+            onValueChange = bankAccountHandlers.onBankContactPhoneTextChange,
+            textFieldTestTag = "BankContactPhoneEntry",
+            cardStyle = CardStyle.Bottom,
+            modifier = Modifier
+                .fillMaxWidth()
+                .standardHorizontalMargin(),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditItemContent.kt
@@ -32,6 +32,7 @@ import com.bitwarden.ui.platform.resource.BitwardenString
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
 import com.x8bit.bitwarden.ui.vault.components.collectionItemsSelector
+import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditBankAccountTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCardTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCommonHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditIdentityTypeHandlers
@@ -52,6 +53,7 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
     identityItemTypeHandlers: VaultAddEditIdentityTypeHandlers,
     cardItemTypeHandlers: VaultAddEditCardTypeHandlers,
     sshKeyItemTypeHandlers: VaultAddEditSshKeyTypeHandlers,
+    bankAccountItemTypeHandlers: VaultAddEditBankAccountTypeHandlers,
     isCardScannerEnabled: Boolean,
     cardHolderNameFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
@@ -279,7 +281,13 @@ fun CoachMarkScope<AddEditItemCoachMark>.VaultAddEditContent(
                 )
             }
 
-            is VaultAddEditState.ViewState.Content.ItemType.BankAccount -> Unit
+            is VaultAddEditState.ViewState.Content.ItemType.BankAccount -> {
+                vaultAddEditBankAccountItems(
+                    bankAccountState = state.type,
+                    bankAccountHandlers = bankAccountItemTypeHandlers,
+                )
+            }
+
             is VaultAddEditState.ViewState.Content.ItemType.DriversLicense -> Unit
             is VaultAddEditState.ViewState.Content.ItemType.Passport -> Unit
         }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreen.kt
@@ -82,6 +82,7 @@ import com.x8bit.bitwarden.ui.platform.feature.settings.accountsecurity.PinInput
 import com.x8bit.bitwarden.ui.platform.manager.biometrics.BiometricsManager
 import com.x8bit.bitwarden.ui.platform.manager.permissions.PermissionsManager
 import com.x8bit.bitwarden.ui.tools.feature.generator.model.GeneratorMode
+import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditBankAccountTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCardTypeHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditCommonHandlers
 import com.x8bit.bitwarden.ui.vault.feature.addedit.handlers.VaultAddEditIdentityTypeHandlers
@@ -234,6 +235,10 @@ fun VaultAddEditScreen(
 
     val sshKeyItemTypeHandlers = remember(viewModel) {
         VaultAddEditSshKeyTypeHandlers.create(viewModel = viewModel)
+    }
+
+    val bankAccountItemTypeHandlers = remember(viewModel) {
+        VaultAddEditBankAccountTypeHandlers.create(viewModel = viewModel)
     }
 
     val archiveClickAction = { viewModel.trySendAction(VaultAddEditAction.Common.ArchiveClick) }
@@ -417,6 +422,7 @@ fun VaultAddEditScreen(
                         identityItemTypeHandlers = identityItemTypeHandlers,
                         cardItemTypeHandlers = cardItemTypeHandlers,
                         sshKeyItemTypeHandlers = sshKeyItemTypeHandlers,
+                        bankAccountItemTypeHandlers = bankAccountItemTypeHandlers,
                         isCardScannerEnabled = state.isCardScannerEnabled,
                         cardHolderNameFocusRequester = cardHolderNameFocusRequester,
                         lazyListState = lazyListState,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -310,6 +310,10 @@ class VaultAddEditViewModel @Inject constructor(
             is VaultAddEditAction.ItemType.IdentityType -> handleIdentityTypeActions(action)
             is VaultAddEditAction.ItemType.CardType -> handleCardTypeActions(action)
             is VaultAddEditAction.ItemType.SshKeyType -> handleSshKeyTypeActions(action)
+            is VaultAddEditAction.ItemType.BankAccountType -> {
+                handleBankAccountTypeActions(action)
+            }
+
             is VaultAddEditAction.Internal -> handleInternalActions(action)
         }
     }
@@ -1691,6 +1695,57 @@ class VaultAddEditViewModel @Inject constructor(
 
     //endregion SSH Key Type Handlers
 
+    //region Bank Account Type Handlers
+
+    @Suppress("LongMethod")
+    private fun handleBankAccountTypeActions(
+        action: VaultAddEditAction.ItemType.BankAccountType,
+    ) {
+        when (action) {
+            is VaultAddEditAction.ItemType.BankAccountType.BankNameTextChange -> {
+                updateBankAccountContent { it.copy(bankName = action.bankName) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.NameOnAccountTextChange -> {
+                updateBankAccountContent { it.copy(nameOnAccount = action.nameOnAccount) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.AccountTypeSelect -> {
+                updateBankAccountContent { it.copy(accountType = action.accountType) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.AccountNumberTextChange -> {
+                updateBankAccountContent { it.copy(accountNumber = action.accountNumber) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.RoutingNumberTextChange -> {
+                updateBankAccountContent { it.copy(routingNumber = action.routingNumber) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.BranchNumberTextChange -> {
+                updateBankAccountContent { it.copy(branchNumber = action.branchNumber) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.PinTextChange -> {
+                updateBankAccountContent { it.copy(pin = action.pin) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.SwiftCodeTextChange -> {
+                updateBankAccountContent { it.copy(swiftCode = action.swiftCode) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.IbanTextChange -> {
+                updateBankAccountContent { it.copy(iban = action.iban) }
+            }
+
+            is VaultAddEditAction.ItemType.BankAccountType.BankContactPhoneTextChange -> {
+                updateBankAccountContent { it.copy(bankContactPhone = action.phone) }
+            }
+        }
+    }
+
+    //endregion Bank Account Type Handlers
+
     //region Internal Type Handlers
 
     private fun handleInternalActions(action: VaultAddEditAction.Internal) {
@@ -2448,6 +2503,16 @@ class VaultAddEditViewModel @Inject constructor(
         }
     }
 
+    private inline fun updateBankAccountContent(
+        crossinline block: (VaultAddEditState.ViewState.Content.ItemType.BankAccount) ->
+        VaultAddEditState.ViewState.Content.ItemType.BankAccount,
+    ) {
+        updateContent { currentContent ->
+            (currentContent.type as? VaultAddEditState.ViewState.Content.ItemType.BankAccount)
+                ?.let { currentContent.copy(type = block(it)) }
+        }
+    }
+
     @Suppress("MaxLineLength")
     private suspend fun VaultAddEditState.ViewState.Content.createCipherForAddAndCloneItemStates(): CreateCipherResult {
         return common.selectedOwner?.collections
@@ -2952,6 +3017,17 @@ data class VaultAddEditState(
 
                 /**
                  * Represents the bank account item information.
+                 *
+                 * @property bankName The name of the bank.
+                 * @property nameOnAccount The name on the bank account.
+                 * @property accountType The selected bank account type.
+                 * @property accountNumber The bank account number.
+                 * @property routingNumber The bank routing number.
+                 * @property branchNumber The bank branch number.
+                 * @property pin The bank account PIN.
+                 * @property swiftCode The bank SWIFT code.
+                 * @property iban The bank IBAN.
+                 * @property bankContactPhone The bank contact phone number.
                  */
                 @Parcelize
                 data class BankAccount(
@@ -3947,6 +4023,64 @@ sealed class VaultAddEditAction {
              * Fired when the private key's visibility has changed.
              */
             data class PrivateKeyVisibilityChange(val isVisible: Boolean) : SshKeyType()
+        }
+
+        /**
+         * Represents actions specific to the Bank Account type.
+         */
+        sealed class BankAccountType : ItemType() {
+
+            /**
+             * Fired when the bank name text input is changed.
+             */
+            data class BankNameTextChange(val bankName: String) : BankAccountType()
+
+            /**
+             * Fired when the name on account text input is changed.
+             */
+            data class NameOnAccountTextChange(val nameOnAccount: String) : BankAccountType()
+
+            /**
+             * Fired when the account type is selected.
+             */
+            data class AccountTypeSelect(
+                val accountType: VaultBankAccountType,
+            ) : BankAccountType()
+
+            /**
+             * Fired when the account number text input is changed.
+             */
+            data class AccountNumberTextChange(val accountNumber: String) : BankAccountType()
+
+            /**
+             * Fired when the routing number text input is changed.
+             */
+            data class RoutingNumberTextChange(val routingNumber: String) : BankAccountType()
+
+            /**
+             * Fired when the branch number text input is changed.
+             */
+            data class BranchNumberTextChange(val branchNumber: String) : BankAccountType()
+
+            /**
+             * Fired when the PIN text input is changed.
+             */
+            data class PinTextChange(val pin: String) : BankAccountType()
+
+            /**
+             * Fired when the SWIFT code text input is changed.
+             */
+            data class SwiftCodeTextChange(val swiftCode: String) : BankAccountType()
+
+            /**
+             * Fired when the IBAN text input is changed.
+             */
+            data class IbanTextChange(val iban: String) : BankAccountType()
+
+            /**
+             * Fired when the bank contact phone text input is changed.
+             */
+            data class BankContactPhoneTextChange(val phone: String) : BankAccountType()
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditBankAccountTypeHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditBankAccountTypeHandlers.kt
@@ -1,0 +1,113 @@
+package com.x8bit.bitwarden.ui.vault.feature.addedit.handlers
+
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditAction
+import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditViewModel
+import com.x8bit.bitwarden.ui.vault.model.VaultBankAccountType
+
+/**
+ * A collection of handler functions for managing user interactions on the Bank Account
+ * portion of the Add/Edit cipher screen.
+ *
+ * @property onBankNameTextChange Handles changes to the bank name text input.
+ * @property onNameOnAccountTextChange Handles changes to the name on account text input.
+ * @property onAccountTypeSelect Handles selection of the account type.
+ * @property onAccountNumberTextChange Handles changes to the account number text input.
+ * @property onRoutingNumberTextChange Handles changes to the routing number text input.
+ * @property onBranchNumberTextChange Handles changes to the branch number text input.
+ * @property onPinTextChange Handles changes to the PIN text input.
+ * @property onSwiftCodeTextChange Handles changes to the SWIFT code text input.
+ * @property onIbanTextChange Handles changes to the IBAN text input.
+ * @property onBankContactPhoneTextChange Handles changes to the bank contact phone text input.
+ */
+@Suppress("LongParameterList")
+data class VaultAddEditBankAccountTypeHandlers(
+    val onBankNameTextChange: (String) -> Unit,
+    val onNameOnAccountTextChange: (String) -> Unit,
+    val onAccountTypeSelect: (VaultBankAccountType) -> Unit,
+    val onAccountNumberTextChange: (String) -> Unit,
+    val onRoutingNumberTextChange: (String) -> Unit,
+    val onBranchNumberTextChange: (String) -> Unit,
+    val onPinTextChange: (String) -> Unit,
+    val onSwiftCodeTextChange: (String) -> Unit,
+    val onIbanTextChange: (String) -> Unit,
+    val onBankContactPhoneTextChange: (String) -> Unit,
+) {
+    @Suppress("UndocumentedPublicClass")
+    companion object {
+
+        /**
+         * Creates an instance of [VaultAddEditBankAccountTypeHandlers] by binding actions to the
+         * provided [VaultAddEditViewModel].
+         */
+        @Suppress("LongMethod")
+        fun create(viewModel: VaultAddEditViewModel): VaultAddEditBankAccountTypeHandlers =
+            VaultAddEditBankAccountTypeHandlers(
+                onBankNameTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.BankNameTextChange(
+                            bankName = it,
+                        ),
+                    )
+                },
+                onNameOnAccountTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.NameOnAccountTextChange(
+                            nameOnAccount = it,
+                        ),
+                    )
+                },
+                onAccountTypeSelect = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.AccountTypeSelect(
+                            accountType = it,
+                        ),
+                    )
+                },
+                onAccountNumberTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.AccountNumberTextChange(
+                            accountNumber = it,
+                        ),
+                    )
+                },
+                onRoutingNumberTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.RoutingNumberTextChange(
+                            routingNumber = it,
+                        ),
+                    )
+                },
+                onBranchNumberTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.BranchNumberTextChange(
+                            branchNumber = it,
+                        ),
+                    )
+                },
+                onPinTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.PinTextChange(pin = it),
+                    )
+                },
+                onSwiftCodeTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.SwiftCodeTextChange(
+                            swiftCode = it,
+                        ),
+                    )
+                },
+                onIbanTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.IbanTextChange(iban = it),
+                    )
+                },
+                onBankContactPhoneTextChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.BankAccountType.BankContactPhoneTextChange(
+                            phone = it,
+                        ),
+                    )
+                },
+            )
+    }
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemViewModel.kt
@@ -1619,9 +1619,7 @@ data class VaultItemState(
     val isFabVisible: Boolean
         get() = viewState is ViewState.Content &&
             !isCipherDeleted &&
-            isCipherEditable &&
-            // TODO: [PM-32810] Re-enable once Bank Account add/edit is wired.
-            viewState.asContentOrNull()?.type !is ViewState.Content.ItemType.BankAccount
+            isCipherEditable
 
     /**
      * Whether the cipher is in a collection.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -3382,9 +3382,7 @@ data class VaultItemListingState(
              */
             data object BankAccount : Vault() {
                 override val titleText: Text get() = BitwardenString.bank_accounts.asText()
-
-                // TODO: [PM-32810] Re-enable once Bank Account add/edit is wired.
-                override val hasFab: Boolean get() = false
+                override val hasFab: Boolean get() = true
             }
 
             /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -68,6 +68,7 @@ import com.x8bit.bitwarden.ui.vault.feature.addedit.model.CustomFieldAction
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.CustomFieldType
 import com.x8bit.bitwarden.ui.vault.feature.addedit.model.UriItem
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
+import com.x8bit.bitwarden.ui.vault.model.VaultBankAccountType
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 import com.x8bit.bitwarden.ui.vault.model.VaultCardExpirationMonth
 import com.x8bit.bitwarden.ui.vault.model.VaultCollection
@@ -2609,6 +2610,176 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `in ItemType_BankAccount changing bank name should trigger BankNameTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "Bank name")
+            .performTextInput(text = "TestBank")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.BankNameTextChange(
+                    bankName = "TestBank",
+                ),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_BankAccount changing the name on account text field should trigger NameOnAccountTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "Name on account")
+            .performTextInput(text = "TestNameOnAccount")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.NameOnAccountTextChange(
+                    nameOnAccount = "TestNameOnAccount",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `in ItemType_BankAccount selecting an account type should trigger AccountTypeSelect`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        // Opens the menu
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "-- Select --. Account type")
+            .performClick()
+
+        // Choose the option from the menu
+        composeTestRule
+            .onAllNodesWithText(text = "Checking")
+            .onLast()
+            .performScrollTo()
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.AccountTypeSelect(
+                    accountType = VaultBankAccountType.CHECKING,
+                ),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_BankAccount changing the account number text field should trigger AccountNumberTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "Account number")
+            .performTextInput(text = "TestAccountNumber")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.AccountNumberTextChange(
+                    accountNumber = "TestAccountNumber",
+                ),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_BankAccount changing the routing number text field should trigger RoutingNumberTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "Routing number")
+            .performTextInput(text = "TestRoutingNumber")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.RoutingNumberTextChange(
+                    routingNumber = "TestRoutingNumber",
+                ),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_BankAccount changing the branch number text field should trigger BranchNumberTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "Branch number")
+            .performTextInput(text = "TestBranchNumber")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.BranchNumberTextChange(
+                    branchNumber = "TestBranchNumber",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `in ItemType_BankAccount changing the PIN text field should trigger PinTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "PIN")
+            .performTextInput(text = "1234")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.PinTextChange(pin = "1234"),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_BankAccount changing the SWIFT code text field should trigger SwiftCodeTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "SWIFT code")
+            .performTextInput(text = "TestSwiftCode")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.SwiftCodeTextChange(
+                    swiftCode = "TestSwiftCode",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `in ItemType_BankAccount changing the IBAN text field should trigger IbanTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "IBAN")
+            .performTextInput(text = "TestIban")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.IbanTextChange(iban = "TestIban"),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_BankAccount changing the bank contact phone text field should trigger BankContactPhoneTextChange`() {
+        mutableStateFlow.value = DEFAULT_STATE_BANK_ACCOUNT
+        composeTestRule
+            .onNodeWithTextAfterScroll(text = "Bank contact phone")
+            .performTextInput(text = "555-1234")
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.BankContactPhoneTextChange(
+                    phone = "555-1234",
+                ),
+            )
+        }
+    }
+
+    @Test
     fun `clicking Add field button should allow creation of Linked type`() {
         mutableStateFlow.value = DEFAULT_STATE_LOGIN
 
@@ -4692,6 +4863,22 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             viewState = VaultAddEditState.ViewState.Content(
                 common = VaultAddEditState.ViewState.Content.Common(),
                 type = VaultAddEditState.ViewState.Content.ItemType.Card(),
+                isIndividualVaultDisabled = false,
+            ),
+            dialog = null,
+            bottomSheetState = null,
+            shouldShowCoachMarkTour = false,
+            defaultUriMatchType = UriMatchTypeModel.EXACT,
+            hasPremium = false,
+            isCardScannerEnabled = false,
+        )
+
+        private val DEFAULT_STATE_BANK_ACCOUNT = VaultAddEditState(
+            vaultAddEditType = VaultAddEditType.AddItem,
+            cipherType = VaultItemCipherType.BANK_ACCOUNT,
+            viewState = VaultAddEditState.ViewState.Content(
+                common = VaultAddEditState.ViewState.Content.Common(),
+                type = VaultAddEditState.ViewState.Content.ItemType.BankAccount(),
                 isIndividualVaultDisabled = false,
             ),
             dialog = null,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -96,6 +96,7 @@ import com.x8bit.bitwarden.ui.vault.feature.addedit.util.createMockPasskeyAttest
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.toDefaultAddTypeContent
 import com.x8bit.bitwarden.ui.vault.feature.addedit.util.toViewState
 import com.x8bit.bitwarden.ui.vault.model.VaultAddEditType
+import com.x8bit.bitwarden.ui.vault.model.VaultBankAccountType
 import com.x8bit.bitwarden.ui.vault.model.VaultCardBrand
 import com.x8bit.bitwarden.ui.vault.model.VaultCardExpirationMonth
 import com.x8bit.bitwarden.ui.vault.model.VaultCollection
@@ -4006,6 +4007,185 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             viewModel.trySendAction(action)
 
             assertEquals(expectedState, viewModel.stateFlow.value)
+        }
+    }
+
+    @Nested
+    inner class VaultAddEditBankAccountTypeItemActions {
+        private lateinit var viewModel: VaultAddEditViewModel
+        private lateinit var vaultAddItemInitialState: VaultAddEditState
+        private lateinit var bankAccountInitialSavedStateHandle: SavedStateHandle
+
+        @BeforeEach
+        fun setup() {
+            mutableVaultDataFlow.value = DataState.Loaded(
+                createVaultData(cipherListView = createMockCipherListView(1)),
+            )
+            vaultAddItemInitialState = createVaultAddItemState(
+                vaultItemCipherType = VaultItemCipherType.BANK_ACCOUNT,
+                typeContentViewState =
+                    VaultAddEditState.ViewState.Content.ItemType.BankAccount(),
+            )
+            bankAccountInitialSavedStateHandle = createSavedStateHandleWithState(
+                state = vaultAddItemInitialState,
+                vaultAddEditType = VaultAddEditType.AddItem,
+                vaultItemCipherType = VaultItemCipherType.BANK_ACCOUNT,
+            )
+            viewModel = createAddVaultItemViewModel(
+                savedStateHandle = bankAccountInitialSavedStateHandle,
+            )
+        }
+
+        private fun expectedBankAccount(
+            block: VaultAddEditState.ViewState.Content.ItemType.BankAccount.() ->
+            VaultAddEditState.ViewState.Content.ItemType.BankAccount,
+        ): VaultAddEditState =
+            createVaultAddItemState(
+                vaultItemCipherType = VaultItemCipherType.BANK_ACCOUNT,
+                typeContentViewState = VaultAddEditState
+                    .ViewState
+                    .Content
+                    .ItemType
+                    .BankAccount()
+                    .block(),
+            )
+
+        @Test
+        fun `BankNameTextChange should update bank name`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.BankNameTextChange(
+                    bankName = "First National",
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(bankName = "First National") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `NameOnAccountTextChange should update name on account`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.NameOnAccountTextChange(
+                    nameOnAccount = "John Doe",
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(nameOnAccount = "John Doe") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `AccountTypeSelect should update account type`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.AccountTypeSelect(
+                    accountType = VaultBankAccountType.CHECKING,
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(accountType = VaultBankAccountType.CHECKING) },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `AccountNumberTextChange should update account number`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.AccountNumberTextChange(
+                    accountNumber = "12345",
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(accountNumber = "12345") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `RoutingNumberTextChange should update routing number`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.RoutingNumberTextChange(
+                    routingNumber = "021000021",
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(routingNumber = "021000021") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `BranchNumberTextChange should update branch number`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.BranchNumberTextChange(
+                    branchNumber = "001",
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(branchNumber = "001") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `PinTextChange should update PIN`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.PinTextChange(pin = "1234"),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(pin = "1234") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `SwiftCodeTextChange should update SWIFT code`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.SwiftCodeTextChange(
+                    swiftCode = "BOFAUS3N",
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(swiftCode = "BOFAUS3N") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `IbanTextChange should update IBAN`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.IbanTextChange(
+                    iban = "GB29NWBK60161331926819",
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(iban = "GB29NWBK60161331926819") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `BankContactPhoneTextChange should update bank contact phone`() = runTest {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.BankAccountType.BankContactPhoneTextChange(
+                    phone = "555-0100",
+                ),
+            )
+
+            assertEquals(
+                expectedBankAccount { copy(bankContactPhone = "555-0100") },
+                viewModel.stateFlow.value,
+            )
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/item/VaultItemScreenTest.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasScrollToNodeAction
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isDialog
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onAllNodesWithContentDescription
@@ -23,6 +25,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onSiblings
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.core.net.toUri
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
@@ -3455,8 +3458,11 @@ class VaultItemScreenTest : BitwardenComposeTest() {
     fun `in bank account state, on copy name on account click should send CopyNameOnAccountClick`() {
         mutableStateFlow.update { it.copy(viewState = DEFAULT_BANK_ACCOUNT_VIEW_STATE) }
         composeTestRule
-            .onNodeWithContentDescriptionAfterScroll("Copy name on account")
-            .performClick()
+            .onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasTestTag("BankAccountCopyNameOnAccountButton"))
+        composeTestRule
+            .onNodeWithTag("BankAccountCopyNameOnAccountButton")
+            .performSemanticsAction(SemanticsActions.OnClick)
 
         verify(exactly = 1) {
             viewModel.trySendAction(
@@ -3507,10 +3513,10 @@ class VaultItemScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `in bank account state, edit fab should not be displayed`() {
+    fun `in bank account state, edit fab should be displayed`() {
         mutableStateFlow.update { it.copy(viewState = DEFAULT_BANK_ACCOUNT_VIEW_STATE) }
 
-        composeTestRule.onNodeWithContentDescription("Edit item").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Edit item").assertIsDisplayed()
     }
 
     //endregion bank account

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -2972,7 +2972,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                     viewState = VaultItemListingState.ViewState.NoItems(
                         header = null,
                         message = BitwardenString.no_bank_accounts.asText(),
-                        shouldShowAddButton = false,
+                        shouldShowAddButton = true,
                         buttonText = BitwardenString.new_bank_account.asText(),
                     ),
                 ),
@@ -6352,6 +6352,11 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
             mutableSnackbarDataFlow.tryEmit(snackbarData)
             assertEquals(VaultItemListingEvent.ShowSnackbar(data = snackbarData), awaitItem())
         }
+    }
+
+    @Test
+    fun `BankAccount listing type should display the FAB`() {
+        assertTrue(VaultItemListingState.ItemListingType.Vault.BankAccount.hasFab)
     }
 
     private fun setupFido2CreateRequest(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
@@ -913,7 +913,7 @@ class VaultItemListingDataExtensionsTest {
         assertEquals(
             VaultItemListingState.ViewState.NoItems(
                 message = BitwardenString.no_bank_accounts.asText(),
-                shouldShowAddButton = false,
+                shouldShowAddButton = true,
                 buttonText = BitwardenString.new_bank_account.asText(),
             ),
             vaultData.toViewState(

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1352,5 +1352,6 @@ Do you want to switch to this account?</string>
     <string name="issue_date">Issue date</string>
     <string name="expiration_date">Expiration date</string>
     <string name="details">Details</string>
+    <string name="account_details">Account details</string>
     <string name="no_bank_accounts">There are no bank accounts in your vault.</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32810](https://bitwarden.atlassian.net/browse/PM-32810)

Stacked parent: #6875

## 📔 Objective

Wire the Bank Account form into the Add/Edit screen so users can create new bank account entries and edit existing ones, including locally-managed visibility toggles for sensitive fields.

## 📸 Screenshots

| Figma | Actual |
|--------|--------|
| N/A | <img width="365" src="https://github.com/user-attachments/assets/868db309-0968-4c2d-bec6-646ec3a4397d" /> |
| <img width="365" src="https://github.com/user-attachments/assets/e4055bbc-37e7-4e96-90a8-5d387a86b4f9" /> | <img width="365" src="https://github.com/user-attachments/assets/a8a3e413-5146-4eef-bb19-31dc496accb6" /> | 




[PM-32810]: https://bitwarden.atlassian.net/browse/PM-32810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ