### PR TITLE
Use string resource for button label

### DIFF
--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialScreen.kt
@@ -156,7 +156,7 @@ private fun TutorialScreenContent(
         )
 
         BitwardenFilledButton(
-            label = state.actionButtonText,
+            label = stringResource(id = state.actionButtonText),
             onClick = { continueClick(state.index) },
             modifier = Modifier
                 .standardHorizontalMargin()

--- a/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialViewModel.kt
+++ b/authenticator/src/main/kotlin/com/bitwarden/authenticator/ui/platform/feature/tutorial/TutorialViewModel.kt
@@ -73,8 +73,12 @@ data class TutorialState(
      * - Displays "Continue" if the user is not on the last page.
      * - Displays "Get Started" if the user is on the last page.
      */
-    val actionButtonText: String
-        get() = if (index != pages.lastIndex) "Continue" else "Get Started"
+    val actionButtonText: Int
+        get() = if (index != pages.lastIndex) {
+            BitwardenString.continue_text
+        } else {
+            BitwardenString.get_started
+        }
 
     /**
      * Indicates whether the current slide is the last in the pages array.

--- a/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/tutorial/TutorialScreenTest.kt
+++ b/authenticator/src/test/kotlin/com/bitwarden/authenticator/ui/authenticator/feature/tutorial/TutorialScreenTest.kt
@@ -79,7 +79,7 @@ class TutorialScreenTest : AuthenticatorComposeTest() {
             it.copy(pages = listOf(TutorialState.TutorialSlide.UniqueCodesSlide))
         }
         composeTestRule
-            .onNodeWithText("Get Started")
+            .onNodeWithText("Get started")
             .assertExists()
             .assertIsDisplayed()
     }
@@ -106,7 +106,7 @@ class TutorialScreenTest : AuthenticatorComposeTest() {
             it.copy(pages = listOf(TutorialState.TutorialSlide.UniqueCodesSlide))
         }
         composeTestRule
-            .onNodeWithText("Get Started")
+            .onNodeWithText("Get started")
             .performClick()
         verify {
             viewModel.trySendAction(TutorialAction.ContinueClick(mutableStateFlow.value.index))

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -812,7 +812,7 @@ Do you want to switch to this account?</string>
     <string name="error_connecting_with_the_duo_service_use_a_different_two_step_login_method_or_contact_duo_for_assistance">Error connecting with the Duo service. Use a different two-step login method or contact Duo for assistance.</string>
     <string name="master_password_hint_not_specified">Master password hint</string>
     <string name="new_master_password_hint">New master password hint</string>
-    <string name="get_started">Get started</string>
+    <string name="get_started">Get Started</string>
     <string name="save_and_protect_your_data">Save and protect your data</string>
     <string name="the_vault_protects_more_than_just_passwords">The vault protects more than just passwords. Store secure logins, IDs, cards and notes securely here.</string>
     <string name="new_login">New login</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -812,7 +812,7 @@ Do you want to switch to this account?</string>
     <string name="error_connecting_with_the_duo_service_use_a_different_two_step_login_method_or_contact_duo_for_assistance">Error connecting with the Duo service. Use a different two-step login method or contact Duo for assistance.</string>
     <string name="master_password_hint_not_specified">Master password hint</string>
     <string name="new_master_password_hint">New master password hint</string>
-    <string name="get_started">Get Started</string>
+    <string name="get_started">Get started</string>
     <string name="save_and_protect_your_data">Save and protect your data</string>
     <string name="the_vault_protects_more_than_just_passwords">The vault protects more than just passwords. Store secure logins, IDs, cards and notes securely here.</string>
     <string name="new_login">New login</string>


### PR DESCRIPTION
## 📔 Objective

Currently a hard coded string is used for the primary button label on tutorial screens in the authenticator app, which makes it impossible to translate. A string resource in now used.
