### PR TITLE
[PM-32810] test: Cover Bank Account vault, listing, and search surfaces

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/SearchNavigation.kt
@@ -1,3 +1,5 @@
+@file:OmitFromCoverage
+
 package com.x8bit.bitwarden.ui.platform.feature.search
 
 import androidx.lifecycle.SavedStateHandle
@@ -5,6 +7,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.toRoute
+import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.ui.platform.base.util.composableWithSlideTransitions
 import com.x8bit.bitwarden.ui.platform.feature.search.model.SearchType
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendRoute

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingNavigation.kt
@@ -1,3 +1,5 @@
+@file:OmitFromCoverage
+
 package com.x8bit.bitwarden.ui.vault.feature.itemlisting
 
 import android.os.Parcelable
@@ -6,6 +8,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.toRoute
+import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.ui.platform.base.util.composableWithPushTransitions
 import com.bitwarden.ui.platform.base.util.composableWithStayTransitions
 import com.bitwarden.ui.platform.util.ParcelableRouteSerializer

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/search/util/SearchTypeDataExtensionsTest.kt
@@ -35,6 +35,7 @@ import java.time.temporal.TemporalAccessor
 
 private const val DEFAULT_FORMATTED_DATE_TIME = "Oct 27, 2023, 12:00 PM"
 
+@Suppress("LargeClass")
 class SearchTypeDataExtensionsTest {
 
     private val clock: Clock = Clock.fixed(
@@ -242,6 +243,19 @@ class SearchTypeDataExtensionsTest {
 
     @Suppress("MaxLineLength")
     @Test
+    fun `updateWithAdditionalDataIfNecessary should return the searchTypeData unchanged for Vault BankAccounts`() {
+        val searchTypeData = SearchTypeData.Vault.BankAccounts
+        assertEquals(
+            searchTypeData,
+            searchTypeData.updateWithAdditionalDataIfNecessary(
+                folderList = listOf(),
+                collectionList = emptyList(),
+            ),
+        )
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
     fun `updateWithAdditionalDataIfNecessary should return the searchTypeData unchanged for Vault VerificationCodes`() {
         val searchTypeData = SearchTypeData.Vault.VerificationCodes
         assertEquals(
@@ -355,6 +369,27 @@ class SearchTypeDataExtensionsTest {
         val ciphers = listOf(match1, match2, match3)
         val result = ciphers.filterAndOrganize(
             searchTypeData = SearchTypeData.Vault.Trash,
+            searchTerm = "match",
+        )
+        assertEquals(listOf(match1, match3), result)
+    }
+
+    @Test
+    fun `CipherViews filterAndOrganize should return list with only bank account items`() {
+        val match1 = createMockCipherListView(
+            number = 1,
+            type = CipherListViewType.BankAccount,
+            name = "match1",
+        )
+        val match2 = createMockCipherListView(number = 2, name = "match2")
+        val match3 = createMockCipherListView(
+            number = 3,
+            type = CipherListViewType.BankAccount,
+            name = "match3",
+        )
+        val ciphers = listOf(match1, match2, match3)
+        val result = ciphers.filterAndOrganize(
+            searchTypeData = SearchTypeData.Vault.BankAccounts,
             searchTerm = "match",
         )
         assertEquals(listOf(match1, match3), result)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingDataExtensionsTest.kt
@@ -400,6 +400,38 @@ class VaultItemListingDataExtensionsTest {
 
     @Test
     @Suppress("MaxLineLength")
+    fun `determineListingPredicate should return the correct predicate for a non trash BankAccount cipherView`() {
+        val cipherView = createMockCipherListView(
+            number = 1,
+            isDeleted = false,
+            type = CipherListViewType.BankAccount,
+        )
+
+        mapOf(
+            VaultItemListingState.ItemListingType.Vault.Login to false,
+            VaultItemListingState.ItemListingType.Vault.Card to false,
+            VaultItemListingState.ItemListingType.Vault.SecureNote to false,
+            VaultItemListingState.ItemListingType.Vault.Identity to false,
+            VaultItemListingState.ItemListingType.Vault.Archive to false,
+            VaultItemListingState.ItemListingType.Vault.Trash to false,
+            VaultItemListingState.ItemListingType.Vault.SshKey to false,
+            VaultItemListingState.ItemListingType.Vault.BankAccount to true,
+            VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId-1") to true,
+            VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId-1") to true,
+        )
+            .forEach { (type, expected) ->
+                val result = cipherView.determineListingPredicate(
+                    itemListingType = type,
+                )
+                assertEquals(
+                    expected,
+                    result,
+                )
+            }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
     fun `determineListingPredicate should return the correct predicate for item not in a folder`() {
         val cipherView = createMockCipherListView(
             number = 1,
@@ -877,6 +909,27 @@ class VaultItemListingDataExtensionsTest {
             ),
         )
 
+        // Bank accounts
+        assertEquals(
+            VaultItemListingState.ViewState.NoItems(
+                message = BitwardenString.no_bank_accounts.asText(),
+                shouldShowAddButton = false,
+                buttonText = BitwardenString.new_bank_account.asText(),
+            ),
+            vaultData.toViewState(
+                itemListingType = VaultItemListingState.ItemListingType.Vault.BankAccount,
+                vaultFilterType = VaultFilterType.AllVaults,
+                hasMasterPassword = true,
+                baseIconUrl = Environment.Us.environmentUrlData.baseIconUrl,
+                isIconLoadingDisabled = false,
+                autofillSelectionData = null,
+                createCredentialRequestData = null,
+                totpData = null,
+                isPremiumUser = true,
+                restrictItemTypesPolicyOrgIds = emptyList(),
+            ),
+        )
+
         // Other ciphers
         // Login Type
         assertEquals(
@@ -1249,6 +1302,15 @@ class VaultItemListingDataExtensionsTest {
         assertEquals(
             VaultItemListingState.ItemListingType.Vault.SshKey,
             VaultItemListingState.ItemListingType.Vault.SshKey
+                .updateWithAdditionalDataIfNecessary(
+                    folderList = folderViewList,
+                    collectionList = collectionViewList,
+                ),
+        )
+
+        assertEquals(
+            VaultItemListingState.ItemListingType.Vault.BankAccount,
+            VaultItemListingState.ItemListingType.Vault.BankAccount
                 .updateWithAdditionalDataIfNecessary(
                     folderList = folderViewList,
                     collectionList = collectionViewList,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/util/VaultItemListingStateExtensionsTest.kt
@@ -133,6 +133,16 @@ class VaultItemListingStateExtensionsTest {
     }
 
     @Test
+    fun `toSearchType should return BankAccounts when item type is BankAccount`() {
+        val expected = SearchType.Vault.BankAccounts
+        val itemType = VaultItemListingState.ItemListingType.Vault.BankAccount
+
+        val result = itemType.toSearchType()
+
+        assertEquals(expected, result)
+    }
+
+    @Test
     fun `toVaultItemCipherType should return the correct response`() {
         val itemListingTypes = listOf(
             VaultItemListingState.ItemListingType.Vault.Card,
@@ -141,6 +151,7 @@ class VaultItemListingStateExtensionsTest {
             VaultItemListingState.ItemListingType.Vault.Login,
             VaultItemListingState.ItemListingType.Vault.Collection(collectionId = "mockId"),
             VaultItemListingState.ItemListingType.Vault.SshKey,
+            VaultItemListingState.ItemListingType.Vault.BankAccount,
             VaultItemListingState.ItemListingType.Vault.Folder(folderId = "mockId"),
         )
 
@@ -154,6 +165,7 @@ class VaultItemListingStateExtensionsTest {
                 VaultItemCipherType.LOGIN,
                 VaultItemCipherType.LOGIN,
                 VaultItemCipherType.SSH_KEY,
+                VaultItemCipherType.BANK_ACCOUNT,
                 VaultItemCipherType.LOGIN,
             ),
             result,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32810](https://bitwarden.atlassian.net/browse/PM-32810)

Follow-up to #6877.

## 📔 Objective

Closes the Bank Account coverage gaps surfaced by Codecov on #6877. Adds test coverage for the new `BankAccount` branches in the Search and Item Listing utility extensions, and excludes the affected navigation files from coverage at both file and class level — matching the convention used by other navigation files in the project.

- `SearchTypeDataExtensions`: covers `BankAccounts` arms in `updateWithAdditionalDataIfNecessary` and `filterAndOrganize`.
- `VaultItemListingStateExtensions`: covers `BankAccount` arms in `toSearchType()` and `toVaultItemCipherType()`.
- `VaultItemListingDataExtensions`: covers the `BankAccount` listing predicate, no-items state (message, button, header), and `updateWithAdditionalDataIfNecessary`.
- `SearchNavigation` and `VaultItemListingNavigation` annotated with `@file:OmitFromCoverage`.

[PM-32810]: https://bitwarden.atlassian.net/browse/PM-32810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ