### PR TITLE
[PM-37286] fix: Route Restart Premium CTA through in-app plan modal

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModel.kt
@@ -18,7 +18,6 @@ import com.bitwarden.core.data.repository.util.map
 import com.bitwarden.core.util.persistentListOfNotNull
 import com.bitwarden.data.repository.util.baseIconUrl
 import com.bitwarden.data.repository.util.baseWebSendUrl
-import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
 import com.bitwarden.network.model.PolicyTypeJson
 import com.bitwarden.send.SendType
 import com.bitwarden.ui.platform.base.BackgroundEvent
@@ -667,16 +666,7 @@ class VaultItemListingViewModel @Inject constructor(
 
     private fun handleUpgradeToPremiumClick() {
         clearDialogState()
-        if (premiumStateManager.isInAppUpgradeAvailable()) {
-            sendEvent(VaultItemListingEvent.NavigateToPlanModal)
-        } else {
-            val baseUrl = environmentRepository
-                .environment
-                .environmentUrlData
-                .baseWebVaultUrlOrDefault
-            val url = "$baseUrl/#/settings/subscription/premium?callToAction=upgradeToPremium"
-            sendEvent(VaultItemListingEvent.NavigateToUrl(url = url))
-        }
+        sendEvent(VaultItemListingEvent.NavigateToPlanModal)
     }
 
     private fun handleRemoveSendPasswordClick(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/itemlisting/VaultItemListingViewModelTest.kt
@@ -302,9 +302,7 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
         every { parse(any<GetPublicKeyCredentialOption>()) } returns DEFAULT_RELYING_PARTY_ID
         every { parse(any<CreatePublicKeyCredentialRequest>()) } returns DEFAULT_RELYING_PARTY_ID
     }
-    private val premiumStateManager: PremiumStateManager = mockk {
-        every { isInAppUpgradeAvailable() } returns false
-    }
+    private val premiumStateManager: PremiumStateManager = mockk()
     private val mutableNewItemTypesFlow = MutableStateFlow(false)
     private val featureFlagManager: FeatureFlagManager = mockk {
         every { getFeatureFlag(FlagKey.NewItemTypes) } answers { mutableNewItemTypesFlow.value }
@@ -1063,35 +1061,16 @@ class VaultItemListingViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `UpgradeToPremiumClick should emit NavigateToUrl when in-app upgrade not available`() =
-        runTest {
-            val viewModel = createVaultItemListingViewModel()
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
-                assertEquals(
-                    VaultItemListingEvent.NavigateToUrl(
-                        url = "https://vault.bitwarden.com/#/" +
-                            "settings/subscription/premium" +
-                            "?callToAction=upgradeToPremium",
-                    ),
-                    awaitItem(),
-                )
-            }
+    fun `UpgradeToPremiumClick should emit NavigateToPlanModal`() = runTest {
+        val viewModel = createVaultItemListingViewModel()
+        viewModel.eventFlow.test {
+            viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
+            assertEquals(
+                VaultItemListingEvent.NavigateToPlanModal,
+                awaitItem(),
+            )
         }
-
-    @Test
-    fun `UpgradeToPremiumClick should emit NavigateToPlanModal when in-app upgrade available`() =
-        runTest {
-            every { premiumStateManager.isInAppUpgradeAvailable() } returns true
-            val viewModel = createVaultItemListingViewModel()
-            viewModel.eventFlow.test {
-                viewModel.trySendAction(VaultItemListingsAction.UpgradeToPremiumClick)
-                assertEquals(
-                    VaultItemListingEvent.NavigateToPlanModal,
-                    awaitItem(),
-                )
-            }
-        }
+    }
 
     @Test
     fun `ArchiveClick without Premium should show ArchiveRequiresPremium dialog`() = runTest {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37286](https://bitwarden.atlassian.net/browse/PM-37286)

## 📔 Objective

Archived and canceled-premium users invoking "Restart Premium" from the Archive screen reached `handleUpgradeToPremiumClick`, which fell back to the legacy web vault URL whenever `PremiumStateManager.isInAppUpgradeAvailable()` returned `false`. On builds where in-app upgrade is gated off, that fallback stranded the user on a Stripe checkout page they could not return from cleanly — defeating the whole point of "Restart Premium."

The PM-33519 rewire established the plan modal as the single upgrade destination for every in-product entry point. Aligning `VaultItemListingViewModel.handleUpgradeToPremiumClick` with that rewire — emitting `NavigateToPlanModal` unconditionally — closes the only remaining branch that still pointed at the legacy URL and matches the routing shape used by `VaultItemViewModel`, `AttachmentsViewModel` (PM-37335), and the rest of the upgrade surface.

[PM-37286]: https://bitwarden.atlassian.net/browse/PM-37286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ