### PR TITLE
chore: Remove background event interface from action

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -4072,7 +4072,7 @@ sealed class VaultItemListingsAction {
          */
         data class SnackbarDataReceived(
             val data: BitwardenSnackbarData,
-        ) : Internal(), BackgroundEvent
+        ) : Internal()
 
         /**
          * Indicates that an error occurred while decrypting a cipher.


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

This PR removes the `BackgroundEvent` interface from the `SnackbarDataReceived` action. Actions never need this interface.
