### PR TITLE
[PM-36867] fix: Disable card scanner on F-Droid builds (hotfix v2026.4.1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -294,12 +294,12 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     // Standard-specific flavor dependencies
-    standardImplementation(libs.google.firebase.cloud.messaging)
-    standardImplementation(platform(libs.google.firebase.bom))
-    standardImplementation(libs.google.firebase.crashlytics)
     standardImplementation(libs.google.billing)
-    standardImplementation(libs.google.play.review)
+    standardImplementation(platform(libs.google.firebase.bom))
+    standardImplementation(libs.google.firebase.cloud.messaging)
+    standardImplementation(libs.google.firebase.crashlytics)
     standardImplementation(libs.google.mlkit.text.recognition)
+    standardImplementation(libs.google.play.review)
 
     // Pull in test fixtures from other modules
     testImplementation(testFixtures(project(":core")))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -299,6 +299,7 @@ dependencies {
     standardImplementation(libs.google.firebase.crashlytics)
     standardImplementation(libs.google.billing)
     standardImplementation(libs.google.play.review)
+    standardImplementation(libs.google.mlkit.text.recognition)
 
     // Pull in test fixtures from other modules
     testImplementation(testFixtures(project(":core")))

--- a/app/src/fdroid/kotlin/com/bitwarden/ui/platform/feature/cardscanner/util/CardTextAnalyzerImpl.kt
+++ b/app/src/fdroid/kotlin/com/bitwarden/ui/platform/feature/cardscanner/util/CardTextAnalyzerImpl.kt
@@ -1,0 +1,28 @@
+package com.bitwarden.ui.platform.feature.cardscanner.util
+
+import androidx.camera.core.ImageProxy
+import com.bitwarden.annotation.OmitFromCoverage
+
+/**
+ * No-op [CardTextAnalyzer] for the F-Droid build flavor.
+ *
+ * Google ML Kit is not permitted in F-Droid releases, so this stub replaces the
+ * standard analyzer at build time. The Scan Card UI is hidden via
+ * `BuildInfoManager.isFdroid`; this implementation exists solely to satisfy the
+ * flavor-uniform construction path used by `LocalManagerProvider`.
+ *
+ * @property cardDataParser Unused; retained so the constructor signature
+ * matches the standard flavor and call sites remain identical.
+ */
+@OmitFromCoverage
+@Suppress("UnusedPrivateProperty")
+class CardTextAnalyzerImpl(
+    private val cardDataParser: CardDataParser,
+) : CardTextAnalyzer {
+
+    override lateinit var onCardScanned: (CardScanData) -> Unit
+
+    override fun analyze(image: ImageProxy) {
+        image.close()
+    }
+}

--- a/app/src/fdroid/kotlin/com/bitwarden/ui/platform/feature/cardscanner/util/CardTextAnalyzerImpl.kt
+++ b/app/src/fdroid/kotlin/com/bitwarden/ui/platform/feature/cardscanner/util/CardTextAnalyzerImpl.kt
@@ -9,15 +9,14 @@ import com.bitwarden.annotation.OmitFromCoverage
  * Google ML Kit is not permitted in F-Droid releases, so this stub replaces the
  * standard analyzer at build time. The Scan Card UI is hidden via
  * `BuildInfoManager.isFdroid`; this implementation exists solely to satisfy the
- * flavor-uniform construction path used by `LocalManagerProvider`.
- *
- * @property cardDataParser Unused; retained so the constructor signature
+ * flavor-uniform construction path used by `LocalManagerProvider`. The
+ * `cardDataParser` argument is unused, retained so the constructor signature
  * matches the standard flavor and call sites remain identical.
  */
 @OmitFromCoverage
-@Suppress("UnusedPrivateProperty")
+@Suppress("UnusedParameter")
 class CardTextAnalyzerImpl(
-    private val cardDataParser: CardDataParser,
+    cardDataParser: CardDataParser,
 ) : CardTextAnalyzer {
 
     override lateinit var onCardScanned: (CardScanData) -> Unit

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -5,6 +5,7 @@ import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.provider.CallingAppInfo
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.manager.toast.ToastManager
 import com.bitwarden.core.data.repository.model.DataState
@@ -126,6 +127,7 @@ class VaultAddEditViewModel @Inject constructor(
     featureFlagManager: FeatureFlagManager,
     generatorRepository: GeneratorRepository,
     cardScanManager: CardScanManager,
+    private val buildInfoManager: BuildInfoManager,
     private val snackbarRelayManager: SnackbarRelayManager<SnackbarRelay>,
     private val toastManager: ToastManager,
     private val authRepository: AuthRepository,
@@ -183,7 +185,8 @@ class VaultAddEditViewModel @Inject constructor(
 
             VaultAddEditState(
                 isArchiveEnabled = featureFlagManager.getFeatureFlag(FlagKey.ArchiveItems),
-                isCardScannerEnabled = featureFlagManager.getFeatureFlag(FlagKey.CardScanner),
+                isCardScannerEnabled = featureFlagManager
+                    .getFeatureFlag(FlagKey.CardScanner) && !buildInfoManager.isFdroid,
                 vaultAddEditType = vaultAddEditType,
                 cipherType = vaultCipherType,
                 viewState = when (vaultAddEditType) {
@@ -1929,7 +1932,9 @@ class VaultAddEditViewModel @Inject constructor(
     private fun handleCardScannerFlagUpdateReceive(
         action: VaultAddEditAction.Internal.CardScannerFlagUpdateReceive,
     ) {
-        mutableStateFlow.update { it.copy(isCardScannerEnabled = action.isEnabled) }
+        mutableStateFlow.update {
+            it.copy(isCardScannerEnabled = action.isEnabled && !buildInfoManager.isFdroid)
+        }
     }
 
     private fun handleCardScanResultReceive(

--- a/app/src/standard/kotlin/com/bitwarden/ui/platform/feature/cardscanner/util/CardTextAnalyzerImpl.kt
+++ b/app/src/standard/kotlin/com/bitwarden/ui/platform/feature/cardscanner/util/CardTextAnalyzerImpl.kt
@@ -13,6 +13,9 @@ import java.util.concurrent.atomic.AtomicBoolean
  * [CardTextAnalyzer] implementation that uses ML Kit Text Recognition
  * to detect credit card details from camera frames.
  *
+ * Only used in the standard build flavor. The F-Droid flavor provides a no-op
+ * stub because Google ML Kit is not permitted in F-Droid builds.
+ *
  * @property cardDataParser The parser used to extract card data from
  * recognized text.
  */
@@ -23,9 +26,10 @@ class CardTextAnalyzerImpl(
 
     private val isInAnalysis = AtomicBoolean(false)
 
-    private val recognizer = TextRecognition.getClient(
-        TextRecognizerOptions.DEFAULT_OPTIONS,
-    )
+    // Lazy so ML Kit is only touched once a scan begins, never during construction.
+    private val recognizer by lazy {
+        TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    }
 
     override lateinit var onCardScanned: (CardScanData) -> Unit
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -7,6 +7,7 @@ import androidx.credentials.provider.ProviderCreateCredentialRequest
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.collections.CollectionView
+import com.bitwarden.core.data.manager.BuildInfoManager
 import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.manager.toast.ToastManager
@@ -238,6 +239,9 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         every { getFeatureFlagFlow(FlagKey.ArchiveItems) } returns mutableArchiveItemsFlow
         every { getFeatureFlag(FlagKey.CardScanner) } answers { mutableCardScannerFlow.value }
         every { getFeatureFlagFlow(FlagKey.CardScanner) } returns mutableCardScannerFlow
+    }
+    private val buildInfoManager: BuildInfoManager = mockk {
+        every { isFdroid } returns false
     }
 
     @BeforeEach
@@ -5143,6 +5147,25 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
         }
 
     @Test
+    fun `isCardScannerEnabled should remain false on F-Droid even when flag is on`() =
+        runTest {
+            every { buildInfoManager.isFdroid } returns true
+            mutableCardScannerFlow.value = true
+            val initState = createVaultAddItemState()
+            val viewModel = createAddVaultItemViewModel()
+            assertEquals(
+                initState.copy(isCardScannerEnabled = false),
+                viewModel.stateFlow.value,
+            )
+            mutableCardScannerFlow.value = false
+            mutableCardScannerFlow.value = true
+            assertEquals(
+                initState.copy(isCardScannerEnabled = false),
+                viewModel.stateFlow.value,
+            )
+        }
+
+    @Test
     fun `CardScanResultReceive with Success should update card fields and focus name`() =
         runTest {
             val viewModel = createAddVaultItemViewModel(
@@ -5523,6 +5546,7 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
             savedStateHandle = savedStateHandle,
             featureFlagManager = featureFlagManager,
             authRepository = authRepository,
+            buildInfoManager = buildInfoManager,
             clipboardManager = bitwardenClipboardManager,
             cardScanManager = cardScanManager,
             policyManager = policyManager,

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -76,7 +76,6 @@ dependencies {
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.bumptech.glide)
-    implementation(libs.google.mlkit.text.recognition)
     implementation(libs.kotlinx.serialization)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.collections.immutable)


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-36867
- https://github.com/bitwarden/android/issues/6884

## 📔 Objective

Hotfix port of #6888 to `release/hotfix-v2026.4.1-bwpm`.

F-Droid builds were crashing on launch because `CardTextAnalyzerImpl` was constructed eagerly as a default parameter on `LocalManagerProvider` — its property initializer called ML Kit's `TextRecognition.getClient(...)` during composition setup at app startup, which fails on devices without functional Google Play Services (GrapheneOS owner profile, restricted GMS, etc.).

F-Droid policy disallows Google ML Kit, so the card scanner is disabled there entirely:

- ML Kit dependency moves from `:ui` to `:app` `standardImplementation`
- `CardTextAnalyzerImpl` is split by flavor: real ML Kit impl in `app/src/standard`, no-op stub in `app/src/fdroid` (matching the existing flavor-stub pattern used by `LogsManagerImpl`, `PlayBillingManagerImpl`, `AppReviewManagerImpl`)
- The standard impl's `recognizer` is now `by lazy` so ML Kit is never touched in `<init>`, hardening against future composition-default mistakes
- `VaultAddEditViewModel.isCardScannerEnabled` is gated on `!buildInfoManager.isFdroid` for both initial state and the runtime feature-flag-update path, so the Scan Card button never renders on F-Droid builds