### PR TITLE
[PM-35434] Update renovate config to remove bundler group and add t:deps label

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,16 +32,6 @@
         "/org.jetbrains.kotlin.*/",
         "/com.google.devtools.ksp/"
       ]
-    },
-    {
-      "groupName": "bundler minor",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "matchManagers": [
-        "bundler"
-      ]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "github>bitwarden/renovate-config"
   ],
+  "labels": ["t:deps"],
   "ignoreDeps": ["com.bitwarden:sdk-android"],
   "enabledManagers": [
     "github-actions",


### PR DESCRIPTION
## 🎟️ Tracking

PM-35434

## 📔 Objective

We found additional libs that are mostly updated with minor / patch values and renovate should create it’s own PR for each update. We’ll keep the GitHub Actions group for now.

While at it, set the t:deps label so all Renovate PRs are opened correctly.