### PR TITLE
[PM-32810] feat: Add Bank Account vault, listing, and search surfaces

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
@@ -42,6 +42,7 @@ enum class SearchableItemType {
     VAULT_FOLDER,
     VAULT_TRASH,
     VAULT_VERIFICATION_CODES,
+    VAULT_BANK_ACCOUNTS,
 }
 
 /**
@@ -72,6 +73,7 @@ fun SavedStateHandle.toSearchArgs(): SearchArgs {
             SearchableItemType.VAULT_NO_FOLDER -> SearchType.Vault.NoFolder
             SearchableItemType.VAULT_TRASH -> SearchType.Vault.Trash
             SearchableItemType.VAULT_VERIFICATION_CODES -> SearchType.Vault.VerificationCodes
+            SearchableItemType.VAULT_BANK_ACCOUNTS -> SearchType.Vault.BankAccounts
             SearchableItemType.VAULT_FOLDER -> SearchType.Vault.Folder(
                 folderId = requireNotNull(route.id),
             )
@@ -140,6 +142,7 @@ private fun SearchType.toSearchableItemType(): SearchableItemType =
         SearchType.Vault.VerificationCodes -> SearchableItemType.VAULT_VERIFICATION_CODES
         SearchType.Vault.SshKeys -> SearchableItemType.VAULT_SSH_KEYS
         SearchType.Vault.Archive -> SearchableItemType.VAULT_ARCHIVE
+        SearchType.Vault.BankAccounts -> SearchableItemType.VAULT_BANK_ACCOUNTS
     }
 
 private fun SearchType.toIdOrNull(): String? =
@@ -159,4 +162,5 @@ private fun SearchType.toIdOrNull(): String? =
         SearchType.Vault.VerificationCodes -> null
         SearchType.Vault.SshKeys -> null
         SearchType.Vault.Archive -> null
+        SearchType.Vault.BankAccounts -> null
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModel.kt
@@ -350,6 +350,14 @@ class SearchViewModel @Inject constructor(
                 handleCopyNumberClick(overflowAction)
             }
 
+            is ListingItemOverflowAction.VaultAction.CopyAccountNumberClick -> {
+                handleCopyAccountNumberClick(overflowAction)
+            }
+
+            is ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick -> {
+                handleCopyRoutingNumberClick(overflowAction)
+            }
+
             is ListingItemOverflowAction.VaultAction.CopyPasswordClick -> {
                 handleCopyPasswordClick(overflowAction)
             }
@@ -525,6 +533,40 @@ class SearchViewModel @Inject constructor(
                     clipboardManager.setText(
                         text = it.card?.number.orEmpty(),
                         toastDescriptorOverride = BitwardenString.number.asText(),
+                    )
+                }
+        }
+    }
+
+    private fun handleCopyAccountNumberClick(
+        action: ListingItemOverflowAction.VaultAction.CopyAccountNumberClick,
+    ) {
+        viewModelScope.launch {
+            decryptCipherViewOrNull(action.cipherId)
+                ?.bankAccount
+                ?.accountNumber
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                    clipboardManager.setText(
+                        text = it,
+                        toastDescriptorOverride = BitwardenString.account_number.asText(),
+                    )
+                }
+        }
+    }
+
+    private fun handleCopyRoutingNumberClick(
+        action: ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick,
+    ) {
+        viewModelScope.launch {
+            decryptCipherViewOrNull(action.cipherId)
+                ?.bankAccount
+                ?.routingNumber
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                    clipboardManager.setText(
+                        text = it,
+                        toastDescriptorOverride = BitwardenString.routing_number.asText(),
                     )
                 }
         }
@@ -1294,6 +1336,14 @@ sealed class SearchTypeData : Parcelable {
         data object SshKeys : Vault() {
             override val title: Text
                 get() = BitwardenString.search_x.asText(BitwardenString.ssh_keys.asText())
+        }
+
+        /**
+         * Indicates that we should be searching only bank account ciphers.
+         */
+        data object BankAccounts : Vault() {
+            override val title: Text
+                get() = BitwardenString.search_x.asText(BitwardenString.bank_accounts.asText())
         }
 
         /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/model/SearchType.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/model/SearchType.kt
@@ -69,6 +69,11 @@ sealed class SearchType : Parcelable {
         data object SshKeys : Vault()
 
         /**
+         * Indicates that we should be searching only bank account ciphers.
+         */
+        data object BankAccounts : Vault()
+
+        /**
          * Indicates that we should be searching only ciphers in the given collection.
          */
         data class Collection(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensions.kt
@@ -71,6 +71,7 @@ fun SearchTypeData.updateWithAdditionalDataIfNecessary(
         SearchTypeData.Vault.Trash -> this
         SearchTypeData.Vault.VerificationCodes -> this
         SearchTypeData.Vault.SshKeys -> this
+        SearchTypeData.Vault.BankAccounts -> this
     }
 
 /**
@@ -125,6 +126,10 @@ private fun CipherListView.filterBySearchType(
         is SearchTypeData.Vault.Logins -> type is CipherListViewType.Login && isActive
         is SearchTypeData.Vault.SecureNotes -> type is CipherListViewType.SecureNote && isActive
         is SearchTypeData.Vault.SshKeys -> type is CipherListViewType.SshKey && isActive
+        is SearchTypeData.Vault.BankAccounts -> {
+            type is CipherListViewType.BankAccount && isActive
+        }
+
         is SearchTypeData.Vault.VerificationCodes -> login?.totp != null && isActive
         is SearchTypeData.Vault.Trash -> deletedDate != null
     }
@@ -266,7 +271,7 @@ private val CipherListViewType.iconRes: Int
         is CipherListViewType.Card -> BitwardenDrawable.ic_payment_card
         CipherListViewType.Identity -> BitwardenDrawable.ic_id_card
         CipherListViewType.SshKey -> BitwardenDrawable.ic_ssh_key
-        CipherListViewType.BankAccount -> BitwardenDrawable.ic_note
+        CipherListViewType.BankAccount -> BitwardenDrawable.ic_payment_card
         CipherListViewType.DriversLicense -> BitwardenDrawable.ic_note
         CipherListViewType.Passport -> BitwardenDrawable.ic_note
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeExtensions.kt
@@ -23,4 +23,5 @@ fun SearchType.toSearchTypeData(): SearchTypeData =
         SearchType.Vault.Trash -> SearchTypeData.Vault.Trash
         SearchType.Vault.VerificationCodes -> SearchTypeData.Vault.VerificationCodes
         SearchType.Vault.SshKeys -> SearchTypeData.Vault.SshKeys
+        SearchType.Vault.BankAccounts -> SearchTypeData.Vault.BankAccounts
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
@@ -97,6 +97,7 @@ enum class ItemListingType {
     SECURE_NOTE,
     CARD,
     SSH_KEY,
+    BANK_ACCOUNT,
     TRASH,
     FOLDER,
     COLLECTION,
@@ -125,6 +126,7 @@ fun SavedStateHandle.toVaultItemListingArgs(): VaultItemListingArgs {
             ItemListingType.IDENTITY -> VaultItemListingType.Identity
             ItemListingType.SECURE_NOTE -> VaultItemListingType.SecureNote
             ItemListingType.SSH_KEY -> VaultItemListingType.SshKey
+            ItemListingType.BANK_ACCOUNT -> VaultItemListingType.BankAccount
             ItemListingType.TRASH -> VaultItemListingType.Trash
             ItemListingType.SEND_FILE -> VaultItemListingType.SendFile
             ItemListingType.SEND_TEXT -> VaultItemListingType.SendText
@@ -310,6 +312,7 @@ private fun VaultItemListingType.toItemListingType(): ItemListingType {
         is VaultItemListingType.SendFile -> ItemListingType.SEND_FILE
         is VaultItemListingType.SendText -> ItemListingType.SEND_TEXT
         is VaultItemListingType.SshKey -> ItemListingType.SSH_KEY
+        is VaultItemListingType.BankAccount -> ItemListingType.BANK_ACCOUNT
     }
 }
 
@@ -326,4 +329,5 @@ private fun VaultItemListingType.toIdOrNull(): String? =
         is VaultItemListingType.SendFile -> null
         is VaultItemListingType.SendText -> null
         is VaultItemListingType.SshKey -> null
+        is VaultItemListingType.BankAccount -> null
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -1279,6 +1279,36 @@ class VaultItemListingViewModel @Inject constructor(
         }
     }
 
+    private fun handleCopyAccountNumberClick(
+        action: ListingItemOverflowAction.VaultAction.CopyAccountNumberClick,
+    ) {
+        viewModelScope.launch {
+            getCipherViewOrNull(action.cipherId)?.bankAccount?.accountNumber
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                    clipboardManager.setText(
+                        text = it,
+                        toastDescriptorOverride = BitwardenString.account_number.asText(),
+                    )
+                }
+        }
+    }
+
+    private fun handleCopyRoutingNumberClick(
+        action: ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick,
+    ) {
+        viewModelScope.launch {
+            getCipherViewOrNull(action.cipherId)?.bankAccount?.routingNumber
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                    clipboardManager.setText(
+                        text = it,
+                        toastDescriptorOverride = BitwardenString.routing_number.asText(),
+                    )
+                }
+        }
+    }
+
     private fun handleCopyPasswordClick(
         action: ListingItemOverflowAction.VaultAction.CopyPasswordClick,
     ) {
@@ -1537,6 +1567,7 @@ class VaultItemListingViewModel @Inject constructor(
         )
     }
 
+    @Suppress("LongMethod")
     private fun handleOverflowOptionClick(action: VaultItemListingsAction.OverflowOptionClick) {
         when (val overflowAction = action.action) {
             is ListingItemOverflowAction.SendAction.CopyUrlClick -> {
@@ -1569,6 +1600,14 @@ class VaultItemListingViewModel @Inject constructor(
 
             is ListingItemOverflowAction.VaultAction.CopyNumberClick -> {
                 handleCopyNumberClick(overflowAction)
+            }
+
+            is ListingItemOverflowAction.VaultAction.CopyAccountNumberClick -> {
+                handleCopyAccountNumberClick(overflowAction)
+            }
+
+            is ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick -> {
+                handleCopyRoutingNumberClick(overflowAction)
             }
 
             is ListingItemOverflowAction.VaultAction.CopyPasswordClick -> {
@@ -2892,6 +2931,7 @@ data class VaultItemListingState(
             ItemListingType.Vault.Login,
             ItemListingType.Vault.SecureNote,
             ItemListingType.Vault.SshKey,
+            ItemListingType.Vault.BankAccount,
             ItemListingType.Vault.Trash,
             ItemListingType.Send.SendFile,
             ItemListingType.Send.SendText,
@@ -3334,6 +3374,16 @@ data class VaultItemListingState(
              */
             data object SshKey : Vault() {
                 override val titleText: Text get() = BitwardenString.ssh_keys.asText()
+                override val hasFab: Boolean get() = false
+            }
+
+            /**
+             * A Bank Account item listing.
+             */
+            data object BankAccount : Vault() {
+                override val titleText: Text get() = BitwardenString.bank_accounts.asText()
+
+                // TODO: [PM-32810] Re-enable once Bank Account add/edit is wired.
                 override val hasFab: Boolean get() = false
             }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/model/ListingItemOverflowAction.kt
@@ -212,6 +212,32 @@ sealed class ListingItemOverflowAction : Parcelable {
         }
 
         /**
+         * Click on the copy bank account number overflow option.
+         */
+        @Parcelize
+        data class CopyAccountNumberClick(
+            val cipherId: String,
+            override val requiresPasswordReprompt: Boolean,
+        ) : VaultAction() {
+            override val title: Text get() = BitwardenString.copy_account_number.asText()
+            override val contentDescription: Text get() = title
+            override val speedBump: BitwardenTwoButtonDialogData? get() = null
+        }
+
+        /**
+         * Click on the copy bank routing number overflow option.
+         */
+        @Parcelize
+        data class CopyRoutingNumberClick(
+            val cipherId: String,
+            override val requiresPasswordReprompt: Boolean,
+        ) : VaultAction() {
+            override val title: Text get() = BitwardenString.copy_routing_number.asText()
+            override val contentDescription: Text get() = title
+            override val speedBump: BitwardenTwoButtonDialogData? get() = null
+        }
+
+        /**
          * Click on the copy secure note overflow option.
          */
         @Parcelize

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensions.kt
@@ -78,6 +78,10 @@ fun CipherListView.determineListingPredicate(
             type is CipherListViewType.SshKey && isActive
         }
 
+        is VaultItemListingState.ItemListingType.Vault.BankAccount -> {
+            type is CipherListViewType.BankAccount && isActive
+        }
+
         is VaultItemListingState.ItemListingType.Vault.Trash -> {
             deletedDate != null
         }
@@ -240,6 +244,10 @@ fun VaultData.toViewState(
                         BitwardenString.no_ssh_keys
                     }
 
+                    VaultItemListingState.ItemListingType.Vault.BankAccount -> {
+                        BitwardenString.no_bank_accounts
+                    }
+
                     VaultItemListingState.ItemListingType.Vault.Archive -> {
                         BitwardenString.no_archives_message
                     }
@@ -268,6 +276,7 @@ fun VaultData.toViewState(
                         VaultItemListingState.ItemListingType.Vault.Login,
                         VaultItemListingState.ItemListingType.Vault.SecureNote,
                         VaultItemListingState.ItemListingType.Vault.SshKey,
+                        VaultItemListingState.ItemListingType.Vault.BankAccount,
                             -> null
 
                         VaultItemListingState.ItemListingType.Vault.Archive -> {
@@ -301,6 +310,10 @@ fun VaultData.toViewState(
                             BitwardenString.new_ssh_key
                         }
 
+                        VaultItemListingState.ItemListingType.Vault.BankAccount -> {
+                            BitwardenString.new_bank_account
+                        }
+
                         else -> BitwardenString.new_item
                     }
                         .asText()
@@ -317,6 +330,7 @@ fun VaultData.toViewState(
                         VaultItemListingState.ItemListingType.Vault.Login,
                         VaultItemListingState.ItemListingType.Vault.SecureNote,
                         VaultItemListingState.ItemListingType.Vault.SshKey,
+                        VaultItemListingState.ItemListingType.Vault.BankAccount,
                             -> null
 
                         VaultItemListingState.ItemListingType.Vault.Archive -> {
@@ -397,6 +411,7 @@ fun VaultItemListingState.ItemListingType.updateWithAdditionalDataIfNecessary(
         is VaultItemListingState.ItemListingType.Send.SendFile -> this
         is VaultItemListingState.ItemListingType.Send.SendText -> this
         is VaultItemListingState.ItemListingType.Vault.SshKey -> this
+        is VaultItemListingState.ItemListingType.Vault.BankAccount -> this
         is VaultItemListingState.ItemListingType.Vault.Archive -> this
     }
 
@@ -590,7 +605,7 @@ private val CipherListViewType.iconRes: Int
         is CipherListViewType.Card -> BitwardenDrawable.ic_payment_card
         CipherListViewType.Identity -> BitwardenDrawable.ic_id_card
         CipherListViewType.SshKey -> BitwardenDrawable.ic_ssh_key
-        CipherListViewType.BankAccount -> BitwardenDrawable.ic_note
+        CipherListViewType.BankAccount -> BitwardenDrawable.ic_payment_card
         CipherListViewType.DriversLicense -> BitwardenDrawable.ic_note
         CipherListViewType.Passport -> BitwardenDrawable.ic_note
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensions.kt
@@ -22,6 +22,10 @@ fun VaultItemListingState.ItemListingType.toSearchType(): SearchType =
         is VaultItemListingState.ItemListingType.Vault.Login -> SearchType.Vault.Logins
         is VaultItemListingState.ItemListingType.Vault.SecureNote -> SearchType.Vault.SecureNotes
         is VaultItemListingState.ItemListingType.Vault.SshKey -> SearchType.Vault.SshKeys
+        is VaultItemListingState.ItemListingType.Vault.BankAccount -> {
+            SearchType.Vault.BankAccounts
+        }
+
         is VaultItemListingState.ItemListingType.Vault.Trash -> SearchType.Vault.Trash
         is VaultItemListingState.ItemListingType.Vault.Collection -> {
             SearchType.Vault.Collection(collectionId = collectionId)
@@ -49,6 +53,10 @@ fun VaultItemListingState.ItemListingType.Vault.toVaultItemCipherType(): VaultIt
         is VaultItemListingState.ItemListingType.Vault.Identity -> VaultItemCipherType.IDENTITY
         is VaultItemListingState.ItemListingType.Vault.SecureNote -> VaultItemCipherType.SECURE_NOTE
         is VaultItemListingState.ItemListingType.Vault.SshKey -> VaultItemCipherType.SSH_KEY
+        is VaultItemListingState.ItemListingType.Vault.BankAccount -> {
+            VaultItemCipherType.BANK_ACCOUNT
+        }
+
         is VaultItemListingState.ItemListingType.Vault.Login -> VaultItemCipherType.LOGIN
         is VaultItemListingState.ItemListingType.Vault.Collection -> VaultItemCipherType.LOGIN
         is VaultItemListingState.ItemListingType.Vault.Folder -> VaultItemCipherType.LOGIN

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingTypeExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingTypeExtensions.kt
@@ -17,6 +17,10 @@ fun VaultItemListingType.toItemListingType(): VaultItemListingState.ItemListingT
         is VaultItemListingType.Login -> VaultItemListingState.ItemListingType.Vault.Login
         is VaultItemListingType.SecureNote -> VaultItemListingState.ItemListingType.Vault.SecureNote
         is VaultItemListingType.SshKey -> VaultItemListingState.ItemListingType.Vault.SshKey
+        is VaultItemListingType.BankAccount -> {
+            VaultItemListingState.ItemListingType.Vault.BankAccount
+        }
+
         is VaultItemListingType.Archive -> VaultItemListingState.ItemListingType.Vault.Archive
         is VaultItemListingType.Trash -> VaultItemListingState.ItemListingType.Vault.Trash
         is VaultItemListingType.Collection -> {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensions.kt
@@ -73,6 +73,28 @@ fun CipherListView.toOverflowActions(
                         this.type is CipherListViewType.SecureNote &&
                             this.copyableFields.contains(CopyableCipherFields.SECURE_NOTES)
                     },
+                ListingItemOverflowAction.VaultAction
+                    .CopyAccountNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = hasMasterPassword,
+                    )
+                    .takeIf {
+                        this.type is CipherListViewType.BankAccount &&
+                            this.copyableFields.contains(
+                                CopyableCipherFields.BANK_ACCOUNT_ACCOUNT_NUMBER,
+                            )
+                    },
+                ListingItemOverflowAction.VaultAction
+                    .CopyRoutingNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = hasMasterPassword,
+                    )
+                    .takeIf {
+                        this.type is CipherListViewType.BankAccount &&
+                            this.copyableFields.contains(
+                                CopyableCipherFields.BANK_ACCOUNT_ROUTING_NUMBER,
+                            )
+                    },
                 ListingItemOverflowAction.VaultAction.ViewClick(
                     cipherId = cipherId,
                     cipherType = this.type.toSdkCipherType(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -259,22 +259,24 @@ fun VaultContent(
             }
         }
 
-        item(key = "bank_accounts_group") {
-            BitwardenGroupItem(
-                startIcon = IconData.Local(
-                    iconRes = BitwardenDrawable.ic_payment_card,
-                    testTag = "BankAccountCipherIcon",
-                ),
-                label = stringResource(id = BitwardenString.type_bank_account),
-                supportingLabel = state.bankAccountItemsCount.toString(),
-                onClick = vaultHandlers.bankAccountGroupClick,
-                cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
-                modifier = Modifier
-                    .animateItem()
-                    .fillMaxWidth()
-                    .testTag("BankAccountFilter")
-                    .standardHorizontalMargin(),
-            )
+        if (state.showBankAccountGroup) {
+            item(key = "bank_accounts_group") {
+                BitwardenGroupItem(
+                    startIcon = IconData.Local(
+                        iconRes = BitwardenDrawable.ic_payment_card,
+                        testTag = "BankAccountCipherIcon",
+                    ),
+                    label = stringResource(id = BitwardenString.type_bank_account),
+                    supportingLabel = state.bankAccountItemsCount.toString(),
+                    onClick = vaultHandlers.bankAccountGroupClick,
+                    cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
+                    modifier = Modifier
+                        .animateItem()
+                        .fillMaxWidth()
+                        .testTag("BankAccountFilter")
+                        .standardHorizontalMargin(),
+                )
+            }
         }
 
         item(key = "identities_group") {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -259,6 +259,24 @@ fun VaultContent(
             }
         }
 
+        item(key = "bank_accounts_group") {
+            BitwardenGroupItem(
+                startIcon = IconData.Local(
+                    iconRes = BitwardenDrawable.ic_payment_card,
+                    testTag = "BankAccountCipherIcon",
+                ),
+                label = stringResource(id = BitwardenString.type_bank_account),
+                supportingLabel = state.bankAccountItemsCount.toString(),
+                onClick = vaultHandlers.bankAccountGroupClick,
+                cardStyle = CardStyle.Middle(dividerPadding = 56.dp),
+                modifier = Modifier
+                    .animateItem()
+                    .fillMaxWidth()
+                    .testTag("BankAccountFilter")
+                    .standardHorizontalMargin(),
+            )
+        }
+
         item(key = "identities_group") {
             BitwardenGroupItem(
                 startIcon = IconData.Local(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -332,6 +332,7 @@ class VaultViewModel @Inject constructor(
             is VaultAction.VaultFilterTypeSelect -> handleVaultFilterTypeSelect(action)
             is VaultAction.SecureNoteGroupClick -> handleSecureNoteClick()
             is VaultAction.SshKeyGroupClick -> handleSshKeyClick()
+            is VaultAction.BankAccountGroupClick -> handleBankAccountClick()
             is VaultAction.ArchiveClick -> handleArchiveClick()
             is VaultAction.TrashClick -> handleTrashClick()
             is VaultAction.VaultItemClick -> handleVaultItemClick(action)
@@ -697,6 +698,10 @@ class VaultViewModel @Inject constructor(
         sendEvent(VaultEvent.NavigateToItemListing(VaultItemListingType.SshKey))
     }
 
+    private fun handleBankAccountClick() {
+        sendEvent(VaultEvent.NavigateToItemListing(VaultItemListingType.BankAccount))
+    }
+
     private fun handleVaultItemClick(action: VaultAction.VaultItemClick) {
         if (action.vaultItem.hasDecryptionError) {
             showCipherDecryptionErrorItemClick(itemId = action.vaultItem.id)
@@ -742,6 +747,14 @@ class VaultViewModel @Inject constructor(
 
             is ListingItemOverflowAction.VaultAction.CopyNumberClick -> {
                 handleCopyNumberClick(overflowAction)
+            }
+
+            is ListingItemOverflowAction.VaultAction.CopyAccountNumberClick -> {
+                handleCopyAccountNumberClick(overflowAction)
+            }
+
+            is ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick -> {
+                handleCopyRoutingNumberClick(overflowAction)
             }
 
             is ListingItemOverflowAction.VaultAction.CopyPasswordClick -> {
@@ -831,6 +844,40 @@ class VaultViewModel @Inject constructor(
                     toastDescriptorOverride = BitwardenString.number.asText(),
                 )
             }
+        }
+    }
+
+    private fun handleCopyAccountNumberClick(
+        action: ListingItemOverflowAction.VaultAction.CopyAccountNumberClick,
+    ) {
+        viewModelScope.launch {
+            getCipherForCopyOrNull(cipherId = action.cipherId)
+                ?.bankAccount
+                ?.accountNumber
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                    clipboardManager.setText(
+                        text = it,
+                        toastDescriptorOverride = BitwardenString.account_number.asText(),
+                    )
+                }
+        }
+    }
+
+    private fun handleCopyRoutingNumberClick(
+        action: ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick,
+    ) {
+        viewModelScope.launch {
+            getCipherForCopyOrNull(cipherId = action.cipherId)
+                ?.bankAccount
+                ?.routingNumber
+                ?.takeIf { it.isNotBlank() }
+                ?.let {
+                    clipboardManager.setText(
+                        text = it,
+                        toastDescriptorOverride = BitwardenString.routing_number.asText(),
+                    )
+                }
         }
     }
 
@@ -1721,6 +1768,7 @@ data class VaultState(
          * @property totpItemsCount The count of totp code items.
          * @property loginItemsCount The count of Login type items.
          * @property cardItemsCount The count of Card type items.
+         * @property bankAccountItemsCount The count of Bank Account type items.
          * @property identityItemsCount The count of Identity type items.
          * @property secureNoteItemsCount The count of Secure Notes type items.
          * @property favoriteItems The list of favorites to be displayed.
@@ -1742,6 +1790,7 @@ data class VaultState(
             val identityItemsCount: Int,
             val secureNoteItemsCount: Int,
             val sshKeyItemsCount: Int,
+            val bankAccountItemsCount: Int,
             val favoriteItems: List<VaultItem>,
             val folderItems: List<FolderItem>,
             val noFolderItems: List<VaultItem>,
@@ -1956,6 +2005,26 @@ data class VaultState(
             ) : VaultItem() {
                 override val supportingLabel: Text? get() = null
                 override val type: VaultItemCipherType get() = VaultItemCipherType.SSH_KEY
+            }
+
+            /**
+             * Represents a Bank Account item within the vault.
+             */
+            @Parcelize
+            data class BankAccount(
+                override val id: String,
+                override val name: Text,
+                override val startIcon: IconData = IconData.Local(
+                    BitwardenDrawable.ic_payment_card,
+                ),
+                override val startIconTestTag: String = "BankAccountCipherIcon",
+                override val extraIconList: ImmutableList<IconData> = persistentListOf(),
+                override val overflowOptions: ImmutableList<ListingItemOverflowAction.VaultAction>,
+                override val shouldShowMasterPasswordReprompt: Boolean,
+                override val hasDecryptionError: Boolean,
+            ) : VaultItem() {
+                override val supportingLabel: Text? get() = null
+                override val type: VaultItemCipherType get() = VaultItemCipherType.BANK_ACCOUNT
             }
         }
     }
@@ -2322,6 +2391,11 @@ sealed class VaultAction {
      * User clicked the SSH key types button.
      */
     data object SshKeyGroupClick : VaultAction()
+
+    /**
+     * User clicked the bank account types button.
+     */
+    data object BankAccountGroupClick : VaultAction()
 
     /**
      * User clicked the archive button.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -297,6 +297,11 @@ class VaultViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
+        featureFlagManager.getFeatureFlagFlow(FlagKey.NewItemTypes)
+            .map { VaultAction.Internal.NewItemTypesFlagUpdateReceive(isEnabled = it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
         viewModelScope.launch {
             delay(timeMillis = BROWSER_AUTOFILL_DIALOG_DELAY)
             mutableStateFlow.update { vaultState ->
@@ -468,8 +473,7 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun handleSelectAddItemType() {
-        val isNewItemTypesEnabled = featureFlagManager
-            .getFeatureFlag(FlagKey.NewItemTypes)
+        val isNewItemTypesEnabled = state.isNewItemTypesEnabled
         // If policy is enable for any organization, exclude the card option
         val excludedOptions = persistentListOfNotNull(
             CreateVaultItemType.SSH_KEY,
@@ -1070,6 +1074,10 @@ class VaultViewModel @Inject constructor(
                 handleKdfSyncCompletedReceive()
             }
 
+            is VaultAction.Internal.NewItemTypesFlagUpdateReceive -> {
+                handleNewItemTypesFlagUpdateReceive(action)
+            }
+
             is VaultAction.Internal.CredentialExchangeProtocolExportFlagUpdateReceive -> {
                 handleCredentialExchangeProtocolExportFlagUpdateReceive(action)
             }
@@ -1141,6 +1149,22 @@ class VaultViewModel @Inject constructor(
                     ),
                 )
             }
+        }
+    }
+
+    private fun handleNewItemTypesFlagUpdateReceive(
+        action: VaultAction.Internal.NewItemTypesFlagUpdateReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(isNewItemTypesEnabled = action.isEnabled)
+        }
+
+        vaultRepository.vaultDataStateFlow.value.data?.let { vaultData ->
+            updateVaultState(
+                vaultData = vaultData,
+                dialog = state.dialog,
+                validTotpIds = state.validTotpIds,
+            )
         }
     }
 
@@ -1386,7 +1410,7 @@ class VaultViewModel @Inject constructor(
             isRefreshing = false,
             restrictItemTypesPolicyOrgIds = state.restrictItemTypesPolicyOrgIds,
             validTotpIds = validTotpIds,
-            isNewItemTypesEnabled = featureFlagManager.getFeatureFlag(FlagKey.NewItemTypes),
+            isNewItemTypesEnabled = state.isNewItemTypesEnabled,
         )
     }
 
@@ -1457,8 +1481,7 @@ class VaultViewModel @Inject constructor(
                     vaultFilterType = vaultFilterTypeOrDefault,
                     restrictItemTypesPolicyOrgIds = state.restrictItemTypesPolicyOrgIds,
                     validTotpIds = validTotpIds,
-                    isNewItemTypesEnabled = featureFlagManager
-                        .getFeatureFlag(FlagKey.NewItemTypes),
+                    isNewItemTypesEnabled = state.isNewItemTypesEnabled,
                 ),
                 dialog = dialog,
                 isRefreshing = false,
@@ -1515,8 +1538,7 @@ class VaultViewModel @Inject constructor(
                     vaultFilterType = vaultFilterTypeOrDefault,
                     restrictItemTypesPolicyOrgIds = state.restrictItemTypesPolicyOrgIds,
                     validTotpIds = validTotpIds,
-                    isNewItemTypesEnabled = featureFlagManager
-                        .getFeatureFlag(FlagKey.NewItemTypes),
+                    isNewItemTypesEnabled = state.isNewItemTypesEnabled,
                 ),
                 validTotpIds = validTotpIds.toImmutableSet(),
             )
@@ -1682,6 +1704,7 @@ data class VaultState(
     val isUpgradedToPremiumCardEligible: Boolean = false,
     val isAwaitingKdfSync: Boolean = false,
     val validTotpIds: ImmutableSet<String>,
+    val isNewItemTypesEnabled: Boolean = false,
 ) : Parcelable {
 
     /**
@@ -2595,6 +2618,13 @@ sealed class VaultAction {
          */
         data class CredentialExchangeProtocolExportFlagUpdateReceive(
             val isCredentialExchangeProtocolExportEnabled: Boolean,
+        ) : Internal()
+
+        /**
+         * Indicates that the New Item Types feature flag has been updated.
+         */
+        data class NewItemTypesFlagUpdateReceive(
+            val isEnabled: Boolean,
         ) : Internal()
 
         /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModel.kt
@@ -1386,6 +1386,7 @@ class VaultViewModel @Inject constructor(
             isRefreshing = false,
             restrictItemTypesPolicyOrgIds = state.restrictItemTypesPolicyOrgIds,
             validTotpIds = validTotpIds,
+            isNewItemTypesEnabled = featureFlagManager.getFeatureFlag(FlagKey.NewItemTypes),
         )
     }
 
@@ -1456,6 +1457,8 @@ class VaultViewModel @Inject constructor(
                     vaultFilterType = vaultFilterTypeOrDefault,
                     restrictItemTypesPolicyOrgIds = state.restrictItemTypesPolicyOrgIds,
                     validTotpIds = validTotpIds,
+                    isNewItemTypesEnabled = featureFlagManager
+                        .getFeatureFlag(FlagKey.NewItemTypes),
                 ),
                 dialog = dialog,
                 isRefreshing = false,
@@ -1512,6 +1515,8 @@ class VaultViewModel @Inject constructor(
                     vaultFilterType = vaultFilterTypeOrDefault,
                     restrictItemTypesPolicyOrgIds = state.restrictItemTypesPolicyOrgIds,
                     validTotpIds = validTotpIds,
+                    isNewItemTypesEnabled = featureFlagManager
+                        .getFeatureFlag(FlagKey.NewItemTypes),
                 ),
                 validTotpIds = validTotpIds.toImmutableSet(),
             )
@@ -1780,6 +1785,7 @@ data class VaultState(
          * @property archiveSubText The subtext to be displayed on the archive item.
          * @property archiveEndIcon The end icon to be displayed on the archive item.
          * @property showCardGroup Is the card group available for display.
+         * @property showBankAccountGroup Is the bank account group available for display.
          */
         @Parcelize
         data class Content(
@@ -1800,6 +1806,7 @@ data class VaultState(
             val archiveSubText: Text?,
             @field:DrawableRes val archiveEndIcon: Int?,
             val showCardGroup: Boolean,
+            val showBankAccountGroup: Boolean,
         ) : ViewState() {
             override val hasFab: Boolean get() = true
             override val isPullToRefreshEnabled: Boolean get() = true
@@ -2015,7 +2022,7 @@ data class VaultState(
                 override val id: String,
                 override val name: Text,
                 override val startIcon: IconData = IconData.Local(
-                    BitwardenDrawable.ic_payment_card,
+                    iconRes = BitwardenDrawable.ic_payment_card,
                 ),
                 override val startIconTestTag: String = "BankAccountCipherIcon",
                 override val extraIconList: ImmutableList<IconData> = persistentListOf(),
@@ -2641,6 +2648,7 @@ private fun MutableStateFlow<VaultState>.updateToErrorStateOrDialog(
     isRefreshing: Boolean,
     restrictItemTypesPolicyOrgIds: List<String>,
     validTotpIds: Set<String>,
+    isNewItemTypesEnabled: Boolean,
 ) {
     this.update {
         if (vaultData != null) {
@@ -2653,6 +2661,7 @@ private fun MutableStateFlow<VaultState>.updateToErrorStateOrDialog(
                     isIconLoadingDisabled = isIconLoadingDisabled,
                     restrictItemTypesPolicyOrgIds = restrictItemTypesPolicyOrgIds,
                     validTotpIds = validTotpIds,
+                    isNewItemTypesEnabled = isNewItemTypesEnabled,
                 ),
                 dialog = VaultState.DialogState.Error(
                     title = errorTitle,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/handlers/VaultHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/handlers/VaultHandlers.kt
@@ -31,6 +31,7 @@ data class VaultHandlers(
     val identityGroupClick: () -> Unit,
     val secureNoteGroupClick: () -> Unit,
     val sshKeyGroupClick: () -> Unit,
+    val bankAccountGroupClick: () -> Unit,
     val archiveClick: () -> Unit,
     val trashClick: () -> Unit,
     val tryAgainClick: () -> Unit,
@@ -96,6 +97,9 @@ data class VaultHandlers(
                     viewModel.trySendAction(VaultAction.SecureNoteGroupClick)
                 },
                 sshKeyGroupClick = { viewModel.trySendAction(VaultAction.SshKeyGroupClick) },
+                bankAccountGroupClick = {
+                    viewModel.trySendAction(VaultAction.BankAccountGroupClick)
+                },
                 archiveClick = { viewModel.trySendAction(VaultAction.ArchiveClick) },
                 trashClick = { viewModel.trySendAction(VaultAction.TrashClick) },
                 tryAgainClick = { viewModel.trySendAction(VaultAction.TryAgainClick) },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
@@ -47,6 +47,7 @@ fun VaultData.toViewState(
     vaultFilterType: VaultFilterType,
     restrictItemTypesPolicyOrgIds: List<String>,
     validTotpIds: Set<String>,
+    isNewItemTypesEnabled: Boolean,
 ): VaultState.ViewState {
     val allCipherViews =
         decryptCipherListResult
@@ -219,6 +220,7 @@ fun VaultData.toViewState(
                 .asText()
                 .takeIf { !isPremium && archiveCount == 0 },
             showCardGroup = cardCount != 0 || restrictItemTypesPolicyOrgIds.isEmpty(),
+            showBankAccountGroup = isNewItemTypesEnabled,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensions.kt
@@ -144,6 +144,8 @@ fun VaultData.toViewState(
                 .count { it.type is CipherListViewType.SecureNote },
             sshKeyItemsCount = activeCipherViews
                 .count { it.type is CipherListViewType.SshKey },
+            bankAccountItemsCount = activeCipherViews
+                .count { it.type is CipherListViewType.BankAccount },
             favoriteItems = activeDecryptedCipherViews
                 .filter { it.favorite }
                 .mapNotNull {
@@ -362,8 +364,20 @@ private fun CipherListView.toVaultItemOrNull(
             hasDecryptionError = hasDecryptionError,
         )
 
-        // TODO: [PM-32009] Map BankAccount to its own VaultItem subclass when the UI is wired.
-        CipherListViewType.BankAccount -> null
+        CipherListViewType.BankAccount -> VaultState.ViewState.VaultItem.BankAccount(
+            id = id,
+            name = name.asText(),
+            overflowOptions = toOverflowActions(
+                hasMasterPassword = hasMasterPassword,
+                isPremiumUser = isPremiumUser,
+            ),
+            extraIconList = toLabelIcons(),
+            shouldShowMasterPasswordReprompt = hasMasterPassword &&
+                reprompt == CipherRepromptType.PASSWORD,
+            hasDecryptionError = hasDecryptionError,
+        )
+
+        // TODO: [PM-32009] Map DriversLicense/Passport when their UIs are wired.
         CipherListViewType.DriversLicense -> null
         CipherListViewType.Passport -> null
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/model/VaultItemListingType.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/model/VaultItemListingType.kt
@@ -36,6 +36,11 @@ sealed class VaultItemListingType {
     data object SshKey : VaultItemListingType()
 
     /**
+     * A Bank Account listing.
+     */
+    data object BankAccount : VaultItemListingType()
+
+    /**
      * A Trash listing.
      */
     data object Trash : VaultItemListingType()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchViewModelTest.kt
@@ -43,6 +43,7 @@ import com.x8bit.bitwarden.data.platform.manager.model.OrganizationEvent
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockBankAccountView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCardView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
@@ -1245,6 +1246,144 @@ class SearchViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `OverflowOptionClick Vault CopyAccountNumberClick should call setText on the ClipboardManager`() =
+        runTest {
+            val accountNumber = "12345678"
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.getCipher(CIPHER_ID)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        accountNumber = accountNumber,
+                    ),
+                ),
+            )
+
+            viewModel.trySendAction(
+                SearchAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyAccountNumberClick(
+                        cipherId = "mockId-1",
+                        requiresPasswordReprompt = true,
+                    ),
+                ),
+            )
+            verify(exactly = 1) {
+                clipboardManager.setText(
+                    text = accountNumber,
+                    toastDescriptorOverride = BitwardenString.account_number.asText(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyAccountNumberClick should not copy when account number is blank`() =
+        runTest {
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.getCipher(CIPHER_ID)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        accountNumber = "",
+                    ),
+                ),
+            )
+
+            viewModel.trySendAction(
+                SearchAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyAccountNumberClick(
+                        cipherId = "mockId-1",
+                        requiresPasswordReprompt = false,
+                    ),
+                ),
+            )
+            verify(exactly = 0) {
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyRoutingNumberClick should call setText on the ClipboardManager`() =
+        runTest {
+            val routingNumber = "021000021"
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.getCipher(CIPHER_ID)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        routingNumber = routingNumber,
+                    ),
+                ),
+            )
+
+            viewModel.trySendAction(
+                SearchAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick(
+                        cipherId = "mockId-1",
+                        requiresPasswordReprompt = true,
+                    ),
+                ),
+            )
+            verify(exactly = 1) {
+                clipboardManager.setText(
+                    text = routingNumber,
+                    toastDescriptorOverride = BitwardenString.routing_number.asText(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyRoutingNumberClick should not copy when routing number is null`() =
+        runTest {
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.getCipher(CIPHER_ID)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        routingNumber = null,
+                    ),
+                ),
+            )
+
+            viewModel.trySendAction(
+                SearchAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick(
+                        cipherId = "mockId-1",
+                        requiresPasswordReprompt = false,
+                    ),
+                ),
+            )
+            verify(exactly = 0) {
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `OverflowOptionClick Vault CopyTotpClick with GenerateTotpCode success should call setText on the ClipboardManager`() =
         runTest {
             val totpCode = "totpCode"
@@ -2004,6 +2143,7 @@ class SearchViewModelTest : BaseViewModelTest() {
                     SearchTypeData.Vault.NoFolder -> SearchType.Vault.NoFolder
                     SearchTypeData.Vault.SecureNotes -> SearchType.Vault.SecureNotes
                     SearchTypeData.Vault.SshKeys -> SearchType.Vault.SshKeys
+                    SearchTypeData.Vault.BankAccounts -> SearchType.Vault.BankAccounts
                     SearchTypeData.Vault.Trash -> SearchType.Vault.Trash
                     SearchTypeData.Vault.VerificationCodes -> SearchType.Vault.VerificationCodes
                     null -> SearchType.Vault.All

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchUtil.kt
@@ -253,7 +253,7 @@ fun createMockDisplayItemForCipher(
                 titleTestTag = "CipherNameLabel",
                 subtitle = null,
                 subtitleTestTag = "CipherSubTitleLabel",
-                iconData = IconData.Local(BitwardenDrawable.ic_note),
+                iconData = IconData.Local(BitwardenDrawable.ic_payment_card),
                 extraIconList = persistentListOf(
                     IconData.Local(
                         iconRes = BitwardenDrawable.ic_collections,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -86,6 +86,7 @@ import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManage
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.util.getSignatureFingerprintAsHexString
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockBankAccountView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCardView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
@@ -2252,6 +2253,142 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `OverflowOptionClick Vault CopyAccountNumberClick should call setText on the ClipboardManager`() =
+        runTest {
+            val accountNumber = "12345678"
+            val cipherId = "mockId-1"
+            val viewModel = createVaultItemListingViewModel()
+            coEvery {
+                vaultRepository.getCipher(cipherId)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        accountNumber = accountNumber,
+                    ),
+                ),
+            )
+
+            viewModel.trySendAction(
+                VaultItemListingsAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyAccountNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = true,
+                    ),
+                ),
+            )
+
+            verify(exactly = 1) {
+                clipboardManager.setText(
+                    text = accountNumber,
+                    toastDescriptorOverride = BitwardenString.account_number.asText(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyAccountNumberClick should not copy when account number is blank`() =
+        runTest {
+            val cipherId = "mockId-1"
+            val viewModel = createVaultItemListingViewModel()
+            coEvery {
+                vaultRepository.getCipher(cipherId)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        accountNumber = "",
+                    ),
+                ),
+            )
+
+            viewModel.trySendAction(
+                VaultItemListingsAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyAccountNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = false,
+                    ),
+                ),
+            )
+
+            verify(exactly = 0) { clipboardManager.setText(text = any<String>()) }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyRoutingNumberClick should call setText on the ClipboardManager`() =
+        runTest {
+            val routingNumber = "021000021"
+            val cipherId = "mockId-1"
+            val viewModel = createVaultItemListingViewModel()
+            coEvery {
+                vaultRepository.getCipher(cipherId)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        routingNumber = routingNumber,
+                    ),
+                ),
+            )
+
+            viewModel.trySendAction(
+                VaultItemListingsAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = true,
+                    ),
+                ),
+            )
+
+            verify(exactly = 1) {
+                clipboardManager.setText(
+                    text = routingNumber,
+                    toastDescriptorOverride = BitwardenString.routing_number.asText(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyRoutingNumberClick should not copy when routing number is null`() =
+        runTest {
+            val cipherId = "mockId-1"
+            val viewModel = createVaultItemListingViewModel()
+            coEvery {
+                vaultRepository.getCipher(cipherId)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        routingNumber = null,
+                    ),
+                ),
+            )
+
+            viewModel.trySendAction(
+                VaultItemListingsAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = false,
+                    ),
+                ),
+            )
+
+            verify(exactly = 0) { clipboardManager.setText(text = any<String>()) }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `OverflowOptionClick Vault CopyTotpClick with GenerateTotpCode success should call setText on the ClipboardManager`() =
         runTest {
             val totpCode = "totpCode"
@@ -2800,6 +2937,43 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
                         message = BitwardenString.no_notes.asText(),
                         shouldShowAddButton = true,
                         buttonText = BitwardenString.new_note.asText(),
+                    ),
+                ),
+                viewModel.stateFlow.value,
+            )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `vaultDataStateFlow Loaded with empty items should update ViewState to NoItems content for BankAccount ItemListingType`() =
+        runTest {
+            val dataState = DataState.Loaded(
+                data = VaultData(
+                    decryptCipherListResult = createMockDecryptCipherListResult(
+                        number = 1,
+                        successes = emptyList(),
+                    ),
+                    folderViewList = emptyList(),
+                    collectionViewList = emptyList(),
+                    sendViewList = emptyList(),
+                ),
+            )
+            val viewModel = createVaultItemListingViewModel(
+                savedStateHandle = createSavedStateHandleWithVaultItemListingType(
+                    vaultItemListingType = VaultItemListingType.BankAccount,
+                ),
+            )
+
+            mutableVaultDataStateFlow.tryEmit(value = dataState)
+
+            assertEquals(
+                createVaultItemListingState(
+                    itemListingType = VaultItemListingState.ItemListingType.Vault.BankAccount,
+                    viewState = VaultItemListingState.ViewState.NoItems(
+                        header = null,
+                        message = BitwardenString.no_bank_accounts.asText(),
+                        shouldShowAddButton = false,
+                        buttonText = BitwardenString.new_bank_account.asText(),
                     ),
                 ),
                 viewModel.stateFlow.value,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataUtil.kt
@@ -286,7 +286,7 @@ fun createMockDisplayItemForCipher(
                 secondSubtitleTestTag = secondSubtitleTestTag,
                 subtitle = subtitle,
                 subtitleTestTag = "CipherSubTitleLabel",
-                iconData = IconData.Local(BitwardenDrawable.ic_note),
+                iconData = IconData.Local(BitwardenDrawable.ic_payment_card),
                 extraIconList = persistentListOf(
                     IconData.Local(
                         iconRes = BitwardenDrawable.ic_collections,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/util/CipherListViewExtensionsTest.kt
@@ -361,6 +361,139 @@ class CipherListViewExtensionsTest {
     }
 
     @Test
+    fun `toOverflowActions should return all copy actions for a bank account cipher`() {
+        val cipher = createMockCipherListView(
+            number = 1,
+            type = CipherListViewType.BankAccount,
+            id = id,
+            copyableFields = listOf(
+                CopyableCipherFields.BANK_ACCOUNT_ACCOUNT_NUMBER,
+                CopyableCipherFields.BANK_ACCOUNT_ROUTING_NUMBER,
+            ),
+        )
+
+        val result = cipher.toOverflowActions(
+            hasMasterPassword = true,
+            isPremiumUser = false,
+        )
+
+        assertEquals(
+            listOf(
+                ListingItemOverflowAction.VaultAction.CopyAccountNumberClick(
+                    cipherId = id,
+                    requiresPasswordReprompt = true,
+                ),
+                ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick(
+                    cipherId = id,
+                    requiresPasswordReprompt = true,
+                ),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    requiresPasswordReprompt = true,
+                ),
+                ListingItemOverflowAction.VaultAction.EditClick(
+                    cipherId = id,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    requiresPasswordReprompt = true,
+                ),
+                ListingItemOverflowAction.VaultAction.ArchiveClick(cipherId = id),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `toOverflowActions should return only available copy actions for a bank account cipher`() {
+        val cipher = createMockCipherListView(
+            number = 1,
+            type = CipherListViewType.BankAccount,
+            id = id,
+            copyableFields = listOf(
+                CopyableCipherFields.BANK_ACCOUNT_ACCOUNT_NUMBER,
+            ),
+        )
+
+        val result = cipher.toOverflowActions(
+            hasMasterPassword = false,
+            isPremiumUser = false,
+        )
+
+        assertEquals(
+            listOf(
+                ListingItemOverflowAction.VaultAction.CopyAccountNumberClick(
+                    cipherId = id,
+                    requiresPasswordReprompt = false,
+                ),
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    requiresPasswordReprompt = false,
+                ),
+                ListingItemOverflowAction.VaultAction.EditClick(
+                    cipherId = id,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    requiresPasswordReprompt = false,
+                ),
+                ListingItemOverflowAction.VaultAction.ArchiveClick(cipherId = id),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `toOverflowActions should return minimum actions for a bank account cipher`() {
+        val cipher = createMockCipherListView(
+            number = 1,
+            id = id,
+            isDeleted = true,
+            isArchived = true,
+            type = CipherListViewType.BankAccount,
+        )
+
+        val result = cipher.toOverflowActions(
+            hasMasterPassword = false,
+            isPremiumUser = false,
+        )
+
+        assertEquals(
+            listOf(
+                ListingItemOverflowAction.VaultAction.ViewClick(
+                    cipherId = id,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    requiresPasswordReprompt = false,
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `toOverflowActions should not return bank-account copy actions for non-bank ciphers`() {
+        val cipher = createMockCipherListView(
+            number = 1,
+            id = id,
+            type = CipherListViewType.Login(createMockLoginListView(number = 1)),
+            copyableFields = listOf(
+                CopyableCipherFields.BANK_ACCOUNT_ACCOUNT_NUMBER,
+                CopyableCipherFields.BANK_ACCOUNT_ROUTING_NUMBER,
+            ),
+        )
+
+        val result = cipher.toOverflowActions(
+            hasMasterPassword = false,
+            isPremiumUser = false,
+        )
+
+        assertTrue(
+            result.none {
+                it is ListingItemOverflowAction.VaultAction.CopyAccountNumberClick ||
+                    it is ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick
+            },
+        )
+    }
+
+    @Test
     fun `toOverflowActions should not return Edit action when cipher cannot be edited`() {
         val type = CipherListViewType.Login(createMockLoginListView(number = 1))
         val cipher = createMockCipherListView(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -2504,6 +2504,7 @@ class VaultScreenTest : BitwardenComposeTest() {
             it.copy(
                 viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
                     bankAccountItemsCount = count,
+                    showBankAccountGroup = true,
                 ),
             )
         }
@@ -2520,6 +2521,7 @@ class VaultScreenTest : BitwardenComposeTest() {
             it.copy(
                 viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
                     bankAccountItemsCount = 1,
+                    showBankAccountGroup = true,
                 ),
             )
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -998,6 +998,7 @@ class VaultScreenTest : BitwardenComposeTest() {
                     identityItemsCount = 0,
                     secureNoteItemsCount = 0,
                     sshKeyItemsCount = 0,
+                    bankAccountItemsCount = 0,
                     favoriteItems = emptyList(),
                     folderItems = emptyList(),
                     noFolderItems = emptyList(),
@@ -2494,6 +2495,40 @@ class VaultScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `Bank account group header should display correctly based on state`() {
+        val count = 2
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
+                    bankAccountItemsCount = count,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithTextAfterScroll("Bank account")
+            .assertTextEquals("Bank account", count.toString())
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `clicking a bank account group should send BankAccountGroupClick action`() {
+        val rowText = "Bank account"
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
+                    bankAccountItemsCount = 1,
+                ),
+            )
+        }
+
+        composeTestRule.onNode(hasScrollToNodeAction()).performScrollToNode(hasText(rowText))
+        composeTestRule.onNodeWithText(rowText).performClick()
+        verify {
+            viewModel.trySendAction(VaultAction.BankAccountGroupClick)
+        }
+    }
+
+    @Test
     fun `LifecycleResumed action is sent when the screen is resumed`() {
         verify { viewModel.trySendAction(VaultAction.LifecycleResumed) }
     }
@@ -2723,6 +2758,7 @@ private val DEFAULT_CONTENT_VIEW_STATE: VaultState.ViewState.Content = VaultStat
     totpItemsCount = 0,
     itemTypesCount = 4,
     sshKeyItemsCount = 0,
+    bankAccountItemsCount = 0,
     archivedItemsCount = 0,
     archiveSubText = null,
     archiveEndIcon = null,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -1008,6 +1008,7 @@ class VaultScreenTest : BitwardenComposeTest() {
                     archiveSubText = null,
                     archiveEndIcon = null,
                     showCardGroup = false,
+                    showBankAccountGroup = false,
                 ),
             )
         }
@@ -2134,6 +2135,7 @@ class VaultScreenTest : BitwardenComposeTest() {
                 viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
                     cardItemsCount = 1,
                     showCardGroup = true,
+                    showBankAccountGroup = false,
                 ),
             )
         }
@@ -2148,6 +2150,7 @@ class VaultScreenTest : BitwardenComposeTest() {
                 viewState = DEFAULT_CONTENT_VIEW_STATE.copy(
                     cardItemsCount = 0,
                     showCardGroup = false,
+                    showBankAccountGroup = false,
                 ),
             )
         }
@@ -2763,4 +2766,5 @@ private val DEFAULT_CONTENT_VIEW_STATE: VaultState.ViewState.Content = VaultStat
     archiveSubText = null,
     archiveEndIcon = null,
     showCardGroup = true,
+    showBankAccountGroup = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -1352,6 +1352,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                 hasMasterPassword = true,
                 restrictItemTypesPolicyOrgIds = emptyList(),
                 validTotpIds = emptySet(),
+                isNewItemTypesEnabled = false,
             ),
         )
             .copy(
@@ -1378,6 +1379,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                     hasMasterPassword = true,
                     restrictItemTypesPolicyOrgIds = emptyList(),
                     validTotpIds = emptySet(),
+                    isNewItemTypesEnabled = false,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -1517,6 +1519,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                     archiveSubText = null,
                     archiveEndIcon = null,
                     showCardGroup = true,
+                    showBankAccountGroup = false,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -1547,6 +1550,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                     archiveSubText = null,
                     archiveEndIcon = null,
                     showCardGroup = true,
+                    showBankAccountGroup = false,
                 ),
             )
             val viewModel = createViewModel()
@@ -1686,6 +1690,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                     archiveSubText = null,
                     archiveEndIcon = null,
                     showCardGroup = true,
+                    showBankAccountGroup = false,
                 ),
             ),
             viewModel.stateFlow.value,
@@ -1827,6 +1832,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = null,
                         archiveEndIcon = null,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                     dialog = VaultState.DialogState.Error(
                         title = BitwardenString.an_error_has_occurred.asText(),
@@ -1895,6 +1901,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = null,
                         archiveEndIcon = null,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                     dialog = VaultState.DialogState.Error(
                         title = BitwardenString.an_error_has_occurred.asText(),
@@ -2011,6 +2018,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = null,
                         archiveEndIcon = null,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                     dialog = null,
                 ),
@@ -2101,6 +2109,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = null,
                         archiveEndIcon = null,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                 ),
                 viewModel.stateFlow.value,
@@ -2350,6 +2359,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = BitwardenString.premium_subscription_required.asText(),
                         archiveEndIcon = BitwardenDrawable.ic_locked,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                 ),
                 viewModel.stateFlow.value,
@@ -2457,6 +2467,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = null,
                         archiveEndIcon = null,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                     dialog = VaultState.DialogState.VaultLoadCipherDecryptionError(
                         title = BitwardenString.decryption_error.asText(),
@@ -2530,6 +2541,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = null,
                         archiveEndIcon = null,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                     dialog = null,
                 ).copy(
@@ -3995,6 +4007,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = null,
                         archiveEndIcon = null,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                     dialog = VaultState.DialogState.VaultLoadKdfUpdateRequired(
                         title = BitwardenString.update_your_encryption_settings.asText(),
@@ -4059,6 +4072,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         archiveSubText = null,
                         archiveEndIcon = null,
                         showCardGroup = true,
+                        showBankAccountGroup = false,
                     ),
                     dialog = null,
                 ),
@@ -4418,4 +4432,5 @@ private val DEFAULT_CONTENT_VIEW_STATE = VaultState.ViewState.Content(
     archiveSubText = null,
     archiveEndIcon = null,
     showCardGroup = true,
+    showBankAccountGroup = false,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -236,7 +236,7 @@ class VaultViewModelTest : BaseViewModelTest() {
         every {
             getFeatureFlagFlow(FlagKey.CredentialExchangeProtocolExport)
         } returns mutableCxpExportFeatureFlagFlow
-        every { getFeatureFlag(FlagKey.NewItemTypes) } answers { mutableNewItemTypesFlagFlow.value }
+        every { getFeatureFlagFlow(FlagKey.NewItemTypes) } returns mutableNewItemTypesFlagFlow
     }
 
     private val mutablePremiumUpgradeBannerEligibleFlow = MutableStateFlow(false)
@@ -3841,6 +3841,7 @@ class VaultViewModelTest : BaseViewModelTest() {
             dialog = VaultState.DialogState.SelectVaultAddItemType(
                 excludedOptions = persistentListOf(CreateVaultItemType.SSH_KEY),
             ),
+            isNewItemTypesEnabled = true,
         )
         assertEquals(
             expectedState,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultViewModelTest.kt
@@ -49,6 +49,7 @@ import com.x8bit.bitwarden.data.platform.manager.network.NetworkConnectionManage
 import com.x8bit.bitwarden.data.platform.repository.SettingsRepository
 import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCardListView
+import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockBankAccountView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCardView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherView
@@ -1511,6 +1512,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                     totpItemsCount = 0,
                     itemTypesCount = CipherType.entries.size,
                     sshKeyItemsCount = 1,
+                    bankAccountItemsCount = 0,
                     archivedItemsCount = 0,
                     archiveSubText = null,
                     archiveEndIcon = null,
@@ -1540,6 +1542,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                     totpItemsCount = 0,
                     itemTypesCount = CipherType.entries.size,
                     sshKeyItemsCount = 0,
+                    bankAccountItemsCount = 0,
                     archivedItemsCount = 0,
                     archiveSubText = null,
                     archiveEndIcon = null,
@@ -1678,6 +1681,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                     totpItemsCount = 0,
                     itemTypesCount = CipherType.entries.size,
                     sshKeyItemsCount = 0,
+                    bankAccountItemsCount = 0,
                     archivedItemsCount = 0,
                     archiveSubText = null,
                     archiveEndIcon = null,
@@ -1818,6 +1822,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 0,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = 0,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -1885,6 +1890,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 0,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = 0,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -2000,6 +2006,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 0,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = 0,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -2089,6 +2096,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 1,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = 0,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -2226,6 +2234,19 @@ class VaultViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `BankAccountGroupClick should emit NavigateToItemListing event with BankAccount type`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(VaultAction.BankAccountGroupClick)
+                assertEquals(
+                    VaultEvent.NavigateToItemListing(VaultItemListingType.BankAccount),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
     fun `ArchiveClick with Premium should emit NavigateToItemListing event with Archive type`() =
         runTest {
             val viewModel = createViewModel()
@@ -2324,6 +2345,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 0,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = null,
                         archiveSubText = BitwardenString.premium_subscription_required.asText(),
                         archiveEndIcon = BitwardenDrawable.ic_locked,
@@ -2430,6 +2452,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 0,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = 1,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -2502,6 +2525,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 0,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = 0,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -2819,6 +2843,144 @@ class VaultViewModelTest : BaseViewModelTest() {
                 ),
                 viewModel.stateFlow.value,
             )
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyAccountNumberClick should call setText on the ClipboardManager`() =
+        runTest {
+            val accountNumber = "12345678"
+            val cipherId = "mockId-1"
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.getCipher(cipherId)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        accountNumber = accountNumber,
+                    ),
+                ),
+            )
+            viewModel.trySendAction(
+                VaultAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyAccountNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = true,
+                    ),
+                ),
+            )
+            verify(exactly = 1) {
+                clipboardManager.setText(
+                    text = accountNumber,
+                    toastDescriptorOverride = BitwardenString.account_number.asText(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyAccountNumberClick should not copy when account number is blank`() =
+        runTest {
+            val cipherId = "mockId-1"
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.getCipher(cipherId)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        accountNumber = "",
+                    ),
+                ),
+            )
+            viewModel.trySendAction(
+                VaultAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyAccountNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = false,
+                    ),
+                ),
+            )
+            verify(exactly = 0) {
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyRoutingNumberClick should call setText on the ClipboardManager`() =
+        runTest {
+            val routingNumber = "021000021"
+            val cipherId = "mockId-1"
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.getCipher(cipherId)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        routingNumber = routingNumber,
+                    ),
+                ),
+            )
+            viewModel.trySendAction(
+                VaultAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = true,
+                    ),
+                ),
+            )
+            verify(exactly = 1) {
+                clipboardManager.setText(
+                    text = routingNumber,
+                    toastDescriptorOverride = BitwardenString.routing_number.asText(),
+                )
+            }
+        }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `OverflowOptionClick Vault CopyRoutingNumberClick should not copy when routing number is null`() =
+        runTest {
+            val cipherId = "mockId-1"
+            val viewModel = createViewModel()
+            coEvery {
+                vaultRepository.getCipher(cipherId)
+            } returns GetCipherResult.Success(
+                createMockCipherView(
+                    number = 1,
+                    cipherType = CipherType.BANK_ACCOUNT,
+                    bankAccount = createMockBankAccountView(
+                        number = 1,
+                        routingNumber = null,
+                    ),
+                ),
+            )
+            viewModel.trySendAction(
+                VaultAction.OverflowOptionClick(
+                    ListingItemOverflowAction.VaultAction.CopyRoutingNumberClick(
+                        cipherId = cipherId,
+                        requiresPasswordReprompt = false,
+                    ),
+                ),
+            )
+            verify(exactly = 0) {
+                clipboardManager.setText(
+                    text = any<String>(),
+                    toastDescriptorOverride = any<Text>(),
+                )
+            }
         }
 
     @Suppress("MaxLineLength")
@@ -3828,6 +3990,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 0,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = 0,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -3891,6 +4054,7 @@ class VaultViewModelTest : BaseViewModelTest() {
                         totpItemsCount = 0,
                         itemTypesCount = CipherType.entries.size,
                         sshKeyItemsCount = 0,
+                        bankAccountItemsCount = 0,
                         archivedItemsCount = 0,
                         archiveSubText = null,
                         archiveEndIcon = null,
@@ -4243,6 +4407,7 @@ private val DEFAULT_CONTENT_VIEW_STATE = VaultState.ViewState.Content(
     identityItemsCount = 0,
     secureNoteItemsCount = 0,
     sshKeyItemsCount = 0,
+    bankAccountItemsCount = 0,
     totpItemsCount = 0,
     favoriteItems = emptyList(),
     folderItems = emptyList(),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
@@ -88,6 +88,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -148,6 +149,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -177,6 +179,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -204,6 +207,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -242,6 +246,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1", "mockId-2"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -280,6 +285,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -305,6 +311,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = emptySet(),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -333,6 +340,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = emptySet(),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -362,6 +370,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -383,6 +392,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -409,6 +419,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = emptySet(),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -430,6 +441,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = BitwardenString.premium_subscription_required.asText(),
                 archiveEndIcon = BitwardenDrawable.ic_locked,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -458,6 +470,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -479,6 +492,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = BitwardenString.premium_subscription_required.asText(),
                 archiveEndIcon = BitwardenDrawable.ic_locked,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -507,6 +521,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -528,6 +543,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = BitwardenString.premium_subscription_required.asText(),
                 archiveEndIcon = BitwardenDrawable.ic_locked,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -740,6 +756,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-3"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -761,6 +778,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -789,6 +807,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = emptySet(),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -810,6 +829,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -841,6 +861,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = (0..99).map { "mockId-$it" }.toSet(),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -868,6 +889,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -900,6 +922,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -939,6 +962,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -977,6 +1001,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -1030,6 +1055,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -1076,6 +1102,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = listOf("restrict_item_type_policy_id"),
             validTotpIds = emptySet(),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -1097,6 +1124,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -1139,6 +1167,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = listOf("restrict_item_type_policy_id"),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -1160,6 +1189,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = false,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -1188,6 +1218,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = setOf("mockId-1"),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -1211,6 +1242,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -1253,6 +1285,7 @@ class VaultDataExtensionsTest {
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
             validTotpIds = emptySet(),
+            isNewItemTypesEnabled = false,
         )
 
         assertEquals(
@@ -1279,6 +1312,7 @@ class VaultDataExtensionsTest {
                 archiveSubText = null,
                 archiveEndIcon = null,
                 showCardGroup = true,
+                showBankAccountGroup = false,
             ),
             actual,
         )
@@ -1290,16 +1324,29 @@ class VaultDataExtensionsTest {
             decryptCipherListResult = createMockDecryptCipherListResult(
                 number = 1,
                 successes = listOf(
-                    createMockCipherListView(number = 1),
-                    createMockCipherListView(number = 2, type = CipherListViewType.BankAccount),
-                    createMockCipherListView(number = 3, type = CipherListViewType.BankAccount),
+                    createMockCipherListView(
+                        number = 1,
+                        type = CipherListViewType.BankAccount,
+                        favorite = true,
+                        folderId = null,
+                    ),
+                    createMockCipherListView(
+                        number = 2,
+                        type = CipherListViewType.BankAccount,
+                        reprompt = CipherRepromptType.PASSWORD,
+                        folderId = null,
+                    ),
+                    createMockCipherListView(
+                        number = 3,
+                        type = CipherListViewType.BankAccount,
+                        folderId = null,
+                    ),
                 ),
             ),
             collectionViewList = listOf(),
             folderViewList = listOf(),
             sendViewList = listOf(),
         )
-
         val actual = vaultData.toViewState(
             isPremium = true,
             isIconLoadingDisabled = false,
@@ -1307,10 +1354,38 @@ class VaultDataExtensionsTest {
             vaultFilterType = VaultFilterType.AllVaults,
             hasMasterPassword = true,
             restrictItemTypesPolicyOrgIds = emptyList(),
+            validTotpIds = emptySet(),
+            isNewItemTypesEnabled = true,
         )
 
-        val content = actual as VaultState.ViewState.Content
-        assertEquals(2, content.bankAccountItemsCount)
+        assertEquals(
+            VaultState.ViewState.Content(
+                loginItemsCount = 0,
+                cardItemsCount = 0,
+                identityItemsCount = 0,
+                secureNoteItemsCount = 0,
+                sshKeyItemsCount = 0,
+                bankAccountItemsCount = 3,
+                favoriteItems = listOf(createMockBankAccountVaultItem(number = 1)),
+                collectionItems = listOf(),
+                folderItems = listOf(),
+                noFolderItems = listOf(
+                    createMockBankAccountVaultItem(number = 1),
+                    createMockBankAccountVaultItem(number = 2)
+                        .copy(shouldShowMasterPasswordReprompt = true),
+                    createMockBankAccountVaultItem(number = 3),
+                ),
+                trashItemsCount = 0,
+                totpItemsCount = 0,
+                itemTypesCount = CipherType.entries.size,
+                archivedItemsCount = 0,
+                archiveSubText = null,
+                archiveEndIcon = null,
+                showCardGroup = true,
+                showBankAccountGroup = true,
+            ),
+            actual,
+        )
     }
 }
 
@@ -1333,6 +1408,43 @@ private fun createMockSshKeyVaultItem(number: Int): VaultState.ViewState.VaultIt
         ),
         startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_ssh_key),
         startIconTestTag = "SshKeyCipherIcon",
+        extraIconList = persistentListOf(
+            IconData.Local(
+                iconRes = BitwardenDrawable.ic_collections,
+                contentDescription = BitwardenString.collections.asText(),
+                testTag = "CipherInCollectionIcon",
+            ),
+            IconData.Local(
+                iconRes = BitwardenDrawable.ic_paperclip,
+                contentDescription = BitwardenString.attachments.asText(),
+                testTag = "CipherWithAttachmentsIcon",
+            ),
+        ),
+        shouldShowMasterPasswordReprompt = false,
+        hasDecryptionError = false,
+    )
+
+private fun createMockBankAccountVaultItem(
+    number: Int,
+): VaultState.ViewState.VaultItem.BankAccount =
+    VaultState.ViewState.VaultItem.BankAccount(
+        id = "mockId-$number",
+        name = "mockName-$number".asText(),
+        overflowOptions = persistentListOf(
+            ListingItemOverflowAction.VaultAction.ViewClick(
+                cipherId = "mockId-$number",
+                cipherType = CipherType.BANK_ACCOUNT,
+                requiresPasswordReprompt = true,
+            ),
+            ListingItemOverflowAction.VaultAction.EditClick(
+                cipherId = "mockId-$number",
+                cipherType = CipherType.BANK_ACCOUNT,
+                requiresPasswordReprompt = true,
+            ),
+            ListingItemOverflowAction.VaultAction.ArchiveClick(cipherId = "mockId-$number"),
+        ),
+        startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_payment_card),
+        startIconTestTag = "BankAccountCipherIcon",
         extraIconList = persistentListOf(
             IconData.Local(
                 iconRes = BitwardenDrawable.ic_collections,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultDataExtensionsTest.kt
@@ -143,6 +143,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 1,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -198,6 +199,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 0,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -273,6 +275,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 0,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -375,6 +378,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 0,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -421,6 +425,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 0,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = null,
                 archiveSubText = BitwardenString.premium_subscription_required.asText(),
                 archiveEndIcon = BitwardenDrawable.ic_locked,
@@ -469,6 +474,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = null,
                 archiveSubText = BitwardenString.premium_subscription_required.asText(),
                 archiveEndIcon = BitwardenDrawable.ic_locked,
@@ -517,6 +523,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = null,
                 archiveSubText = BitwardenString.premium_subscription_required.asText(),
                 archiveEndIcon = BitwardenDrawable.ic_locked,
@@ -749,6 +756,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 0,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -797,6 +805,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 0,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 0,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -854,6 +863,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 100,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 0,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -924,6 +934,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 0,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -1014,6 +1025,7 @@ class VaultDataExtensionsTest {
                 totpItemsCount = 1,
                 itemTypesCount = CipherType.entries.size,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 archivedItemsCount = 0,
                 archiveSubText = null,
                 archiveEndIcon = null,
@@ -1073,6 +1085,7 @@ class VaultDataExtensionsTest {
                 identityItemsCount = 0,
                 secureNoteItemsCount = 0,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 favoriteItems = listOf(),
                 collectionItems = listOf(),
                 folderItems = listOf(),
@@ -1135,6 +1148,7 @@ class VaultDataExtensionsTest {
                 identityItemsCount = 0,
                 secureNoteItemsCount = 0,
                 sshKeyItemsCount = 0,
+                bankAccountItemsCount = 0,
                 favoriteItems = listOf(),
                 collectionItems = listOf(),
                 folderItems = listOf(),
@@ -1184,6 +1198,7 @@ class VaultDataExtensionsTest {
                 secureNoteItemsCount = 0,
                 // Verify SSH key vault items are counted
                 sshKeyItemsCount = 1,
+                bankAccountItemsCount = 0,
                 favoriteItems = listOf(),
                 collectionItems = listOf(),
                 folderItems = listOf(),
@@ -1247,6 +1262,7 @@ class VaultDataExtensionsTest {
                 identityItemsCount = 0,
                 secureNoteItemsCount = 0,
                 sshKeyItemsCount = 3,
+                bankAccountItemsCount = 0,
                 favoriteItems = listOf(createMockSshKeyVaultItem(number = 1)),
                 collectionItems = listOf(),
                 folderItems = listOf(),
@@ -1266,6 +1282,35 @@ class VaultDataExtensionsTest {
             ),
             actual,
         )
+    }
+
+    @Test
+    fun `toViewState should count bank account vault items in bankAccountItemsCount`() {
+        val vaultData = VaultData(
+            decryptCipherListResult = createMockDecryptCipherListResult(
+                number = 1,
+                successes = listOf(
+                    createMockCipherListView(number = 1),
+                    createMockCipherListView(number = 2, type = CipherListViewType.BankAccount),
+                    createMockCipherListView(number = 3, type = CipherListViewType.BankAccount),
+                ),
+            ),
+            collectionViewList = listOf(),
+            folderViewList = listOf(),
+            sendViewList = listOf(),
+        )
+
+        val actual = vaultData.toViewState(
+            isPremium = true,
+            isIconLoadingDisabled = false,
+            baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
+            vaultFilterType = VaultFilterType.AllVaults,
+            hasMasterPassword = true,
+            restrictItemTypesPolicyOrgIds = emptyList(),
+        )
+
+        val content = actual as VaultState.ViewState.Content
+        assertEquals(2, content.bankAccountItemsCount)
     }
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultStateExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultStateExtensionsTest.kt
@@ -85,6 +85,7 @@ class VaultStateExtensionsTest {
             totpItemsCount = 1,
             itemTypesCount = 4,
             sshKeyItemsCount = 0,
+            bankAccountItemsCount = 0,
             archivedItemsCount = 0,
             archiveSubText = null,
             archiveEndIcon = null,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultStateExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultStateExtensionsTest.kt
@@ -90,5 +90,6 @@ class VaultStateExtensionsTest {
             archiveSubText = null,
             archiveEndIcon = null,
             showCardGroup = true,
+            showBankAccountGroup = false,
         )
 }

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1350,4 +1350,5 @@ Do you want to switch to this account?</string>
     <string name="issue_date">Issue date</string>
     <string name="expiration_date">Expiration date</string>
     <string name="details">Details</string>
+    <string name="no_bank_accounts">There are no bank accounts in your vault.</string>
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32810](https://bitwarden.atlassian.net/browse/PM-32810)

Stacked parent: #6875

## 📔 Objective

Surface Bank Account ciphers across the discovery surfaces — the My Vault group list, the dedicated Bank Account listing screen, and search — and add overflow copy actions for account number and routing number. Pairs with the detail-screen slice in #6875 to complete the read-only Bank Account experience.

## 📸 Screenshots

<img width="365" src="https://github.com/user-attachments/assets/9aaf8b45-cfbd-4917-8772-a1ded31930c3" />

<img width="365" src="https://github.com/user-attachments/assets/4e448fcf-a666-4dfb-9dca-4f98edb6fca9" />


[PM-32810]: https://bitwarden.atlassian.net/browse/PM-32810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ