### PR TITLE
llm: Expand string resource naming convention in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,7 +99,7 @@ User Request (UI Action)
 - **Formatter**: Android Studio with `bitwarden-style.xml` | **Line Limit**: 100 chars | **Detekt**: Enabled
 - **Naming**: `camelCase` (vars/fns), `PascalCase` (classes), `SCREAMING_SNAKE_CASE` (constants), `...Impl` (implementations)
 - **KDoc**: Required for all public APIs
-- **String Resources**: Add new strings to `:ui` module (`ui/src/main/res/values/strings.xml`). Use typographic quotes/apostrophes (`"` `"` `'`) not escaped ASCII (`\"` `\'`)
+- **String Resources**: Add new strings to `:ui` module (`ui/src/main/res/values/strings.xml`). Use typographic quotes/apostrophes (`"` `"` `'`) not escaped ASCII (`\"` `\'`). Name each resource from its own text content in `snake_case` — not with generic suffixes (`_message`, `_title`). E.g., `one_or_more_email_addresses_are_incorrect`, not `invalid_email_addresses_message`.
 
 > For complete style rules (imports, formatting, documentation, Compose conventions), see `docs/STYLE_AND_BEST_PRACTICES.md`.
 


### PR DESCRIPTION
## 🎟️ Tracking

Internal tooling improvement — no Jira ticket.

## 📔 Objective

Expands the string resource guidance in `CLAUDE.md` to include the naming convention: each resource name should be derived from its own text content in `snake_case`, rather than using generic suffixes like `_message` or `_title`.

For example:
- `one_or_more_email_addresses_are_incorrect` ✅
- `invalid_email_addresses_message` ❌

This helps Claude (and contributors) produce consistent, self-documenting string resource names from the start, reducing review churn.