### PR TITLE
PM-36475: bug: Update when search icon is shown

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -2972,7 +2972,10 @@ data class VaultItemListingState(
      * Whether the search icon should be shown.
      */
     val shouldShowSearchIcon: Boolean
-        get() = viewState is ViewState.Content
+        get() = viewState is ViewState.Content ||
+            isAutofill ||
+            isTotp ||
+            isCredentialManagerCreation
 
     /**
      * Whether the overflow menu should be shown.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36475](https://bitwarden.atlassian.net/browse/PM-36475)

## 📔 Objective

This PR updates when the search icon is displayed on the Vault Item Listing Screen. We were hiding the icon when not in the content state but we need to display it when in various Autofill states as ell to allow users to search for pre-existing unmatched items.


[PM-36475]: https://bitwarden.atlassian.net/browse/PM-36475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ