### PR TITLE
Bug: Fix CipherType crash

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensions.kt
@@ -739,9 +739,8 @@ fun CipherTypeJson.toSdkCipherType(): CipherType =
         CipherTypeJson.IDENTITY -> CipherType.IDENTITY
         CipherTypeJson.SSH_KEY -> CipherType.SSH_KEY
         CipherTypeJson.BANK_ACCOUNT -> CipherType.BANK_ACCOUNT
-        CipherTypeJson.DRIVERS_LICENSE,
-        CipherTypeJson.PASSPORT,
-            -> throw IllegalArgumentException("SDK mapping not yet available for $this")
+        CipherTypeJson.DRIVERS_LICENSE -> CipherType.DRIVERS_LICENSE
+        CipherTypeJson.PASSPORT -> CipherType.PASSPORT
     }
 
 /**

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/vault/repository/util/VaultSdkCipherExtensionsTest.kt
@@ -39,7 +39,6 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkSshKey
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockSdkUri
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.jupiter.api.assertNull
@@ -357,21 +356,20 @@ class VaultSdkCipherExtensionsTest {
         )
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `toSdkCipherType should throw for DRIVERS_LICENSE since SDK mapping is not yet available`() {
-        val error = assertThrows(IllegalArgumentException::class.java) {
-            CipherTypeJson.DRIVERS_LICENSE.toSdkCipherType()
-        }
-        assertEquals("SDK mapping not yet available for DRIVERS_LICENSE", error.message)
+    fun `toSdkCipherType should map LICENSE to the SDK LICENSE type`() {
+        assertEquals(
+            CipherType.DRIVERS_LICENSE,
+            CipherTypeJson.DRIVERS_LICENSE.toSdkCipherType(),
+        )
     }
 
     @Test
-    fun `toSdkCipherType should throw for PASSPORT since SDK mapping is not yet available`() {
-        val error = assertThrows(IllegalArgumentException::class.java) {
-            CipherTypeJson.PASSPORT.toSdkCipherType()
-        }
-        assertEquals("SDK mapping not yet available for PASSPORT", error.message)
+    fun `toSdkCipherType should map PASSPORT to the SDK PASSPORT type`() {
+        assertEquals(
+            CipherType.PASSPORT,
+            CipherTypeJson.PASSPORT.toSdkCipherType(),
+        )
     }
 
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR fixes a crash if the server sends a Passport of License CipherType to the application.
