### PR TITLE
[PM-37335] fix: Route attachments upgrade CTA through in-app plan modal

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/vaultunlocked/VaultUnlockedNavigation.kt
@@ -282,6 +282,7 @@ fun NavGraphBuilder.vaultUnlockedGraph(
         attachmentDestination(
             onNavigateBack = { navController.popBackStack() },
             onNavigateToPreviewAttachment = { navController.navigateToPreviewAttachment(it) },
+            onNavigateToPlan = { navController.navigateToPlanModal() },
         )
         setupUnlockDestination(
             onNavigateBack = {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsNavigation.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsNavigation.kt
@@ -36,11 +36,13 @@ fun SavedStateHandle.toAttachmentsArgs(): AttachmentsArgs {
 fun NavGraphBuilder.attachmentDestination(
     onNavigateBack: () -> Unit,
     onNavigateToPreviewAttachment: (route: PreviewAttachmentRoute) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     composableWithSlideTransitions<AttachmentsRoute> {
         AttachmentsScreen(
             onNavigateBack = onNavigateBack,
             onNavigateToPreview = onNavigateToPreviewAttachment,
+            onNavigateToPlan = onNavigateToPlan,
         )
     }
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreen.kt
@@ -45,6 +45,7 @@ fun AttachmentsScreen(
     intentManager: IntentManager = LocalIntentManager.current,
     onNavigateBack: () -> Unit,
     onNavigateToPreview: (route: PreviewAttachmentRoute) -> Unit,
+    onNavigateToPlan: () -> Unit,
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
     val attachmentsHandlers = remember(viewModel) { AttachmentsHandlers.create(viewModel) }
@@ -57,6 +58,7 @@ fun AttachmentsScreen(
     EventsEffect(viewModel = viewModel) { event ->
         when (event) {
             AttachmentsEvent.NavigateBack -> onNavigateBack()
+            AttachmentsEvent.NavigateToPlanModal -> onNavigateToPlan()
             is AttachmentsEvent.NavigateToUri -> intentManager.launchUri(event.uri.toUri())
             AttachmentsEvent.ShowChooserSheet -> {
                 fileChooserLauncher.launch(

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModel.kt
@@ -17,6 +17,7 @@ import com.bitwarden.ui.util.concat
 import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
@@ -50,6 +51,7 @@ class AttachmentsViewModel @Inject constructor(
     private val authRepo: AuthRepository,
     private val environmentRepo: EnvironmentRepository,
     private val vaultRepo: VaultRepository,
+    private val premiumStateManager: PremiumStateManager,
     featureFlagManager: FeatureFlagManager,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<AttachmentsState, AttachmentsEvent, AttachmentsAction>(
@@ -168,15 +170,19 @@ class AttachmentsViewModel @Inject constructor(
 
     private fun handleUpgradeToPremiumClick() {
         mutableStateFlow.update { it.copy(dialogState = null) }
-        val baseUrl = environmentRepo
-            .environment
-            .environmentUrlData
-            .baseWebVaultUrlOrDefault
-        sendEvent(
-            AttachmentsEvent.NavigateToUri(
-                uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium",
-            ),
-        )
+        if (premiumStateManager.isInAppUpgradeAvailable()) {
+            sendEvent(AttachmentsEvent.NavigateToPlanModal)
+        } else {
+            val baseUrl = environmentRepo
+                .environment
+                .environmentUrlData
+                .baseWebVaultUrlOrDefault
+            sendEvent(
+                AttachmentsEvent.NavigateToUri(
+                    uri = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium",
+                ),
+            )
+        }
     }
 
     private fun handleChooseFileClick() {
@@ -522,6 +528,11 @@ sealed class AttachmentsEvent {
      * Navigates to upgrade to the given Uri.
      */
     data class NavigateToUri(val uri: String) : AttachmentsEvent()
+
+    /**
+     * Navigates to the in-app plan modal for premium upgrade.
+     */
+    data object NavigateToPlanModal : AttachmentsEvent()
 
     /**
      * Navigates to preview the attachment.

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsScreenTest.kt
@@ -36,6 +36,7 @@ import org.junit.Test
 class AttachmentsScreenTest : BitwardenComposeTest() {
     private var onNavigateBackCalled = false
     private var onNavigateToPreviewCalled = false
+    private var onNavigateToPlanCalled = false
 
     private val mutableStateFlow = MutableStateFlow(DEFAULT_STATE)
     private val mutableEventFlow = bufferedMutableSharedFlow<AttachmentsEvent>()
@@ -55,6 +56,7 @@ class AttachmentsScreenTest : BitwardenComposeTest() {
                 viewModel = viewModel,
                 onNavigateBack = { onNavigateBackCalled = true },
                 onNavigateToPreview = { onNavigateToPreviewCalled = true },
+                onNavigateToPlan = { onNavigateToPlanCalled = true },
             )
         }
     }
@@ -72,6 +74,12 @@ class AttachmentsScreenTest : BitwardenComposeTest() {
         verify(exactly = 1) {
             intentManager.launchUri(uriString.toUri())
         }
+    }
+
+    @Test
+    fun `NavigateToPlanModal should call onNavigateToPlan`() {
+        mutableEventFlow.tryEmit(AttachmentsEvent.NavigateToPlanModal)
+        assertTrue(onNavigateToPlanCalled)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/attachments/AttachmentsViewModelTest.kt
@@ -15,6 +15,7 @@ import com.bitwarden.vault.CipherView
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.OnboardingStatus
 import com.x8bit.bitwarden.data.auth.repository.AuthRepository
 import com.x8bit.bitwarden.data.auth.repository.model.UserState
+import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.platform.error.NoActiveUserException
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.model.FirstTimeState
@@ -53,6 +54,9 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
         MutableStateFlow<DataState<CipherView?>>(DataState.Loading)
     private val vaultRepository: VaultRepository = mockk {
         every { getVaultItemStateFlow(any()) } returns mutableVaultItemStateFlow
+    }
+    private val premiumStateManager: PremiumStateManager = mockk {
+        every { isInAppUpgradeAvailable() } returns false
     }
     private val mutableAttachmentUpdatesFlow = MutableStateFlow(true)
     private val featureFlagManager: FeatureFlagManager = mockk {
@@ -146,22 +150,34 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `UpgradeToPremiumClick should emit NavigateToUri`() = runTest {
-        val viewModel = createViewModel()
-        viewModel.eventFlow.test {
-            viewModel.trySendAction(AttachmentsAction.UpgradeToPremiumClick)
-            assertEquals(
-                AttachmentsEvent.NavigateToUri(
-                    uri = "https://vault.bitwarden.com/#/settings/subscription" +
-                        "/premium?callToAction=upgradeToPremium",
-                ),
-                awaitItem(),
-            )
+    fun `UpgradeToPremiumClick should emit NavigateToUri when in-app upgrade not available`() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(AttachmentsAction.UpgradeToPremiumClick)
+                assertEquals(
+                    AttachmentsEvent.NavigateToUri(
+                        uri = "https://vault.bitwarden.com/#/settings/subscription" +
+                            "/premium?callToAction=upgradeToPremium",
+                    ),
+                    awaitItem(),
+                )
+            }
+            verify(exactly = 1) {
+                environmentRepository.environment
+            }
         }
-        verify(exactly = 1) {
-            environmentRepository.environment
+
+    @Test
+    fun `UpgradeToPremiumClick should emit NavigateToPlanModal when in-app upgrade available`() =
+        runTest {
+            every { premiumStateManager.isInAppUpgradeAvailable() } returns true
+            val viewModel = createViewModel()
+            viewModel.eventFlow.test {
+                viewModel.trySendAction(AttachmentsAction.UpgradeToPremiumClick)
+                assertEquals(AttachmentsEvent.NavigateToPlanModal, awaitItem())
+            }
         }
-    }
 
     @Test
     fun `FileNameChange should update the newAttachment state`() = runTest {
@@ -803,6 +819,7 @@ class AttachmentsViewModelTest : BaseViewModelTest() {
         authRepo = authRepository,
         environmentRepo = environmentRepository,
         vaultRepo = vaultRepository,
+        premiumStateManager = premiumStateManager,
         featureFlagManager = featureFlagManager,
         savedStateHandle = SavedStateHandle().apply {
             set("state", initialState)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37335](https://bitwarden.atlassian.net/browse/PM-37335)

## 📔 Objective

The Attachments "Upgrade to Premium" dialog was missed by the PM-33519 rewire and continued sending users to the legacy web URL even when the in-app upgrade path was available. Users on cloud accounts with in-app upgrade enabled would leave the app to complete what should be an in-app flow — inconsistent with every other upgrade entry point already routed through the plan modal.

`AttachmentsViewModel.handleUpgradeToPremiumClick` now consults `PremiumStateManager.isInAppUpgradeAvailable()` and emits `NavigateToPlanModal` when in-app upgrade is supported, falling back to the existing web URL for environments where it is not. Mirrors the `VaultItemViewModel.handleUpgradeToPremiumClick` shape already in place for the item-detail upgrade CTA.

[PM-37335]: https://bitwarden.atlassian.net/browse/PM-37335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ