### PR TITLE
[PM-35435] ci: Stop applying Change Type labels based on changed files

### DIFF
--- a/.github/label-pr.json
+++ b/.github/label-pr.json
@@ -27,32 +27,6 @@
     ],
     "app:authenticator": [
       "authenticator/"
-    ],
-    "t:feature": [
-      "app/src/main/assets/fido2_privileged_community.json",
-      "app/src/main/assets/fido2_privileged_google.json",
-      "testharness/"
-    ],
-    "t:tech-debt": [
-      "gradle.properties",
-      "keystore/"
-    ],
-    "t:ci": [
-      ".checkmarx/",
-      ".github/",
-      "scripts/",
-      "fastlane/",
-      ".gradle/",
-      "detekt-config.yml"
-    ],
-    "t:docs": [
-      "docs/"
-    ],
-    "t:deps": [
-      "gradle/"
-    ],
-    "t:llm": [
-      ".claude/"
     ]
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-35435

## 📔 Objective

Based on team feedback we’ll stop applying Change Type (t:) labels based on changed files. 

This decision was made based on:

1. Single Change Type label t: restriction, enforced by our Enforce Labels workflow, given that GitHub Release Notes Categories will only list a given PR in a single category.
2. Title convention has been the preferred option for the team.
3. Matching changed files leading to multiple labels being matched introducing unnecessary friction for the team.
