### PR TITLE
[PM-37284] fix: Show Upgraded to Premium card across all Send view states

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
@@ -69,7 +69,7 @@ fun SendContent(
                         .fillMaxWidth()
                         .standardHorizontalMargin(),
                 )
-                Spacer(modifier = Modifier.height(height = 12.dp))
+                Spacer(modifier = Modifier.height(height = 16.dp))
             }
         }
         if (policyDisablesSend) {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
@@ -26,6 +26,7 @@ import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.ui.platform.components.listitem.BitwardenGroupItem
 import com.x8bit.bitwarden.ui.tools.feature.send.handlers.SendHandlers
+import com.x8bit.bitwarden.ui.tools.feature.send.model.UpgradedToPremiumCardData
 
 private const val SEND_TYPES_COUNT: Int = 2
 
@@ -37,17 +38,15 @@ private const val SEND_TYPES_COUNT: Int = 2
 fun SendContent(
     policyDisablesSend: Boolean,
     state: SendState.ViewState.Content,
-    isUpgradedToPremiumCardEligible: Boolean,
+    upgradedToPremiumCardData: UpgradedToPremiumCardData?,
     sendHandlers: SendHandlers,
-    onUpgradedToPremiumCardClick: () -> Unit,
-    onUpgradedToPremiumCardDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(modifier = modifier) {
         item {
             Spacer(modifier = Modifier.height(height = 12.dp))
         }
-        if (isUpgradedToPremiumCardEligible) {
+        upgradedToPremiumCardData?.let {
             item {
                 BitwardenActionCard(
                     cardTitle = stringResource(id = BitwardenString.upgraded_to_premium),
@@ -63,8 +62,8 @@ fun SendContent(
                             tint = BitwardenTheme.colorScheme.icon.secondary,
                         )
                     },
-                    onActionClick = onUpgradedToPremiumCardClick,
-                    onDismissClick = onUpgradedToPremiumCardDismiss,
+                    onActionClick = it.onCardClick,
+                    onDismissClick = it.onCardDismiss,
                     modifier = Modifier
                         .fillMaxWidth()
                         .standardHorizontalMargin(),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -15,15 +14,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bitwarden.ui.platform.base.util.standardHorizontalMargin
 import com.bitwarden.ui.platform.base.util.toListItemCardStyle
-import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.card.BitwardenInfoCalloutCard
 import com.bitwarden.ui.platform.components.header.BitwardenListHeaderText
 import com.bitwarden.ui.platform.components.icon.model.IconData
 import com.bitwarden.ui.platform.components.model.CardStyle
-import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
-import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.x8bit.bitwarden.ui.platform.components.listitem.BitwardenGroupItem
 import com.x8bit.bitwarden.ui.tools.feature.send.handlers.SendHandlers
 import com.x8bit.bitwarden.ui.tools.feature.send.model.UpgradedToPremiumCardData
@@ -48,20 +44,7 @@ fun SendContent(
         }
         upgradedToPremiumCardData?.let {
             item {
-                BitwardenActionCard(
-                    cardTitle = stringResource(id = BitwardenString.upgraded_to_premium),
-                    cardSubtitle = stringResource(
-                        id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
-                    ),
-                    actionText = stringResource(id = BitwardenString.learn_more),
-                    isExternalLink = true,
-                    leadingContent = {
-                        Icon(
-                            painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),
-                            contentDescription = null,
-                            tint = BitwardenTheme.colorScheme.icon.secondary,
-                        )
-                    },
+                UpgradedToPremiumActionCard(
                     onActionClick = it.onCardClick,
                     onDismissClick = it.onCardDismiss,
                     modifier = Modifier

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendEmpty.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendEmpty.kt
@@ -31,6 +31,7 @@ import com.bitwarden.ui.platform.components.util.rememberVectorPainter
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
 import com.bitwarden.ui.platform.theme.BitwardenTheme
+import com.x8bit.bitwarden.ui.tools.feature.send.model.UpgradedToPremiumCardData
 
 /**
  * Content for the empty state of the [SendScreen].
@@ -40,20 +41,18 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
 fun SendEmpty(
     policyDisablesSend: Boolean,
     onAddItemClick: () -> Unit,
-    isUpgradedToPremiumCardEligible: Boolean,
-    onUpgradedToPremiumCardClick: () -> Unit,
-    onUpgradedToPremiumCardDismiss: () -> Unit,
+    upgradedToPremiumCardData: UpgradedToPremiumCardData?,
     modifier: Modifier = Modifier,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.verticalScroll(rememberScrollState()),
     ) {
-        if (isUpgradedToPremiumCardEligible) {
+        upgradedToPremiumCardData?.let {
             Spacer(modifier = Modifier.height(height = 12.dp))
             UpgradedToPremiumActionCard(
-                onActionClick = onUpgradedToPremiumCardClick,
-                onDismissClick = onUpgradedToPremiumCardDismiss,
+                onActionClick = it.onCardClick,
+                onDismissClick = it.onCardDismiss,
                 modifier = Modifier
                     .fillMaxWidth()
                     .standardHorizontalMargin(),
@@ -132,9 +131,7 @@ private fun SendEmpty_preview() {
             SendEmpty(
                 policyDisablesSend = false,
                 onAddItemClick = {},
-                isUpgradedToPremiumCardEligible = false,
-                onUpgradedToPremiumCardClick = {},
-                onUpgradedToPremiumCardDismiss = {},
+                upgradedToPremiumCardData = null,
             )
         }
     }
@@ -151,9 +148,7 @@ private fun SendEmptyPolicyDisabled_preview() {
             SendEmpty(
                 policyDisablesSend = true,
                 onAddItemClick = {},
-                isUpgradedToPremiumCardEligible = false,
-                onUpgradedToPremiumCardClick = {},
-                onUpgradedToPremiumCardDismiss = {},
+                upgradedToPremiumCardData = null,
             )
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendEmpty.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendEmpty.kt
@@ -40,12 +40,25 @@ import com.bitwarden.ui.platform.theme.BitwardenTheme
 fun SendEmpty(
     policyDisablesSend: Boolean,
     onAddItemClick: () -> Unit,
+    isUpgradedToPremiumCardEligible: Boolean,
+    onUpgradedToPremiumCardClick: () -> Unit,
+    onUpgradedToPremiumCardDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.verticalScroll(rememberScrollState()),
     ) {
+        if (isUpgradedToPremiumCardEligible) {
+            Spacer(modifier = Modifier.height(height = 12.dp))
+            UpgradedToPremiumActionCard(
+                onActionClick = onUpgradedToPremiumCardClick,
+                onDismissClick = onUpgradedToPremiumCardDismiss,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .standardHorizontalMargin(),
+            )
+        }
         if (policyDisablesSend) {
             Spacer(modifier = Modifier.height(12.dp))
             BitwardenInfoCalloutCard(
@@ -119,6 +132,9 @@ private fun SendEmpty_preview() {
             SendEmpty(
                 policyDisablesSend = false,
                 onAddItemClick = {},
+                isUpgradedToPremiumCardEligible = false,
+                onUpgradedToPremiumCardClick = {},
+                onUpgradedToPremiumCardDismiss = {},
             )
         }
     }
@@ -135,6 +151,9 @@ private fun SendEmptyPolicyDisabled_preview() {
             SendEmpty(
                 policyDisablesSend = true,
                 onAddItemClick = {},
+                isUpgradedToPremiumCardEligible = false,
+                onUpgradedToPremiumCardClick = {},
+                onUpgradedToPremiumCardDismiss = {},
             )
         }
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -23,6 +24,7 @@ import com.bitwarden.ui.platform.components.appbar.action.BitwardenOverflowActio
 import com.bitwarden.ui.platform.components.appbar.action.BitwardenSearchActionItem
 import com.bitwarden.ui.platform.components.appbar.model.OverflowMenuItemData
 import com.bitwarden.ui.platform.components.button.model.BitwardenButtonData
+import com.bitwarden.ui.platform.components.card.BitwardenActionCard
 import com.bitwarden.ui.platform.components.content.BitwardenErrorContent
 import com.bitwarden.ui.platform.components.content.BitwardenLoadingContent
 import com.bitwarden.ui.platform.components.dialog.BitwardenBasicDialog
@@ -39,6 +41,7 @@ import com.bitwarden.ui.platform.composition.LocalIntentManager
 import com.bitwarden.ui.platform.manager.IntentManager
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
 import com.bitwarden.ui.platform.resource.BitwardenString
+import com.bitwarden.ui.platform.theme.BitwardenTheme
 import com.bitwarden.ui.util.asText
 import com.x8bit.bitwarden.data.platform.manager.model.AppResumeScreenData
 import com.x8bit.bitwarden.data.platform.manager.util.AppResumeStateManager
@@ -199,6 +202,13 @@ fun SendScreen(
             SendState.ViewState.Empty -> SendEmpty(
                 policyDisablesSend = state.policyDisablesSend,
                 onAddItemClick = { viewModel.trySendAction(SendAction.AddSendClick) },
+                isUpgradedToPremiumCardEligible = state.isUpgradedToPremiumCardEligible,
+                onUpgradedToPremiumCardClick = {
+                    viewModel.trySendAction(SendAction.UpgradedToPremiumCardClick)
+                },
+                onUpgradedToPremiumCardDismiss = {
+                    viewModel.trySendAction(SendAction.UpgradedToPremiumCardDismiss)
+                },
                 modifier = contentModifier,
             )
 
@@ -250,4 +260,33 @@ private fun SendDialogs(
 
         null -> Unit
     }
+}
+
+/**
+ * Action card rendered at the top of the Send list when the user has just upgraded to premium.
+ * Owned by the screen so it can be hosted inside each view state's scrollable container.
+ */
+@Composable
+internal fun UpgradedToPremiumActionCard(
+    onActionClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BitwardenActionCard(
+        cardTitle = stringResource(id = BitwardenString.upgraded_to_premium),
+        cardSubtitle = stringResource(
+            id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
+        ),
+        actionText = stringResource(id = BitwardenString.learn_more),
+        leadingContent = {
+            Icon(
+                painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),
+                contentDescription = null,
+                tint = BitwardenTheme.colorScheme.icon.secondary,
+            )
+        },
+        onActionClick = onActionClick,
+        onDismissClick = onDismissClick,
+        modifier = modifier,
+    )
 }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -52,6 +52,7 @@ import com.x8bit.bitwarden.ui.tools.feature.send.addedit.AddEditSendRoute
 import com.x8bit.bitwarden.ui.tools.feature.send.addedit.ModeType
 import com.x8bit.bitwarden.ui.tools.feature.send.handlers.SendHandlers
 import com.x8bit.bitwarden.ui.tools.feature.send.model.SendItemType
+import com.x8bit.bitwarden.ui.tools.feature.send.model.UpgradedToPremiumCardData
 import com.x8bit.bitwarden.ui.tools.feature.send.util.selectionText
 import com.x8bit.bitwarden.ui.tools.feature.send.viewsend.ViewSendRoute
 import kotlinx.collections.immutable.persistentListOf
@@ -184,31 +185,27 @@ fun SendScreen(
         snackbarHost = { BitwardenSnackbarHost(bitwardenHostState = snackbarHostState) },
     ) {
         val contentModifier = Modifier.fillMaxSize()
+        val upgradedToPremiumCardData = UpgradedToPremiumCardData(
+            onCardClick = {
+                viewModel.trySendAction(SendAction.UpgradedToPremiumCardClick)
+            },
+            onCardDismiss = {
+                viewModel.trySendAction(SendAction.UpgradedToPremiumCardDismiss)
+            },
+        ).takeIf { state.isUpgradedToPremiumCardEligible }
         when (val viewState = state.viewState) {
             is SendState.ViewState.Content -> SendContent(
                 policyDisablesSend = state.policyDisablesSend,
                 state = viewState,
-                isUpgradedToPremiumCardEligible = state.isUpgradedToPremiumCardEligible,
+                upgradedToPremiumCardData = upgradedToPremiumCardData,
                 sendHandlers = sendHandlers,
-                onUpgradedToPremiumCardClick = {
-                    viewModel.trySendAction(SendAction.UpgradedToPremiumCardClick)
-                },
-                onUpgradedToPremiumCardDismiss = {
-                    viewModel.trySendAction(SendAction.UpgradedToPremiumCardDismiss)
-                },
                 modifier = contentModifier,
             )
 
             SendState.ViewState.Empty -> SendEmpty(
                 policyDisablesSend = state.policyDisablesSend,
                 onAddItemClick = { viewModel.trySendAction(SendAction.AddSendClick) },
-                isUpgradedToPremiumCardEligible = state.isUpgradedToPremiumCardEligible,
-                onUpgradedToPremiumCardClick = {
-                    viewModel.trySendAction(SendAction.UpgradedToPremiumCardClick)
-                },
-                onUpgradedToPremiumCardDismiss = {
-                    viewModel.trySendAction(SendAction.UpgradedToPremiumCardDismiss)
-                },
+                upgradedToPremiumCardData = upgradedToPremiumCardData,
                 modifier = contentModifier,
             )
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreen.kt
@@ -285,6 +285,7 @@ internal fun UpgradedToPremiumActionCard(
                 tint = BitwardenTheme.colorScheme.icon.secondary,
             )
         },
+        isExternalLink = true,
         onActionClick = onActionClick,
         onDismissClick = onDismissClick,
         modifier = modifier,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/model/UpgradedToPremiumCardData.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/model/UpgradedToPremiumCardData.kt
@@ -1,0 +1,11 @@
+package com.x8bit.bitwarden.ui.tools.feature.send.model
+
+/**
+ * Handlers for the "Upgraded to Premium" action card shown on Send surfaces.
+ *
+ * Pass `null` to indicate the card should not be displayed.
+ */
+data class UpgradedToPremiumCardData(
+    val onCardClick: () -> Unit,
+    val onCardDismiss: () -> Unit,
+)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
@@ -1000,6 +1000,51 @@ class SendScreenTest : BitwardenComposeTest() {
             viewModel.trySendAction(SendAction.UpgradedToPremiumCardDismiss)
         }
     }
+
+    @Test
+    fun `UpgradedToPremium action card should display in Empty viewState when eligible`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = SendState.ViewState.Empty,
+                isUpgradedToPremiumCardEligible = true,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Upgraded to Premium")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(text = "Learn more")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `UpgradedToPremium action card should not display in Loading viewState`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = SendState.ViewState.Loading,
+                isUpgradedToPremiumCardEligible = true,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Upgraded to Premium")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `UpgradedToPremium action card should not display in Error viewState`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = SendState.ViewState.Error("Fail".asText()),
+                isUpgradedToPremiumCardEligible = true,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Upgraded to Premium")
+            .assertDoesNotExist()
+    }
 }
 
 private val DEFAULT_STATE: SendState = SendState(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37284](https://bitwarden.atlassian.net/browse/PM-37284)

## 📔 Objective

The Send tab's "Upgraded to Premium" celebration card was rendered as the first item of the `Content` branch's `LazyColumn`, so users whose Send tab was in `Empty`, `Loading`, or `Error` view state never saw the card even when they were eligible. Eligibility was the intended gate; viewState was incidentally gating it.

Move card rendering into each scrollable container — first `LazyColumn` item in `SendContent` and first child of `SendEmpty`'s `verticalScroll` Column — so the card surfaces in both states that have a scrollable surface and flows with the rest of the view (a scaffold-body hoist pinned the card above `SendEmpty`'s centered illustration and broke the intended visual continuity). `Loading` and `Error` remain full-screen non-scrolling placeholders and do not host the card. Extract the inline `BitwardenActionCard` block into a private `UpgradedToPremiumActionCard` composable to match the screen-owned action-card convention used in `VaultContent.kt`.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/fdca4a8a-4e19-449c-a335-29f02a877eab" /> | <img width="365" src="https://github.com/user-attachments/assets/f5b51a49-ed1a-4282-b34d-9fb320c7cacc" /> |

[PM-37284]: https://bitwarden.atlassian.net/browse/PM-37284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ