### PR TITLE
[PM-36886] fix: Gate premium upgrade flow on self-hosted environments

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -128,14 +128,14 @@ fun PlanScreen(
     ) {
         when (val viewState = state.viewState) {
             is PlanState.ViewState.Free.Cloud -> {
-                FreeContent(
+                FreeCloudContent(
                     viewState = viewState,
                     handlers = handlers,
                 )
             }
 
             is PlanState.ViewState.Free.SelfHosted -> {
-                SelfHostedContent()
+                FreeSelfHostedContent()
             }
 
             is PlanState.ViewState.Premium -> {
@@ -259,7 +259,7 @@ private fun PlanDialogs(
 }
 
 @Composable
-private fun FreeContent(
+private fun FreeCloudContent(
     viewState: PlanState.ViewState.Free.Cloud,
     handlers: PlanHandlers,
     modifier: Modifier = Modifier,
@@ -308,7 +308,7 @@ private fun FreeContent(
 
 @Suppress("MaxLineLength")
 @Composable
-private fun SelfHostedContent(
+private fun FreeSelfHostedContent(
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -714,10 +714,10 @@ private fun SubscriptionLineItem(
 @Preview
 @OmitFromCoverage
 @Composable
-private fun PlanScreenFreeAccount_preview() {
+private fun PlanScreenFreeCloudAccount_preview() {
     BitwardenTheme {
         BitwardenScaffold {
-            FreeContent(
+            FreeCloudContent(
                 viewState = PlanState.ViewState.Free.Cloud(
                     rate = "$1.67",
                     checkoutUrl = null,
@@ -749,10 +749,10 @@ private fun PlanScreenFreeAccount_preview() {
 @Preview
 @OmitFromCoverage
 @Composable
-private fun PlanScreenSelfHostedFreeAccount_preview() {
+private fun PlanScreenFreeSelfHostedFreeAccount_preview() {
     BitwardenTheme {
         BitwardenScaffold {
-            SelfHostedContent()
+            FreeSelfHostedContent()
         }
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -46,12 +45,13 @@ import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.badge.BitwardenStatusBadge
 import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
-import com.bitwarden.ui.platform.components.card.BitwardenActionCard
+import com.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.bitwarden.ui.platform.components.content.BitwardenContentBlock
 import com.bitwarden.ui.platform.components.content.model.ContentBlockData
 import com.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
 import com.bitwarden.ui.platform.components.dialog.BitwardenTwoButtonDialog
 import com.bitwarden.ui.platform.components.divider.BitwardenHorizontalDivider
+import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.components.model.CardStyle
 import com.bitwarden.ui.platform.components.scaffold.BitwardenScaffold
 import com.bitwarden.ui.platform.components.util.rememberVectorPainter
@@ -99,7 +99,6 @@ fun PlanScreen(
             }
 
             is PlanEvent.LaunchPortal -> intentManager.launchUri(event.url.toUri())
-            is PlanEvent.LaunchWebVault -> intentManager.launchUri(event.url.toUri())
             PlanEvent.NavigateBack -> onNavigateBack()
             PlanEvent.NavigateToUpgradedToPremium -> onNavigateToUpgradedToPremium()
         }
@@ -136,7 +135,7 @@ fun PlanScreen(
             }
 
             is PlanState.ViewState.Free.SelfHosted -> {
-                SelfHostedContent(handlers = handlers)
+                SelfHostedContent()
             }
 
             is PlanState.ViewState.Premium -> {
@@ -307,9 +306,9 @@ private fun FreeContent(
     }
 }
 
+@Suppress("MaxLineLength")
 @Composable
 private fun SelfHostedContent(
-    handlers: PlanHandlers,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -318,27 +317,69 @@ private fun SelfHostedContent(
             .verticalScroll(rememberScrollState()),
     ) {
         Spacer(modifier = Modifier.height(12.dp))
-        BitwardenActionCard(
-            cardTitle = stringResource(id = BitwardenString.upgrade_to_premium),
-            cardSubtitle = stringResource(
-                id = BitwardenString.manage_your_premium_subscription_on_the_web_vault,
+        BitwardenInfoCalloutCard(
+            text = stringResource(
+                id = BitwardenString
+                    .to_manage_your_premium_subscription_youll_need_to_login_to_your_web_vault_on_a_computer,
             ),
-            actionText = stringResource(id = BitwardenString.go_to_web_vault),
-            leadingContent = {
-                Icon(
-                    painter = rememberVectorPainter(id = BitwardenDrawable.ic_info_circle),
-                    contentDescription = null,
-                    tint = BitwardenTheme.colorScheme.icon.secondary,
-                )
-            },
-            onActionClick = handlers.onManageOnWebVaultClick,
+            startIcon = IconData.Local(iconRes = BitwardenDrawable.ic_info_circle),
             modifier = Modifier
                 .standardHorizontalMargin()
                 .fillMaxWidth()
-                .testTag("SelfHostedManageOnWebVaultCard"),
+                .testTag("SelfHostedManageOnWebVaultCallout"),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        PremiumFeaturesCard(
+            modifier = Modifier
+                .standardHorizontalMargin()
+                .fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(16.dp))
         Spacer(modifier = Modifier.navigationBarsPadding())
+    }
+}
+
+@Composable
+private fun PremiumFeaturesCard(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .cardStyle(
+                cardStyle = CardStyle.Full,
+                // Override bottom padding to account for custom
+                // `BitwardenContentBlock` vertical padding, below.
+                paddingBottom = 0.dp,
+            ),
+    ) {
+        Text(
+            text = stringResource(id = BitwardenString.unlock_premium_features),
+            style = BitwardenTheme.typography.labelLarge,
+            color = BitwardenTheme.colorScheme.text.primary,
+            modifier = Modifier
+                .padding(bottom = 16.dp)
+                .standardHorizontalMargin(),
+        )
+
+        BitwardenHorizontalDivider()
+
+        val features = listOf(
+            BitwardenString.built_in_authenticator,
+            BitwardenString.emergency_access,
+            BitwardenString.secure_file_storage,
+            BitwardenString.breach_monitoring,
+        )
+        features.forEachIndexed { index, featureStringRes ->
+            BitwardenContentBlock(
+                data = ContentBlockData(
+                    headerText = stringResource(id = featureStringRes),
+                    iconVectorResource = BitwardenDrawable.ic_check_mark,
+                ),
+                headerTextStyle = BitwardenTheme.typography.titleMedium,
+                showDivider = index != features.lastIndex,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+        }
     }
 }
 
@@ -684,7 +725,6 @@ private fun PlanScreenFreeAccount_preview() {
                 ),
                 handlers = PlanHandlers(
                     onBackClick = {},
-                    onManageOnWebVaultClick = {},
                     onUpgradeNowClick = {},
                     onDismissError = {},
                     onRetryClick = {},
@@ -712,27 +752,7 @@ private fun PlanScreenFreeAccount_preview() {
 private fun PlanScreenSelfHostedFreeAccount_preview() {
     BitwardenTheme {
         BitwardenScaffold {
-            SelfHostedContent(
-                handlers = PlanHandlers(
-                    onBackClick = {},
-                    onManageOnWebVaultClick = {},
-                    onUpgradeNowClick = {},
-                    onDismissError = {},
-                    onRetryClick = {},
-                    onRetryPricingClick = {},
-                    onClosePricingErrorClick = {},
-                    onCancelWaiting = {},
-                    onGoBackClick = {},
-                    onSyncClick = {},
-                    onContinueClick = {},
-                    onManagePlanClick = {},
-                    onCancelPremiumClick = {},
-                    onConfirmCancelClick = {},
-                    onDismissCancelConfirmation = {},
-                    onDismissPortalError = {},
-                    onRetrySubscriptionClick = {},
-                ),
-            )
+            SelfHostedContent()
         }
     }
 }
@@ -756,7 +776,6 @@ private fun PlanScreenPremiumAccount_preview() {
                 ),
                 handlers = PlanHandlers(
                     onBackClick = {},
-                    onManageOnWebVaultClick = {},
                     onUpgradeNowClick = {},
                     onDismissError = {},
                     onRetryClick = {},

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -45,6 +46,7 @@ import com.bitwarden.ui.platform.components.appbar.BitwardenTopAppBar
 import com.bitwarden.ui.platform.components.badge.BitwardenStatusBadge
 import com.bitwarden.ui.platform.components.button.BitwardenFilledButton
 import com.bitwarden.ui.platform.components.button.BitwardenOutlinedButton
+import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.content.BitwardenContentBlock
 import com.bitwarden.ui.platform.components.content.model.ContentBlockData
 import com.bitwarden.ui.platform.components.dialog.BitwardenLoadingDialog
@@ -97,6 +99,7 @@ fun PlanScreen(
             }
 
             is PlanEvent.LaunchPortal -> intentManager.launchUri(event.url.toUri())
+            is PlanEvent.LaunchWebVault -> intentManager.launchUri(event.url.toUri())
             PlanEvent.NavigateBack -> onNavigateBack()
             PlanEvent.NavigateToUpgradedToPremium -> onNavigateToUpgradedToPremium()
         }
@@ -125,11 +128,15 @@ fun PlanScreen(
         },
     ) {
         when (val viewState = state.viewState) {
-            is PlanState.ViewState.Free -> {
+            is PlanState.ViewState.Free.Cloud -> {
                 FreeContent(
                     viewState = viewState,
                     handlers = handlers,
                 )
+            }
+
+            is PlanState.ViewState.Free.SelfHosted -> {
+                SelfHostedContent(handlers = handlers)
             }
 
             is PlanState.ViewState.Premium -> {
@@ -254,7 +261,7 @@ private fun PlanDialogs(
 
 @Composable
 private fun FreeContent(
-    viewState: PlanState.ViewState.Free,
+    viewState: PlanState.ViewState.Free.Cloud,
     handlers: PlanHandlers,
     modifier: Modifier = Modifier,
 ) {
@@ -295,6 +302,41 @@ private fun FreeContent(
                 .testTag("StripeFooterText"),
         )
 
+        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.navigationBarsPadding())
+    }
+}
+
+@Composable
+private fun SelfHostedContent(
+    handlers: PlanHandlers,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        Spacer(modifier = Modifier.height(12.dp))
+        BitwardenActionCard(
+            cardTitle = stringResource(id = BitwardenString.upgrade_to_premium),
+            cardSubtitle = stringResource(
+                id = BitwardenString.manage_your_premium_subscription_on_the_web_vault,
+            ),
+            actionText = stringResource(id = BitwardenString.go_to_web_vault),
+            leadingContent = {
+                Icon(
+                    painter = rememberVectorPainter(id = BitwardenDrawable.ic_info_circle),
+                    contentDescription = null,
+                    tint = BitwardenTheme.colorScheme.icon.secondary,
+                )
+            },
+            onActionClick = handlers.onManageOnWebVaultClick,
+            modifier = Modifier
+                .standardHorizontalMargin()
+                .fillMaxWidth()
+                .testTag("SelfHostedManageOnWebVaultCard"),
+        )
         Spacer(modifier = Modifier.height(16.dp))
         Spacer(modifier = Modifier.navigationBarsPadding())
     }
@@ -635,13 +677,45 @@ private fun PlanScreenFreeAccount_preview() {
     BitwardenTheme {
         BitwardenScaffold {
             FreeContent(
-                viewState = PlanState.ViewState.Free(
+                viewState = PlanState.ViewState.Free.Cloud(
                     rate = "$1.67",
                     checkoutUrl = null,
                     isAwaitingPremiumStatus = false,
                 ),
                 handlers = PlanHandlers(
                     onBackClick = {},
+                    onManageOnWebVaultClick = {},
+                    onUpgradeNowClick = {},
+                    onDismissError = {},
+                    onRetryClick = {},
+                    onRetryPricingClick = {},
+                    onClosePricingErrorClick = {},
+                    onCancelWaiting = {},
+                    onGoBackClick = {},
+                    onSyncClick = {},
+                    onContinueClick = {},
+                    onManagePlanClick = {},
+                    onCancelPremiumClick = {},
+                    onConfirmCancelClick = {},
+                    onDismissCancelConfirmation = {},
+                    onDismissPortalError = {},
+                    onRetrySubscriptionClick = {},
+                ),
+            )
+        }
+    }
+}
+
+@Preview
+@OmitFromCoverage
+@Composable
+private fun PlanScreenSelfHostedFreeAccount_preview() {
+    BitwardenTheme {
+        BitwardenScaffold {
+            SelfHostedContent(
+                handlers = PlanHandlers(
+                    onBackClick = {},
+                    onManageOnWebVaultClick = {},
                     onUpgradeNowClick = {},
                     onDismissError = {},
                     onRetryClick = {},
@@ -682,6 +756,7 @@ private fun PlanScreenPremiumAccount_preview() {
                 ),
                 handlers = PlanHandlers(
                     onBackClick = {},
+                    onManageOnWebVaultClick = {},
                     onUpgradeNowClick = {},
                     onDismissError = {},
                     onRetryClick = {},

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -6,6 +6,8 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.util.toFormattedDateStyle
+import com.bitwarden.data.repository.model.Environment
+import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
@@ -27,6 +29,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -65,6 +68,7 @@ class PlanViewModel @Inject constructor(
     private val billingRepository: BillingRepository,
     private val authRepository: AuthRepository,
     private val premiumStateManager: PremiumStateManager,
+    private val environmentRepository: EnvironmentRepository,
     private val specialCircumstanceManager: SpecialCircumstanceManager,
     private val vaultRepository: VaultRepository,
     private val clock: Clock,
@@ -78,12 +82,13 @@ class PlanViewModel @Inject constructor(
             ?.isPremium == true
         val showsPremiumView = isPremium ||
             premiumStateManager.subscriptionStatusStateFlow.value.isPremiumViewEligible()
+        val isSelfHosted = environmentRepository.environment is Environment.SelfHosted
         PlanState(
             planMode = planMode,
-            viewState = if (showsPremiumView) {
-                PlanState.ViewState.Premium()
-            } else {
-                PlanState.ViewState.Free(
+            viewState = when {
+                showsPremiumView -> PlanState.ViewState.Premium()
+                isSelfHosted -> PlanState.ViewState.Free.SelfHosted
+                else -> PlanState.ViewState.Free.Cloud(
                     rate = PLACEHOLDER_TEXT,
                     checkoutUrl = null,
                     isAwaitingPremiumStatus = false,
@@ -120,7 +125,7 @@ class PlanViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
-        onFreeContent {
+        onFreeCloudContent {
             viewModelScope.launch {
                 sendAction(
                     PlanAction.Internal.PricingResultReceive(
@@ -151,6 +156,7 @@ class PlanViewModel @Inject constructor(
     override fun handleAction(action: PlanAction) {
         when (action) {
             is PlanAction.BackClick -> handleBackClick()
+            is PlanAction.ManageOnWebVaultClick -> handleManageOnWebVaultClick()
             is PlanAction.UpgradeNowClick -> handleUpgradeNowClick()
             is PlanAction.DismissError -> handleDismissError()
             is PlanAction.ClosePricingErrorClick -> handleClosePricingErrorClick()
@@ -187,6 +193,14 @@ class PlanViewModel @Inject constructor(
 
     private fun handleBackClick() {
         sendEvent(PlanEvent.NavigateBack)
+    }
+
+    private fun handleManageOnWebVaultClick() {
+        val webVaultUrl = environmentRepository
+            .environment
+            .environmentUrlData
+            .baseWebVaultUrlOrDefault
+        sendEvent(PlanEvent.LaunchWebVault(url = "$webVaultUrl/#/settings/subscription/premium"))
     }
 
     // region Free user handlers
@@ -242,7 +256,7 @@ class PlanViewModel @Inject constructor(
     }
 
     private fun handleGoBackClick() {
-        onFreeContent { freeState ->
+        onFreeCloudContent { freeState ->
             freeState.checkoutUrl?.let { url ->
                 sendEvent(
                     PlanEvent.LaunchBrowser(
@@ -269,7 +283,7 @@ class PlanViewModel @Inject constructor(
                         ),
                     ),
                 )
-                onFreeContent { freeState ->
+                onFreeCloudContent { freeState ->
                     mutableStateFlow.update {
                         it.copy(
                             viewState = freeState.copy(
@@ -386,7 +400,7 @@ class PlanViewModel @Inject constructor(
             SubscriptionResult.NotFound -> {
                 mutableStateFlow.update {
                     it.copy(
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = PLACEHOLDER_TEXT,
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
@@ -426,8 +440,8 @@ class PlanViewModel @Inject constructor(
         val status = (action.state as? SubscriptionStatusState.Available)?.status
             ?: return
         if (!status.isPremiumViewEligible()) return
-        onFreeContent { freeState ->
-            if (freeState.isAwaitingPremiumStatus) return@onFreeContent
+        onFreeCloudContent { freeState ->
+            if (freeState.isAwaitingPremiumStatus) return@onFreeCloudContent
             mutableStateFlow.update {
                 it.copy(
                     viewState = PlanState.ViewState.Premium(),
@@ -453,8 +467,8 @@ class PlanViewModel @Inject constructor(
     private fun handleUserStateUpdateReceive(
         action: PlanAction.Internal.UserStateUpdateReceive,
     ) {
-        onFreeContent { freeState ->
-            if (!freeState.isAwaitingPremiumStatus) return@onFreeContent
+        onFreeCloudContent { freeState ->
+            if (!freeState.isAwaitingPremiumStatus) return@onFreeCloudContent
 
             val isPremium = action.userState?.activeAccount?.isPremium == true
             if (isPremium) {
@@ -471,7 +485,7 @@ class PlanViewModel @Inject constructor(
         specialCircumstanceManager.specialCircumstance = null
 
         if (checkoutResult.callbackResult is PremiumCheckoutCallbackResult.Canceled) {
-            onFreeContent { freeState ->
+            onFreeCloudContent { freeState ->
                 mutableStateFlow.update {
                     it.copy(
                         viewState = freeState.copy(
@@ -492,7 +506,7 @@ class PlanViewModel @Inject constructor(
         if (isPremium) {
             onPremiumUpgradeSuccess()
         } else {
-            onFreeContent { freeState ->
+            onFreeCloudContent { freeState ->
                 mutableStateFlow.update {
                     it.copy(
                         viewState = freeState.copy(
@@ -516,8 +530,8 @@ class PlanViewModel @Inject constructor(
     }
 
     private fun handleSyncCompleteReceive() {
-        onFreeContent { freeState ->
-            if (!freeState.isAwaitingPremiumStatus) return@onFreeContent
+        onFreeCloudContent { freeState ->
+            if (!freeState.isAwaitingPremiumStatus) return@onFreeCloudContent
 
             val isPremium = authRepository
                 .userStateFlow
@@ -537,7 +551,7 @@ class PlanViewModel @Inject constructor(
     }
 
     private fun onPremiumUpgradeSuccess() {
-        onFreeContent {
+        onFreeCloudContent {
             mutableStateFlow.update {
                 it.copy(
                     viewState = PlanState.ViewState.Premium(),
@@ -556,7 +570,7 @@ class PlanViewModel @Inject constructor(
         }
         // The Upgraded to Premium route uses `launchSingleTop = true` so a duplicate event is a
         // no-op for the user. The event itself is harmless to re-emit; the state mutation above
-        // is what's guarded by `onFreeContent`.
+        // is what's guarded by `onFreeCloudContent`.
         sendEvent(PlanEvent.NavigateToUpgradedToPremium)
     }
 
@@ -569,8 +583,10 @@ class PlanViewModel @Inject constructor(
                     .format(result.annualPrice / MONTHS_PER_YEAR)
                 mutableStateFlow.update { currentState ->
                     val updatedViewState = when (val vs = currentState.viewState) {
-                        is PlanState.ViewState.Free -> vs.copy(rate = formattedRate)
-                        is PlanState.ViewState.Premium -> vs
+                        is PlanState.ViewState.Free.Cloud -> vs.copy(rate = formattedRate)
+                        is PlanState.ViewState.Free.SelfHosted,
+                        is PlanState.ViewState.Premium,
+                            -> vs
                     }
                     currentState.copy(
                         viewState = updatedViewState,
@@ -610,10 +626,10 @@ class PlanViewModel @Inject constructor(
         }
     }
 
-    private inline fun onFreeContent(
-        block: (PlanState.ViewState.Free) -> Unit,
+    private inline fun onFreeCloudContent(
+        block: (PlanState.ViewState.Free.Cloud) -> Unit,
     ) {
-        (state.viewState as? PlanState.ViewState.Free)?.let(block)
+        (state.viewState as? PlanState.ViewState.Free.Cloud)?.let(block)
     }
 
     private inline fun onPremiumContent(
@@ -728,14 +744,30 @@ data class PlanState(
     sealed class ViewState : Parcelable {
 
         /**
-         * Free user view — shows upgrade pricing and feature list.
+         * Free user view — shows the upgrade flow for cloud accounts or a
+         * "manage on web vault" info card for self-hosted accounts.
          */
-        @Parcelize
-        data class Free(
-            val rate: String,
-            val checkoutUrl: String?,
-            val isAwaitingPremiumStatus: Boolean,
-        ) : ViewState()
+        sealed class Free : ViewState() {
+
+            /**
+             * Free user on a cloud-hosted environment — shows upgrade pricing
+             * and feature list.
+             */
+            @Parcelize
+            data class Cloud(
+                val rate: String,
+                val checkoutUrl: String?,
+                val isAwaitingPremiumStatus: Boolean,
+            ) : Free()
+
+            /**
+             * Free user on a self-hosted environment — Stripe checkout is
+             * unavailable, so the screen redirects the user to manage their
+             * subscription on the web vault.
+             */
+            @Parcelize
+            data object SelfHosted : Free()
+        }
 
         /**
          * Premium user view — shows subscription details and management options.
@@ -855,6 +887,13 @@ sealed class PlanEvent {
     ) : PlanEvent()
 
     /**
+     * Launch the user's browser with the given web vault subscription [url].
+     */
+    data class LaunchWebVault(
+        val url: String,
+    ) : PlanEvent()
+
+    /**
      * Navigate back to the previous screen.
      */
     data object NavigateBack : PlanEvent()
@@ -876,6 +915,11 @@ sealed class PlanAction {
      * The user clicked the back/close button.
      */
     data object BackClick : PlanAction()
+
+    /**
+     * The user clicked the "Go to web vault" CTA on the self-hosted variant.
+     */
+    data object ManageOnWebVaultClick : PlanAction()
 
     // region Free user actions
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.util.toFormattedDateStyle
 import com.bitwarden.data.repository.model.Environment
-import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
@@ -156,7 +155,6 @@ class PlanViewModel @Inject constructor(
     override fun handleAction(action: PlanAction) {
         when (action) {
             is PlanAction.BackClick -> handleBackClick()
-            is PlanAction.ManageOnWebVaultClick -> handleManageOnWebVaultClick()
             is PlanAction.UpgradeNowClick -> handleUpgradeNowClick()
             is PlanAction.DismissError -> handleDismissError()
             is PlanAction.ClosePricingErrorClick -> handleClosePricingErrorClick()
@@ -193,14 +191,6 @@ class PlanViewModel @Inject constructor(
 
     private fun handleBackClick() {
         sendEvent(PlanEvent.NavigateBack)
-    }
-
-    private fun handleManageOnWebVaultClick() {
-        val webVaultUrl = environmentRepository
-            .environment
-            .environmentUrlData
-            .baseWebVaultUrlOrDefault
-        sendEvent(PlanEvent.LaunchWebVault(url = "$webVaultUrl/#/settings/subscription/premium"))
     }
 
     // region Free user handlers
@@ -887,13 +877,6 @@ sealed class PlanEvent {
     ) : PlanEvent()
 
     /**
-     * Launch the user's browser with the given web vault subscription [url].
-     */
-    data class LaunchWebVault(
-        val url: String,
-    ) : PlanEvent()
-
-    /**
      * Navigate back to the previous screen.
      */
     data object NavigateBack : PlanEvent()
@@ -915,11 +898,6 @@ sealed class PlanAction {
      * The user clicked the back/close button.
      */
     data object BackClick : PlanAction()
-
-    /**
-     * The user clicked the "Go to web vault" CTA on the self-hosted variant.
-     */
-    data object ManageOnWebVaultClick : PlanAction()
 
     // region Free user actions
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
@@ -10,7 +10,6 @@ import com.x8bit.bitwarden.ui.platform.feature.premium.plan.PlanViewModel
 @Suppress("LongParameterList")
 data class PlanHandlers(
     val onBackClick: () -> Unit,
-    val onManageOnWebVaultClick: () -> Unit,
     val onUpgradeNowClick: () -> Unit,
     val onDismissError: () -> Unit,
     val onRetryClick: () -> Unit,
@@ -35,9 +34,6 @@ data class PlanHandlers(
          */
         fun create(viewModel: PlanViewModel): PlanHandlers = PlanHandlers(
             onBackClick = { viewModel.trySendAction(PlanAction.BackClick) },
-            onManageOnWebVaultClick = {
-                viewModel.trySendAction(PlanAction.ManageOnWebVaultClick)
-            },
             onUpgradeNowClick = { viewModel.trySendAction(PlanAction.UpgradeNowClick) },
             onDismissError = { viewModel.trySendAction(PlanAction.DismissError) },
             onRetryClick = { viewModel.trySendAction(PlanAction.RetryClick) },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/handlers/PlanHandlers.kt
@@ -10,6 +10,7 @@ import com.x8bit.bitwarden.ui.platform.feature.premium.plan.PlanViewModel
 @Suppress("LongParameterList")
 data class PlanHandlers(
     val onBackClick: () -> Unit,
+    val onManageOnWebVaultClick: () -> Unit,
     val onUpgradeNowClick: () -> Unit,
     val onDismissError: () -> Unit,
     val onRetryClick: () -> Unit,
@@ -34,6 +35,9 @@ data class PlanHandlers(
          */
         fun create(viewModel: PlanViewModel): PlanHandlers = PlanHandlers(
             onBackClick = { viewModel.trySendAction(PlanAction.BackClick) },
+            onManageOnWebVaultClick = {
+                viewModel.trySendAction(PlanAction.ManageOnWebVaultClick)
+            },
             onUpgradeNowClick = { viewModel.trySendAction(PlanAction.UpgradeNowClick) },
             onDismissError = { viewModel.trySendAction(PlanAction.DismissError) },
             onRetryClick = { viewModel.trySendAction(PlanAction.RetryClick) },

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.material3.Text
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.DeferredBackgroundEvent
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
@@ -15,6 +16,7 @@ import com.x8bit.bitwarden.data.billing.manager.UPGRADED_TO_PREMIUM_LEARN_MORE_U
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -32,6 +34,7 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     specialCircumstanceManager: SpecialCircumstanceManager,
     firstTimeActionManager: FirstTimeActionManager,
+    environmentRepository: EnvironmentRepository,
     private val premiumStateManager: PremiumStateManager,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<SettingsState, SettingsEvent, SettingsAction>(
@@ -41,6 +44,7 @@ class SettingsViewModel @Inject constructor(
         autoFillCount = firstTimeActionManager.allAutofillSettingsBadgeCountFlow.value,
         vaultCount = firstTimeActionManager.allVaultSettingsBadgeCountFlow.value,
         isPlanRowEligible = premiumStateManager.isPlanRowEligibleFlow.value,
+        isSelfHosted = environmentRepository.environment is Environment.SelfHosted,
         isUpgradedToPremiumCardEligible = premiumStateManager
             .isUpgradedToPremiumCardEligibleFlow
             .value,
@@ -76,6 +80,16 @@ class SettingsViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
+        environmentRepository
+            .environmentStateFlow
+            .map {
+                SettingsAction.Internal.EnvironmentReceive(
+                    isSelfHosted = it is Environment.SelfHosted,
+                )
+            }
+            .onEach(::sendAction)
+            .launchIn(viewModelScope)
+
         when (specialCircumstanceManager.specialCircumstance) {
             SpecialCircumstance.AccountSecurityShortcut -> {
                 sendEvent(SettingsEvent.NavigateAccountSecurityShortcut)
@@ -101,6 +115,18 @@ class SettingsViewModel @Inject constructor(
 
         is SettingsAction.Internal.UpgradedToPremiumCardEligibilityReceive -> {
             handleUpgradedToPremiumCardEligibilityReceive(action)
+        }
+
+        is SettingsAction.Internal.EnvironmentReceive -> {
+            handleEnvironmentReceive(action)
+        }
+    }
+
+    private fun handleEnvironmentReceive(
+        action: SettingsAction.Internal.EnvironmentReceive,
+    ) {
+        mutableStateFlow.update {
+            it.copy(isSelfHosted = action.isSelfHosted)
         }
     }
 
@@ -185,6 +211,7 @@ data class SettingsState(
     private val securityCount: Int,
     private val vaultCount: Int,
     private val isPlanRowEligible: Boolean,
+    private val isSelfHosted: Boolean = false,
     private val isUpgradedToPremiumCardEligible: Boolean = false,
 ) {
     val shouldShowCloseButton: Boolean = isPreAuth
@@ -199,9 +226,10 @@ data class SettingsState(
      * Whether the plan row should be shown. The row is visible post-authentication when the user
      * is eligible per [PremiumStateManager.isPlanRowEligibleFlow] — currently, when the in-app
      * upgrade feature is enabled and the user is not relying solely on organization-granted
-     * Premium.
+     * Premium — and the account is on a cloud-hosted environment. Self-hosted users manage their
+     * subscription on the web vault.
      */
-    private val shouldShowPlanRow: Boolean = !isPreAuth && isPlanRowEligible
+    private val shouldShowPlanRow: Boolean = !isPreAuth && isPlanRowEligible && !isSelfHosted
 
     val settingRows: ImmutableList<Settings> = Settings
         .entries
@@ -333,6 +361,13 @@ sealed class SettingsAction {
          */
         data class UpgradedToPremiumCardEligibilityReceive(
             val isEligible: Boolean,
+        ) : Internal()
+
+        /**
+         * Indicates that the environment has been updated.
+         */
+        data class EnvironmentReceive(
+            val isSelfHosted: Boolean,
         ) : Internal()
     }
 }

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -997,6 +997,55 @@ class PlanScreenTest : BitwardenComposeTest() {
 
     // endregion Premium-flow dialogs
 
+    // region Self-hosted free flow
+
+    @Test
+    fun `manage subscription info callout should render when self-hosted free`() {
+        mutableStateFlow.update {
+            it.copy(viewState = PlanState.ViewState.Free.SelfHosted)
+        }
+        composeTestRule
+            .onNodeWithText(
+                "To manage your Premium subscription, " +
+                    "you’ll need to login to your web vault on a computer.",
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("SelfHostedManageOnWebVaultCallout")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `premium features header should render when self-hosted free`() {
+        mutableStateFlow.update {
+            it.copy(viewState = PlanState.ViewState.Free.SelfHosted)
+        }
+        composeTestRule
+            .onNodeWithText("Unlock more advanced features with a Premium plan.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `premium feature list items should render when self-hosted free`() {
+        mutableStateFlow.update {
+            it.copy(viewState = PlanState.ViewState.Free.SelfHosted)
+        }
+        composeTestRule
+            .onNodeWithText("Built-in authenticator")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Emergency access")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Secure file storage")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Breach monitoring")
+            .assertIsDisplayed()
+    }
+
+    // endregion Self-hosted free flow
+
     // region LaunchPortal event
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -1011,7 +1011,7 @@ class PlanScreenTest : BitwardenComposeTest() {
 
 private val DEFAULT_FREE_STATE = PlanState(
     planMode = PlanMode.Modal,
-    viewState = PlanState.ViewState.Free(
+    viewState = PlanState.ViewState.Free.Cloud(
         rate = "$1.65",
         checkoutUrl = null,
         isAwaitingPremiumStatus = false,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -643,29 +643,6 @@ class PlanViewModelTest : BaseViewModelTest() {
         }
     }
 
-    @Test
-    fun `ManageOnWebVaultClick on self-hosted should emit LaunchWebVault with web vault URL`() =
-        runTest {
-            val customWebVault = "https://vault.example.com"
-            mutableEnvironmentFlow.value = Environment.SelfHosted(
-                environmentUrlData = EnvironmentUrlDataJson(
-                    base = "https://example.com",
-                    webVault = customWebVault,
-                ),
-            )
-            val viewModel = createViewModel(pricingResult = null)
-
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(PlanAction.ManageOnWebVaultClick)
-                assertEquals(
-                    PlanEvent.LaunchWebVault(
-                        url = "$customWebVault/#/settings/subscription/premium",
-                    ),
-                    awaitItem(),
-                )
-            }
-        }
-
     // endregion Self-hosted path
 
     // region Pricing fetch

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -2,6 +2,8 @@ package com.x8bit.bitwarden.ui.platform.feature.premium.plan
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
+import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
 import com.bitwarden.ui.platform.resource.BitwardenString
@@ -21,6 +23,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import com.x8bit.bitwarden.data.billing.util.PremiumCheckoutCallbackResult
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.manager.model.SyncVaultDataResult
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import io.mockk.coEvery
@@ -66,6 +69,11 @@ class PlanViewModelTest : BaseViewModelTest() {
         MutableStateFlow<SubscriptionStatusState>(SubscriptionStatusState.NoSubscription)
     private val mockPremiumStateManager: PremiumStateManager = mockk {
         every { subscriptionStatusStateFlow } returns mutableSubscriptionStatusStateFlow
+    }
+    private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
+    private val mockEnvironmentRepository: EnvironmentRepository = mockk {
+        every { environment } answers { mutableEnvironmentFlow.value }
+        every { environmentStateFlow } returns mutableEnvironmentFlow
     }
 
     @BeforeEach
@@ -130,7 +138,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "$1.67",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = true,
@@ -210,7 +218,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 )
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "$1.67",
                             checkoutUrl = checkoutUrl,
                             isAwaitingPremiumStatus = false,
@@ -300,7 +308,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 )
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "$1.67",
                             checkoutUrl = checkoutUrl,
                             isAwaitingPremiumStatus = false,
@@ -372,7 +380,7 @@ class PlanViewModelTest : BaseViewModelTest() {
     fun `GoBackClick should emit LaunchBrowser with checkout URL when URL is available`() =
         runTest {
             val checkoutUrl = "https://checkout.stripe.com/session123"
-            val freeState = PlanState.ViewState.Free(
+            val freeState = PlanState.ViewState.Free.Cloud(
                 rate = "$1.67",
                 checkoutUrl = checkoutUrl,
                 isAwaitingPremiumStatus = false,
@@ -420,7 +428,7 @@ class PlanViewModelTest : BaseViewModelTest() {
         runTest {
             val viewModel = createViewModel(
                 initialState = DEFAULT_FREE_STATE.copy(
-                    viewState = PlanState.ViewState.Free(
+                    viewState = PlanState.ViewState.Free.Cloud(
                         rate = "$1.67",
                         checkoutUrl = null,
                         isAwaitingPremiumStatus = true,
@@ -462,7 +470,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "$1.67",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = true,
@@ -517,7 +525,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 // Sync completes without premium — PendingUpgrade shown.
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "$1.67",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = true,
@@ -541,7 +549,7 @@ class PlanViewModelTest : BaseViewModelTest() {
         runTest {
             val viewModel = createViewModel(
                 initialState = DEFAULT_FREE_STATE.copy(
-                    viewState = PlanState.ViewState.Free(
+                    viewState = PlanState.ViewState.Free.Cloud(
                         rate = "$1.67",
                         checkoutUrl = null,
                         isAwaitingPremiumStatus = true,
@@ -600,6 +608,66 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     // endregion Free user path
 
+    // region Self-hosted path
+
+    @Test
+    fun `initial state on self-hosted should be Free SelfHosted ViewState`() = runTest {
+        mutableEnvironmentFlow.value = Environment.SelfHosted(
+            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+        )
+        val viewModel = createViewModel(
+            pricingResult = null,
+        )
+
+        viewModel.stateFlow.test {
+            assertEquals(
+                PlanState(
+                    planMode = PlanMode.Modal,
+                    viewState = PlanState.ViewState.Free.SelfHosted,
+                    dialogState = null,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `initial state on self-hosted should not fetch pricing`() = runTest {
+        mutableEnvironmentFlow.value = Environment.SelfHosted(
+            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+        )
+        createViewModel(pricingResult = null)
+
+        coVerify(exactly = 0) {
+            mockBillingRepository.getPremiumPlanPricing()
+        }
+    }
+
+    @Test
+    fun `ManageOnWebVaultClick on self-hosted should emit LaunchWebVault with web vault URL`() =
+        runTest {
+            val customWebVault = "https://vault.example.com"
+            mutableEnvironmentFlow.value = Environment.SelfHosted(
+                environmentUrlData = EnvironmentUrlDataJson(
+                    base = "https://example.com",
+                    webVault = customWebVault,
+                ),
+            )
+            val viewModel = createViewModel(pricingResult = null)
+
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(PlanAction.ManageOnWebVaultClick)
+                assertEquals(
+                    PlanEvent.LaunchWebVault(
+                        url = "$customWebVault/#/settings/subscription/premium",
+                    ),
+                    awaitItem(),
+                )
+            }
+        }
+
+    // endregion Self-hosted path
+
     // region Pricing fetch
 
     @Test
@@ -611,7 +679,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     PlanState(
                         planMode = PlanMode.Modal,
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
@@ -636,7 +704,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     PlanState(
                         planMode = PlanMode.Modal,
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
@@ -664,7 +732,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     PlanState(
                         planMode = PlanMode.Modal,
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
@@ -687,7 +755,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     PlanState(
                         planMode = PlanMode.Modal,
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
@@ -718,7 +786,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     PlanState(
                         planMode = PlanMode.Modal,
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
@@ -736,7 +804,7 @@ class PlanViewModelTest : BaseViewModelTest() {
                 assertEquals(
                     PlanState(
                         planMode = PlanMode.Modal,
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
@@ -907,7 +975,7 @@ class PlanViewModelTest : BaseViewModelTest() {
             viewModel.stateFlow.test {
                 assertEquals(
                     DEFAULT_FREE_STATE.copy(
-                        viewState = PlanState.ViewState.Free(
+                        viewState = PlanState.ViewState.Free.Cloud(
                             rate = "--",
                             checkoutUrl = null,
                             isAwaitingPremiumStatus = false,
@@ -1405,6 +1473,7 @@ class PlanViewModelTest : BaseViewModelTest() {
             authRepository = mockAuthRepository,
             billingRepository = mockBillingRepository,
             premiumStateManager = mockPremiumStateManager,
+            environmentRepository = mockEnvironmentRepository,
             specialCircumstanceManager = mockSpecialCircumstanceManager,
             vaultRepository = mockVaultRepository,
             clock = clock,
@@ -1443,7 +1512,7 @@ private val DEFAULT_USER_STATE = UserState(
 
 private val DEFAULT_FREE_STATE = PlanState(
     planMode = PlanMode.Modal,
-    viewState = PlanState.ViewState.Free(
+    viewState = PlanState.ViewState.Free.Cloud(
         rate = "$1.67",
         checkoutUrl = null,
         isAwaitingPremiumStatus = false,

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -2,11 +2,14 @@ package com.x8bit.bitwarden.ui.platform.feature.settings
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
+import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -46,6 +49,11 @@ class SettingsViewModelTest : BaseViewModelTest() {
         every {
             isUpgradedToPremiumCardEligibleFlow
         } returns mutableUpgradedToPremiumCardEligibleFlow
+    }
+    private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
+    private val environmentRepository: EnvironmentRepository = mockk {
+        every { environment } answers { mutableEnvironmentFlow.value }
+        every { environmentStateFlow } returns mutableEnvironmentFlow
     }
 
     @BeforeEach
@@ -323,9 +331,42 @@ class SettingsViewModelTest : BaseViewModelTest() {
         }
     }
 
+    @Test
+    fun `Plan row should be hidden when environment is self-hosted`() {
+        mutablePlanRowEligibleFlow.value = true
+        mutableEnvironmentFlow.value = Environment.SelfHosted(
+            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+        )
+        val viewModel = createViewModel()
+        assertFalse(
+            viewModel.stateFlow.value.settingRows
+                .contains(Settings.PLAN),
+        )
+    }
+
+    @Test
+    fun `Plan row should update when environment changes to self-hosted`() = runTest {
+        mutablePlanRowEligibleFlow.value = true
+        val viewModel = createViewModel()
+        assertTrue(
+            viewModel.stateFlow.value.settingRows
+                .contains(Settings.PLAN),
+        )
+
+        mutableEnvironmentFlow.value = Environment.SelfHosted(
+            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+        )
+        viewModel.stateFlow.test {
+            assertFalse(
+                awaitItem().settingRows.contains(Settings.PLAN),
+            )
+        }
+    }
+
     private fun createViewModel(isPreAuth: Boolean = false) = SettingsViewModel(
         firstTimeActionManager = firstTimeManager,
         specialCircumstanceManager = specialCircumstanceManager,
+        environmentRepository = environmentRepository,
         premiumStateManager = premiumStateManager,
         savedStateHandle = SavedStateHandle().apply {
             every { toSettingsArgs() } returns SettingsArgs(isPreAuth = isPreAuth)

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1218,6 +1218,7 @@ Do you want to switch to this account?</string>
     <string name="upgrade_to_premium">Upgrade to Premium</string>
     <string name="plan">Plan</string>
     <string name="manage_your_premium_subscription_on_the_web_vault">Manage your Premium subscription on the web vault.</string>
+    <string name="to_manage_your_premium_subscription_youll_need_to_login_to_your_web_vault_on_a_computer">To manage your Premium subscription, you’ll need to login to your web vault on a computer.</string>
     <string name="go_to_web_vault">Go to web vault</string>
     <string name="unlock_advanced_security_features">Unlock advanced security features</string>
     <string name="a_premium_plan_gives_you_more_tools_to_stay_secure_and_in_control">A Premium plan gives you more tools to stay secure and in control.</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1217,9 +1217,7 @@ Do you want to switch to this account?</string>
     <string name="archiving_items_is_a_premium_feature">Archiving items is a Premium feature. Your current plan does not include access to this feature.</string>
     <string name="upgrade_to_premium">Upgrade to Premium</string>
     <string name="plan">Plan</string>
-    <string name="manage_your_premium_subscription_on_the_web_vault">Manage your Premium subscription on the web vault.</string>
     <string name="to_manage_your_premium_subscription_youll_need_to_login_to_your_web_vault_on_a_computer">To manage your Premium subscription, you’ll need to login to your web vault on a computer.</string>
-    <string name="go_to_web_vault">Go to web vault</string>
     <string name="unlock_advanced_security_features">Unlock advanced security features</string>
     <string name="a_premium_plan_gives_you_more_tools_to_stay_secure_and_in_control">A Premium plan gives you more tools to stay secure and in control.</string>
     <string name="this_item_is_archived">This item is archived.</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1217,6 +1217,8 @@ Do you want to switch to this account?</string>
     <string name="archiving_items_is_a_premium_feature">Archiving items is a Premium feature. Your current plan does not include access to this feature.</string>
     <string name="upgrade_to_premium">Upgrade to Premium</string>
     <string name="plan">Plan</string>
+    <string name="manage_your_premium_subscription_on_the_web_vault">Manage your Premium subscription on the web vault.</string>
+    <string name="go_to_web_vault">Go to web vault</string>
     <string name="unlock_advanced_security_features">Unlock advanced security features</string>
     <string name="a_premium_plan_gives_you_more_tools_to_stay_secure_and_in_control">A Premium plan gives you more tools to stay secure and in control.</string>
     <string name="this_item_is_archived">This item is archived.</string>


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-36886
- https://bitwarden.atlassian.net/browse/PM-36887
- https://bitwarden.atlassian.net/browse/PM-36889
- https://bitwarden.atlassian.net/browse/PM-37472

## 📔 Objective

Free self-hosted users have no Stripe pricing endpoint or checkout session available to them, so the existing premium upgrade surfaces either showed broken pricing, errored on the pricing fetch, or routed users into a checkout that cannot complete. Subscription management for self-hosted accounts lives exclusively on the web vault.

Gate the in-app upgrade affordance on cloud environments and surface a non-actionable info callout in its place:

- `SettingsViewModel` hides the Plan row entirely when the active environment is self-hosted.
- `PlanViewModel` skips the Stripe pricing fetch on self-hosted and emits a dedicated `Free.SelfHosted` view state.
- `PlanScreen` renders a `BitwardenInfoCalloutCard` directing the user to log in to the web vault on a computer to manage their subscription, alongside the static premium feature list so self-hosted users can still see what Premium unlocks.

## 📸 Screenshots

| Figma | Actual |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/2e597466-37ed-4674-b39b-0c9e40614ab9" /> | <img width="365" src="https://github.com/user-attachments/assets/3de58907-c6e2-46fb-b883-8c80873ab114" /> |
| <img width="365" src="https://github.com/user-attachments/assets/5ebd13eb-a193-42b8-a960-3d83b0fbbfdf" /> | <img width="365" src="https://github.com/user-attachments/assets/5e116bfd-ddad-4ed8-ac90-8ade98c5726b" /> |