### PR TITLE
[PM-37294] fix: Announce external-link affordance on premium upgrade CTAs

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreen.kt
@@ -397,6 +397,7 @@ private fun PremiumContent(
             label = stringResource(id = BitwardenString.manage_plan),
             onClick = handlers.onManagePlanClick,
             icon = rememberVectorPainter(id = BitwardenDrawable.ic_external_link),
+            isExternalLink = true,
             modifier = Modifier
                 .standardHorizontalMargin()
                 .fillMaxWidth()
@@ -409,6 +410,7 @@ private fun PremiumContent(
                 label = stringResource(id = BitwardenString.cancel_premium),
                 onClick = handlers.onCancelPremiumClick,
                 icon = rememberVectorPainter(id = BitwardenDrawable.ic_external_link),
+                isExternalLink = true,
                 modifier = Modifier
                     .standardHorizontalMargin()
                     .fillMaxWidth()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreen.kt
@@ -108,6 +108,7 @@ fun SettingsScreen(
                         id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
                     ),
                     actionText = stringResource(id = BitwardenString.learn_more),
+                    isExternalLink = true,
                     leadingContent = {
                         Icon(
                             painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreen.kt
@@ -398,6 +398,7 @@ private fun CoachMarkScope<ExploreGeneratorCoachMark>.ScrollContent(
                         id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
                     ),
                     actionText = stringResource(id = BitwardenString.learn_more),
+                    isExternalLink = true,
                     leadingContent = {
                         Icon(
                             painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendContent.kt
@@ -55,6 +55,7 @@ fun SendContent(
                         id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
                     ),
                     actionText = stringResource(id = BitwardenString.learn_more),
+                    isExternalLink = true,
                     leadingContent = {
                         Icon(
                             painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultContent.kt
@@ -556,6 +556,7 @@ private fun ActionCard(
                     id = BitwardenString.you_now_have_access_to_all_advanced_security_features,
                 ),
                 actionText = stringResource(id = BitwardenString.learn_more),
+                isExternalLink = true,
                 leadingContent = {
                     Icon(
                         painter = rememberVectorPainter(id = BitwardenDrawable.ic_star),

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanScreenTest.kt
@@ -648,6 +648,15 @@ class PlanScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `manage plan button should announce external-link affordance`() {
+        mutableStateFlow.update { it.copy(viewState = DEFAULT_PREMIUM_VIEW_STATE) }
+        composeTestRule
+            .onNodeWithContentDescription(label = "Manage plan, External link")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun `cancel premium button should render when showCancelButton is true`() {
         mutableStateFlow.update {
             it.copy(
@@ -657,6 +666,19 @@ class PlanScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithTag("CancelPremiumButton")
             .assertExists()
+    }
+
+    @Test
+    fun `cancel premium button should announce external-link affordance`() {
+        mutableStateFlow.update {
+            it.copy(
+                viewState = DEFAULT_PREMIUM_VIEW_STATE.copy(showCancelButton = true),
+            )
+        }
+        composeTestRule
+            .onNodeWithContentDescription(label = "Cancel Premium, External link")
+            .performScrollTo()
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsScreenTest.kt
@@ -254,6 +254,9 @@ class SettingsScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = "Learn more")
             .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription(label = "Learn more, External link")
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -153,26 +153,6 @@ class GeneratorScreenTest : BitwardenComposeTest() {
     }
 
     @Test
-    fun `UpgradedToPremium action card should display when eligible in Default mode`() {
-        updateState(
-            DEFAULT_STATE.copy(
-                generatorMode = GeneratorMode.Default,
-                isUpgradedToPremiumCardEligible = true,
-            ),
-        )
-
-        composeTestRule
-            .onNodeWithText(text = "Upgraded to Premium")
-            .assertIsDisplayed()
-        composeTestRule
-            .onNodeWithText(text = "Learn more")
-            .assertIsDisplayed()
-        composeTestRule
-            .onNodeWithContentDescription(label = "Learn more, External link")
-            .assertIsDisplayed()
-    }
-
-    @Test
     fun `MainTypeOption select control should be hidden for password mode`() {
         updateState(DEFAULT_STATE.copy(generatorMode = GeneratorMode.Modal.Password))
 
@@ -1867,6 +1847,9 @@ class GeneratorScreenTest : BitwardenComposeTest() {
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithText(text = "Learn more")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription(label = "Learn more, External link")
             .assertIsDisplayed()
     }
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/generator/GeneratorScreenTest.kt
@@ -153,6 +153,26 @@ class GeneratorScreenTest : BitwardenComposeTest() {
     }
 
     @Test
+    fun `UpgradedToPremium action card should display when eligible in Default mode`() {
+        updateState(
+            DEFAULT_STATE.copy(
+                generatorMode = GeneratorMode.Default,
+                isUpgradedToPremiumCardEligible = true,
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithText(text = "Upgraded to Premium")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(text = "Learn more")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription(label = "Learn more, External link")
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun `MainTypeOption select control should be hidden for password mode`() {
         updateState(DEFAULT_STATE.copy(generatorMode = GeneratorMode.Modal.Password))
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/tools/feature/send/SendScreenTest.kt
@@ -960,6 +960,9 @@ class SendScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = "Learn more")
             .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription(label = "Learn more, External link")
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/vault/feature/vault/VaultScreenTest.kt
@@ -1704,6 +1704,9 @@ class VaultScreenTest : BitwardenComposeTest() {
         composeTestRule
             .onNodeWithText(text = "Learn more")
             .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription(label = "Learn more, External link")
+            .assertIsDisplayed()
     }
 
     @Test

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCard.kt
@@ -50,6 +50,8 @@ import com.bitwarden.ui.util.asText
  * @param cardSubtitle The subtitle of the card.
  * @param secondaryButton The optional data for a secondary button.
  * @param leadingContent Optional content to display on the leading side of the [cardTitle] [Text].
+ * @param isExternalLink Whether the CTA launches an external link, which announces the
+ * external-link affordance to screen readers via the shared `external_link_format` string.
  */
 @Suppress("LongMethod")
 @Composable
@@ -62,6 +64,7 @@ fun BitwardenActionCard(
     cardSubtitle: String? = null,
     secondaryButton: BitwardenButtonData? = null,
     leadingContent: @Composable (() -> Unit)? = null,
+    isExternalLink: Boolean = false,
 ) {
     Card(
         modifier = modifier,
@@ -133,6 +136,7 @@ fun BitwardenActionCard(
         BitwardenFilledButton(
             label = actionText,
             onClick = onActionClick,
+            isExternalLink = isExternalLink,
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth(),

--- a/ui/src/test/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCardTest.kt
+++ b/ui/src/test/kotlin/com/bitwarden/ui/platform/components/card/BitwardenActionCardTest.kt
@@ -1,0 +1,47 @@
+package com.bitwarden.ui.platform.components.card
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import com.bitwarden.ui.platform.base.BaseComposeTest
+import com.bitwarden.ui.platform.theme.BitwardenTheme
+import org.junit.Test
+
+class BitwardenActionCardTest : BaseComposeTest() {
+
+    @Test
+    fun `action button content description defaults to actionText`() {
+        setTestContent {
+            BitwardenTheme {
+                BitwardenActionCard(
+                    cardTitle = "Title",
+                    actionText = "Learn more",
+                    onActionClick = {},
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithContentDescription(label = "Learn more")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `action button announces external-link affordance when isExternalLink is true`() {
+        setTestContent {
+            BitwardenTheme {
+                BitwardenActionCard(
+                    cardTitle = "Title",
+                    actionText = "Learn more",
+                    isExternalLink = true,
+                    onActionClick = {},
+                )
+            }
+        }
+        composeTestRule
+            .onNodeWithContentDescription(label = "Learn more, External link")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(text = "Learn more")
+            .assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-37294
- https://bitwarden.atlassian.net/browse/PM-37717
- https://bitwarden.atlassian.net/browse/PM-37718

## 📔 Objective

Screen readers announced only the visible label on the premium upgrade CTAs that leave the app for a web destination, so users hit a surprise context switch. Mark each as an external link so the affordance is appended to the announced label:

- **PM-37294** — "Learn more" on the Upgraded-to-Premium action card (Vault, Send, Settings, Generator)
- **PM-37717** — Manage plan on the Premium plan screen
- **PM-37718** — Cancel Premium on the Premium plan screen