### PR TITLE
PM-37573: feat: Add DatePicker functionality to VaultAddEditScreen

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLicenseItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditLicenseItems.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
-import com.bitwarden.ui.platform.components.button.BitwardenTextSelectionButton
+import com.bitwarden.ui.platform.components.dropdown.BitwardenDatePickerButton
 import com.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
@@ -91,11 +91,10 @@ fun LazyListScope.vaultAddEditLicenseItems(
     }
 
     item {
-        BitwardenTextSelectionButton(
+        BitwardenDatePickerButton(
             label = stringResource(id = BitwardenString.date_of_birth),
-            selectedOption = licenseState.dateOfBirth,
-            // TODO: Open a native Material date picker (separate ticket TBD).
-            onClick = {},
+            currentDate = licenseState.dateOfBirth,
+            onDateSelect = licenseHandlers.onDateOfBirthChange,
             textFieldTestTag = "LicenseDateOfBirthEntry",
             cardStyle = CardStyle.Middle(),
             modifier = Modifier
@@ -144,11 +143,10 @@ fun LazyListScope.vaultAddEditLicenseItems(
     }
 
     item {
-        BitwardenTextSelectionButton(
+        BitwardenDatePickerButton(
             label = stringResource(id = BitwardenString.issue_date),
-            selectedOption = licenseState.issueDate,
-            // TODO: Open a native Material date picker (separate ticket TBD).
-            onClick = {},
+            currentDate = licenseState.issueDate,
+            onDateSelect = licenseHandlers.onIssueDateChange,
             textFieldTestTag = "LicenseIssueDateEntry",
             cardStyle = CardStyle.Middle(),
             modifier = Modifier
@@ -158,11 +156,10 @@ fun LazyListScope.vaultAddEditLicenseItems(
     }
 
     item {
-        BitwardenTextSelectionButton(
+        BitwardenDatePickerButton(
             label = stringResource(id = BitwardenString.expiration_date),
-            selectedOption = licenseState.expirationDate,
-            // TODO: Open a native Material date picker (separate ticket TBD).
-            onClick = {},
+            currentDate = licenseState.expirationDate,
+            onDateSelect = licenseHandlers.onExpirationDateChange,
             textFieldTestTag = "LicenseExpirationDateEntry",
             cardStyle = CardStyle.Middle(),
             modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditPassportItems.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditPassportItems.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
-import com.bitwarden.ui.platform.components.button.BitwardenTextSelectionButton
+import com.bitwarden.ui.platform.components.dropdown.BitwardenDatePickerButton
 import com.bitwarden.ui.platform.components.field.BitwardenPasswordField
 import com.bitwarden.ui.platform.components.field.BitwardenTextField
 import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
@@ -64,11 +64,10 @@ fun LazyListScope.vaultAddEditPassportItems(
     }
 
     item {
-        BitwardenTextSelectionButton(
+        BitwardenDatePickerButton(
             label = stringResource(id = BitwardenString.date_of_birth),
-            selectedOption = passportState.dateOfBirth,
-            // TODO: Open a native Material date picker (separate ticket TBD).
-            onClick = {},
+            currentDate = passportState.dateOfBirth,
+            onDateSelect = passportHandlers.onDateOfBirthChange,
             textFieldTestTag = "PassportDateOfBirthEntry",
             cardStyle = CardStyle.Middle(),
             modifier = Modifier
@@ -184,11 +183,10 @@ fun LazyListScope.vaultAddEditPassportItems(
     }
 
     item {
-        BitwardenTextSelectionButton(
+        BitwardenDatePickerButton(
             label = stringResource(id = BitwardenString.issue_date),
-            selectedOption = passportState.issueDate,
-            // TODO: Open a native Material date picker (separate ticket TBD).
-            onClick = {},
+            currentDate = passportState.issueDate,
+            onDateSelect = passportHandlers.onIssueDateChange,
             textFieldTestTag = "PassportIssueDateEntry",
             cardStyle = CardStyle.Middle(),
             modifier = Modifier
@@ -198,11 +196,10 @@ fun LazyListScope.vaultAddEditPassportItems(
     }
 
     item {
-        BitwardenTextSelectionButton(
+        BitwardenDatePickerButton(
             label = stringResource(id = BitwardenString.expiration_date),
-            selectedOption = passportState.expirationDate,
-            // TODO: Open a native Material date picker (separate ticket TBD).
-            onClick = {},
+            currentDate = passportState.expirationDate,
+            onDateSelect = passportHandlers.onExpirationDateChange,
             textFieldTestTag = "PassportExpirationDateEntry",
             cardStyle = CardStyle.Bottom,
             modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModel.kt
@@ -107,6 +107,7 @@ import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.time.Clock
+import java.time.LocalDate
 import java.util.Collections
 import java.util.UUID
 import javax.inject.Inject
@@ -1792,6 +1793,18 @@ class VaultAddEditViewModel @Inject constructor(
             is VaultAddEditAction.ItemType.LicenseType.LicenseClassTextChange -> {
                 updateLicenseContent { it.copy(licenseClass = action.licenseClass) }
             }
+
+            is VaultAddEditAction.ItemType.LicenseType.DateOfBirthChange -> {
+                updateLicenseContent { it.copy(dateOfBirth = action.dateOfBirth) }
+            }
+
+            is VaultAddEditAction.ItemType.LicenseType.IssueDateChange -> {
+                updateLicenseContent { it.copy(issueDate = action.issueDate) }
+            }
+
+            is VaultAddEditAction.ItemType.LicenseType.ExpirationDateChange -> {
+                updateLicenseContent { it.copy(expirationDate = action.expirationDate) }
+            }
         }
     }
 
@@ -1844,6 +1857,18 @@ class VaultAddEditViewModel @Inject constructor(
 
             is VaultAddEditAction.ItemType.PassportType.IssuingAuthorityTextChange -> {
                 updatePassportContent { it.copy(issuingAuthority = action.authority) }
+            }
+
+            is VaultAddEditAction.ItemType.PassportType.DateOfBirthChange -> {
+                updatePassportContent { it.copy(dateOfBirth = action.dateOfBirth) }
+            }
+
+            is VaultAddEditAction.ItemType.PassportType.ExpirationDateChange -> {
+                updatePassportContent { it.copy(expirationDate = action.expirationDate) }
+            }
+
+            is VaultAddEditAction.ItemType.PassportType.IssueDateChange -> {
+                updatePassportContent { it.copy(issueDate = action.issueDate) }
             }
         }
     }
@@ -3181,13 +3206,13 @@ data class VaultAddEditState(
                     val firstName: String = "",
                     val middleName: String = "",
                     val lastName: String = "",
-                    val dateOfBirth: String = "",
+                    val dateOfBirth: LocalDate? = null,
                     val licenseNumber: String = "",
                     val issuingCountry: String = "",
                     val issuingState: String = "",
                     val issuingAuthority: String = "",
-                    val issueDate: String = "",
-                    val expirationDate: String = "",
+                    val issueDate: LocalDate? = null,
+                    val expirationDate: LocalDate? = null,
                     val licenseClass: String = "",
                 ) : ItemType() {
                     override val itemTypeOption: ItemTypeOption
@@ -3206,7 +3231,7 @@ data class VaultAddEditState(
                 data class Passport(
                     val givenName: String = "",
                     val surname: String = "",
-                    val dateOfBirth: String = "",
+                    val dateOfBirth: LocalDate? = null,
                     val sex: String = "",
                     val birthPlace: String = "",
                     val nationality: String = "",
@@ -3215,8 +3240,8 @@ data class VaultAddEditState(
                     val nationalIdentificationNumber: String = "",
                     val issuingCountry: String = "",
                     val issuingAuthority: String = "",
-                    val issueDate: String = "",
-                    val expirationDate: String = "",
+                    val issueDate: LocalDate? = null,
+                    val expirationDate: LocalDate? = null,
                 ) : ItemType() {
                     override val itemTypeOption: ItemTypeOption
                         get() = ItemTypeOption.PASSPORT
@@ -4261,6 +4286,21 @@ sealed class VaultAddEditAction {
              * Fired when the issuing authority text input is changed.
              */
             data class IssuingAuthorityTextChange(val authority: String) : PassportType()
+
+            /**
+             * Fired when the date of birth input is changed.
+             */
+            data class DateOfBirthChange(val dateOfBirth: LocalDate?) : PassportType()
+
+            /**
+             * Fired when the issue date input is changed.
+             */
+            data class IssueDateChange(val issueDate: LocalDate?) : PassportType()
+
+            /**
+             * Fired when the expiration date input is changed.
+             */
+            data class ExpirationDateChange(val expirationDate: LocalDate?) : PassportType()
         }
 
         /**
@@ -4307,6 +4347,27 @@ sealed class VaultAddEditAction {
              * Fired when the license class text input is changed.
              */
             data class LicenseClassTextChange(val licenseClass: String) : LicenseType()
+
+            /**
+             * Fired when the date of birth input is changed.
+             */
+            data class DateOfBirthChange(
+                val dateOfBirth: LocalDate?,
+            ) : LicenseType()
+
+            /**
+             * Fired when the issue date input is changed.
+             */
+            data class IssueDateChange(
+                val issueDate: LocalDate?,
+            ) : LicenseType()
+
+            /**
+             * Fired when the expiration date input is changed.
+             */
+            data class ExpirationDateChange(
+                val expirationDate: LocalDate?,
+            ) : LicenseType()
         }
     }
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditLicenseTypeHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditLicenseTypeHandlers.kt
@@ -2,6 +2,7 @@ package com.x8bit.bitwarden.ui.vault.feature.addedit.handlers
 
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditAction
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditViewModel
+import java.time.LocalDate
 
 /**
  * A collection of handler functions for managing user interactions on the License portion of the
@@ -26,6 +27,9 @@ data class VaultAddEditLicenseTypeHandlers(
     val onIssuingStateTextChange: (String) -> Unit,
     val onIssuingAuthorityTextChange: (String) -> Unit,
     val onLicenseClassTextChange: (String) -> Unit,
+    val onDateOfBirthChange: (LocalDate?) -> Unit,
+    val onIssueDateChange: (LocalDate?) -> Unit,
+    val onExpirationDateChange: (LocalDate?) -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -92,6 +96,27 @@ data class VaultAddEditLicenseTypeHandlers(
                     viewModel.trySendAction(
                         VaultAddEditAction.ItemType.LicenseType.LicenseClassTextChange(
                             licenseClass = it,
+                        ),
+                    )
+                },
+                onDateOfBirthChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.LicenseType.DateOfBirthChange(
+                            dateOfBirth = it,
+                        ),
+                    )
+                },
+                onIssueDateChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.LicenseType.IssueDateChange(
+                            issueDate = it,
+                        ),
+                    )
+                },
+                onExpirationDateChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.LicenseType.ExpirationDateChange(
+                            expirationDate = it,
                         ),
                     )
                 },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditPassportTypeHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/handlers/VaultAddEditPassportTypeHandlers.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditAction
 import com.x8bit.bitwarden.ui.vault.feature.addedit.VaultAddEditViewModel
+import java.time.LocalDate
 
 /**
  * A collection of handler functions for managing user interactions on the Passport portion of the
@@ -33,6 +34,9 @@ data class VaultAddEditPassportTypeHandlers(
     val onNationalIdentificationNumberTextChange: (String) -> Unit,
     val onIssuingCountryTextChange: (String) -> Unit,
     val onIssuingAuthorityTextChange: (String) -> Unit,
+    val onDateOfBirthChange: (LocalDate?) -> Unit,
+    val onIssueDateChange: (LocalDate?) -> Unit,
+    val onExpirationDateChange: (LocalDate?) -> Unit,
 ) {
     @Suppress("UndocumentedPublicClass")
     companion object {
@@ -114,6 +118,27 @@ data class VaultAddEditPassportTypeHandlers(
                     viewModel.trySendAction(
                         VaultAddEditAction.ItemType.PassportType.IssuingAuthorityTextChange(
                             authority = it,
+                        ),
+                    )
+                },
+                onDateOfBirthChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.PassportType.DateOfBirthChange(
+                            dateOfBirth = it,
+                        ),
+                    )
+                },
+                onIssueDateChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.PassportType.IssueDateChange(
+                            issueDate = it,
+                        ),
+                    )
+                },
+                onExpirationDateChange = {
+                    viewModel.trySendAction(
+                        VaultAddEditAction.ItemType.PassportType.ExpirationDateChange(
+                            expirationDate = it,
                         ),
                     )
                 },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensions.kt
@@ -29,6 +29,8 @@ import com.x8bit.bitwarden.ui.vault.model.VaultIdentityTitle
 import com.x8bit.bitwarden.ui.vault.model.VaultLinkedFieldType.Companion.fromId
 import com.x8bit.bitwarden.ui.vault.model.findVaultCardBrandWithNameOrNull
 import java.time.Clock
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
 import java.time.format.FormatStyle
 import java.util.UUID
 
@@ -121,15 +123,18 @@ fun CipherView.toViewState(
                     licenseNumber = driversLicense?.licenseNumber.orEmpty(),
                     issuingCountry = driversLicense?.issuingCountry.orEmpty(),
                     issuingState = driversLicense?.issuingState.orEmpty(),
-                    expirationDate = driversLicense?.expirationDate.orEmpty(),
+                    expirationDate = driversLicense?.expirationDate?.toLocalDate(),
                     licenseClass = driversLicense?.licenseClass.orEmpty(),
+                    dateOfBirth = driversLicense?.dateOfBirth?.toLocalDate(),
+                    issuingAuthority = driversLicense?.issuingAuthority.orEmpty(),
+                    issueDate = driversLicense?.issueDate?.toLocalDate(),
                 )
             }
 
             CipherType.PASSPORT -> VaultAddEditState.ViewState.Content.ItemType.Passport(
                 givenName = passport?.givenName.orEmpty(),
                 surname = passport?.surname.orEmpty(),
-                dateOfBirth = passport?.dateOfBirth.orEmpty(),
+                dateOfBirth = passport?.dateOfBirth?.toLocalDate(),
                 sex = passport?.sex.orEmpty(),
                 birthPlace = passport?.birthPlace.orEmpty(),
                 nationality = passport?.nationality.orEmpty(),
@@ -138,8 +143,8 @@ fun CipherView.toViewState(
                 nationalIdentificationNumber = passport?.nationalIdentificationNumber.orEmpty(),
                 issuingCountry = passport?.issuingCountry.orEmpty(),
                 issuingAuthority = passport?.issuingAuthority.orEmpty(),
-                issueDate = passport?.issueDate.orEmpty(),
-                expirationDate = passport?.expirationDate.orEmpty(),
+                issueDate = passport?.issueDate?.toLocalDate(),
+                expirationDate = passport?.expirationDate?.toLocalDate(),
             )
         },
         common = VaultAddEditState.ViewState.Content.Common(
@@ -168,6 +173,12 @@ fun CipherView.toViewState(
         ),
         isIndividualVaultDisabled = isIndividualVaultDisabled,
     )
+
+private fun String.toLocalDate(): LocalDate? = try {
+    LocalDate.parse(this)
+} catch (_: DateTimeParseException) {
+    null
+}
 
 /**
  * Adds Folder and Owner data to [VaultAddEditState.ViewState].

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensions.kt
@@ -128,13 +128,13 @@ private fun VaultAddEditState.ViewState.Content.ItemType.toDriversLicense(): Dri
             firstName = it.firstName.orNullIfBlank(),
             middleName = it.middleName.orNullIfBlank(),
             lastName = it.lastName.orNullIfBlank(),
-            dateOfBirth = it.dateOfBirth.orNullIfBlank(),
+            dateOfBirth = it.dateOfBirth?.toString(),
             licenseNumber = it.licenseNumber.orNullIfBlank(),
             issuingCountry = it.issuingCountry.orNullIfBlank(),
             issuingState = it.issuingState.orNullIfBlank(),
-            issueDate = it.issueDate.orNullIfBlank(),
+            issueDate = it.issueDate?.toString(),
             issuingAuthority = it.issuingAuthority.orNullIfBlank(),
-            expirationDate = it.expirationDate.orNullIfBlank(),
+            expirationDate = it.expirationDate?.toString(),
             licenseClass = it.licenseClass.orNullIfBlank(),
         )
     }
@@ -144,7 +144,7 @@ private fun VaultAddEditState.ViewState.Content.ItemType.toPassport(): PassportV
         PassportView(
             surname = it.surname.orNullIfBlank(),
             givenName = it.givenName.orNullIfBlank(),
-            dateOfBirth = it.dateOfBirth.orNullIfBlank(),
+            dateOfBirth = it.dateOfBirth?.toString(),
             birthPlace = it.birthPlace.orNullIfBlank(),
             sex = it.sex.orNullIfBlank(),
             nationality = it.nationality.orNullIfBlank(),
@@ -152,8 +152,8 @@ private fun VaultAddEditState.ViewState.Content.ItemType.toPassport(): PassportV
             passportType = it.passportType.orNullIfBlank(),
             issuingCountry = it.issuingCountry.orNullIfBlank(),
             issuingAuthority = it.issuingAuthority.orNullIfBlank(),
-            issueDate = it.issueDate.orNullIfBlank(),
-            expirationDate = it.expirationDate.orNullIfBlank(),
+            issueDate = it.issueDate?.toString(),
+            expirationDate = it.expirationDate?.toString(),
             nationalIdentificationNumber = it.nationalIdentificationNumber.orNullIfBlank(),
         )
     }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditScreenTest.kt
@@ -87,6 +87,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.time.LocalDate
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType as UriMatchTypeModel
 
 @Suppress("LargeClass")
@@ -2912,6 +2913,120 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `in ItemType_License the date of birth should display the selected date from the state`() {
+        mutableStateFlow.value = DEFAULT_STATE_LICENSE
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Date of birth")
+            .assertIsDisplayed()
+
+        mutableStateFlow.update { currentState ->
+            updateLicenseType(currentState) {
+                copy(dateOfBirth = LocalDate.of(1990, 8, 10))
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "August 10, 1990. Date of birth")
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_License clicking the date of birth clear button should trigger DateOfBirthChange with null`() {
+        mutableStateFlow.value = DEFAULT_STATE_LICENSE
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Date of birth")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(testTag = "ClearButton")
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.LicenseType.DateOfBirthChange(dateOfBirth = null),
+            )
+        }
+    }
+
+    @Test
+    fun `in ItemType_License the issue date should display the selected date from the state`() {
+        mutableStateFlow.value = DEFAULT_STATE_LICENSE
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Issue date")
+            .assertIsDisplayed()
+
+        mutableStateFlow.update { currentState ->
+            updateLicenseType(currentState) {
+                copy(issueDate = LocalDate.of(2020, 1, 15))
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "January 15, 2020. Issue date")
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_License clicking the issue date clear button should trigger IssueDateChange with null`() {
+        mutableStateFlow.value = DEFAULT_STATE_LICENSE
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Issue date")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(testTag = "ClearButton")
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.LicenseType.IssueDateChange(issueDate = null),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_License the expiration date should display the selected date from the state`() {
+        mutableStateFlow.value = DEFAULT_STATE_LICENSE
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Expiration date")
+            .assertIsDisplayed()
+
+        mutableStateFlow.update { currentState ->
+            updateLicenseType(currentState) {
+                copy(expirationDate = LocalDate.of(2025, 12, 31))
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "December 31, 2025. Expiration date")
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_License clicking the expiration date clear button should trigger ExpirationDateChange with null`() {
+        mutableStateFlow.value = DEFAULT_STATE_LICENSE
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Expiration date")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(testTag = "ClearButton")
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.LicenseType.ExpirationDateChange(
+                    expirationDate = null,
+                ),
+            )
+        }
+    }
+
+    @Test
     fun `in ItemType_Passport changing first name should trigger GivenNameTextChange`() {
         mutableStateFlow.value = DEFAULT_STATE_PASSPORT
         composeTestRule
@@ -3071,6 +3186,121 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
             viewModel.trySendAction(
                 VaultAddEditAction.ItemType.PassportType.IssuingAuthorityTextChange(
                     authority = "U.S. Department of State",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `in ItemType_Passport the date of birth should display the selected date from the state`() {
+        mutableStateFlow.value = DEFAULT_STATE_PASSPORT
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Date of birth")
+            .assertIsDisplayed()
+
+        mutableStateFlow.update { currentState ->
+            updatePassportType(currentState) {
+                copy(dateOfBirth = LocalDate.of(1990, 8, 10))
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "August 10, 1990. Date of birth")
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_Passport clicking the date of birth clear button should trigger DateOfBirthChange with null`() {
+        mutableStateFlow.value = DEFAULT_STATE_PASSPORT
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Date of birth")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(testTag = "ClearButton")
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.PassportType.DateOfBirthChange(dateOfBirth = null),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_Passport the issue date should display the selected date from the state`() {
+        mutableStateFlow.value = DEFAULT_STATE_PASSPORT
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Issue date")
+            .assertIsDisplayed()
+
+        mutableStateFlow.update { currentState ->
+            updatePassportType(currentState) {
+                copy(issueDate = LocalDate.of(2021, 3, 20))
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "March 20, 2021. Issue date")
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_Passport clicking the issue date clear button should trigger IssueDateChange with null`() {
+        mutableStateFlow.value = DEFAULT_STATE_PASSPORT
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Issue date")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(testTag = "ClearButton")
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.PassportType.IssueDateChange(issueDate = null),
+            )
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_Passport the expiration date should display the selected date from the state`() {
+        mutableStateFlow.value = DEFAULT_STATE_PASSPORT
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Expiration date")
+            .assertIsDisplayed()
+
+        mutableStateFlow.update { currentState ->
+            updatePassportType(currentState) {
+                copy(expirationDate = LocalDate.of(2031, 3, 20))
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "March 20, 2031. Expiration date")
+            .assertIsDisplayed()
+    }
+
+    @Suppress("MaxLineLength")
+    @Test
+    fun `in ItemType_Passport clicking the expiration date clear button should trigger ExpirationDateChange with null`() {
+        mutableStateFlow.value = DEFAULT_STATE_PASSPORT
+        composeTestRule
+            .onNodeWithContentDescriptionAfterScroll(label = "null. Expiration date")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(testTag = "ClearButton")
+            .performClick()
+
+        verify {
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.PassportType.ExpirationDateChange(
+                    expirationDate = null,
                 ),
             )
         }
@@ -5101,6 +5331,52 @@ class VaultAddEditScreenTest : BitwardenComposeTest() {
         verify(exactly = 1) {
             viewModel.trySendAction(VaultAddEditAction.Common.UnarchiveClick)
         }
+    }
+
+    private fun updateLicenseType(
+        currentState: VaultAddEditState,
+        transform: VaultAddEditState.ViewState.Content.ItemType.License.() ->
+        VaultAddEditState.ViewState.Content.ItemType.License,
+    ): VaultAddEditState {
+        val updatedType = when (val viewState = currentState.viewState) {
+            is VaultAddEditState.ViewState.Content -> {
+                when (val type = viewState.type) {
+                    is VaultAddEditState.ViewState.Content.ItemType.License -> {
+                        viewState.copy(
+                            type = type.transform(),
+                        )
+                    }
+
+                    else -> viewState
+                }
+            }
+
+            else -> viewState
+        }
+        return currentState.copy(viewState = updatedType)
+    }
+
+    private fun updatePassportType(
+        currentState: VaultAddEditState,
+        transform: VaultAddEditState.ViewState.Content.ItemType.Passport.() ->
+        VaultAddEditState.ViewState.Content.ItemType.Passport,
+    ): VaultAddEditState {
+        val updatedType = when (val viewState = currentState.viewState) {
+            is VaultAddEditState.ViewState.Content -> {
+                when (val type = viewState.type) {
+                    is VaultAddEditState.ViewState.Content.ItemType.Passport -> {
+                        viewState.copy(
+                            type = type.transform(),
+                        )
+                    }
+
+                    else -> viewState
+                }
+            }
+
+            else -> viewState
+        }
+        return currentState.copy(viewState = updatedType)
     }
 
     //endregion Helper functions

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/VaultAddEditViewModelTest.kt
@@ -129,6 +129,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.UUID
 import com.x8bit.bitwarden.data.platform.repository.model.UriMatchType as UriMatchTypeModel
@@ -4337,6 +4338,47 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
                 viewModel.stateFlow.value,
             )
         }
+
+        @Test
+        fun `DateOfBirthChange should update date of birth`() = runTest {
+            val localDate = LocalDate.of(1990, 8, 10)
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.LicenseType.DateOfBirthChange(dateOfBirth = localDate),
+            )
+
+            assertEquals(
+                expectedLicense { copy(dateOfBirth = localDate) },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `IssueDateChange should update issue date`() = runTest {
+            val localDate = LocalDate.of(2020, 1, 15)
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.LicenseType.IssueDateChange(issueDate = localDate),
+            )
+
+            assertEquals(
+                expectedLicense { copy(issueDate = localDate) },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `ExpirationDateChange should update expiration date`() = runTest {
+            val localDate = LocalDate.of(2025, 12, 31)
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.LicenseType.ExpirationDateChange(
+                    expirationDate = localDate,
+                ),
+            )
+
+            assertEquals(
+                expectedLicense { copy(expirationDate = localDate) },
+                viewModel.stateFlow.value,
+            )
+        }
     }
 
     @Nested
@@ -4516,6 +4558,47 @@ class VaultAddEditViewModelTest : BaseViewModelTest() {
 
             assertEquals(
                 expectedPassport { copy(issuingAuthority = "U.S. Department of State") },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `DateOfBirthChange should update date of birth`() = runTest {
+            val localDate = LocalDate.of(1990, 8, 10)
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.PassportType.DateOfBirthChange(dateOfBirth = localDate),
+            )
+
+            assertEquals(
+                expectedPassport { copy(dateOfBirth = localDate) },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `IssueDateChange should update issue date`() = runTest {
+            val localDate = LocalDate.of(2021, 3, 20)
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.PassportType.IssueDateChange(issueDate = localDate),
+            )
+
+            assertEquals(
+                expectedPassport { copy(issueDate = localDate) },
+                viewModel.stateFlow.value,
+            )
+        }
+
+        @Test
+        fun `ExpirationDateChange should update expiration date`() = runTest {
+            val localDate = LocalDate.of(2031, 3, 20)
+            viewModel.trySendAction(
+                VaultAddEditAction.ItemType.PassportType.ExpirationDateChange(
+                    expirationDate = localDate,
+                ),
+            )
+
+            assertEquals(
+                expectedPassport { copy(expirationDate = localDate) },
                 viewModel.stateFlow.value,
             )
         }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/addedit/util/CipherViewExtensionsTest.kt
@@ -13,10 +13,10 @@ import com.bitwarden.vault.FieldView
 import com.bitwarden.vault.IdentityView
 import com.bitwarden.vault.LoginUriView
 import com.bitwarden.vault.LoginView
+import com.bitwarden.vault.PassportView
 import com.bitwarden.vault.PasswordHistoryView
 import com.bitwarden.vault.SecureNoteType
 import com.bitwarden.vault.SecureNoteView
-import com.bitwarden.vault.PassportView
 import com.bitwarden.vault.SshKeyView
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.UUID
 
@@ -412,7 +413,7 @@ class CipherViewExtensionsTest {
                 type = VaultAddEditState.ViewState.Content.ItemType.Passport(
                     givenName = "the given name",
                     surname = "the surname",
-                    dateOfBirth = "the date of birth",
+                    dateOfBirth = LocalDate.of(1990, 8, 10),
                     sex = "the sex",
                     birthPlace = "the birth place",
                     nationality = "the nationality",
@@ -421,8 +422,8 @@ class CipherViewExtensionsTest {
                     nationalIdentificationNumber = "the national identification number",
                     issuingCountry = "the issuing country",
                     issuingAuthority = "the issuing authority",
-                    issueDate = "the issue date",
-                    expirationDate = "the expiration date",
+                    issueDate = LocalDate.of(2021, 3, 20),
+                    expirationDate = LocalDate.of(2031, 3, 20),
                 ),
             ),
             result,
@@ -957,7 +958,7 @@ private val DEFAULT_PASSPORT_CIPHER_VIEW: CipherView = DEFAULT_BASE_CIPHER_VIEW.
     passport = PassportView(
         surname = "the surname",
         givenName = "the given name",
-        dateOfBirth = "the date of birth",
+        dateOfBirth = "1990-08-10",
         birthPlace = "the birth place",
         sex = "the sex",
         nationality = "the nationality",
@@ -965,8 +966,8 @@ private val DEFAULT_PASSPORT_CIPHER_VIEW: CipherView = DEFAULT_BASE_CIPHER_VIEW.
         passportType = "the passport type",
         issuingCountry = "the issuing country",
         issuingAuthority = "the issuing authority",
-        issueDate = "the issue date",
-        expirationDate = "the expiration date",
+        issueDate = "2021-03-20",
+        expirationDate = "2031-03-20",
         nationalIdentificationNumber = "the national identification number",
     ),
 )

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/util/VaultAddItemStateExtensionsTest.kt
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneOffset
 
 @Suppress("LargeClass")
@@ -570,7 +571,7 @@ class VaultAddItemStateExtensionsTest {
             type = VaultAddEditState.ViewState.Content.ItemType.Passport(
                 givenName = "Bruce",
                 surname = "Wayne",
-                dateOfBirth = "1939-05-27",
+                dateOfBirth = LocalDate.of(1939, 5, 27),
                 sex = "M",
                 birthPlace = "Gotham City",
                 nationality = "American",
@@ -579,8 +580,8 @@ class VaultAddItemStateExtensionsTest {
                 nationalIdentificationNumber = "987-65-4321",
                 issuingCountry = "USA",
                 issuingAuthority = "U.S. Department of State",
-                issueDate = "2020-01-15",
-                expirationDate = "2030-01-15",
+                issueDate = LocalDate.of(2020, 1, 15),
+                expirationDate = LocalDate.of(2030, 1, 15),
             ),
         )
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37573](https://bitwarden.atlassian.net/browse/PM-37573)

## 📔 Objective

This PR implements the `BitwardenDatePicker` on the `VaultAddEditScreen` for the `Passport` and License` cipher types.

## 📸 Screenshots

[Screen_recording_20260518_110902.webm](https://github.com/user-attachments/assets/525fa020-290a-474c-ac96-c3c50997bb05)

[PM-37573]: https://bitwarden.atlassian.net/browse/PM-37573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ