### PR TITLE
PM-36474: bug: Ensure shared totp labels do not parse secret

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/util/SharedAccountDataExtensions.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/data/authenticator/repository/util/SharedAccountDataExtensions.kt
@@ -25,7 +25,8 @@ fun List<SharedAccountData.Account>.toAuthenticatorItems(): List<AuthenticatorIt
                     .pathSegments
                     .firstOrNull()
                     ?.removePrefix("$issuer:")
-                    ?.takeUnless { it.isBlank() }
+                    // If there is no scheme, then the whole uri is the secret.
+                    ?.takeUnless { it.isBlank() || uri.scheme == null }
                     ?: cipherData.username
 
                 AuthenticatorItem(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36474](https://bitwarden.atlassian.net/browse/PM-36474)

## 📔 Objective

This PR ensures that we do not parse the totp label as the secret for manually entered codes.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="350" src="https://github.com/user-attachments/assets/68138a5f-0fc0-413e-92f0-e00db1e78621" /> | <img width="350" src="https://github.com/user-attachments/assets/f64ef493-e9aa-406e-81f3-94a643899a8f" /> |


[PM-36474]: https://bitwarden.atlassian.net/browse/PM-36474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ