### PR TITLE
[PM-36969] feat: Surface subscription substate to premium gates

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/di/BillingModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/di/BillingModule.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.network.service.BillingService
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
-import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManager
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManagerImpl
 import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
@@ -54,7 +53,6 @@ object BillingModule {
     @Singleton
     fun providePremiumStateManager(
         authDiskSource: AuthDiskSource,
-        authRepository: AuthRepository,
         billingRepository: BillingRepository,
         settingsDiskSource: SettingsDiskSource,
         vaultRepository: VaultRepository,
@@ -64,7 +62,6 @@ object BillingModule {
         dispatcherManager: DispatcherManager,
     ): PremiumStateManager = PremiumStateManagerImpl(
         authDiskSource = authDiskSource,
-        authRepository = authRepository,
         billingRepository = billingRepository,
         settingsDiskSource = settingsDiskSource,
         vaultRepository = vaultRepository,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -38,10 +38,13 @@ interface PremiumStateManager {
     val isPlanRowEligibleFlow: StateFlow<Boolean>
 
     /**
-     * Emits the active user's latest [SubscriptionStatusState]. Fetches lazily when the
-     * active account is premium; emits [SubscriptionStatusState.NoSubscription] for
-     * non-premium accounts and for 404 responses (no `GatewaySubscriptionId`).
+     * Emits the active user's latest [SubscriptionStatusState]. Fetches whenever there is
+     * an active user (regardless of `Account.isPremium`) so that users whose Stripe
+     * subscription has moved to a terminal state still surface the correct substate; emits
+     * [SubscriptionStatusState.NoSubscription] when there is no active user or when the
+     * server returns 404 (no `GatewaySubscriptionId`).
      */
+    val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState>
     val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState>
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -1,5 +1,6 @@
 package com.x8bit.bitwarden.data.billing.manager
 
+import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -15,7 +16,11 @@ interface PremiumStateManager {
 
     /**
      * Emits `true` when the current user is eligible to see the Premium upgrade banner,
-     * or `false` otherwise.
+     * or `false` otherwise. A user is "effectively premium" — and therefore ineligible
+     * for the banner — only when their account is premium and their subscription is not
+     * in a recovery or terminal state. Trouble states (past due, update payment, canceled,
+     * expired, paused) flip eligibility back on even while the server still reports
+     * `isPremium=true` during the grace window.
      */
     val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean>
 
@@ -31,6 +36,13 @@ interface PremiumStateManager {
      * otherwise.
      */
     val isPlanRowEligibleFlow: StateFlow<Boolean>
+
+    /**
+     * Emits the active user's latest [SubscriptionStatusState]. Fetches lazily when the
+     * active account is premium; emits [SubscriptionStatusState.NoSubscription] for
+     * non-premium accounts and for 404 responses (no `GatewaySubscriptionId`).
+     */
+    val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState>
 
     /**
      * Returns `true` when the in-app upgrade flow is available, or `false` otherwise.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -19,7 +19,7 @@ interface PremiumStateManager {
      * or `false` otherwise. A user is "effectively premium" — and therefore ineligible
      * for the banner — only when their account is premium and their subscription is not
      * in a recovery or terminal state. Trouble states (past due, update payment, canceled,
-     * expired, paused) flip eligibility back on even while the server still reports
+     * paused) flip eligibility back on even while the server still reports
      * `isPremium=true` during the grace window.
      */
     val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean>

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -16,11 +16,7 @@ interface PremiumStateManager {
 
     /**
      * Emits `true` when the current user is eligible to see the Premium upgrade banner,
-     * or `false` otherwise. A user is "effectively premium" — and therefore ineligible
-     * for the banner — only when their account is premium and their subscription is not
-     * in a recovery or terminal state. Trouble states (past due, update payment, canceled,
-     * paused) flip eligibility back on even while the server still reports
-     * `isPremium=true` during the grace window.
+     * or `false` otherwise.
      */
     val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean>
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -38,13 +38,8 @@ interface PremiumStateManager {
     val isPlanRowEligibleFlow: StateFlow<Boolean>
 
     /**
-     * Emits the active user's latest [SubscriptionStatusState]. Fetches whenever there is
-     * an active user (regardless of `Account.isPremium`) so that users whose Stripe
-     * subscription has moved to a terminal state still surface the correct substate; emits
-     * [SubscriptionStatusState.NoSubscription] when there is no active user or when the
-     * server returns 404 (no `GatewaySubscriptionId`).
+     * Emits the active user's latest [SubscriptionStatusState].
      */
-    val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState>
     val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState>
 
     /**

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -63,10 +63,10 @@ class PremiumStateManagerImpl(
     override val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState> =
         authRepository
             .userStateFlow
-            .map { state -> state?.activeAccount?.let { it.userId to it.isPremium } }
+            .map { state -> state?.activeAccount?.userId }
             .distinctUntilChanged()
-            .flatMapLatest { activeAccount ->
-                if (activeAccount?.second == true) {
+            .flatMapLatest { userId ->
+                if (userId != null) {
                     fetchSubscriptionStatusFlow()
                 } else {
                     flowOf(SubscriptionStatusState.NoSubscription)

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -59,6 +59,14 @@ class PremiumStateManagerImpl(
     private val subscriptionRefreshTriggerFlow =
         MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
 
+    /**
+     * Keyed on the active user's id so a logout/switch retriggers the fetch. Runs whenever
+     * there is an active user regardless of `Account.isPremium` — users whose Stripe
+     * subscription has moved to a terminal state need their substate surfaced even though
+     * the server reports them as non-premium. Emits [SubscriptionStatusState.NoSubscription]
+     * when there is no active user or when the server returns 404 (no `GatewaySubscriptionId`,
+     * i.e. genuinely free users).
+     */
     @OptIn(ExperimentalCoroutinesApi::class)
     override val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState> =
         authRepository

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -63,13 +63,13 @@ class PremiumStateManagerImpl(
     override val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState> =
         authRepository
             .userStateFlow
-            .map { it?.activeAccount?.userId }
+            .map { state -> state?.activeAccount?.let { it.userId to it.isPremium } }
             .distinctUntilChanged()
-            .flatMapLatest { userId ->
-                if (userId == null) {
-                    flowOf(SubscriptionStatusState.NoSubscription)
-                } else {
+            .flatMapLatest { activeAccount ->
+                if (activeAccount?.second == true) {
                     fetchSubscriptionStatusFlow()
+                } else {
+                    flowOf(SubscriptionStatusState.NoSubscription)
                 }
             }
             .stateIn(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -292,12 +292,12 @@ class PremiumStateManagerImpl(
 
     private suspend fun fetchSubscriptionStatusOnce(): SubscriptionStatusState =
         when (val result = billingRepository.getSubscription()) {
-            is SubscriptionResult.Success ->
+            is SubscriptionResult.Success -> {
                 SubscriptionStatusState.Available(status = result.subscription.status)
+            }
 
             SubscriptionResult.NotFound -> SubscriptionStatusState.NoSubscription
-            is SubscriptionResult.Error ->
-                SubscriptionStatusState.Error(throwable = result.error)
+            is SubscriptionResult.Error -> SubscriptionStatusState.Error(throwable = result.error)
         }
 }
 
@@ -313,17 +313,17 @@ private data class BannerInputs(
  * Returns `true` when the given [SubscriptionStatusState] represents a subscription substate
  * that should disqualify a user from being treated as effectively premium.
  */
-private fun SubscriptionStatusState.isInTroubleState(): Boolean = this is
-    SubscriptionStatusState.Available &&
-    when (this.status) {
-        PremiumSubscriptionStatus.CANCELED,
-        PremiumSubscriptionStatus.PAST_DUE,
-        PremiumSubscriptionStatus.PAUSED,
-        PremiumSubscriptionStatus.UPDATE_PAYMENT,
-        -> true
+private fun SubscriptionStatusState.isInTroubleState(): Boolean =
+    this is SubscriptionStatusState.Available &&
+        when (this.status) {
+            PremiumSubscriptionStatus.CANCELED,
+            PremiumSubscriptionStatus.PAST_DUE,
+            PremiumSubscriptionStatus.PAUSED,
+            PremiumSubscriptionStatus.UPDATE_PAYMENT,
+                -> true
 
-        PremiumSubscriptionStatus.ACTIVE -> false
-    }
+            PremiumSubscriptionStatus.ACTIVE -> false
+        }
 
 /**
  * Returns `true` if this [Instant] is older than the given number of [days] based on

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -4,8 +4,7 @@ import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
-import com.x8bit.bitwarden.data.auth.repository.AuthRepository
-import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
@@ -44,7 +43,6 @@ import java.time.Instant
 @Suppress("LongParameterList", "LargeClass")
 class PremiumStateManagerImpl(
     private val authDiskSource: AuthDiskSource,
-    authRepository: AuthRepository,
     private val billingRepository: BillingRepository,
     private val settingsDiskSource: SettingsDiskSource,
     vaultRepository: VaultRepository,
@@ -69,10 +67,8 @@ class PremiumStateManagerImpl(
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     override val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState> =
-        authRepository
-            .userStateFlow
-            .map { state -> state?.activeAccount?.userId }
-            .distinctUntilChanged()
+        authDiskSource
+            .activeUserIdChangesFlow
             .flatMapLatest { userId ->
                 if (userId != null) {
                     fetchSubscriptionStatusFlow()
@@ -89,7 +85,7 @@ class PremiumStateManagerImpl(
     @OptIn(ExperimentalCoroutinesApi::class)
     override val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean> =
         combine(
-            authRepository.userStateFlow,
+            authDiskSource.userStateFlow,
             billingRepository.isInAppBillingSupportedFlow,
             featureFlagManager.getFeatureFlagFlow(FlagKey.MobilePremiumUpgrade),
             authDiskSource.activeUserIdChangesFlow
@@ -119,14 +115,16 @@ class PremiumStateManagerImpl(
             )
         }
             .combine(subscriptionStatusStateFlow) { inputs, subscriptionStatus ->
-                val activeAccount = inputs.userState?.activeAccount
+                val profile = inputs.userState?.activeAccount?.profile
                     ?: return@combine false
-                val isAccountOldEnough = activeAccount.creationDate.isOlderThanDays(
+                val isAccountOldEnough = profile.creationDate.isOlderThanDays(
                     days = PREMIUM_UPGRADE_MINIMUM_ACCOUNT_AGE_DAYS,
                     clock = clock,
                 )
                 val itemCount = inputs.vaultDataState.activeVaultItemCount()
-                val isEffectivelyPremium = activeAccount.isPremium &&
+                val hasPremium = profile.hasPremiumPersonally == true ||
+                    profile.hasPremiumFromOrganization == true
+                val isEffectivelyPremium = hasPremium &&
                     !subscriptionStatus.isInTroubleState()
 
                 !isEffectivelyPremium &&
@@ -149,11 +147,14 @@ class PremiumStateManagerImpl(
      */
     override val isPlanRowEligibleFlow: StateFlow<Boolean> =
         combine(
-            authRepository.userStateFlow,
+            authDiskSource.userStateFlow,
             featureFlagManager.getFeatureFlagFlow(FlagKey.MobilePremiumUpgrade),
         ) { userState, featureFlagEnabled ->
-            val activeAccount = userState?.activeAccount ?: return@combine false
-            val isOrgOnlyPremium = activeAccount.isPremium && !activeAccount.isPremiumFromSelf
+            val profile = userState?.activeAccount?.profile ?: return@combine false
+            val hasPremium = profile.hasPremiumPersonally == true ||
+                profile.hasPremiumFromOrganization == true
+            val isPremiumFromSelf = profile.hasPremiumPersonally == true
+            val isOrgOnlyPremium = hasPremium && !isPremiumFromSelf
             featureFlagEnabled && !isOrgOnlyPremium
         }
             .stateIn(
@@ -183,9 +184,11 @@ class PremiumStateManagerImpl(
                         settingsDiskSource
                             .getUpgradedToPremiumCardConsumedFlow(userId)
                             .map { it ?: false },
-                        authRepository
+                        authDiskSource
                             .userStateFlow
-                            .map { it?.activeAccount?.isPremiumFromSelf == true },
+                            .map {
+                                it?.activeAccount?.profile?.hasPremiumPersonally == true
+                            },
                     ) { isPending, isConsumed, isPremiumFromSelf ->
                         isPending && !isConsumed && isPremiumFromSelf
                     }
@@ -214,12 +217,15 @@ class PremiumStateManagerImpl(
             .launchIn(unconfinedScope)
 
         // Sync-delta detection: observe the active user's personal premium flag transitioning
-        // false → true (e.g., F-Droid users without push support). Keyed on `isPremiumFromSelf`
-        // so that organization-granted premium does not trigger the personal-upgrade card.
-        authRepository
+        // false → true (e.g., F-Droid users without push support). Keyed on
+        // `hasPremiumPersonally` so that organization-granted premium does not trigger the
+        // personal-upgrade card.
+        authDiskSource
             .userStateFlow
             .map { state ->
-                state?.activeAccount?.let { it.userId to it.isPremiumFromSelf }
+                state?.activeAccount?.profile?.let {
+                    it.userId to (it.hasPremiumPersonally == true)
+                }
             }
             .distinctUntilChanged()
             .scanPairs()
@@ -296,7 +302,7 @@ class PremiumStateManagerImpl(
 }
 
 private data class BannerInputs(
-    val userState: UserState?,
+    val userState: UserStateJson?,
     val isInAppBillingSupported: Boolean,
     val featureFlagEnabled: Boolean,
     val isDismissed: Boolean,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -5,8 +5,12 @@ import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
+import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
+import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
+import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
+import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
@@ -16,14 +20,18 @@ import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import java.time.Clock
@@ -33,7 +41,7 @@ import java.time.Instant
 /**
  * Default implementation of [PremiumStateManager].
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LargeClass")
 class PremiumStateManagerImpl(
     private val authDiskSource: AuthDiskSource,
     authRepository: AuthRepository,
@@ -47,6 +55,28 @@ class PremiumStateManagerImpl(
 ) : PremiumStateManager {
 
     private val unconfinedScope = CoroutineScope(dispatcherManager.unconfined)
+
+    private val subscriptionRefreshTriggerFlow =
+        MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState> =
+        authRepository
+            .userStateFlow
+            .map { it?.activeAccount?.userId }
+            .distinctUntilChanged()
+            .flatMapLatest { userId ->
+                if (userId == null) {
+                    flowOf(SubscriptionStatusState.NoSubscription)
+                } else {
+                    fetchSubscriptionStatusFlow()
+                }
+            }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = SubscriptionStatusState.Loading,
+            )
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override val isPremiumUpgradeBannerEligibleFlow: StateFlow<Boolean> =
@@ -72,22 +102,32 @@ class PremiumStateManagerImpl(
                 isDismissed,
                 vaultDataState,
             ->
-            val activeAccount = userState?.activeAccount
-                ?: return@combine false
-            val isPremium = activeAccount.isPremium
-            val isAccountOldEnough = activeAccount.creationDate.isOlderThanDays(
-                days = PREMIUM_UPGRADE_MINIMUM_ACCOUNT_AGE_DAYS,
-                clock = clock,
+            BannerInputs(
+                userState = userState,
+                isInAppBillingSupported = isInAppBillingSupported,
+                featureFlagEnabled = featureFlagEnabled,
+                isDismissed = isDismissed,
+                vaultDataState = vaultDataState,
             )
-            val itemCount = vaultDataState.activeVaultItemCount()
-
-            !isPremium &&
-                isInAppBillingSupported &&
-                featureFlagEnabled &&
-                !isDismissed &&
-                isAccountOldEnough &&
-                itemCount >= PREMIUM_UPGRADE_MINIMUM_VAULT_ITEMS
         }
+            .combine(subscriptionStatusStateFlow) { inputs, subscriptionStatus ->
+                val activeAccount = inputs.userState?.activeAccount
+                    ?: return@combine false
+                val isAccountOldEnough = activeAccount.creationDate.isOlderThanDays(
+                    days = PREMIUM_UPGRADE_MINIMUM_ACCOUNT_AGE_DAYS,
+                    clock = clock,
+                )
+                val itemCount = inputs.vaultDataState.activeVaultItemCount()
+                val isEffectivelyPremium = activeAccount.isPremium &&
+                    !subscriptionStatus.isInTroubleState()
+
+                !isEffectivelyPremium &&
+                    inputs.isInAppBillingSupported &&
+                    inputs.featureFlagEnabled &&
+                    !inputs.isDismissed &&
+                    isAccountOldEnough &&
+                    itemCount >= PREMIUM_UPGRADE_MINIMUM_VAULT_ITEMS
+            }
             .stateIn(
                 scope = unconfinedScope,
                 started = SharingStarted.Eagerly,
@@ -159,6 +199,9 @@ class PremiumStateManagerImpl(
                 if (data.isPremium) {
                     markUpgradedToPremiumCardPending(userId = data.userId)
                 }
+                // Push always re-fetches: a status push can mean either "newly premium" or
+                // "subscription moved into a trouble state" (e.g. past_due → unpaid).
+                subscriptionRefreshTriggerFlow.tryEmit(Unit)
             }
             .launchIn(unconfinedScope)
 
@@ -219,7 +262,54 @@ class PremiumStateManagerImpl(
             isPending = true,
         )
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun fetchSubscriptionStatusFlow(): Flow<SubscriptionStatusState> =
+        merge(
+            flowOf(Unit),
+            subscriptionRefreshTriggerFlow,
+        )
+            .flatMapLatest {
+                flow {
+                    emit(SubscriptionStatusState.Loading)
+                    emit(fetchSubscriptionStatusOnce())
+                }
+            }
+
+    private suspend fun fetchSubscriptionStatusOnce(): SubscriptionStatusState =
+        when (val result = billingRepository.getSubscription()) {
+            is SubscriptionResult.Success ->
+                SubscriptionStatusState.Available(status = result.subscription.status)
+
+            SubscriptionResult.NotFound -> SubscriptionStatusState.NoSubscription
+            is SubscriptionResult.Error ->
+                SubscriptionStatusState.Error(throwable = result.error)
+        }
 }
+
+private data class BannerInputs(
+    val userState: UserState?,
+    val isInAppBillingSupported: Boolean,
+    val featureFlagEnabled: Boolean,
+    val isDismissed: Boolean,
+    val vaultDataState: DataState<VaultData>,
+)
+
+/**
+ * Returns `true` when the given [SubscriptionStatusState] represents a subscription substate
+ * that should disqualify a user from being treated as effectively premium.
+ */
+private fun SubscriptionStatusState.isInTroubleState(): Boolean = this is
+    SubscriptionStatusState.Available &&
+    when (this.status) {
+        PremiumSubscriptionStatus.CANCELED,
+        PremiumSubscriptionStatus.PAST_DUE,
+        PremiumSubscriptionStatus.PAUSED,
+        PremiumSubscriptionStatus.UPDATE_PAYMENT,
+        -> true
+
+        PremiumSubscriptionStatus.ACTIVE -> false
+    }
 
 /**
  * Returns `true` if this [Instant] is older than the given number of [days] based on

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepository.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepository.kt
@@ -32,7 +32,9 @@ interface BillingRepository {
     suspend fun getPremiumPlanPricing(): PremiumPlanPricingResult
 
     /**
-     * Fetches the current user's premium subscription details.
+     * Fetches the current user's premium subscription details. The endpoint 404s when the
+     * user has no `GatewaySubscriptionId` (free user); callers receive
+     * [SubscriptionResult.NotFound] in that case instead of [SubscriptionResult.Error].
      */
     suspend fun getSubscription(): SubscriptionResult
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.x8bit.bitwarden.data.billing.repository
 
-import com.bitwarden.network.model.BitwardenError
-import com.bitwarden.network.model.toBitwardenError
+import com.bitwarden.network.model.GetSubscriptionResponse
 import com.bitwarden.network.service.BillingService
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManager
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
@@ -10,8 +9,6 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResul
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
 import com.x8bit.bitwarden.data.billing.repository.util.toSubscriptionInfo
 import kotlinx.coroutines.flow.StateFlow
-
-private const val HTTP_CODE_NOT_FOUND: Int = 404
 
 /**
  * The default implementation of [BillingRepository].
@@ -58,20 +55,15 @@ class BillingRepositoryImpl(
         billingService
             .getSubscription()
             .fold(
-                onSuccess = {
-                    SubscriptionResult.Success(
-                        subscription = it.toSubscriptionInfo(),
-                    )
-                },
-                onFailure = { throwable ->
-                    val bitwardenError = throwable.toBitwardenError()
-                    if (bitwardenError is BitwardenError.Http &&
-                        bitwardenError.code == HTTP_CODE_NOT_FOUND
-                    ) {
-                        SubscriptionResult.NotFound
-                    } else {
-                        SubscriptionResult.Error(error = throwable)
+                onSuccess = { response ->
+                    when (response) {
+                        is GetSubscriptionResponse.Success -> SubscriptionResult.Success(
+                            subscription = response.subscription.toSubscriptionInfo(),
+                        )
+
+                        is GetSubscriptionResponse.NotFound -> SubscriptionResult.NotFound
                     }
                 },
+                onFailure = { SubscriptionResult.Error(error = it) },
             )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.x8bit.bitwarden.data.billing.repository
 
+import com.bitwarden.network.model.BitwardenError
+import com.bitwarden.network.model.toBitwardenError
 import com.bitwarden.network.service.BillingService
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManager
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
@@ -8,6 +10,8 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResul
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
 import com.x8bit.bitwarden.data.billing.repository.util.toSubscriptionInfo
 import kotlinx.coroutines.flow.StateFlow
+
+private const val HTTP_CODE_NOT_FOUND: Int = 404
 
 /**
  * The default implementation of [BillingRepository].
@@ -59,6 +63,15 @@ class BillingRepositoryImpl(
                         subscription = it.toSubscriptionInfo(),
                     )
                 },
-                onFailure = { SubscriptionResult.Error(error = it) },
+                onFailure = { throwable ->
+                    val bitwardenError = throwable.toBitwardenError()
+                    if (bitwardenError is BitwardenError.Http &&
+                        bitwardenError.code == HTTP_CODE_NOT_FOUND
+                    ) {
+                        SubscriptionResult.NotFound
+                    } else {
+                        SubscriptionResult.Error(error = throwable)
+                    }
+                },
             )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumSubscriptionStatus.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/PremiumSubscriptionStatus.kt
@@ -6,7 +6,7 @@ package com.x8bit.bitwarden.data.billing.repository.model
 enum class PremiumSubscriptionStatus {
     ACTIVE,
     CANCELED,
-    OVERDUE_PAYMENT,
     PAST_DUE,
     PAUSED,
+    UPDATE_PAYMENT,
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/SubscriptionResult.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/SubscriptionResult.kt
@@ -12,6 +12,13 @@ sealed class SubscriptionResult {
     ) : SubscriptionResult()
 
     /**
+     * The endpoint returned 404, indicating the user has no subscription on record
+     * (e.g., the active account has never had a Stripe `GatewaySubscriptionId`).
+     * Consumers should treat this as a free user.
+     */
+    data object NotFound : SubscriptionResult()
+
+    /**
      * An error occurred while fetching subscription details.
      */
     data class Error(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/SubscriptionStatusState.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/SubscriptionStatusState.kt
@@ -1,0 +1,28 @@
+package com.x8bit.bitwarden.data.billing.repository.model
+
+/**
+ * Latest observed substate of the active user's premium subscription.
+ *
+ * The subscription endpoint is only meaningful for users who have a `GatewaySubscriptionId`
+ * on the server, so [NoSubscription] is emitted both for users we never queried (no personal
+ * premium signal) and for users whose fetch returned 404. [Error] preserves the failure for
+ * retry, while [Available] surfaces the raw status so consumers can apply their own policy.
+ */
+sealed class SubscriptionStatusState {
+
+    /** No fetch has been attempted yet for the active user. */
+    data object Loading : SubscriptionStatusState()
+
+    /** The active user has no recorded premium subscription. */
+    data object NoSubscription : SubscriptionStatusState()
+
+    /** The active user has a subscription with the given [status]. */
+    data class Available(
+        val status: PremiumSubscriptionStatus,
+    ) : SubscriptionStatusState()
+
+    /** The fetch failed for a reason other than 404. */
+    data class Error(
+        val throwable: Throwable,
+    ) : SubscriptionStatusState()
+}

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/SubscriptionStatusState.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/model/SubscriptionStatusState.kt
@@ -10,18 +10,26 @@ package com.x8bit.bitwarden.data.billing.repository.model
  */
 sealed class SubscriptionStatusState {
 
-    /** No fetch has been attempted yet for the active user. */
+    /**
+     * No fetch has been attempted yet for the active user.
+     */
     data object Loading : SubscriptionStatusState()
 
-    /** The active user has no recorded premium subscription. */
+    /**
+     * The active user has no recorded premium subscription.
+     */
     data object NoSubscription : SubscriptionStatusState()
 
-    /** The active user has a subscription with the given [status]. */
+    /**
+     * The active user has a subscription with the given [status].
+     */
     data class Available(
         val status: PremiumSubscriptionStatus,
     ) : SubscriptionStatusState()
 
-    /** The fetch failed for a reason other than 404. */
+    /**
+     * The fetch failed for a reason other than 404.
+     */
     data class Error(
         val throwable: Throwable,
     ) : SubscriptionStatusState()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensions.kt
@@ -63,7 +63,7 @@ private fun SubscriptionStatusJson.toPremiumSubscriptionStatus(): PremiumSubscri
 
         SubscriptionStatusJson.INCOMPLETE,
         SubscriptionStatusJson.UNPAID,
-        -> PremiumSubscriptionStatus.OVERDUE_PAYMENT
+        -> PremiumSubscriptionStatus.UPDATE_PAYMENT
 
         SubscriptionStatusJson.PAST_DUE -> PremiumSubscriptionStatus.PAST_DUE
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -39,6 +39,7 @@ import com.bitwarden.ui.platform.base.util.EventsEffect
 import com.bitwarden.ui.platform.base.util.annotatedPluralsResource
 import com.bitwarden.ui.platform.base.util.annotatedStringResource
 import com.bitwarden.ui.platform.base.util.cardStyle
+import com.bitwarden.ui.platform.base.util.spanStyleOf
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.badge.BitwardenStatusBadge
@@ -553,40 +554,50 @@ private fun subscriptionDescriptionText(
     canceledDateText: String?,
     suspensionDateText: String?,
     gracePeriodDays: Int?,
-): AnnotatedString? = when (status) {
-    PremiumSubscriptionStatus.ACTIVE -> annotatedStringResource(
-        id = BitwardenString.premium_next_charge_summary,
-        args = arrayOf(
-            nextChargeTotalText ?: PLACEHOLDER_TEXT,
-            nextChargeDateText ?: PLACEHOLDER_TEXT,
-        ),
+): AnnotatedString? {
+    val baseStyle = spanStyleOf(
+        color = BitwardenTheme.colorScheme.text.secondary,
+        textStyle = BitwardenTheme.typography.bodyMedium,
     )
-
-    PremiumSubscriptionStatus.CANCELED -> annotatedStringResource(
-        id = BitwardenString.subscription_canceled_description,
-        args = arrayOf(canceledDateText ?: PLACEHOLDER_TEXT),
-    )
-
-    PremiumSubscriptionStatus.UPDATE_PAYMENT -> annotatedStringResource(
-        id = BitwardenString.subscription_update_payment_description,
-        args = arrayOf(suspensionDateText ?: PLACEHOLDER_TEXT),
-    )
-
-    PremiumSubscriptionStatus.PAST_DUE -> {
-        val days = gracePeriodDays ?: 0
-        annotatedPluralsResource(
-            id = BitwardenPlurals.subscription_past_due_description,
-            quantity = days,
-            days.toString(),
-            suspensionDateText ?: PLACEHOLDER_TEXT,
+    return when (status) {
+        PremiumSubscriptionStatus.ACTIVE -> annotatedStringResource(
+            id = BitwardenString.premium_next_charge_summary,
+            args = arrayOf(
+                nextChargeTotalText ?: PLACEHOLDER_TEXT,
+                nextChargeDateText ?: PLACEHOLDER_TEXT,
+            ),
+            style = baseStyle,
         )
+
+        PremiumSubscriptionStatus.CANCELED -> annotatedStringResource(
+            id = BitwardenString.subscription_canceled_description,
+            args = arrayOf(canceledDateText ?: PLACEHOLDER_TEXT),
+            style = baseStyle,
+        )
+
+        PremiumSubscriptionStatus.UPDATE_PAYMENT -> annotatedStringResource(
+            id = BitwardenString.subscription_update_payment_description,
+            args = arrayOf(suspensionDateText ?: PLACEHOLDER_TEXT),
+            style = baseStyle,
+        )
+
+        PremiumSubscriptionStatus.PAST_DUE -> {
+            val days = gracePeriodDays ?: 0
+            annotatedPluralsResource(
+                id = BitwardenPlurals.subscription_past_due_description,
+                quantity = days,
+                days.toString(),
+                suspensionDateText ?: PLACEHOLDER_TEXT,
+                style = baseStyle,
+            )
+        }
+
+        PremiumSubscriptionStatus.PAUSED -> AnnotatedString(
+            stringResource(id = BitwardenString.subscription_paused_description),
+        )
+
+        null -> null
     }
-
-    PremiumSubscriptionStatus.PAUSED -> AnnotatedString(
-        stringResource(id = BitwardenString.subscription_paused_description),
-    )
-
-    null -> null
 }
 
 @Composable

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -571,7 +571,7 @@ private fun subscriptionDescriptionText(
 
         PremiumSubscriptionStatus.CANCELED -> annotatedStringResource(
             id = BitwardenString.subscription_canceled_description,
-            args = arrayOf(canceledDateText ?: PLACEHOLDER_TEXT),
+            args = arrayOf(canceledDateText ?: suspensionDateText ?: PLACEHOLDER_TEXT),
             style = baseStyle,
         )
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -35,6 +36,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bitwarden.annotation.OmitFromCoverage
 import com.bitwarden.ui.platform.base.util.EventsEffect
+import com.bitwarden.ui.platform.base.util.annotatedPluralsResource
+import com.bitwarden.ui.platform.base.util.annotatedStringResource
 import com.bitwarden.ui.platform.base.util.cardStyle
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
@@ -52,9 +55,9 @@ import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
+import com.bitwarden.ui.platform.resource.BitwardenPlurals
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
-import com.bitwarden.ui.util.Text
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
 import com.x8bit.bitwarden.ui.platform.composition.LocalAuthTabLaunchers
@@ -62,6 +65,8 @@ import com.x8bit.bitwarden.ui.platform.feature.premium.plan.handlers.PlanHandler
 import com.x8bit.bitwarden.ui.platform.feature.premium.plan.util.badgeColors
 import com.x8bit.bitwarden.ui.platform.feature.premium.plan.util.labelRes
 import com.x8bit.bitwarden.ui.platform.model.AuthTabLaunchers
+
+private const val PLACEHOLDER_TEXT: String = "--"
 
 /**
  * The screen for the plan — shows the upgrade flow for free users and the
@@ -441,7 +446,11 @@ private fun SubscriptionCard(
     ) {
         SubscriptionHeader(
             status = viewState.status,
-            descriptionText = viewState.descriptionText,
+            nextChargeTotalText = viewState.nextChargeTotalText,
+            nextChargeDateText = viewState.nextChargeDateText,
+            canceledDateText = viewState.canceledDateText,
+            suspensionDateText = viewState.suspensionDateText,
+            gracePeriodDays = viewState.gracePeriodDays,
             modifier = Modifier
                 .padding(bottom = 16.dp)
                 .standardHorizontalMargin(),
@@ -493,7 +502,11 @@ private fun SubscriptionCard(
 @Composable
 private fun SubscriptionHeader(
     status: PremiumSubscriptionStatus?,
-    descriptionText: Text?,
+    nextChargeTotalText: String?,
+    nextChargeDateText: String?,
+    canceledDateText: String?,
+    suspensionDateText: String?,
+    gracePeriodDays: Int?,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -512,15 +525,68 @@ private fun SubscriptionHeader(
             }
         }
 
+        val descriptionText = subscriptionDescriptionText(
+            status = status,
+            nextChargeTotalText = nextChargeTotalText,
+            nextChargeDateText = nextChargeDateText,
+            canceledDateText = canceledDateText,
+            suspensionDateText = suspensionDateText,
+            gracePeriodDays = gracePeriodDays,
+        )
+
         descriptionText?.let {
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = it(),
+                text = it,
                 style = BitwardenTheme.typography.bodyMedium,
                 color = BitwardenTheme.colorScheme.text.secondary,
             )
         }
     }
+}
+
+@Composable
+private fun subscriptionDescriptionText(
+    status: PremiumSubscriptionStatus?,
+    nextChargeTotalText: String?,
+    nextChargeDateText: String?,
+    canceledDateText: String?,
+    suspensionDateText: String?,
+    gracePeriodDays: Int?,
+): AnnotatedString? = when (status) {
+    PremiumSubscriptionStatus.ACTIVE -> annotatedStringResource(
+        id = BitwardenString.premium_next_charge_summary,
+        args = arrayOf(
+            nextChargeTotalText ?: PLACEHOLDER_TEXT,
+            nextChargeDateText ?: PLACEHOLDER_TEXT,
+        ),
+    )
+
+    PremiumSubscriptionStatus.CANCELED -> annotatedStringResource(
+        id = BitwardenString.subscription_canceled_description,
+        args = arrayOf(canceledDateText ?: PLACEHOLDER_TEXT),
+    )
+
+    PremiumSubscriptionStatus.UPDATE_PAYMENT -> annotatedStringResource(
+        id = BitwardenString.subscription_update_payment_description,
+        args = arrayOf(suspensionDateText ?: PLACEHOLDER_TEXT),
+    )
+
+    PremiumSubscriptionStatus.PAST_DUE -> {
+        val days = gracePeriodDays ?: 0
+        annotatedPluralsResource(
+            id = BitwardenPlurals.subscription_past_due_description,
+            quantity = days,
+            days.toString(),
+            suspensionDateText ?: PLACEHOLDER_TEXT,
+        )
+    }
+
+    PremiumSubscriptionStatus.PAUSED -> AnnotatedString(
+        stringResource(id = BitwardenString.subscription_paused_description),
+    )
+
+    null -> null
 }
 
 @Composable
@@ -595,14 +661,11 @@ private fun PlanScreenPremiumAccount_preview() {
             PremiumContent(
                 viewState = PlanState.ViewState.Premium(
                     status = PremiumSubscriptionStatus.ACTIVE,
-                    descriptionText = BitwardenString.premium_next_charge_summary.asText(
-                        "$45.55",
-                        "April 2, 2026",
-                    ),
                     billingAmountText = BitwardenString.billing_rate_per_year.asText("$19.80"),
                     storageCostText = "$24.00",
                     discountAmountText = "-$2.10",
                     estimatedTaxText = "$3.85",
+                    nextChargeTotalText = "$45.55",
                     nextChargeDateText = "April 2, 2026",
                     showCancelButton = true,
                 ),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -1035,7 +1035,7 @@ private fun PremiumSubscriptionStatus.canBeCanceled(): Boolean = when (this) {
     PremiumSubscriptionStatus.PAST_DUE,
     PremiumSubscriptionStatus.PAUSED,
     PremiumSubscriptionStatus.UPDATE_PAYMENT,
-    -> true
+        -> true
 }
 
 /**
@@ -1049,7 +1049,7 @@ private fun PremiumSubscriptionStatus.isPremiumViewEligible(): Boolean = when (t
     PremiumSubscriptionStatus.PAST_DUE,
     PremiumSubscriptionStatus.PAUSED,
     PremiumSubscriptionStatus.UPDATE_PAYMENT,
-    -> true
+        -> true
 
     PremiumSubscriptionStatus.ACTIVE -> false
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -391,7 +391,9 @@ class PlanViewModel @Inject constructor(
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
                         ),
-                        dialogState = null,
+                        dialogState = PlanState.DialogState.Loading(
+                            message = BitwardenString.loading.asText(),
+                        ),
                     )
                 }
                 viewModelScope.launch {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -9,10 +9,8 @@ import com.bitwarden.core.data.util.toFormattedDateStyle
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
-import com.bitwarden.ui.platform.resource.BitwardenPlurals
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.util.Text
-import com.bitwarden.ui.util.asPluralsText
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
@@ -630,17 +628,15 @@ class PlanViewModel @Inject constructor(
 
         return PlanState.ViewState.Premium(
             status = status,
-            descriptionText = toDescriptionText(
-                formattedTotal = formattedTotal,
-                nextChargeDate = formattedDate,
-                canceledDate = formattedCanceled,
-                suspensionDate = formattedSuspension,
-            ),
             billingAmountText = seatsCost.toBillingAmountText(cadence),
             storageCostText = storageCost.toMoneyText(),
             discountAmountText = discountAmount.toMoneyText(negative = true),
             estimatedTaxText = estimatedTax.toMoneyText(),
+            nextChargeTotalText = formattedTotal,
             nextChargeDateText = formattedDate,
+            canceledDateText = formattedCanceled,
+            suspensionDateText = formattedSuspension,
+            gracePeriodDays = gracePeriodDays,
             showCancelButton = status.canBeCanceled(),
         )
     }
@@ -660,40 +656,6 @@ class PlanViewModel @Inject constructor(
             this == null || this.signum() == 0 -> PLACEHOLDER_TEXT
             negative -> "-${currencyFormatter.format(this)}"
             else -> currencyFormatter.format(this)
-        }
-
-    private fun SubscriptionInfo.toDescriptionText(
-        formattedTotal: String,
-        nextChargeDate: String?,
-        canceledDate: String?,
-        suspensionDate: String?,
-    ): Text =
-        when (status) {
-            PremiumSubscriptionStatus.ACTIVE ->
-                BitwardenString.premium_next_charge_summary.asText(
-                    formattedTotal,
-                    nextChargeDate ?: PLACEHOLDER_TEXT,
-                )
-
-            PremiumSubscriptionStatus.CANCELED ->
-                BitwardenString.subscription_canceled_description.asText(
-                    canceledDate ?: PLACEHOLDER_TEXT,
-                )
-
-            PremiumSubscriptionStatus.UPDATE_PAYMENT ->
-                BitwardenString.subscription_update_payment_description.asText(
-                    suspensionDate ?: PLACEHOLDER_TEXT,
-                )
-
-            PremiumSubscriptionStatus.PAST_DUE ->
-                BitwardenPlurals.subscription_past_due_description.asPluralsText(
-                    gracePeriodDays ?: 0,
-                    gracePeriodDays ?: 0,
-                    suspensionDate ?: PLACEHOLDER_TEXT,
-                )
-
-            PremiumSubscriptionStatus.PAUSED ->
-                BitwardenString.subscription_paused_description.asText()
         }
 
     private fun Instant.toLocalizedDate(): String =
@@ -784,12 +746,15 @@ data class PlanState(
         @Parcelize
         data class Premium(
             val status: PremiumSubscriptionStatus? = null,
-            val descriptionText: Text? = null,
             val billingAmountText: Text = PLACEHOLDER_TEXT.asText(),
             val storageCostText: String = PLACEHOLDER_TEXT,
             val discountAmountText: String = PLACEHOLDER_TEXT,
             val estimatedTaxText: String = PLACEHOLDER_TEXT,
+            val nextChargeTotalText: String? = null,
             val nextChargeDateText: String? = null,
+            val canceledDateText: String? = null,
+            val suspensionDateText: String? = null,
+            val gracePeriodDays: Int? = null,
             val showCancelButton: Boolean = false,
         ) : ViewState()
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -16,6 +16,7 @@ import com.bitwarden.ui.util.asPluralsText
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.CustomerPortalResult
@@ -24,6 +25,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResul
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
+import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
@@ -58,12 +60,13 @@ const val PREMIUM_CHECKOUT_CALLBACK_URL = "bitwarden://premium-checkout-result"
  * View model for the plan screen, driving the upgrade flow for free users and
  * the subscription management surface for premium users.
  */
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
 @HiltViewModel
 class PlanViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val billingRepository: BillingRepository,
     private val authRepository: AuthRepository,
+    private val premiumStateManager: PremiumStateManager,
     private val specialCircumstanceManager: SpecialCircumstanceManager,
     private val vaultRepository: VaultRepository,
     private val clock: Clock,
@@ -75,9 +78,11 @@ class PlanViewModel @Inject constructor(
             .value
             ?.activeAccount
             ?.isPremium == true
+        val showsPremiumView = isPremium ||
+            premiumStateManager.subscriptionStatusStateFlow.value.isPremiumViewEligible()
         PlanState(
             planMode = planMode,
-            viewState = if (isPremium) {
+            viewState = if (showsPremiumView) {
                 PlanState.ViewState.Premium()
             } else {
                 PlanState.ViewState.Free(
@@ -108,6 +113,12 @@ class PlanViewModel @Inject constructor(
         specialCircumstanceManager
             .specialCircumstanceStateFlow
             .map { PlanAction.Internal.SpecialCircumstanceReceive(it) }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
+        premiumStateManager
+            .subscriptionStatusStateFlow
+            .map { PlanAction.Internal.SubscriptionStatusUpdateReceive(it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -168,6 +179,10 @@ class PlanViewModel @Inject constructor(
             is PlanAction.Internal.PortalUrlReceive -> handlePortalUrlReceive(action)
             is PlanAction.Internal.SubscriptionResultReceive -> {
                 handleSubscriptionResultReceive(action)
+            }
+
+            is PlanAction.Internal.SubscriptionStatusUpdateReceive -> {
+                handleSubscriptionStatusUpdateReceive(action)
             }
         }
     }
@@ -370,6 +385,26 @@ class PlanViewModel @Inject constructor(
                 }
             }
 
+            SubscriptionResult.NotFound -> {
+                mutableStateFlow.update {
+                    it.copy(
+                        viewState = PlanState.ViewState.Free(
+                            rate = PLACEHOLDER_TEXT,
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
+                        ),
+                        dialogState = null,
+                    )
+                }
+                viewModelScope.launch {
+                    sendAction(
+                        PlanAction.Internal.PricingResultReceive(
+                            result = billingRepository.getPremiumPlanPricing(),
+                        ),
+                    )
+                }
+            }
+
             is SubscriptionResult.Error -> {
                 mutableStateFlow.update {
                     it.copy(
@@ -381,6 +416,32 @@ class PlanViewModel @Inject constructor(
                         ),
                     )
                 }
+            }
+        }
+    }
+
+    private fun handleSubscriptionStatusUpdateReceive(
+        action: PlanAction.Internal.SubscriptionStatusUpdateReceive,
+    ) {
+        val status = (action.state as? SubscriptionStatusState.Available)?.status
+            ?: return
+        if (!status.isPremiumViewEligible()) return
+        onFreeContent { freeState ->
+            if (freeState.isAwaitingPremiumStatus) return@onFreeContent
+            mutableStateFlow.update {
+                it.copy(
+                    viewState = PlanState.ViewState.Premium(),
+                    dialogState = PlanState.DialogState.Loading(
+                        message = BitwardenString.loading_subscription.asText(),
+                    ),
+                )
+            }
+            viewModelScope.launch {
+                sendAction(
+                    PlanAction.Internal.SubscriptionResultReceive(
+                        result = billingRepository.getSubscription(),
+                    ),
+                )
             }
         }
     }
@@ -580,7 +641,7 @@ class PlanViewModel @Inject constructor(
             discountAmountText = discountAmount.toMoneyText(negative = true),
             estimatedTaxText = estimatedTax.toMoneyText(),
             nextChargeDateText = formattedDate,
-            showCancelButton = status != PremiumSubscriptionStatus.CANCELED,
+            showCancelButton = status.canBeCanceled(),
         )
     }
 
@@ -619,8 +680,8 @@ class PlanViewModel @Inject constructor(
                     canceledDate ?: PLACEHOLDER_TEXT,
                 )
 
-            PremiumSubscriptionStatus.OVERDUE_PAYMENT ->
-                BitwardenString.subscription_overdue_description.asText(
+            PremiumSubscriptionStatus.UPDATE_PAYMENT ->
+                BitwardenString.subscription_update_payment_description.asText(
                     suspensionDate ?: PLACEHOLDER_TEXT,
                 )
 
@@ -985,5 +1046,50 @@ sealed class PlanAction {
         data class SubscriptionResultReceive(
             val result: SubscriptionResult,
         ) : Internal()
+
+        /**
+         * The shared subscription status state for the active user has updated.
+         */
+        data class SubscriptionStatusUpdateReceive(
+            val state: SubscriptionStatusState,
+        ) : Internal()
     }
 }
+
+/**
+ * Returns `true` when this status corresponds to a subscription that the user can still
+ * cancel through the Stripe portal — i.e., a live or recoverable subscription. Terminal
+ * states (canceled) do not present a cancel action.
+ */
+private fun PremiumSubscriptionStatus.canBeCanceled(): Boolean = when (this) {
+    PremiumSubscriptionStatus.CANCELED -> false
+
+    PremiumSubscriptionStatus.ACTIVE,
+    PremiumSubscriptionStatus.PAST_DUE,
+    PremiumSubscriptionStatus.PAUSED,
+    PremiumSubscriptionStatus.UPDATE_PAYMENT,
+    -> true
+}
+
+/**
+ * Returns `true` when this status should route the Plan screen to the Premium view even
+ * if `Account.isPremium=false`. Trouble states (canceled, past due, paused, update payment)
+ * carry enough context to render a status badge and Manage/Resubscribe affordances, which
+ * the Free view does not surface.
+ */
+private fun PremiumSubscriptionStatus.isPremiumViewEligible(): Boolean = when (this) {
+    PremiumSubscriptionStatus.CANCELED,
+    PremiumSubscriptionStatus.PAST_DUE,
+    PremiumSubscriptionStatus.PAUSED,
+    PremiumSubscriptionStatus.UPDATE_PAYMENT,
+    -> true
+
+    PremiumSubscriptionStatus.ACTIVE -> false
+}
+
+/**
+ * Returns `true` when the current [SubscriptionStatusState] indicates that the Plan screen
+ * should render the Premium view, even if the user account's `isPremium` flag is `false`.
+ */
+private fun SubscriptionStatusState.isPremiumViewEligible(): Boolean =
+    this is SubscriptionStatusState.Available && this.status.isPremiumViewEligible()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/util/PremiumSubscriptionStatusExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/util/PremiumSubscriptionStatusExtensions.kt
@@ -14,12 +14,9 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStat
 fun PremiumSubscriptionStatus.labelRes(): Int = when (this) {
     PremiumSubscriptionStatus.ACTIVE -> BitwardenString.subscription_status_active
     PremiumSubscriptionStatus.CANCELED -> BitwardenString.subscription_status_canceled
-    PremiumSubscriptionStatus.OVERDUE_PAYMENT -> {
-        BitwardenString.subscription_status_overdue_payment
-    }
-
     PremiumSubscriptionStatus.PAST_DUE -> BitwardenString.subscription_status_past_due
     PremiumSubscriptionStatus.PAUSED -> BitwardenString.subscription_status_paused
+    PremiumSubscriptionStatus.UPDATE_PAYMENT -> BitwardenString.subscription_status_update_payment
 }
 
 /**
@@ -31,10 +28,8 @@ fun PremiumSubscriptionStatus.badgeColors(): BitwardenColorScheme.StatusBadgeVar
     when (this) {
         PremiumSubscriptionStatus.ACTIVE -> BitwardenTheme.colorScheme.statusBadge.success
         PremiumSubscriptionStatus.CANCELED -> BitwardenTheme.colorScheme.statusBadge.error
-        PremiumSubscriptionStatus.OVERDUE_PAYMENT,
         PremiumSubscriptionStatus.PAST_DUE,
         PremiumSubscriptionStatus.PAUSED,
-            -> {
-            BitwardenTheme.colorScheme.statusBadge.warning
-        }
+        PremiumSubscriptionStatus.UPDATE_PAYMENT,
+            -> BitwardenTheme.colorScheme.statusBadge.warning
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
@@ -12,6 +12,11 @@ import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
+import com.x8bit.bitwarden.data.billing.repository.model.PlanCadence
+import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
+import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
+import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
+import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
@@ -20,11 +25,13 @@ import com.x8bit.bitwarden.data.platform.manager.model.PremiumStatusChangedData
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -52,6 +59,7 @@ class PremiumStateManagerImplTest {
     private val mutableIsInAppBillingSupportedFlow = MutableStateFlow(true)
     private val billingRepository: BillingRepository = mockk {
         every { isInAppBillingSupportedFlow } returns mutableIsInAppBillingSupportedFlow
+        coEvery { getSubscription() } returns SubscriptionResult.NotFound
     }
 
     private val fakeSettingsDiskSource = FakeSettingsDiskSource()
@@ -723,7 +731,160 @@ class PremiumStateManagerImplTest {
             expected = null,
         )
     }
+
+    @Test
+    fun `subscriptionStatusStateFlow emits NoSubscription when there is no active user`() =
+        runTest {
+            mutableUserStateFlow.value = null
+            val manager = createManager()
+            manager.subscriptionStatusStateFlow.test {
+                assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
+            }
+        }
+
+    @Test
+    fun `subscriptionStatusStateFlow emits NoSubscription on 404 from BillingRepository`() =
+        runTest {
+            coEvery { billingRepository.getSubscription() } returns SubscriptionResult.NotFound
+            val manager = createManager()
+            manager.subscriptionStatusStateFlow.test {
+                assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
+            }
+        }
+
+    @Test
+    fun `subscriptionStatusStateFlow emits Available with status on Success`() = runTest {
+        coEvery {
+            billingRepository.getSubscription()
+        } returns SubscriptionResult.Success(
+            subscription = createSubscriptionInfo(
+                status = PremiumSubscriptionStatus.CANCELED,
+            ),
+        )
+        val manager = createManager()
+        manager.subscriptionStatusStateFlow.test {
+            assertEquals(
+                SubscriptionStatusState.Available(
+                    status = PremiumSubscriptionStatus.CANCELED,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `subscriptionStatusStateFlow emits Error on non-404 failure`() = runTest {
+        val exception = IllegalStateException("boom")
+        coEvery {
+            billingRepository.getSubscription()
+        } returns SubscriptionResult.Error(error = exception)
+        val manager = createManager()
+        manager.subscriptionStatusStateFlow.test {
+            assertEquals(SubscriptionStatusState.Error(throwable = exception), awaitItem())
+        }
+    }
+
+    @Test
+    fun `subscriptionStatusStateFlow refetches on premium-status push`() = runTest {
+        coEvery {
+            billingRepository.getSubscription()
+        } returns SubscriptionResult.NotFound andThen
+            SubscriptionResult.Success(
+                subscription = createSubscriptionInfo(
+                    status = PremiumSubscriptionStatus.ACTIVE,
+                ),
+            )
+        val manager = createManager()
+        manager.subscriptionStatusStateFlow.test {
+            assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
+            mutablePremiumStatusChangedFlow.tryEmit(
+                PremiumStatusChangedData(
+                    userId = ACTIVE_USER_ID,
+                    isPremium = true,
+                ),
+            )
+            assertEquals(
+                SubscriptionStatusState.Available(
+                    status = PremiumSubscriptionStatus.ACTIVE,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `banner ineligible when account is premium and status is ACTIVE`() = runTest {
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        )
+        coEvery {
+            billingRepository.getSubscription()
+        } returns SubscriptionResult.Success(
+            subscription = createSubscriptionInfo(status = PremiumSubscriptionStatus.ACTIVE),
+        )
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            assertFalse(awaitItem())
+        }
+    }
+
+    @Test
+    fun `banner eligible when account is premium but status is in a trouble state`() = runTest {
+        listOf(
+            PremiumSubscriptionStatus.CANCELED,
+            PremiumSubscriptionStatus.PAST_DUE,
+            PremiumSubscriptionStatus.PAUSED,
+            PremiumSubscriptionStatus.UPDATE_PAYMENT,
+        ).forEach { status ->
+            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+            )
+            coEvery {
+                billingRepository.getSubscription()
+            } returns SubscriptionResult.Success(
+                subscription = createSubscriptionInfo(status = status),
+            )
+            val manager = createManager()
+            manager.isPremiumUpgradeBannerEligibleFlow.test {
+                assertTrue(awaitItem(), "Expected banner eligible for status=$status")
+            }
+        }
+    }
+
+    @Test
+    fun `banner ineligible when account is premium and substate is still loading`() = runTest {
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        )
+        coEvery {
+            billingRepository.getSubscription()
+        } coAnswers {
+            kotlinx.coroutines.awaitCancellation()
+        }
+        val manager = createManager()
+        manager.isPremiumUpgradeBannerEligibleFlow.test {
+            // Loading is not treated as a trouble state so a premium user is still effectively
+            // premium during the initial fetch.
+            assertFalse(awaitItem())
+        }
+    }
 }
+
+private fun createSubscriptionInfo(
+    status: PremiumSubscriptionStatus,
+): SubscriptionInfo = SubscriptionInfo(
+    status = status,
+    cadence = PlanCadence.ANNUALLY,
+    seatsCost = java.math.BigDecimal("19.80"),
+    storageCost = null,
+    discountAmount = null,
+    estimatedTax = java.math.BigDecimal.ZERO,
+    nextChargeTotal = java.math.BigDecimal("19.80"),
+    nextCharge = null,
+    canceledDate = null,
+    suspensionDate = null,
+    gracePeriodDays = null,
+)
 
 /**
  * Creates [VaultData] with the given number of non-deleted cipher items.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
@@ -744,13 +744,39 @@ class PremiumStateManagerImplTest {
         }
 
     @Test
-    fun `subscriptionStatusStateFlow emits NoSubscription for a free active user`() = runTest {
-        val manager = createManager()
-        manager.subscriptionStatusStateFlow.test {
-            assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
+    fun `subscriptionStatusStateFlow emits NoSubscription on 404 for a free active user`() =
+        runTest {
+            // Default mock returns SubscriptionResult.NotFound; the fetch runs even when
+            // isPremium is false so users with canceled / expired subscriptions are routed
+            // through the Premium view rather than the Free view.
+            val manager = createManager()
+            manager.subscriptionStatusStateFlow.test {
+                assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
+            }
+            coVerify(exactly = 1) { billingRepository.getSubscription() }
         }
-        coVerify(exactly = 0) { billingRepository.getSubscription() }
-    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `subscriptionStatusStateFlow emits Available when free active user has a canceled subscription`() =
+        runTest {
+            coEvery {
+                billingRepository.getSubscription()
+            } returns SubscriptionResult.Success(
+                subscription = createSubscriptionInfo(
+                    status = PremiumSubscriptionStatus.CANCELED,
+                ),
+            )
+            val manager = createManager()
+            manager.subscriptionStatusStateFlow.test {
+                assertEquals(
+                    SubscriptionStatusState.Available(
+                        status = PremiumSubscriptionStatus.CANCELED,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
 
     @Test
     fun `subscriptionStatusStateFlow emits NoSubscription on 404 from BillingRepository`() =
@@ -804,29 +830,40 @@ class PremiumStateManagerImplTest {
     }
 
     @Test
-    fun `subscriptionStatusStateFlow refetches when active user transitions to premium`() =
-        runTest {
-            coEvery {
-                billingRepository.getSubscription()
-            } returns SubscriptionResult.Success(
-                subscription = createSubscriptionInfo(
+    fun `subscriptionStatusStateFlow refetches when active user changes`() = runTest {
+        coEvery {
+            billingRepository.getSubscription()
+        } returns SubscriptionResult.Success(
+            subscription = createSubscriptionInfo(
+                status = PremiumSubscriptionStatus.ACTIVE,
+            ),
+        ) andThen SubscriptionResult.Success(
+            subscription = createSubscriptionInfo(
+                status = PremiumSubscriptionStatus.CANCELED,
+            ),
+        )
+        val manager = createManager()
+        manager.subscriptionStatusStateFlow.test {
+            assertEquals(
+                SubscriptionStatusState.Available(
                     status = PremiumSubscriptionStatus.ACTIVE,
                 ),
+                awaitItem(),
             )
-            val manager = createManager()
-            manager.subscriptionStatusStateFlow.test {
-                assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
-                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                    accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
-                )
-                assertEquals(
-                    SubscriptionStatusState.Available(
-                        status = PremiumSubscriptionStatus.ACTIVE,
-                    ),
-                    awaitItem(),
-                )
-            }
+            val otherUserId = "otherUserId"
+            mutableUserStateFlow.value = UserState(
+                activeUserId = otherUserId,
+                accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(userId = otherUserId)),
+            )
+            assertEquals(
+                SubscriptionStatusState.Available(
+                    status = PremiumSubscriptionStatus.CANCELED,
+                ),
+                awaitItem(),
+            )
         }
+        coVerify(exactly = 2) { billingRepository.getSubscription() }
+    }
 
     @Test
     fun `subscriptionStatusStateFlow refetches on push when active user is premium`() =

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
@@ -4,13 +4,11 @@ import app.cash.turbine.test
 import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
 import com.bitwarden.vault.DecryptCipherListResult
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
-import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.util.FakeAuthDiskSource
-import com.x8bit.bitwarden.data.auth.repository.AuthRepository
-import com.x8bit.bitwarden.data.auth.repository.model.UserState
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.PlanCadence
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
@@ -20,7 +18,6 @@ import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
-import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
 import com.x8bit.bitwarden.data.platform.manager.model.PremiumStatusChangedData
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
@@ -49,12 +46,7 @@ class PremiumStateManagerImplTest {
     )
 
     private val fakeAuthDiskSource = FakeAuthDiskSource().apply {
-        userState = DISK_USER_STATE
-    }
-
-    private val mutableUserStateFlow = MutableStateFlow<UserState?>(DEFAULT_USER_STATE)
-    private val authRepository: AuthRepository = mockk {
-        every { userStateFlow } returns mutableUserStateFlow
+        userState = DEFAULT_USER_STATE_JSON
     }
 
     private val mutableIsInAppBillingSupportedFlow = MutableStateFlow(true)
@@ -93,7 +85,6 @@ class PremiumStateManagerImplTest {
 
     private fun createManager(): PremiumStateManagerImpl = PremiumStateManagerImpl(
         authDiskSource = fakeAuthDiskSource,
-        authRepository = authRepository,
         billingRepository = billingRepository,
         settingsDiskSource = fakeSettingsDiskSource,
         vaultRepository = vaultRepository,
@@ -113,8 +104,8 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `ineligible when user is Premium should emit false`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(hasPremiumPersonally = true),
         )
         val manager = createManager()
         manager.isPremiumUpgradeBannerEligibleFlow.test {
@@ -155,11 +146,9 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `ineligible when account is too new should emit false`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(
-                DEFAULT_ACTIVE_ACCOUNT.copy(
-                    creationDate = Instant.parse("2023-10-25T12:00:00Z"),
-                ),
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(
+                creationDate = Instant.parse("2023-10-25T12:00:00Z"),
             ),
         )
         val manager = createManager()
@@ -170,10 +159,8 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `ineligible when creation date is null should emit false`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(
-                DEFAULT_ACTIVE_ACCOUNT.copy(creationDate = null),
-            ),
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(creationDate = null),
         )
         val manager = createManager()
         manager.isPremiumUpgradeBannerEligibleFlow.test {
@@ -194,7 +181,7 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `ineligible when userState is null should emit false`() = runTest {
-        mutableUserStateFlow.value = null
+        fakeAuthDiskSource.userState = null
         val manager = createManager()
         manager.isPremiumUpgradeBannerEligibleFlow.test {
             assertFalse(awaitItem())
@@ -314,11 +301,9 @@ class PremiumStateManagerImplTest {
     @Test
     fun `eligible when account age is exactly 7 days should emit true`() =
         runTest {
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        creationDate = Instant.parse("2023-10-20T12:00:00Z"),
-                    ),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(
+                    creationDate = Instant.parse("2023-10-20T12:00:00Z"),
                 ),
             )
             val manager = createManager()
@@ -404,14 +389,7 @@ class PremiumStateManagerImplTest {
     @Test
     fun `isPlanRowEligibleFlow emits true for a free user when feature flag is enabled`() =
         runTest {
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        isPremium = false,
-                        isPremiumFromSelf = false,
-                    ),
-                ),
-            )
+            fakeAuthDiskSource.userState = userStateJsonWith(account = createAccountJson())
             val manager = createManager()
             manager.isPlanRowEligibleFlow.test {
                 assertTrue(awaitItem())
@@ -420,13 +398,8 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `isPlanRowEligibleFlow emits true for a personal Premium user`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(
-                DEFAULT_ACTIVE_ACCOUNT.copy(
-                    isPremium = true,
-                    isPremiumFromSelf = true,
-                ),
-            ),
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(hasPremiumPersonally = true),
         )
         val manager = createManager()
         manager.isPlanRowEligibleFlow.test {
@@ -437,13 +410,8 @@ class PremiumStateManagerImplTest {
     @Test
     fun `isPlanRowEligibleFlow emits false for a user with only org-granted Premium`() =
         runTest {
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        isPremium = true,
-                        isPremiumFromSelf = false,
-                    ),
-                ),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumFromOrganization = true),
             )
             val manager = createManager()
             manager.isPlanRowEligibleFlow.test {
@@ -462,7 +430,7 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `isPlanRowEligibleFlow emits false when userState is null`() = runTest {
-        mutableUserStateFlow.value = null
+        fakeAuthDiskSource.userState = null
         val manager = createManager()
         manager.isPlanRowEligibleFlow.test {
             assertFalse(awaitItem())
@@ -471,34 +439,15 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `isPlanRowEligibleFlow updates as the user gains and loses org-only Premium`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(
-                DEFAULT_ACTIVE_ACCOUNT.copy(
-                    isPremium = false,
-                    isPremiumFromSelf = false,
-                ),
-            ),
-        )
+        fakeAuthDiskSource.userState = userStateJsonWith(account = createAccountJson())
         val manager = createManager()
         manager.isPlanRowEligibleFlow.test {
             assertTrue(awaitItem())
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        isPremium = true,
-                        isPremiumFromSelf = false,
-                    ),
-                ),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumFromOrganization = true),
             )
             assertFalse(awaitItem())
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        isPremium = false,
-                        isPremiumFromSelf = false,
-                    ),
-                ),
-            )
+            fakeAuthDiskSource.userState = userStateJsonWith(account = createAccountJson())
             assertTrue(awaitItem())
         }
     }
@@ -517,13 +466,8 @@ class PremiumStateManagerImplTest {
         runTest {
             // Sync has caught up to the upgrade by the time the push lands — the active user
             // already holds personal Premium.
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        isPremium = true,
-                        isPremiumFromSelf = true,
-                    ),
-                ),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumPersonally = true),
             )
             val manager = createManager()
             manager.isUpgradedToPremiumCardEligibleFlow.test {
@@ -549,13 +493,8 @@ class PremiumStateManagerImplTest {
             // Simulates the debug-menu trigger (or a stray PREMIUM_STATUS_CHANGED push routed to
             // an organization-granted user): pending is written directly to disk, but the active
             // user has no personal subscription. The read-side gate must withhold the card.
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        isPremium = true,
-                        isPremiumFromSelf = false,
-                    ),
-                ),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumFromOrganization = true),
             )
             fakeSettingsDiskSource.storeUpgradedToPremiumCardPending(
                 userId = ACTIVE_USER_ID,
@@ -593,25 +532,13 @@ class PremiumStateManagerImplTest {
     fun `userState transition from non-Premium to personal Premium for the same user marks card pending`() =
         runTest {
             // Start as Free.
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        isPremium = false,
-                        isPremiumFromSelf = false,
-                    ),
-                ),
-            )
+            fakeAuthDiskSource.userState = userStateJsonWith(account = createAccountJson())
             val manager = createManager()
             manager.isUpgradedToPremiumCardEligibleFlow.test {
                 assertFalse(awaitItem())
                 // Transition to personal Premium for the same user.
-                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                    accounts = listOf(
-                        DEFAULT_ACTIVE_ACCOUNT.copy(
-                            isPremium = true,
-                            isPremiumFromSelf = true,
-                        ),
-                    ),
+                fakeAuthDiskSource.userState = userStateJsonWith(
+                    account = createAccountJson(hasPremiumPersonally = true),
                 )
                 assertTrue(awaitItem())
                 fakeSettingsDiskSource.assertUpgradedToPremiumCardPending(
@@ -624,26 +551,14 @@ class PremiumStateManagerImplTest {
     @Test
     fun `userState transition that only flips org-granted Premium should not mark card pending`() =
         runTest {
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(
-                    DEFAULT_ACTIVE_ACCOUNT.copy(
-                        isPremium = false,
-                        isPremiumFromSelf = false,
-                    ),
-                ),
-            )
+            fakeAuthDiskSource.userState = userStateJsonWith(account = createAccountJson())
             val manager = createManager()
             manager.isUpgradedToPremiumCardEligibleFlow.test {
                 assertFalse(awaitItem())
                 // Aggregate isPremium becomes true via the user's organization, but personal
                 // premium stays false — the card must not arm.
-                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                    accounts = listOf(
-                        DEFAULT_ACTIVE_ACCOUNT.copy(
-                            isPremium = true,
-                            isPremiumFromSelf = false,
-                        ),
-                    ),
+                fakeAuthDiskSource.userState = userStateJsonWith(
+                    account = createAccountJson(hasPremiumFromOrganization = true),
                 )
                 expectNoEvents()
                 fakeSettingsDiskSource.assertUpgradedToPremiumCardPending(
@@ -657,17 +572,12 @@ class PremiumStateManagerImplTest {
     fun `Premium account that signs in for the first time should not mark the card pending`() =
         runTest {
             // Initial userState is null, then becomes a Premium account in one step.
-            mutableUserStateFlow.value = null
+            fakeAuthDiskSource.userState = null
             val manager = createManager()
             manager.isUpgradedToPremiumCardEligibleFlow.test {
                 assertFalse(awaitItem())
-                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                    accounts = listOf(
-                        DEFAULT_ACTIVE_ACCOUNT.copy(
-                            isPremium = true,
-                            isPremiumFromSelf = true,
-                        ),
-                    ),
+                fakeAuthDiskSource.userState = userStateJsonWith(
+                    account = createAccountJson(hasPremiumPersonally = true),
                 )
                 expectNoEvents()
                 fakeSettingsDiskSource.assertUpgradedToPremiumCardPending(
@@ -736,7 +646,7 @@ class PremiumStateManagerImplTest {
     @Test
     fun `subscriptionStatusStateFlow emits NoSubscription when there is no active user`() =
         runTest {
-            mutableUserStateFlow.value = null
+            fakeAuthDiskSource.userState = null
             val manager = createManager()
             manager.subscriptionStatusStateFlow.test {
                 assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
@@ -781,8 +691,8 @@ class PremiumStateManagerImplTest {
     @Test
     fun `subscriptionStatusStateFlow emits NoSubscription on 404 from BillingRepository`() =
         runTest {
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumPersonally = true),
             )
             coEvery { billingRepository.getSubscription() } returns SubscriptionResult.NotFound
             val manager = createManager()
@@ -793,8 +703,8 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `subscriptionStatusStateFlow emits Available with status on Success`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(hasPremiumPersonally = true),
         )
         coEvery {
             billingRepository.getSubscription()
@@ -816,8 +726,8 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `subscriptionStatusStateFlow emits Error on non-404 failure`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(hasPremiumPersonally = true),
         )
         val exception = IllegalStateException("boom")
         coEvery {
@@ -851,9 +761,8 @@ class PremiumStateManagerImplTest {
                 awaitItem(),
             )
             val otherUserId = "otherUserId"
-            mutableUserStateFlow.value = UserState(
-                activeUserId = otherUserId,
-                accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(userId = otherUserId)),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(userId = otherUserId),
             )
             assertEquals(
                 SubscriptionStatusState.Available(
@@ -868,8 +777,8 @@ class PremiumStateManagerImplTest {
     @Test
     fun `subscriptionStatusStateFlow refetches on push when active user is premium`() =
         runTest {
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumPersonally = true),
             )
             coEvery {
                 billingRepository.getSubscription()
@@ -907,8 +816,8 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `banner ineligible when account is premium and status is ACTIVE`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(hasPremiumPersonally = true),
         )
         coEvery {
             billingRepository.getSubscription()
@@ -929,8 +838,8 @@ class PremiumStateManagerImplTest {
             PremiumSubscriptionStatus.PAUSED,
             PremiumSubscriptionStatus.UPDATE_PAYMENT,
         ).forEach { status ->
-            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-                accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+            fakeAuthDiskSource.userState = userStateJsonWith(
+                account = createAccountJson(hasPremiumPersonally = true),
             )
             coEvery {
                 billingRepository.getSubscription()
@@ -946,8 +855,8 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `banner ineligible when account is premium and substate is still loading`() = runTest {
-        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
-            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        fakeAuthDiskSource.userState = userStateJsonWith(
+            account = createAccountJson(hasPremiumPersonally = true),
         )
         coEvery {
             billingRepository.getSubscription()
@@ -994,38 +903,48 @@ private fun createVaultDataWithItemCount(count: Int): VaultData = VaultData(
 
 private const val ACTIVE_USER_ID = "activeUserId"
 private const val FIXED_DATETIME = "2023-10-27T12:00:00Z"
+private val DEFAULT_CREATION_DATE: Instant = Instant.parse("2023-10-01T12:00:00Z")
 
-private val DEFAULT_ACTIVE_ACCOUNT = UserState.Account(
-    userId = ACTIVE_USER_ID,
-    name = "Active User",
-    email = "active@bitwarden.com",
-    avatarColorHex = "#aa00aa",
-    environment = com.bitwarden.data.repository.model.Environment.Us,
-    isPremium = false,
-    isPremiumFromSelf = false,
-    isLoggedIn = true,
-    isVaultUnlocked = true,
-    needsPasswordReset = false,
-    isBiometricsEnabled = false,
-    organizations = emptyList(),
-    needsMasterPassword = false,
-    trustedDevice = null,
-    hasMasterPassword = true,
-    isUsingKeyConnector = false,
-    onboardingStatus = OnboardingStatus.COMPLETE,
-    firstTimeState = FirstTimeState(),
-    isExportable = true,
-    creationDate = Instant.parse("2023-10-01T12:00:00Z"),
-)
-
-private val DEFAULT_USER_STATE = UserState(
-    activeUserId = ACTIVE_USER_ID,
-    accounts = listOf(DEFAULT_ACTIVE_ACCOUNT),
-)
-
-private val DISK_USER_STATE = UserStateJson(
-    activeUserId = ACTIVE_USER_ID,
-    accounts = mapOf(
-        ACTIVE_USER_ID to mockk<AccountJson>(),
+/**
+ * Builds an [AccountJson] for tests, defaulting to a non-premium account whose creation date is
+ * old enough to satisfy the banner's account-age gate.
+ */
+private fun createAccountJson(
+    userId: String = ACTIVE_USER_ID,
+    hasPremiumPersonally: Boolean = false,
+    hasPremiumFromOrganization: Boolean = false,
+    creationDate: Instant? = DEFAULT_CREATION_DATE,
+): AccountJson = AccountJson(
+    profile = AccountJson.Profile(
+        userId = userId,
+        email = "active@bitwarden.com",
+        isEmailVerified = true,
+        isTwoFactorEnabled = false,
+        name = "Active User",
+        stamp = null,
+        organizationId = null,
+        avatarColorHex = "#aa00aa",
+        hasPremiumPersonally = hasPremiumPersonally,
+        hasPremiumFromOrganization = hasPremiumFromOrganization,
+        forcePasswordResetReason = null,
+        kdfType = null,
+        kdfIterations = null,
+        kdfMemory = null,
+        kdfParallelism = null,
+        userDecryptionOptions = null,
+        creationDate = creationDate,
     ),
+    settings = AccountJson.Settings(environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US),
 )
+
+/**
+ * Builds a [UserStateJson] whose active account is [account], keyed by `userId`.
+ */
+private fun userStateJsonWith(account: AccountJson): UserStateJson = UserStateJson(
+    activeUserId = account.profile.userId,
+    accounts = mapOf(account.profile.userId to account),
+)
+
+private val DEFAULT_ACTIVE_ACCOUNT_JSON: AccountJson = createAccountJson()
+private val DEFAULT_USER_STATE_JSON: UserStateJson =
+    userStateJsonWith(account = DEFAULT_ACTIVE_ACCOUNT_JSON)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImplTest.kt
@@ -26,6 +26,7 @@ import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListV
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -743,8 +744,20 @@ class PremiumStateManagerImplTest {
         }
 
     @Test
+    fun `subscriptionStatusStateFlow emits NoSubscription for a free active user`() = runTest {
+        val manager = createManager()
+        manager.subscriptionStatusStateFlow.test {
+            assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
+        }
+        coVerify(exactly = 0) { billingRepository.getSubscription() }
+    }
+
+    @Test
     fun `subscriptionStatusStateFlow emits NoSubscription on 404 from BillingRepository`() =
         runTest {
+            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+            )
             coEvery { billingRepository.getSubscription() } returns SubscriptionResult.NotFound
             val manager = createManager()
             manager.subscriptionStatusStateFlow.test {
@@ -754,6 +767,9 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `subscriptionStatusStateFlow emits Available with status on Success`() = runTest {
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        )
         coEvery {
             billingRepository.getSubscription()
         } returns SubscriptionResult.Success(
@@ -774,6 +790,9 @@ class PremiumStateManagerImplTest {
 
     @Test
     fun `subscriptionStatusStateFlow emits Error on non-404 failure`() = runTest {
+        mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+            accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+        )
         val exception = IllegalStateException("boom")
         coEvery {
             billingRepository.getSubscription()
@@ -785,32 +804,69 @@ class PremiumStateManagerImplTest {
     }
 
     @Test
-    fun `subscriptionStatusStateFlow refetches on premium-status push`() = runTest {
-        coEvery {
-            billingRepository.getSubscription()
-        } returns SubscriptionResult.NotFound andThen
-            SubscriptionResult.Success(
+    fun `subscriptionStatusStateFlow refetches when active user transitions to premium`() =
+        runTest {
+            coEvery {
+                billingRepository.getSubscription()
+            } returns SubscriptionResult.Success(
                 subscription = createSubscriptionInfo(
                     status = PremiumSubscriptionStatus.ACTIVE,
                 ),
             )
-        val manager = createManager()
-        manager.subscriptionStatusStateFlow.test {
-            assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
-            mutablePremiumStatusChangedFlow.tryEmit(
-                PremiumStatusChangedData(
-                    userId = ACTIVE_USER_ID,
-                    isPremium = true,
-                ),
+            val manager = createManager()
+            manager.subscriptionStatusStateFlow.test {
+                assertEquals(SubscriptionStatusState.NoSubscription, awaitItem())
+                mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                    accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
+                )
+                assertEquals(
+                    SubscriptionStatusState.Available(
+                        status = PremiumSubscriptionStatus.ACTIVE,
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `subscriptionStatusStateFlow refetches on push when active user is premium`() =
+        runTest {
+            mutableUserStateFlow.value = DEFAULT_USER_STATE.copy(
+                accounts = listOf(DEFAULT_ACTIVE_ACCOUNT.copy(isPremium = true)),
             )
-            assertEquals(
-                SubscriptionStatusState.Available(
+            coEvery {
+                billingRepository.getSubscription()
+            } returns SubscriptionResult.Success(
+                subscription = createSubscriptionInfo(
                     status = PremiumSubscriptionStatus.ACTIVE,
                 ),
-                awaitItem(),
+            ) andThen SubscriptionResult.Success(
+                subscription = createSubscriptionInfo(
+                    status = PremiumSubscriptionStatus.PAST_DUE,
+                ),
             )
+            val manager = createManager()
+            manager.subscriptionStatusStateFlow.test {
+                assertEquals(
+                    SubscriptionStatusState.Available(
+                        status = PremiumSubscriptionStatus.ACTIVE,
+                    ),
+                    awaitItem(),
+                )
+                mutablePremiumStatusChangedFlow.tryEmit(
+                    PremiumStatusChangedData(
+                        userId = ACTIVE_USER_ID,
+                        isPremium = true,
+                    ),
+                )
+                assertEquals(
+                    SubscriptionStatusState.Available(
+                        status = PremiumSubscriptionStatus.PAST_DUE,
+                    ),
+                    awaitItem(),
+                )
+            }
         }
-    }
 
     @Test
     fun `banner ineligible when account is premium and status is ACTIVE`() = runTest {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -38,7 +38,7 @@ import java.time.Instant
 import java.time.ZoneOffset
 
 @Suppress("LargeClass")
-class PremiumStateManagerImplTest {
+class PremiumStateManagerTest {
 
     private val fixedClock: Clock = Clock.fixed(
         Instant.parse(FIXED_DATETIME),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
@@ -12,6 +12,7 @@ import com.bitwarden.network.model.PasswordManagerCartItemsJson
 import com.bitwarden.network.model.PortalUrlResponseJson
 import com.bitwarden.network.model.PremiumPlanResponseJson
 import com.bitwarden.network.model.SubscriptionStatusJson
+import com.bitwarden.network.model.toBitwardenError
 import com.bitwarden.network.service.BillingService
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManager
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
@@ -21,7 +22,6 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResul
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
-import com.bitwarden.network.model.toBitwardenError
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -29,9 +29,11 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
@@ -48,6 +50,16 @@ class BillingRepositoryTest {
         playBillingManager = playBillingManager,
         billingService = billingService,
     )
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
+    }
 
     @Test
     fun `isInAppBillingSupportedFlow should delegate to PlayBillingManager`() =
@@ -217,7 +229,6 @@ class BillingRepositoryTest {
         val bitwardenHttpError = mockk<BitwardenError.Http> {
             every { code } returns NOT_FOUND_CODE
         }
-        mockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
         every { throwable.toBitwardenError() } returns bitwardenHttpError
         coEvery {
             billingService.getSubscription()
@@ -226,7 +237,6 @@ class BillingRepositoryTest {
         val result = repository.getSubscription()
 
         assertEquals(SubscriptionResult.NotFound, result)
-        unmockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
     }
 
     @Test
@@ -235,7 +245,6 @@ class BillingRepositoryTest {
         val bitwardenHttpError = mockk<BitwardenError.Http> {
             every { code } returns SERVER_ERROR_CODE
         }
-        mockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
         every { throwable.toBitwardenError() } returns bitwardenHttpError
         coEvery {
             billingService.getSubscription()
@@ -244,7 +253,6 @@ class BillingRepositoryTest {
         val result = repository.getSubscription()
 
         assertEquals(SubscriptionResult.Error(error = throwable), result)
-        unmockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
     }
 }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.data.billing.repository
 
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
+import com.bitwarden.network.model.BitwardenError
 import com.bitwarden.network.model.BitwardenSubscriptionResponseJson
 import com.bitwarden.network.model.CadenceTypeJson
 import com.bitwarden.network.model.CartItemJson
@@ -20,9 +21,12 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResul
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
+import com.bitwarden.network.model.toBitwardenError
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -206,7 +210,46 @@ class BillingRepositoryTest {
                 result,
             )
         }
+
+    @Test
+    fun `getSubscription with 404 BitwardenError Http should return NotFound`() = runTest {
+        val throwable = RuntimeException("not found")
+        val bitwardenHttpError = mockk<BitwardenError.Http> {
+            every { code } returns NOT_FOUND_CODE
+        }
+        mockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
+        every { throwable.toBitwardenError() } returns bitwardenHttpError
+        coEvery {
+            billingService.getSubscription()
+        } returns throwable.asFailure()
+
+        val result = repository.getSubscription()
+
+        assertEquals(SubscriptionResult.NotFound, result)
+        unmockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
+    }
+
+    @Test
+    fun `getSubscription with non-404 BitwardenError Http should return Error`() = runTest {
+        val throwable = RuntimeException("server error")
+        val bitwardenHttpError = mockk<BitwardenError.Http> {
+            every { code } returns SERVER_ERROR_CODE
+        }
+        mockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
+        every { throwable.toBitwardenError() } returns bitwardenHttpError
+        coEvery {
+            billingService.getSubscription()
+        } returns throwable.asFailure()
+
+        val result = repository.getSubscription()
+
+        assertEquals(SubscriptionResult.Error(error = throwable), result)
+        unmockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
+    }
 }
+
+private const val NOT_FOUND_CODE: Int = 404
+private const val SERVER_ERROR_CODE: Int = 500
 
 private const val ANNUAL_PRICE = 19.99
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
@@ -198,9 +198,7 @@ class BillingRepositoryTest {
     fun `getSubscription when service returns NotFound should return NotFound`() = runTest {
         coEvery {
             billingService.getSubscription()
-        } returns GetSubscriptionResponse.NotFound(
-            throwable = RuntimeException("not found"),
-        ).asSuccess()
+        } returns GetSubscriptionResponse.NotFound.asSuccess()
 
         val result = repository.getSubscription()
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/BillingRepositoryTest.kt
@@ -2,17 +2,16 @@ package com.x8bit.bitwarden.data.billing.repository
 
 import com.bitwarden.core.data.util.asFailure
 import com.bitwarden.core.data.util.asSuccess
-import com.bitwarden.network.model.BitwardenError
 import com.bitwarden.network.model.BitwardenSubscriptionResponseJson
 import com.bitwarden.network.model.CadenceTypeJson
 import com.bitwarden.network.model.CartItemJson
 import com.bitwarden.network.model.CartJson
 import com.bitwarden.network.model.CheckoutSessionResponseJson
+import com.bitwarden.network.model.GetSubscriptionResponse
 import com.bitwarden.network.model.PasswordManagerCartItemsJson
 import com.bitwarden.network.model.PortalUrlResponseJson
 import com.bitwarden.network.model.PremiumPlanResponseJson
 import com.bitwarden.network.model.SubscriptionStatusJson
-import com.bitwarden.network.model.toBitwardenError
 import com.bitwarden.network.service.BillingService
 import com.x8bit.bitwarden.data.billing.manager.PlayBillingManager
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
@@ -25,15 +24,11 @@ import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
@@ -50,16 +45,6 @@ class BillingRepositoryTest {
         playBillingManager = playBillingManager,
         billingService = billingService,
     )
-
-    @BeforeEach
-    fun setup() {
-        mockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
-    }
-
-    @AfterEach
-    fun tearDown() {
-        unmockkStatic("com.bitwarden.network.model.BitwardenErrorKt")
-    }
 
     @Test
     fun `isInAppBillingSupportedFlow should delegate to PlayBillingManager`() =
@@ -179,11 +164,13 @@ class BillingRepositoryTest {
         }
 
     @Test
-    fun `getSubscription when service returns success should return Success`() =
+    fun `getSubscription when service returns Success should return Success`() =
         runTest {
             coEvery {
                 billingService.getSubscription()
-            } returns ACTIVE_SUBSCRIPTION_RESPONSE.asSuccess()
+            } returns GetSubscriptionResponse.Success(
+                subscription = ACTIVE_SUBSCRIPTION_RESPONSE,
+            ).asSuccess()
 
             val result = repository.getSubscription()
 
@@ -208,6 +195,19 @@ class BillingRepositoryTest {
         }
 
     @Test
+    fun `getSubscription when service returns NotFound should return NotFound`() = runTest {
+        coEvery {
+            billingService.getSubscription()
+        } returns GetSubscriptionResponse.NotFound(
+            throwable = RuntimeException("not found"),
+        ).asSuccess()
+
+        val result = repository.getSubscription()
+
+        assertEquals(SubscriptionResult.NotFound, result)
+    }
+
+    @Test
     fun `getSubscription when service returns failure should return Error`() =
         runTest {
             val exception = RuntimeException("Network error")
@@ -222,42 +222,7 @@ class BillingRepositoryTest {
                 result,
             )
         }
-
-    @Test
-    fun `getSubscription with 404 BitwardenError Http should return NotFound`() = runTest {
-        val throwable = RuntimeException("not found")
-        val bitwardenHttpError = mockk<BitwardenError.Http> {
-            every { code } returns NOT_FOUND_CODE
-        }
-        every { throwable.toBitwardenError() } returns bitwardenHttpError
-        coEvery {
-            billingService.getSubscription()
-        } returns throwable.asFailure()
-
-        val result = repository.getSubscription()
-
-        assertEquals(SubscriptionResult.NotFound, result)
-    }
-
-    @Test
-    fun `getSubscription with non-404 BitwardenError Http should return Error`() = runTest {
-        val throwable = RuntimeException("server error")
-        val bitwardenHttpError = mockk<BitwardenError.Http> {
-            every { code } returns SERVER_ERROR_CODE
-        }
-        every { throwable.toBitwardenError() } returns bitwardenHttpError
-        coEvery {
-            billingService.getSubscription()
-        } returns throwable.asFailure()
-
-        val result = repository.getSubscription()
-
-        assertEquals(SubscriptionResult.Error(error = throwable), result)
-    }
 }
-
-private const val NOT_FOUND_CODE: Int = 404
-private const val SERVER_ERROR_CODE: Int = 500
 
 private const val ANNUAL_PRICE = 19.99
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/repository/util/BitwardenSubscriptionResponseJsonExtensionsTest.kt
@@ -28,21 +28,24 @@ class BitwardenSubscriptionResponseJsonExtensionsTest {
     }
 
     @Test
-    fun `toSubscriptionInfo maps CANCELED and INCOMPLETE_EXPIRED to CANCELED`() {
-        listOf(
-            SubscriptionStatusJson.CANCELED,
-            SubscriptionStatusJson.INCOMPLETE_EXPIRED,
-        ).forEach {
-            val info = buildResponse(status = it).toSubscriptionInfo()
-            assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
-        }
+    fun `toSubscriptionInfo maps CANCELED to CANCELED`() {
+        val info = buildResponse(status = SubscriptionStatusJson.CANCELED).toSubscriptionInfo()
+        assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
     }
 
     @Test
-    fun `toSubscriptionInfo maps INCOMPLETE and UNPAID to OVERDUE_PAYMENT`() {
+    fun `toSubscriptionInfo maps INCOMPLETE_EXPIRED to CANCELED`() {
+        val info = buildResponse(
+            status = SubscriptionStatusJson.INCOMPLETE_EXPIRED,
+        ).toSubscriptionInfo()
+        assertEquals(PremiumSubscriptionStatus.CANCELED, info.status)
+    }
+
+    @Test
+    fun `toSubscriptionInfo maps INCOMPLETE and UNPAID to UPDATE_PAYMENT`() {
         listOf(SubscriptionStatusJson.INCOMPLETE, SubscriptionStatusJson.UNPAID).forEach {
             val info = buildResponse(status = it).toSubscriptionInfo()
-            assertEquals(PremiumSubscriptionStatus.OVERDUE_PAYMENT, info.status)
+            assertEquals(PremiumSubscriptionStatus.UPDATE_PAYMENT, info.status)
         }
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -1011,8 +1011,10 @@ private val DEFAULT_PREMIUM_VIEW_STATE = PlanState.ViewState.Premium(
 )
 
 /**
- * Asserts that the [boldSubstring] within this node's rendered text carries a [FontWeight.Bold]
- * span style. Fails if the substring cannot be located or if no bold span overlaps it.
+ * Asserts that exactly the [boldSubstring] within this node's rendered text carries a heavy
+ * font-weight span style — i.e. no heavy-weight span extends beyond the substring. Fails if the
+ * substring cannot be located, if no heavy span aligns with it, or if any heavy span covers
+ * additional characters outside it.
  */
 private fun SemanticsNodeInteraction.assertTextRangeHasBoldSpan(boldSubstring: String) {
     val texts = fetchSemanticsNode().config.getOrNull(SemanticsProperties.Text)
@@ -1022,13 +1024,18 @@ private fun SemanticsNodeInteraction.assertTextRangeHasBoldSpan(boldSubstring: S
     }
     val start = match.text.indexOf(boldSubstring)
     val end = start + boldSubstring.length
-    val hasBold = match.spanStyles.any { range ->
-        range.item.fontWeight == FontWeight.Bold &&
-            range.start <= start &&
-            range.end >= end
+    val heavySpans = match.spanStyles.filter { range ->
+        val weight = range.item.fontWeight
+        weight != null && weight.weight >= FontWeight.SemiBold.weight
     }
-    require(hasBold) {
-        "Expected bold span over \"$boldSubstring\" (indices $start..$end) " +
-            "but spans were: ${match.spanStyles}"
+    val coversSubstring = heavySpans.any { it.start == start && it.end == end }
+    require(coversSubstring) {
+        "Expected a heavy-weight span to cover exactly \"$boldSubstring\" " +
+            "(indices $start..$end) but spans were: ${match.spanStyles}"
+    }
+    val overreaches = heavySpans.filter { it.start < start || it.end > end }
+    require(overreaches.isEmpty()) {
+        "Heavy-weight span(s) extended beyond \"$boldSubstring\" " +
+            "(indices $start..$end): $overreaches"
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -577,11 +577,12 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `ACTIVE description should bold the next charge date`() {
+    fun `ACTIVE description should bold the next charge total and date`() {
         mutableStateFlow.update { it.copy(viewState = DEFAULT_PREMIUM_VIEW_STATE) }
-        composeTestRule
+        val node = composeTestRule
             .onNodeWithText("Your next charge is for $45.55 USD due on April 2, 2026.")
-            .assertTextRangeHasBoldSpan(boldSubstring = "April 2, 2026")
+        node.assertTextRangeHasBoldSpan(boldSubstring = "$45.55")
+        node.assertTextRangeHasBoldSpan(boldSubstring = "April 2, 2026")
     }
 
     @Test
@@ -600,6 +601,25 @@ class PlanScreenTest : BitwardenComposeTest() {
                     "Resubscribe to continue using premium features.",
             )
             .assertTextRangeHasBoldSpan(boldSubstring = "April 21, 2026")
+    }
+
+    @Test
+    fun `CANCELED description falls back to suspension date when canceled date is null`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.CANCELED,
+                    canceledDateText = null,
+                    suspensionDateText = "May 15, 2026",
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(
+                "Your subscription was canceled on May 15, 2026. " +
+                    "Resubscribe to continue using premium features.",
+            )
+            .assertTextRangeHasBoldSpan(boldSubstring = "May 15, 2026")
     }
 
     @Test
@@ -1012,9 +1032,8 @@ private val DEFAULT_PREMIUM_VIEW_STATE = PlanState.ViewState.Premium(
 
 /**
  * Asserts that exactly the [boldSubstring] within this node's rendered text carries a heavy
- * font-weight span style — i.e. no heavy-weight span extends beyond the substring. Fails if the
- * substring cannot be located, if no heavy span aligns with it, or if any heavy span covers
- * additional characters outside it.
+ * font-weight span style. Fails if the substring cannot be located, if no heavy span aligns with
+ * it, or if any heavy span partially overlaps it. Other heavy spans on disjoint ranges are fine.
  */
 private fun SemanticsNodeInteraction.assertTextRangeHasBoldSpan(boldSubstring: String) {
     val texts = fetchSemanticsNode().config.getOrNull(SemanticsProperties.Text)
@@ -1028,14 +1047,18 @@ private fun SemanticsNodeInteraction.assertTextRangeHasBoldSpan(boldSubstring: S
         val weight = range.item.fontWeight
         weight != null && weight.weight >= FontWeight.SemiBold.weight
     }
-    val coversSubstring = heavySpans.any { it.start == start && it.end == end }
-    require(coversSubstring) {
+    val coversExactly = heavySpans.any { it.start == start && it.end == end }
+    require(coversExactly) {
         "Expected a heavy-weight span to cover exactly \"$boldSubstring\" " +
             "(indices $start..$end) but spans were: ${match.spanStyles}"
     }
-    val overreaches = heavySpans.filter { it.start < start || it.end > end }
-    require(overreaches.isEmpty()) {
-        "Heavy-weight span(s) extended beyond \"$boldSubstring\" " +
-            "(indices $start..$end): $overreaches"
+    val partialOverlaps = heavySpans.filter { span ->
+        val overlaps = span.start < end && span.end > start
+        val matchesExactly = span.start == start && span.end == end
+        overlaps && !matchesExactly
+    }
+    require(partialOverlaps.isEmpty()) {
+        "Heavy-weight span(s) partially overlap \"$boldSubstring\" " +
+            "(indices $start..$end): $partialOverlaps"
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -549,7 +549,6 @@ class PlanScreenTest : BitwardenComposeTest() {
         }
         composeTestRule.onNodeWithText("Active").assertDoesNotExist()
         composeTestRule.onNodeWithText("Canceled").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Expired").assertDoesNotExist()
         composeTestRule.onNodeWithText("Past due").assertDoesNotExist()
         composeTestRule.onNodeWithText("Paused").assertDoesNotExist()
         composeTestRule.onNodeWithText("Update payment").assertDoesNotExist()

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -499,16 +499,16 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `status badge should render with Overdue payment label for OVERDUE_PAYMENT status`() {
+    fun `status badge should render with Update payment label for UPDATE_PAYMENT status`() {
         mutableStateFlow.update {
             it.copy(
                 viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
-                    status = PremiumSubscriptionStatus.OVERDUE_PAYMENT,
+                    status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
                 ),
             )
         }
         composeTestRule
-            .onNodeWithText("Overdue payment")
+            .onNodeWithText("Update payment")
             .assertIsDisplayed()
     }
 
@@ -549,9 +549,10 @@ class PlanScreenTest : BitwardenComposeTest() {
         }
         composeTestRule.onNodeWithText("Active").assertDoesNotExist()
         composeTestRule.onNodeWithText("Canceled").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Overdue payment").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Expired").assertDoesNotExist()
         composeTestRule.onNodeWithText("Past due").assertDoesNotExist()
         composeTestRule.onNodeWithText("Paused").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Update payment").assertDoesNotExist()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -11,8 +11,12 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.text.font.FontWeight
 import androidx.core.net.toUri
 import com.bitwarden.core.data.repository.util.bufferedMutableSharedFlow
 import com.bitwarden.ui.platform.manager.IntentManager
@@ -555,7 +559,7 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `description text should render when descriptionText is present`() {
+    fun `description text should render for ACTIVE status`() {
         mutableStateFlow.update { it.copy(viewState = DEFAULT_PREMIUM_VIEW_STATE) }
         composeTestRule
             .onNodeWithText("Your next charge is for $45.55 USD due on April 2, 2026.")
@@ -563,15 +567,92 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `description text should not render when descriptionText is null`() {
+    fun `description text should not render when status is null`() {
         mutableStateFlow.update {
-            it.copy(
-                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(descriptionText = null),
-            )
+            it.copy(viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(status = null))
         }
         composeTestRule
             .onNodeWithText("Your next charge is for $45.55 USD due on April 2, 2026.")
             .assertDoesNotExist()
+    }
+
+    @Test
+    fun `ACTIVE description should bold the next charge date`() {
+        mutableStateFlow.update { it.copy(viewState = DEFAULT_PREMIUM_VIEW_STATE) }
+        composeTestRule
+            .onNodeWithText("Your next charge is for $45.55 USD due on April 2, 2026.")
+            .assertTextRangeHasBoldSpan(boldSubstring = "April 2, 2026")
+    }
+
+    @Test
+    fun `CANCELED description should bold the canceled date`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.CANCELED,
+                    canceledDateText = "April 21, 2026",
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(
+                "Your subscription was canceled on April 21, 2026. " +
+                    "Resubscribe to continue using premium features.",
+            )
+            .assertTextRangeHasBoldSpan(boldSubstring = "April 21, 2026")
+    }
+
+    @Test
+    fun `UPDATE_PAYMENT description should bold the suspension date`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
+                    suspensionDateText = "April 21, 2026",
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(
+                "We couldn’t process your payment. Update your payment before " +
+                    "your subscription ends on April 21, 2026.",
+            )
+            .assertTextRangeHasBoldSpan(boldSubstring = "April 21, 2026")
+    }
+
+    @Test
+    fun `PAST_DUE description should bold the suspension date`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.PAST_DUE,
+                    suspensionDateText = "April 21, 2026",
+                    gracePeriodDays = 7,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(
+                "You have a grace period of 7 days from your subscription expiration date. " +
+                    "Please resolve the past due amount by April 21, 2026.",
+            )
+            .assertTextRangeHasBoldSpan(boldSubstring = "April 21, 2026")
+    }
+
+    @Test
+    fun `PAUSED description should render plain text`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(
+                    status = PremiumSubscriptionStatus.PAUSED,
+                ),
+            )
+        }
+        composeTestRule
+            .onNodeWithText(
+                "Your subscription is paused. Resume to continue using premium features.",
+            )
+            .assertIsDisplayed()
     }
 
     // endregion Premium content rendering
@@ -920,14 +1001,34 @@ private val DEFAULT_FREE_STATE = PlanState(
 
 private val DEFAULT_PREMIUM_VIEW_STATE = PlanState.ViewState.Premium(
     status = PremiumSubscriptionStatus.ACTIVE,
-    descriptionText = BitwardenString.premium_next_charge_summary.asText(
-        "$45.55",
-        "April 2, 2026",
-    ),
     billingAmountText = BitwardenString.billing_rate_per_year.asText("$19.80"),
     storageCostText = "$24.00",
     discountAmountText = "-$2.10",
     estimatedTaxText = "$3.85",
+    nextChargeTotalText = "$45.55",
     nextChargeDateText = "April 2, 2026",
     showCancelButton = true,
 )
+
+/**
+ * Asserts that the [boldSubstring] within this node's rendered text carries a [FontWeight.Bold]
+ * span style. Fails if the substring cannot be located or if no bold span overlaps it.
+ */
+private fun SemanticsNodeInteraction.assertTextRangeHasBoldSpan(boldSubstring: String) {
+    val texts = fetchSemanticsNode().config.getOrNull(SemanticsProperties.Text)
+    val match = texts?.firstOrNull { it.text.contains(boldSubstring) }
+    requireNotNull(match) {
+        "No rendered text contained substring \"$boldSubstring\". Found: $texts"
+    }
+    val start = match.text.indexOf(boldSubstring)
+    val end = start + boldSubstring.length
+    val hasBold = match.spanStyles.any { range ->
+        range.item.fontWeight == FontWeight.Bold &&
+            range.start <= start &&
+            range.end >= end
+    }
+    require(hasBold) {
+        "Expected bold span over \"$boldSubstring\" (indices $start..$end) " +
+            "but spans were: ${match.spanStyles}"
+    }
+}

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -4,9 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
-import com.bitwarden.ui.platform.resource.BitwardenPlurals
 import com.bitwarden.ui.platform.resource.BitwardenString
-import com.bitwarden.ui.util.asPluralsText
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
@@ -832,9 +830,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                     DEFAULT_PREMIUM_LOADED_STATE.copy(
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
                             status = PremiumSubscriptionStatus.CANCELED,
-                            descriptionText = BitwardenString
-                                .subscription_canceled_description
-                                .asText("April 21, 2026"),
+                            canceledDateText = "April 21, 2026",
                             showCancelButton = false,
                         ),
                     ),
@@ -875,9 +871,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
                         status = PremiumSubscriptionStatus.CANCELED,
-                        descriptionText = BitwardenString
-                            .subscription_canceled_description
-                            .asText("April 21, 2026"),
+                        canceledDateText = "April 21, 2026",
                         showCancelButton = false,
                     ),
                     loadedState.viewState,
@@ -932,9 +926,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                     DEFAULT_PREMIUM_LOADED_STATE.copy(
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
                             status = PremiumSubscriptionStatus.CANCELED,
-                            descriptionText = BitwardenString
-                                .subscription_canceled_description
-                                .asText("April 21, 2026"),
+                            canceledDateText = "April 21, 2026",
                             showCancelButton = false,
                         ),
                     ),
@@ -962,9 +954,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                     DEFAULT_PREMIUM_LOADED_STATE.copy(
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
                             status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
-                            descriptionText = BitwardenString
-                                .subscription_update_payment_description
-                                .asText("April 21, 2026"),
+                            suspensionDateText = "April 21, 2026",
                         ),
                     ),
                     awaitItem(),
@@ -992,9 +982,8 @@ class PlanViewModelTest : BaseViewModelTest() {
                     DEFAULT_PREMIUM_LOADED_STATE.copy(
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
                             status = PremiumSubscriptionStatus.PAST_DUE,
-                            descriptionText = BitwardenPlurals
-                                .subscription_past_due_description
-                                .asPluralsText(7, 7, "April 21, 2026"),
+                            suspensionDateText = "April 21, 2026",
+                            gracePeriodDays = 7,
                         ),
                     ),
                     awaitItem(),
@@ -1022,9 +1011,8 @@ class PlanViewModelTest : BaseViewModelTest() {
                     DEFAULT_PREMIUM_LOADED_STATE.copy(
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
                             status = PremiumSubscriptionStatus.PAST_DUE,
-                            descriptionText = BitwardenPlurals
-                                .subscription_past_due_description
-                                .asPluralsText(0, 0, "April 21, 2026"),
+                            suspensionDateText = "April 21, 2026",
+                            gracePeriodDays = null,
                         ),
                     ),
                     awaitItem(),
@@ -1050,9 +1038,6 @@ class PlanViewModelTest : BaseViewModelTest() {
                     DEFAULT_PREMIUM_LOADED_STATE.copy(
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
                             status = PremiumSubscriptionStatus.PAUSED,
-                            descriptionText = BitwardenString
-                                .subscription_paused_description
-                                .asText(),
                         ),
                     ),
                     awaitItem(),
@@ -1185,9 +1170,6 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_PREMIUM_LOADED_STATE.copy(
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
-                            descriptionText = BitwardenString
-                                .premium_next_charge_summary
-                                .asText("$45.55", PLACEHOLDER),
                             nextChargeDateText = null,
                         ),
                     ),
@@ -1473,14 +1455,11 @@ private const val PLACEHOLDER = "--"
 
 private val DEFAULT_PREMIUM_ACTIVE_VIEW_STATE = PlanState.ViewState.Premium(
     status = PremiumSubscriptionStatus.ACTIVE,
-    descriptionText = BitwardenString.premium_next_charge_summary.asText(
-        "$45.55",
-        "April 2, 2026",
-    ),
     billingAmountText = BitwardenString.billing_rate_per_year.asText("$19.80"),
     storageCostText = "$24.00",
     discountAmountText = "-$2.10",
     estimatedTaxText = "$3.85",
+    nextChargeTotalText = "$45.55",
     nextChargeDateText = "April 2, 2026",
     showCancelButton = true,
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -893,6 +893,34 @@ class PlanViewModelTest : BaseViewModelTest() {
             }
         }
 
+    @Suppress("MaxLineLength")
+    @Test
+    fun `SubscriptionResultReceive NotFound keeps Loading dialog up while pricing fetch is pending`() =
+        runTest {
+            markUserPremium()
+
+            val viewModel = createViewModel(
+                subscriptionResult = SubscriptionResult.NotFound,
+                pricingResult = null,
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_FREE_STATE.copy(
+                        viewState = PlanState.ViewState.Free(
+                            rate = "--",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
+                        ),
+                        dialogState = PlanState.DialogState.Loading(
+                            message = BitwardenString.loading.asText(),
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
     @Test
     fun `SubscriptionResultReceive Success should populate Premium state from SubscriptionInfo`() =
         runTest {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -10,6 +10,7 @@ import com.bitwarden.ui.util.asPluralsText
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.billing.repository.BillingRepository
 import com.x8bit.bitwarden.data.billing.repository.model.CheckoutSessionResult
 import com.x8bit.bitwarden.data.billing.repository.model.CustomerPortalResult
@@ -18,6 +19,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.PremiumPlanPricingResul
 import com.x8bit.bitwarden.data.billing.repository.model.PremiumSubscriptionStatus
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionInfo
 import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionResult
+import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
@@ -61,6 +63,11 @@ class PlanViewModelTest : BaseViewModelTest() {
         coEvery {
             syncForResult(any())
         } returns SyncVaultDataResult.Success(itemsAvailable = true)
+    }
+    private val mutableSubscriptionStatusStateFlow =
+        MutableStateFlow<SubscriptionStatusState>(SubscriptionStatusState.NoSubscription)
+    private val mockPremiumStateManager: PremiumStateManager = mockk {
+        every { subscriptionStatusStateFlow } returns mutableSubscriptionStatusStateFlow
     }
 
     @BeforeEach
@@ -806,6 +813,93 @@ class PlanViewModelTest : BaseViewModelTest() {
     }
 
     @Test
+    fun `init opens Premium view when account is free but status is in a trouble state`() =
+        runTest {
+            mutableSubscriptionStatusStateFlow.value = SubscriptionStatusState.Available(
+                status = PremiumSubscriptionStatus.CANCELED,
+            )
+            val viewModel = createViewModel(
+                subscriptionResult = SubscriptionResult.Success(
+                    subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
+                        status = PremiumSubscriptionStatus.CANCELED,
+                        canceledDate = Instant.parse("2026-04-21T00:00:00Z"),
+                    ),
+                ),
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    DEFAULT_PREMIUM_LOADED_STATE.copy(
+                        viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
+                            status = PremiumSubscriptionStatus.CANCELED,
+                            descriptionText = BitwardenString
+                                .subscription_canceled_description
+                                .asText("April 21, 2026"),
+                            showCancelButton = false,
+                        ),
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `SubscriptionStatusUpdateReceive promotes Free view to Premium on trouble status`() =
+        runTest {
+            val viewModel = createViewModel(
+                subscriptionResult = SubscriptionResult.Success(
+                    subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
+                        status = PremiumSubscriptionStatus.CANCELED,
+                        canceledDate = Instant.parse("2026-04-21T00:00:00Z"),
+                    ),
+                ),
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_FREE_STATE, awaitItem())
+                mutableSubscriptionStatusStateFlow.value = SubscriptionStatusState.Available(
+                    status = PremiumSubscriptionStatus.CANCELED,
+                )
+                val loadingState = awaitItem()
+                assertEquals(
+                    PlanState.ViewState.Premium(),
+                    loadingState.viewState,
+                )
+                assertEquals(
+                    PlanState.DialogState.Loading(
+                        message = BitwardenString.loading_subscription.asText(),
+                    ),
+                    loadingState.dialogState,
+                )
+                val loadedState = awaitItem()
+                assertEquals(
+                    DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
+                        status = PremiumSubscriptionStatus.CANCELED,
+                        descriptionText = BitwardenString
+                            .subscription_canceled_description
+                            .asText("April 21, 2026"),
+                        showCancelButton = false,
+                    ),
+                    loadedState.viewState,
+                )
+            }
+        }
+
+    @Test
+    fun `SubscriptionResultReceive NotFound falls back to Free view and fetches pricing`() =
+        runTest {
+            markUserPremium()
+
+            val viewModel = createViewModel(
+                subscriptionResult = SubscriptionResult.NotFound,
+            )
+
+            viewModel.stateFlow.test {
+                assertEquals(DEFAULT_FREE_STATE, awaitItem())
+            }
+        }
+
+    @Test
     fun `SubscriptionResultReceive Success should populate Premium state from SubscriptionInfo`() =
         runTest {
             markUserPremium()
@@ -850,14 +944,14 @@ class PlanViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `SubscriptionResultReceive Success with OverduePayment status should describe overdue`() =
+    fun `SubscriptionResultReceive Success with UpdatePayment status should describe update`() =
         runTest {
             markUserPremium()
 
             val viewModel = createViewModel(
                 subscriptionResult = SubscriptionResult.Success(
                     subscription = SUBSCRIPTION_INFO_ACTIVE.copy(
-                        status = PremiumSubscriptionStatus.OVERDUE_PAYMENT,
+                        status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
                         suspensionDate = Instant.parse("2026-04-21T00:00:00Z"),
                     ),
                 ),
@@ -867,9 +961,9 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     DEFAULT_PREMIUM_LOADED_STATE.copy(
                         viewState = DEFAULT_PREMIUM_ACTIVE_VIEW_STATE.copy(
-                            status = PremiumSubscriptionStatus.OVERDUE_PAYMENT,
+                            status = PremiumSubscriptionStatus.UPDATE_PAYMENT,
                             descriptionText = BitwardenString
-                                .subscription_overdue_description
+                                .subscription_update_payment_description
                                 .asText("April 21, 2026"),
                         ),
                     ),
@@ -1300,6 +1394,7 @@ class PlanViewModelTest : BaseViewModelTest() {
             savedStateHandle = savedStateHandle,
             authRepository = mockAuthRepository,
             billingRepository = mockBillingRepository,
+            premiumStateManager = mockPremiumStateManager,
             specialCircumstanceManager = mockSpecialCircumstanceManager,
             vaultRepository = mockVaultRepository,
             clock = clock,

--- a/network/src/main/kotlin/com/bitwarden/network/model/GetSubscriptionResponse.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/GetSubscriptionResponse.kt
@@ -1,0 +1,20 @@
+package com.bitwarden.network.model
+
+/**
+ * Models response body from fetching the current user's subscription.
+ */
+sealed class GetSubscriptionResponse {
+    /**
+     * Models the response of a successful Get Subscription request.
+     */
+    data class Success(
+        val subscription: BitwardenSubscriptionResponseJson,
+    ) : GetSubscriptionResponse()
+
+    /**
+     * Models the response when the user has no subscription on file (server returns 404).
+     */
+    data class NotFound(
+        val throwable: Throwable,
+    ) : GetSubscriptionResponse()
+}

--- a/network/src/main/kotlin/com/bitwarden/network/model/GetSubscriptionResponse.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/model/GetSubscriptionResponse.kt
@@ -14,7 +14,5 @@ sealed class GetSubscriptionResponse {
     /**
      * Models the response when the user has no subscription on file (server returns 404).
      */
-    data class NotFound(
-        val throwable: Throwable,
-    ) : GetSubscriptionResponse()
+    data object NotFound : GetSubscriptionResponse()
 }

--- a/network/src/main/kotlin/com/bitwarden/network/service/BillingService.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/BillingService.kt
@@ -1,7 +1,7 @@
 package com.bitwarden.network.service
 
-import com.bitwarden.network.model.BitwardenSubscriptionResponseJson
 import com.bitwarden.network.model.CheckoutSessionResponseJson
+import com.bitwarden.network.model.GetSubscriptionResponse
 import com.bitwarden.network.model.PortalUrlResponseJson
 import com.bitwarden.network.model.PremiumPlanResponseJson
 
@@ -28,5 +28,5 @@ interface BillingService {
     /**
      * Retrieves the user's premium subscription details.
      */
-    suspend fun getSubscription(): Result<BitwardenSubscriptionResponseJson>
+    suspend fun getSubscription(): Result<GetSubscriptionResponse>
 }

--- a/network/src/main/kotlin/com/bitwarden/network/service/BillingServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/BillingServiceImpl.kt
@@ -1,11 +1,14 @@
 package com.bitwarden.network.service
 
 import com.bitwarden.network.api.AuthenticatedBillingApi
-import com.bitwarden.network.model.BitwardenSubscriptionResponseJson
 import com.bitwarden.network.model.CheckoutSessionRequestJson
 import com.bitwarden.network.model.CheckoutSessionResponseJson
+import com.bitwarden.network.model.GetSubscriptionResponse
 import com.bitwarden.network.model.PortalUrlResponseJson
 import com.bitwarden.network.model.PremiumPlanResponseJson
+import com.bitwarden.network.model.toBitwardenError
+import com.bitwarden.network.util.NetworkErrorCode
+import com.bitwarden.network.util.isErrorCode
 import com.bitwarden.network.util.toResult
 
 private const val PLATFORM = "android"
@@ -34,8 +37,17 @@ internal class BillingServiceImpl(
             .getPremiumPlan()
             .toResult()
 
-    override suspend fun getSubscription(): Result<BitwardenSubscriptionResponseJson> =
+    override suspend fun getSubscription(): Result<GetSubscriptionResponse> =
         authenticatedBillingApi
             .getSubscription()
             .toResult()
+            .map { GetSubscriptionResponse.Success(subscription = it) }
+            .recoverCatching { throwable ->
+                val bitwardenError = throwable.toBitwardenError()
+                if (bitwardenError.isErrorCode(code = NetworkErrorCode.NOT_FOUND)) {
+                    GetSubscriptionResponse.NotFound(throwable = throwable)
+                } else {
+                    throw throwable
+                }
+            }
 }

--- a/network/src/main/kotlin/com/bitwarden/network/service/BillingServiceImpl.kt
+++ b/network/src/main/kotlin/com/bitwarden/network/service/BillingServiceImpl.kt
@@ -45,7 +45,7 @@ internal class BillingServiceImpl(
             .recoverCatching { throwable ->
                 val bitwardenError = throwable.toBitwardenError()
                 if (bitwardenError.isErrorCode(code = NetworkErrorCode.NOT_FOUND)) {
-                    GetSubscriptionResponse.NotFound(throwable = throwable)
+                    GetSubscriptionResponse.NotFound
                 } else {
                     throw throwable
                 }

--- a/network/src/test/kotlin/com/bitwarden/network/service/BillingServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/BillingServiceTest.kt
@@ -183,12 +183,10 @@ class BillingServiceTest : BaseServiceTest() {
             server.enqueue(response)
             val actual = service.getSubscription()
             assertEquals(
-                DiscountTypeJson.AMOUNT_OFF,
-                (actual.getOrNull() as? GetSubscriptionResponse.Success)
-                    ?.subscription
-                    ?.cart
-                    ?.discount
-                    ?.type,
+                GetSubscriptionResponse.Success(
+                    subscription = SUBSCRIPTION_RESPONSE_AMOUNT_OFF,
+                ).asSuccess(),
+                actual,
             )
         }
 
@@ -201,12 +199,10 @@ class BillingServiceTest : BaseServiceTest() {
             server.enqueue(response)
             val actual = service.getSubscription()
             assertEquals(
-                DiscountTypeJson.PERCENT_OFF,
-                (actual.getOrNull() as? GetSubscriptionResponse.Success)
-                    ?.subscription
-                    ?.cart
-                    ?.discount
-                    ?.type,
+                GetSubscriptionResponse.Success(
+                    subscription = SUBSCRIPTION_RESPONSE_PERCENT_OFF,
+                ).asSuccess(),
+                actual,
             )
         }
 
@@ -487,6 +483,15 @@ private const val SUBSCRIPTION_RESPONSE_AMOUNT_OFF_JSON = """
 }
 """
 
+private val SUBSCRIPTION_RESPONSE_AMOUNT_OFF = SUBSCRIPTION_RESPONSE_MINIMAL.copy(
+    cart = SUBSCRIPTION_RESPONSE_MINIMAL.cart.copy(
+        discount = BitwardenDiscountJson(
+            type = DiscountTypeJson.AMOUNT_OFF,
+            value = BigDecimal("5.00"),
+        ),
+    ),
+)
+
 private const val SUBSCRIPTION_RESPONSE_PERCENT_OFF_JSON = """
 {
   "status": "active",
@@ -516,6 +521,15 @@ private const val SUBSCRIPTION_RESPONSE_PERCENT_OFF_JSON = """
   "gracePeriod": null
 }
 """
+
+private val SUBSCRIPTION_RESPONSE_PERCENT_OFF = SUBSCRIPTION_RESPONSE_MINIMAL.copy(
+    cart = SUBSCRIPTION_RESPONSE_MINIMAL.cart.copy(
+        discount = BitwardenDiscountJson(
+            type = DiscountTypeJson.PERCENT_OFF,
+            value = BigDecimal("15.00"),
+        ),
+    ),
+)
 
 private const val SUBSCRIPTION_RESPONSE_UNKNOWN_CADENCE_JSON = """
 {

--- a/network/src/test/kotlin/com/bitwarden/network/service/BillingServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/BillingServiceTest.kt
@@ -10,6 +10,7 @@ import com.bitwarden.network.model.CartItemJson
 import com.bitwarden.network.model.CartJson
 import com.bitwarden.network.model.CheckoutSessionResponseJson
 import com.bitwarden.network.model.DiscountTypeJson
+import com.bitwarden.network.model.GetSubscriptionResponse
 import com.bitwarden.network.model.PasswordManagerCartItemsJson
 import com.bitwarden.network.model.PortalUrlResponseJson
 import com.bitwarden.network.model.PremiumPlanResponseJson
@@ -91,12 +92,22 @@ class BillingServiceTest : BaseServiceTest() {
         }
 
     @Test
-    fun `getSubscription when response is Failure should return Failure`() =
+    fun `getSubscription when response is non-404 Failure should return Failure`() =
         runTest {
             val response = MockResponse().setResponseCode(400)
             server.enqueue(response)
             val actual = service.getSubscription()
             assertTrue(actual.isFailure)
+        }
+
+    @Test
+    fun `getSubscription when response is 404 should return NotFound`() =
+        runTest {
+            val response = MockResponse().setResponseCode(404)
+            server.enqueue(response)
+            val actual = service.getSubscription()
+            assertTrue(actual.isSuccess)
+            assertTrue(actual.getOrNull() is GetSubscriptionResponse.NotFound)
         }
 
     @Test
@@ -107,7 +118,10 @@ class BillingServiceTest : BaseServiceTest() {
                 .setResponseCode(200)
             server.enqueue(response)
             val actual = service.getSubscription()
-            assertEquals(SUBSCRIPTION_RESPONSE.asSuccess(), actual)
+            assertEquals(
+                GetSubscriptionResponse.Success(subscription = SUBSCRIPTION_RESPONSE).asSuccess(),
+                actual,
+            )
         }
 
     @Test
@@ -120,7 +134,10 @@ class BillingServiceTest : BaseServiceTest() {
             val actual = service.getSubscription()
             assertEquals(
                 CadenceTypeJson.MONTHLY,
-                actual.getOrNull()?.cart?.cadence,
+                (actual.getOrNull() as? GetSubscriptionResponse.Success)
+                    ?.subscription
+                    ?.cart
+                    ?.cadence,
             )
         }
 
@@ -134,7 +151,12 @@ class BillingServiceTest : BaseServiceTest() {
                     .setResponseCode(200)
                 server.enqueue(response)
                 val actual = service.getSubscription()
-                assertEquals(status, actual.getOrNull()?.status)
+                assertEquals(
+                    status,
+                    (actual.getOrNull() as? GetSubscriptionResponse.Success)
+                        ?.subscription
+                        ?.status,
+                )
             }
         }
 
@@ -147,6 +169,7 @@ class BillingServiceTest : BaseServiceTest() {
             server.enqueue(response)
             val actual = service.getSubscription()
             assertTrue(actual.isSuccess)
+            assertTrue(actual.getOrNull() is GetSubscriptionResponse.Success)
         }
 
     @Test
@@ -159,7 +182,11 @@ class BillingServiceTest : BaseServiceTest() {
             val actual = service.getSubscription()
             assertEquals(
                 DiscountTypeJson.AMOUNT_OFF,
-                actual.getOrNull()?.cart?.discount?.type,
+                (actual.getOrNull() as? GetSubscriptionResponse.Success)
+                    ?.subscription
+                    ?.cart
+                    ?.discount
+                    ?.type,
             )
         }
 
@@ -173,7 +200,11 @@ class BillingServiceTest : BaseServiceTest() {
             val actual = service.getSubscription()
             assertEquals(
                 DiscountTypeJson.PERCENT_OFF,
-                actual.getOrNull()?.cart?.discount?.type,
+                (actual.getOrNull() as? GetSubscriptionResponse.Success)
+                    ?.subscription
+                    ?.cart
+                    ?.discount
+                    ?.type,
             )
         }
 

--- a/network/src/test/kotlin/com/bitwarden/network/service/BillingServiceTest.kt
+++ b/network/src/test/kotlin/com/bitwarden/network/service/BillingServiceTest.kt
@@ -106,8 +106,7 @@ class BillingServiceTest : BaseServiceTest() {
             val response = MockResponse().setResponseCode(404)
             server.enqueue(response)
             val actual = service.getSubscription()
-            assertTrue(actual.isSuccess)
-            assertTrue(actual.getOrNull() is GetSubscriptionResponse.NotFound)
+            assertEquals(GetSubscriptionResponse.NotFound.asSuccess(), actual)
         }
 
     @Test
@@ -133,11 +132,10 @@ class BillingServiceTest : BaseServiceTest() {
             server.enqueue(response)
             val actual = service.getSubscription()
             assertEquals(
-                CadenceTypeJson.MONTHLY,
-                (actual.getOrNull() as? GetSubscriptionResponse.Success)
-                    ?.subscription
-                    ?.cart
-                    ?.cadence,
+                GetSubscriptionResponse.Success(
+                    subscription = SUBSCRIPTION_RESPONSE_MONTHLY,
+                ).asSuccess(),
+                actual,
             )
         }
 
@@ -168,8 +166,12 @@ class BillingServiceTest : BaseServiceTest() {
                 .setResponseCode(200)
             server.enqueue(response)
             val actual = service.getSubscription()
-            assertTrue(actual.isSuccess)
-            assertTrue(actual.getOrNull() is GetSubscriptionResponse.Success)
+            assertEquals(
+                GetSubscriptionResponse.Success(
+                    subscription = SUBSCRIPTION_RESPONSE_MINIMAL,
+                ).asSuccess(),
+                actual,
+            )
         }
 
     @Test
@@ -378,6 +380,31 @@ private const val SUBSCRIPTION_RESPONSE_MONTHLY_JSON = """
 }
 """
 
+private val SUBSCRIPTION_RESPONSE_MONTHLY = BitwardenSubscriptionResponseJson(
+    status = SubscriptionStatusJson.ACTIVE,
+    cart = CartJson(
+        passwordManager = PasswordManagerCartItemsJson(
+            seats = CartItemJson(
+                translationKey = "premiumMembership",
+                quantity = 1,
+                cost = BigDecimal("1.67"),
+                discount = null,
+            ),
+            additionalStorage = null,
+        ),
+        secretsManager = null,
+        cadence = CadenceTypeJson.MONTHLY,
+        discount = null,
+        estimatedTax = BigDecimal("0"),
+    ),
+    storage = null,
+    cancelAt = null,
+    canceled = null,
+    nextCharge = null,
+    suspension = null,
+    gracePeriod = null,
+)
+
 private const val SUBSCRIPTION_RESPONSE_MINIMAL_JSON = """
 {
   "status": "active",
@@ -404,6 +431,31 @@ private const val SUBSCRIPTION_RESPONSE_MINIMAL_JSON = """
   "gracePeriod": null
 }
 """
+
+private val SUBSCRIPTION_RESPONSE_MINIMAL = BitwardenSubscriptionResponseJson(
+    status = SubscriptionStatusJson.ACTIVE,
+    cart = CartJson(
+        passwordManager = PasswordManagerCartItemsJson(
+            seats = CartItemJson(
+                translationKey = "premiumMembership",
+                quantity = 1,
+                cost = BigDecimal("19.80"),
+                discount = null,
+            ),
+            additionalStorage = null,
+        ),
+        secretsManager = null,
+        cadence = CadenceTypeJson.ANNUALLY,
+        discount = null,
+        estimatedTax = BigDecimal("0"),
+    ),
+    storage = null,
+    cancelAt = null,
+    canceled = null,
+    nextCharge = null,
+    suspension = null,
+    gracePeriod = null,
+)
 
 private const val SUBSCRIPTION_RESPONSE_AMOUNT_OFF_JSON = """
 {

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StringResExtensions.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StringResExtensions.kt
@@ -4,6 +4,7 @@ import android.content.res.Resources
 import android.text.Annotation
 import android.text.SpannableStringBuilder
 import android.text.SpannedString
+import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -61,13 +62,91 @@ fun @receiver:StringRes Int.toAnnotatedString(
     linkHighlightStyle,
     onAnnotationClick,
 ) {
-    // The spannableBuilder is used to help parse through the annotations in the string resource.
-    val spannableBuilder = try {
-        SpannableStringBuilder(resources.getText(this) as SpannedString)
+    val spannedString = try {
+        resources.getText(this) as SpannedString
     } catch (_: ClassCastException) {
-        // the resource did not contain and valid spans so we just return the raw string.
+        // the resource did not contain any valid spans so we just return the raw string.
         return@remember resources.getString(this, *args).toAnnotatedString()
     }
+    spannedString.buildAnnotatedString(
+        args = args,
+        style = style,
+        emphasisHighlightStyle = emphasisHighlightStyle,
+        linkHighlightStyle = linkHighlightStyle,
+        onAnnotationClick = onAnnotationClick,
+    )
+}
+
+/**
+ * Creates an [AnnotatedString] from a plurals resource allowing for optional arguments to be
+ * applied.
+ *
+ * @param quantity The quantity used to select the appropriate plural form from the resource.
+ * @param args Optional arguments to be applied to the string resource, must already be a
+ * [CharSequence]. Integer plural quantity arguments (`%1$d`) should be passed as a [CharSequence]
+ * (for example, `"$count"`).
+ * @param style Style to apply to the entire string.
+ * @param emphasisHighlightStyle Style to apply to part of the resource that has been annotated
+ * with the "emphasis" annotation.
+ * @param linkHighlightStyle Style to apply to part of the resource that has been annotated with
+ * the "link" annotation.
+ * @param resources The resources used to access the strings.
+ * @param onAnnotationClick Callback to invoke when a link annotation is clicked. Will pass back
+ * the value of the annotation as a string to allow for delineation if there are multiple callbacks
+ * to be applied.
+ *
+ * Annotation conventions match those documented on [Int.toAnnotatedString]; the resource must
+ * declare `<annotation arg="N">` wrappers around any format arguments that should be replaced.
+ */
+@Composable
+fun @receiver:PluralsRes Int.toAnnotatedPluralsString(
+    quantity: Int,
+    vararg args: CharSequence,
+    style: SpanStyle = bitwardenDefaultSpanStyle,
+    emphasisHighlightStyle: SpanStyle = bitwardenBoldSpanStyle,
+    linkHighlightStyle: SpanStyle = bitwardenClickableTextSpanStyle,
+    resources: Resources = LocalResources.current,
+    onAnnotationClick: ((annotationKey: String) -> Unit)? = null,
+): AnnotatedString = remember(
+    this,
+    quantity,
+    args,
+    style,
+    emphasisHighlightStyle,
+    linkHighlightStyle,
+    onAnnotationClick,
+) {
+    val spannedString = try {
+        resources.getQuantityText(this, quantity) as SpannedString
+    } catch (_: ClassCastException) {
+        // the resource did not contain any valid spans so we just return the raw string.
+        return@remember resources
+            .getQuantityString(this, quantity, *args)
+            .toAnnotatedString()
+    }
+    spannedString.buildAnnotatedString(
+        args = args,
+        style = style,
+        emphasisHighlightStyle = emphasisHighlightStyle,
+        linkHighlightStyle = linkHighlightStyle,
+        onAnnotationClick = onAnnotationClick,
+    )
+}
+
+/**
+ * Shared annotation-processing pipeline for both string and plurals resources. Replaces any
+ * `arg` annotations with the corresponding [args] entry then applies emphasis and link styles
+ * to the resulting [AnnotatedString].
+ */
+private fun SpannedString.buildAnnotatedString(
+    args: Array<out CharSequence>,
+    style: SpanStyle,
+    emphasisHighlightStyle: SpanStyle,
+    linkHighlightStyle: SpanStyle,
+    onAnnotationClick: ((annotationKey: String) -> Unit)?,
+): AnnotatedString {
+    // The spannableBuilder is used to help parse through the annotations in the string resource.
+    val spannableBuilder = SpannableStringBuilder(this)
     // Replace any format arguments with the provided arguments.
     spannableBuilder.applyArgAnnotations(args = args)
 
@@ -116,7 +195,7 @@ fun @receiver:StringRes Int.toAnnotatedString(
             ValidAnnotationType.ARG -> Unit
         }
     }
-    return@remember annotatedStringBuilder.toAnnotatedString()
+    return annotatedStringBuilder.toAnnotatedString()
 }
 
 /**
@@ -124,7 +203,7 @@ fun @receiver:StringRes Int.toAnnotatedString(
  * replaced with the index value in the provided [args].
  */
 private fun SpannableStringBuilder.applyArgAnnotations(
-    vararg args: CharSequence,
+    args: Array<out CharSequence>,
 ) {
     val argAnnotations = getSpans<Annotation>()
         .filter { it.isArgAnnotation() }

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StringUtil.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/base/util/StringUtil.kt
@@ -3,6 +3,7 @@
 package com.bitwarden.ui.platform.base.util
 
 import android.content.res.Resources
+import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalResources
@@ -27,6 +28,33 @@ fun annotatedStringResource(
     onAnnotationClick: ((annotationKey: String) -> Unit)? = null,
 ): AnnotatedString =
     id.toAnnotatedString(
+        args = args,
+        style = style,
+        emphasisHighlightStyle = emphasisHighlightStyle,
+        linkHighlightStyle = linkHighlightStyle,
+        resources = resources,
+        onAnnotationClick = onAnnotationClick,
+    )
+
+/**
+ * Creates an [AnnotatedString] from a plurals resource and allows for optional arguments to be
+ * applied.
+ *
+ * @see Int.toAnnotatedPluralsString
+ */
+@Composable
+fun annotatedPluralsResource(
+    @PluralsRes id: Int,
+    quantity: Int,
+    vararg args: CharSequence,
+    style: SpanStyle = bitwardenDefaultSpanStyle,
+    emphasisHighlightStyle: SpanStyle = bitwardenBoldSpanStyle,
+    linkHighlightStyle: SpanStyle = bitwardenClickableTextSpanStyle,
+    resources: Resources = LocalResources.current,
+    onAnnotationClick: ((annotationKey: String) -> Unit)? = null,
+): AnnotatedString =
+    id.toAnnotatedPluralsString(
+        quantity = quantity,
         args = args,
         style = style,
         emphasisHighlightStyle = emphasisHighlightStyle,

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1288,12 +1288,12 @@ Do you want to switch to this account?</string>
     <string name="cancel_premium_confirmation">You’ll continue to have Premium access until %1$s.</string>
     <string name="subscription_status_active">Active</string>
     <string name="subscription_status_canceled">Canceled</string>
-    <string name="subscription_status_overdue_payment">Overdue payment</string>
     <string name="subscription_status_past_due">Past due</string>
     <string name="subscription_status_paused">Paused</string>
+    <string name="subscription_status_update_payment">Update payment</string>
     <string name="premium_next_charge_summary">Your next charge is for %1$s USD due on %2$s.</string>
     <string name="subscription_canceled_description">Your subscription was canceled on %1$s. Resubscribe to continue using premium features.</string>
-    <string name="subscription_overdue_description">We couldn’t process your payment. Update your payment before your subscription ends on %1$s.</string>
+    <string name="subscription_update_payment_description">We couldn’t process your payment. Update your payment before your subscription ends on %1$s.</string>
     <plurals name="subscription_past_due_description">
         <item quantity="one">You have a grace period of %1$d day from your subscription expiration date. Please resolve the past due amount by %2$s.</item>
         <item quantity="other">You have a grace period of %1$d days from your subscription expiration date. Please resolve the past due amount by %2$s.</item>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1291,7 +1291,7 @@ Do you want to switch to this account?</string>
     <string name="subscription_status_past_due">Past due</string>
     <string name="subscription_status_paused">Paused</string>
     <string name="subscription_status_update_payment">Update payment</string>
-    <string name="premium_next_charge_summary">Your next charge is for <annotation arg="0">%1$s</annotation> USD due on <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</string>
+    <string name="premium_next_charge_summary">Your next charge is for <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation> USD due on <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</string>
     <string name="subscription_canceled_description">Your subscription was canceled on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using premium features.</string>
     <string name="subscription_update_payment_description">We couldn’t process your payment. Update your payment before your subscription ends on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>.</string>
     <plurals name="subscription_past_due_description">

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1291,12 +1291,12 @@ Do you want to switch to this account?</string>
     <string name="subscription_status_past_due">Past due</string>
     <string name="subscription_status_paused">Paused</string>
     <string name="subscription_status_update_payment">Update payment</string>
-    <string name="premium_next_charge_summary">Your next charge is for %1$s USD due on %2$s.</string>
-    <string name="subscription_canceled_description">Your subscription was canceled on %1$s. Resubscribe to continue using premium features.</string>
-    <string name="subscription_update_payment_description">We couldn’t process your payment. Update your payment before your subscription ends on %1$s.</string>
+    <string name="premium_next_charge_summary">Your next charge is for <annotation arg="0">%1$s</annotation> USD due on <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</string>
+    <string name="subscription_canceled_description">Your subscription was canceled on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>. Resubscribe to continue using premium features.</string>
+    <string name="subscription_update_payment_description">We couldn’t process your payment. Update your payment before your subscription ends on <annotation emphasis="bold"><annotation arg="0">%1$s</annotation></annotation>.</string>
     <plurals name="subscription_past_due_description">
-        <item quantity="one">You have a grace period of %1$d day from your subscription expiration date. Please resolve the past due amount by %2$s.</item>
-        <item quantity="other">You have a grace period of %1$d days from your subscription expiration date. Please resolve the past due amount by %2$s.</item>
+        <item quantity="one">You have a grace period of <annotation arg="0">%1$d</annotation> day from your subscription expiration date. Please resolve the past due amount by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
+        <item quantity="other">You have a grace period of <annotation arg="0">%1$d</annotation> days from your subscription expiration date. Please resolve the past due amount by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
     </plurals>
     <string name="subscription_paused_description">Your subscription is paused. Resume to continue using premium features.</string>
     <string name="loading_subscription">Loading subscription…</string>

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/base/util/StringResExtensionsTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/base/util/StringResExtensionsTest.kt
@@ -110,4 +110,55 @@ class StringResExtensionsTest : BaseComposeTest() {
             .onNodeWithText("Nothing special here, except this.")
             .assertIsDisplayed()
     }
+
+    @Test
+    fun `toAnnotatedPluralsString resolves singular form and applies arg annotations`() {
+        setTestContent {
+            Text(
+                text = R.plurals.test_for_plurals_with_annotation_and_arg_annotation
+                    .toAnnotatedPluralsString(
+                        quantity = 1,
+                        args = arrayOf("1", "April 21, 2026"),
+                    ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText("You have 1 day to resolve by April 21, 2026.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `toAnnotatedPluralsString resolves plural form and applies arg annotations`() {
+        setTestContent {
+            Text(
+                text = R.plurals.test_for_plurals_with_annotation_and_arg_annotation
+                    .toAnnotatedPluralsString(
+                        quantity = 7,
+                        args = arrayOf("7", "April 21, 2026"),
+                    ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText("You have 7 days to resolve by April 21, 2026.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `toAnnotatedPluralsString without annotations falls back to formatted quantity string`() {
+        setTestContent {
+            Text(
+                text = R.plurals.test_for_plurals_with_no_annotations
+                    .toAnnotatedPluralsString(
+                        quantity = 3,
+                        args = arrayOf("3"),
+                    ),
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText("3 days remaining.")
+            .assertIsDisplayed()
+    }
 }

--- a/ui/src/test/res/values/strings_for_tests_only.xml
+++ b/ui/src/test/res/values/strings_for_tests_only.xml
@@ -6,5 +6,13 @@
     <string name="test_for_string_with_no_annotations">Nothing special here.</string>
     <string name="test_for_string_with_no_annotations_with_format_arg">Nothing special here, except %1$s.</string>
     <string name="test_for_string_with_annotation_and_arg_annotation">On your computer, open a new browser tab and <annotation emphasis="bold">go to <annotation arg="0">%1$s</annotation></annotation></string>
+    <plurals name="test_for_plurals_with_annotation_and_arg_annotation">
+        <item quantity="one">You have <annotation arg="0">%1$d</annotation> day to resolve by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
+        <item quantity="other">You have <annotation arg="0">%1$d</annotation> days to resolve by <annotation emphasis="bold"><annotation arg="1">%2$s</annotation></annotation>.</item>
+    </plurals>
+    <plurals name="test_for_plurals_with_no_annotations">
+        <item quantity="one">%1$s day remaining.</item>
+        <item quantity="other">%1$s days remaining.</item>
+    </plurals>
     <!-- /StringResExtensions Test value -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-36969
- https://bitwarden.atlassian.net/browse/PM-36970
- https://bitwarden.atlassian.net/browse/PM-37093
- https://bitwarden.atlassian.net/browse/PM-37177
- https://bitwarden.atlassian.net/browse/PM-37180
- https://bitwarden.atlassian.net/browse/PM-37181

## 📔 Objective

The server keeps `Profile.Premium=true` during the grace window after a subscription enters a recovery or terminal Stripe state. Surfaces that gate purely on `isPremium` either suppress the Plan-screen badge that would explain the user's situation, or hide the upgrade CTA users need to recover their account.

Adds `PremiumStateManager.subscriptionStatusStateFlow` (`Loading`/`NoSubscription`/`Available`/`Error`) so callers can derive "effectively premium" from both the account flag and the Stripe substate. The upgrade banner now flips back on when the active subscription is in a trouble state (`past_due`, `update_payment`, `canceled`, `paused`) even while the server still reports premium. The Plan screen routes free-with-trouble-substate users to the Premium view so they see the right badge and Manage/Resubscribe affordances.

Renames `OVERDUE_PAYMENT → UPDATE_PAYMENT` so the badge label matches the Figma frame. A new `SubscriptionResult.NotFound` maps the 404 returned for users without a `GatewaySubscriptionId` to "free, show upgrade CTA" instead of an error dialog.

## 📸 Screenshots

| Figma | Actual |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/90631634-abdb-4d2a-b45c-acb52e464a25" /> | <img width="365" src="https://github.com/user-attachments/assets/3bf18ba8-4883-41bd-a850-3763ceb253de" /> |
| <img width="365" src="https://github.com/user-attachments/assets/6f5cab38-c1e4-4a9a-be91-59016abba3ad" /> | <img width="365" src="https://github.com/user-attachments/assets/6b91e605-f929-4c96-8d13-8bfccc9afee6" /> |
| <img width="365" src="https://github.com/user-attachments/assets/996a5ea2-15ce-4acf-99fa-de0ea60e580f" /> | <img width="365" src="https://github.com/user-attachments/assets/d4a47f49-50dc-4393-91b0-dbbba4d812b5" /> |
| <img width="365" src="https://github.com/user-attachments/assets/c6c163aa-75ff-4f34-960e-c218015bce7a" /> | <img width="365" src="https://github.com/user-attachments/assets/50eeffac-fc23-4bd9-8de9-bcfc358d684e" /> |