### PR TITLE
[PM-37814] feat: Add debug flag to disable self-host premium check

### DIFF
--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/di/BillingModule.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/di/BillingModule.kt
@@ -13,6 +13,7 @@ import com.x8bit.bitwarden.data.billing.repository.BillingRepositoryImpl
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import dagger.Module
 import dagger.Provides
@@ -57,6 +58,7 @@ object BillingModule {
         settingsDiskSource: SettingsDiskSource,
         vaultRepository: VaultRepository,
         featureFlagManager: FeatureFlagManager,
+        environmentRepository: EnvironmentRepository,
         pushManager: PushManager,
         clock: Clock,
         dispatcherManager: DispatcherManager,
@@ -66,6 +68,7 @@ object BillingModule {
         settingsDiskSource = settingsDiskSource,
         vaultRepository = vaultRepository,
         featureFlagManager = featureFlagManager,
+        environmentRepository = environmentRepository,
         pushManager = pushManager,
         clock = clock,
         dispatcherManager = dispatcherManager,

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -39,10 +39,8 @@ interface PremiumStateManager {
     val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState>
 
     /**
-     * Emits the latest "is the environment effectively self-hosted for premium upgrade gating"
-     * value. Mirrors [isSelfHosted] but reacts to both environment changes and toggles of the
-     * [com.bitwarden.core.data.manager.model.FlagKey.DebugDisableSelfHostPremiumCheck] debug
-     * flag, so consumers stay in sync when QA flips the override at runtime.
+     * Emits whether the current state should be treated as self-hosted for premium upgrade
+     * gating. Reactive equivalent of [isSelfHosted].
      */
     val isSelfHostedFlow: StateFlow<Boolean>
 
@@ -52,10 +50,8 @@ interface PremiumStateManager {
     fun isInAppUpgradeAvailable(): Boolean
 
     /**
-     * Returns `true` when the current environment is effectively self-hosted for
-     * premium upgrade gating. Returns `false` for cloud environments and for
-     * self-hosted environments when [com.bitwarden.core.data.manager.model.FlagKey.DebugDisableSelfHostPremiumCheck]
-     * is enabled (QA bypass for testing premium flows on internal self-hosted envs).
+     * Returns `true` when the current state should be treated as self-hosted for premium
+     * upgrade gating, or `false` otherwise.
      */
     fun isSelfHosted(): Boolean
 

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -45,15 +45,15 @@ interface PremiumStateManager {
     val isSelfHostedFlow: StateFlow<Boolean>
 
     /**
+     * `true` when the current state should be treated as self-hosted for premium upgrade
+     * gating, or `false` otherwise.
+     */
+    val isSelfHosted: Boolean
+
+    /**
      * Returns `true` when the in-app upgrade flow is available, or `false` otherwise.
      */
     fun isInAppUpgradeAvailable(): Boolean
-
-    /**
-     * Returns `true` when the current state should be treated as self-hosted for premium
-     * upgrade gating, or `false` otherwise.
-     */
-    fun isSelfHosted(): Boolean
 
     /**
      * Marks the Premium upgrade banner as dismissed for the current user.

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -39,6 +39,14 @@ interface PremiumStateManager {
     val subscriptionStatusStateFlow: StateFlow<SubscriptionStatusState>
 
     /**
+     * Emits the latest "is the environment effectively self-hosted for premium upgrade gating"
+     * value. Mirrors [isSelfHosted] but reacts to both environment changes and toggles of the
+     * [com.bitwarden.core.data.manager.model.FlagKey.DebugDisableSelfHostPremiumCheck] debug
+     * flag, so consumers stay in sync when QA flips the override at runtime.
+     */
+    val isSelfHostedFlow: StateFlow<Boolean>
+
+    /**
      * Returns `true` when the in-app upgrade flow is available, or `false` otherwise.
      */
     fun isInAppUpgradeAvailable(): Boolean

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManager.kt
@@ -44,6 +44,14 @@ interface PremiumStateManager {
     fun isInAppUpgradeAvailable(): Boolean
 
     /**
+     * Returns `true` when the current environment is effectively self-hosted for
+     * premium upgrade gating. Returns `false` for cloud environments and for
+     * self-hosted environments when [com.bitwarden.core.data.manager.model.FlagKey.DebugDisableSelfHostPremiumCheck]
+     * is enabled (QA bypass for testing premium flows on internal self-hosted envs).
+     */
+    fun isSelfHosted(): Boolean
+
+    /**
      * Marks the Premium upgrade banner as dismissed for the current user.
      */
     fun dismissPremiumUpgradeBanner()

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -259,11 +259,11 @@ class PremiumStateManagerImpl(
             .launchIn(unconfinedScope)
     }
 
+    override val isSelfHosted: Boolean get() = isSelfHostedFlow.value
+
     override fun isInAppUpgradeAvailable(): Boolean =
         billingRepository.isInAppBillingSupportedFlow.value &&
             featureFlagManager.getFeatureFlag(FlagKey.MobilePremiumUpgrade)
-
-    override fun isSelfHosted(): Boolean = isSelfHostedFlow.value
 
     override fun dismissPremiumUpgradeBanner() {
         val activeUserId = authDiskSource.userState?.activeUserId ?: return

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -263,10 +263,7 @@ class PremiumStateManagerImpl(
         billingRepository.isInAppBillingSupportedFlow.value &&
             featureFlagManager.getFeatureFlag(FlagKey.MobilePremiumUpgrade)
 
-    override fun isSelfHosted(): Boolean {
-        if (environmentRepository.environment !is Environment.SelfHosted) return false
-        return !featureFlagManager.getFeatureFlag(FlagKey.DebugDisableSelfHostPremiumCheck)
-    }
+    override fun isSelfHosted(): Boolean = isSelfHostedFlow.value
 
     override fun dismissPremiumUpgradeBanner() {
         val activeUserId = authDiskSource.userState?.activeUserId ?: return

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -143,6 +143,20 @@ class PremiumStateManagerImpl(
                 initialValue = false,
             )
 
+    override val isSelfHostedFlow: StateFlow<Boolean> =
+        combine(
+            environmentRepository.environmentStateFlow,
+            featureFlagManager.getFeatureFlagFlow(FlagKey.DebugDisableSelfHostPremiumCheck),
+        ) { environment, isDebugBypassEnabled ->
+            environment is Environment.SelfHosted && !isDebugBypassEnabled
+        }
+            .stateIn(
+                scope = unconfinedScope,
+                started = SharingStarted.Eagerly,
+                initialValue = environmentRepository.environment is Environment.SelfHosted &&
+                    !featureFlagManager.getFeatureFlag(FlagKey.DebugDisableSelfHostPremiumCheck),
+            )
+
     /**
      * Eligibility is keyed on the user holding personal Premium (or being eligible to purchase
      * it). Organization-granted Premium does not surface the Plan row, since the user has no

--- a/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerImpl.kt
@@ -3,6 +3,7 @@ package com.x8bit.bitwarden.data.billing.manager
 import com.bitwarden.core.data.manager.dispatcher.DispatcherManager
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
+import com.bitwarden.data.repository.model.Environment
 import com.x8bit.bitwarden.data.auth.datasource.disk.AuthDiskSource
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
 import com.x8bit.bitwarden.data.auth.repository.util.activeUserIdChangesFlow
@@ -13,6 +14,7 @@ import com.x8bit.bitwarden.data.billing.repository.model.SubscriptionStatusState
 import com.x8bit.bitwarden.data.platform.datasource.disk.SettingsDiskSource
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
+import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import com.x8bit.bitwarden.data.platform.util.isActive
 import com.x8bit.bitwarden.data.platform.util.scanPairs
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
@@ -47,6 +49,7 @@ class PremiumStateManagerImpl(
     private val settingsDiskSource: SettingsDiskSource,
     vaultRepository: VaultRepository,
     private val featureFlagManager: FeatureFlagManager,
+    private val environmentRepository: EnvironmentRepository,
     pushManager: PushManager,
     private val clock: Clock,
     dispatcherManager: DispatcherManager,
@@ -245,6 +248,11 @@ class PremiumStateManagerImpl(
     override fun isInAppUpgradeAvailable(): Boolean =
         billingRepository.isInAppBillingSupportedFlow.value &&
             featureFlagManager.getFeatureFlag(FlagKey.MobilePremiumUpgrade)
+
+    override fun isSelfHosted(): Boolean {
+        if (environmentRepository.environment !is Environment.SelfHosted) return false
+        return !featureFlagManager.getFeatureFlag(FlagKey.DebugDisableSelfHostPremiumCheck)
+    }
 
     override fun dismissPremiumUpgradeBanner() {
         val activeUserId = authDiskSource.userState?.activeUserId ?: return

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -6,7 +6,6 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bitwarden.core.data.util.toFormattedDateStyle
-import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.data.repository.util.baseWebVaultUrlOrDefault
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.manager.intent.model.AuthTabData
@@ -82,7 +81,7 @@ class PlanViewModel @Inject constructor(
             ?.isPremium == true
         val showsPremiumView = isPremium ||
             premiumStateManager.subscriptionStatusStateFlow.value.isPremiumViewEligible()
-        val isSelfHosted = environmentRepository.environment is Environment.SelfHosted
+        val isSelfHosted = premiumStateManager.isSelfHosted()
         PlanState(
             planMode = planMode,
             viewState = when {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModel.kt
@@ -81,7 +81,7 @@ class PlanViewModel @Inject constructor(
             ?.isPremium == true
         val showsPremiumView = isPremium ||
             premiumStateManager.subscriptionStatusStateFlow.value.isPremiumViewEligible()
-        val isSelfHosted = premiumStateManager.isSelfHosted()
+        val isSelfHosted = premiumStateManager.isSelfHosted
         PlanState(
             planMode = planMode,
             viewState = when {

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
@@ -15,7 +15,6 @@ import com.x8bit.bitwarden.data.billing.manager.UPGRADED_TO_PREMIUM_LEARN_MORE_U
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -33,7 +32,6 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     specialCircumstanceManager: SpecialCircumstanceManager,
     firstTimeActionManager: FirstTimeActionManager,
-    environmentRepository: EnvironmentRepository,
     private val premiumStateManager: PremiumStateManager,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<SettingsState, SettingsEvent, SettingsAction>(
@@ -43,7 +41,7 @@ class SettingsViewModel @Inject constructor(
         autoFillCount = firstTimeActionManager.allAutofillSettingsBadgeCountFlow.value,
         vaultCount = firstTimeActionManager.allVaultSettingsBadgeCountFlow.value,
         isPlanRowEligible = premiumStateManager.isPlanRowEligibleFlow.value,
-        isSelfHosted = premiumStateManager.isSelfHosted(),
+        isSelfHosted = premiumStateManager.isSelfHostedFlow.value,
         isUpgradedToPremiumCardEligible = premiumStateManager
             .isUpgradedToPremiumCardEligibleFlow
             .value,
@@ -79,13 +77,9 @@ class SettingsViewModel @Inject constructor(
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
-        environmentRepository
-            .environmentStateFlow
-            .map {
-                SettingsAction.Internal.EnvironmentReceive(
-                    isSelfHosted = premiumStateManager.isSelfHosted(),
-                )
-            }
+        premiumStateManager
+            .isSelfHostedFlow
+            .map { SettingsAction.Internal.SelfHostedStatusReceive(isSelfHosted = it) }
             .onEach(::sendAction)
             .launchIn(viewModelScope)
 
@@ -116,13 +110,13 @@ class SettingsViewModel @Inject constructor(
             handleUpgradedToPremiumCardEligibilityReceive(action)
         }
 
-        is SettingsAction.Internal.EnvironmentReceive -> {
-            handleEnvironmentReceive(action)
+        is SettingsAction.Internal.SelfHostedStatusReceive -> {
+            handleSelfHostedStatusReceive(action)
         }
     }
 
-    private fun handleEnvironmentReceive(
-        action: SettingsAction.Internal.EnvironmentReceive,
+    private fun handleSelfHostedStatusReceive(
+        action: SettingsAction.Internal.SelfHostedStatusReceive,
     ) {
         mutableStateFlow.update {
             it.copy(isSelfHosted = action.isSelfHosted)
@@ -363,9 +357,10 @@ sealed class SettingsAction {
         ) : Internal()
 
         /**
-         * Indicates that the environment has been updated.
+         * Indicates that the effective self-hosted status for premium gating has been updated —
+         * driven by environment changes or by the debug-only self-host-bypass flag.
          */
-        data class EnvironmentReceive(
+        data class SelfHostedStatusReceive(
             val isSelfHosted: Boolean,
         ) : Internal()
     }

--- a/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DrawableRes
 import androidx.compose.material3.Text
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModel
 import com.bitwarden.ui.platform.base.DeferredBackgroundEvent
 import com.bitwarden.ui.platform.resource.BitwardenDrawable
@@ -44,7 +43,7 @@ class SettingsViewModel @Inject constructor(
         autoFillCount = firstTimeActionManager.allAutofillSettingsBadgeCountFlow.value,
         vaultCount = firstTimeActionManager.allVaultSettingsBadgeCountFlow.value,
         isPlanRowEligible = premiumStateManager.isPlanRowEligibleFlow.value,
-        isSelfHosted = environmentRepository.environment is Environment.SelfHosted,
+        isSelfHosted = premiumStateManager.isSelfHosted(),
         isUpgradedToPremiumCardEligible = premiumStateManager
             .isUpgradedToPremiumCardEligibleFlow
             .value,
@@ -84,7 +83,7 @@ class SettingsViewModel @Inject constructor(
             .environmentStateFlow
             .map {
                 SettingsAction.Internal.EnvironmentReceive(
-                    isSelfHosted = it is Environment.SelfHosted,
+                    isSelfHosted = premiumStateManager.isSelfHosted(),
                 )
             }
             .onEach(::sendAction)

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -5,6 +5,7 @@ import com.bitwarden.core.data.manager.dispatcher.FakeDispatcherManager
 import com.bitwarden.core.data.manager.model.FlagKey
 import com.bitwarden.core.data.repository.model.DataState
 import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
+import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.vault.DecryptCipherListResult
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.AccountJson
 import com.x8bit.bitwarden.data.auth.datasource.disk.model.UserStateJson
@@ -19,6 +20,7 @@ import com.x8bit.bitwarden.data.platform.datasource.disk.util.FakeSettingsDiskSo
 import com.x8bit.bitwarden.data.platform.manager.FeatureFlagManager
 import com.x8bit.bitwarden.data.platform.manager.PushManager
 import com.x8bit.bitwarden.data.platform.manager.model.PremiumStatusChangedData
+import com.x8bit.bitwarden.data.platform.repository.util.FakeEnvironmentRepository
 import com.x8bit.bitwarden.data.vault.datasource.sdk.model.createMockCipherListView
 import com.x8bit.bitwarden.data.vault.repository.VaultRepository
 import com.x8bit.bitwarden.data.vault.repository.model.VaultData
@@ -66,6 +68,7 @@ class PremiumStateManagerTest {
     }
 
     private val mutableMobilePremiumUpgradeFlagFlow = MutableStateFlow(true)
+    private val mutableDebugDisableSelfHostPremiumCheckFlagFlow = MutableStateFlow(false)
     private val featureFlagManager: FeatureFlagManager = mockk {
         every {
             getFeatureFlagFlow(FlagKey.MobilePremiumUpgrade)
@@ -73,7 +76,12 @@ class PremiumStateManagerTest {
         every {
             getFeatureFlag(FlagKey.MobilePremiumUpgrade)
         } answers { mutableMobilePremiumUpgradeFlagFlow.value }
+        every {
+            getFeatureFlag(FlagKey.DebugDisableSelfHostPremiumCheck)
+        } answers { mutableDebugDisableSelfHostPremiumCheckFlagFlow.value }
     }
+
+    private val fakeEnvironmentRepository = FakeEnvironmentRepository()
 
     private val dispatcherManager = FakeDispatcherManager()
 
@@ -89,6 +97,7 @@ class PremiumStateManagerTest {
         settingsDiskSource = fakeSettingsDiskSource,
         vaultRepository = vaultRepository,
         featureFlagManager = featureFlagManager,
+        environmentRepository = fakeEnvironmentRepository,
         pushManager = pushManager,
         clock = fixedClock,
         dispatcherManager = dispatcherManager,
@@ -363,6 +372,36 @@ class PremiumStateManagerTest {
         mutableMobilePremiumUpgradeFlagFlow.value = false
         val manager = createManager()
         assertFalse(manager.isInAppUpgradeAvailable())
+    }
+
+    @Test
+    fun `isSelfHosted should return false on cloud environment regardless of flag`() {
+        fakeEnvironmentRepository.environment = Environment.Us
+        val manager = createManager()
+        mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = false
+        assertFalse(manager.isSelfHosted())
+        mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = true
+        assertFalse(manager.isSelfHosted())
+    }
+
+    @Test
+    fun `isSelfHosted should return true on self-hosted environment when flag is disabled`() {
+        fakeEnvironmentRepository.environment = Environment.SelfHosted(
+            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+        )
+        mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = false
+        val manager = createManager()
+        assertTrue(manager.isSelfHosted())
+    }
+
+    @Test
+    fun `isSelfHosted should return false on self-hosted environment when flag is enabled`() {
+        fakeEnvironmentRepository.environment = Environment.SelfHosted(
+            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+        )
+        mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = true
+        val manager = createManager()
+        assertFalse(manager.isSelfHosted())
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -382,9 +382,9 @@ class PremiumStateManagerTest {
         fakeEnvironmentRepository.environment = Environment.Us
         val manager = createManager()
         mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = false
-        assertFalse(manager.isSelfHosted())
+        assertFalse(manager.isSelfHosted)
         mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = true
-        assertFalse(manager.isSelfHosted())
+        assertFalse(manager.isSelfHosted)
     }
 
     @Test
@@ -394,7 +394,7 @@ class PremiumStateManagerTest {
         )
         mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = false
         val manager = createManager()
-        assertTrue(manager.isSelfHosted())
+        assertTrue(manager.isSelfHosted)
     }
 
     @Test
@@ -404,7 +404,7 @@ class PremiumStateManagerTest {
         )
         mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = true
         val manager = createManager()
-        assertFalse(manager.isSelfHosted())
+        assertFalse(manager.isSelfHosted)
     }
 
     @Test

--- a/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/data/billing/manager/PremiumStateManagerTest.kt
@@ -79,6 +79,9 @@ class PremiumStateManagerTest {
         every {
             getFeatureFlag(FlagKey.DebugDisableSelfHostPremiumCheck)
         } answers { mutableDebugDisableSelfHostPremiumCheckFlagFlow.value }
+        every {
+            getFeatureFlagFlow(FlagKey.DebugDisableSelfHostPremiumCheck)
+        } returns mutableDebugDisableSelfHostPremiumCheckFlagFlow
     }
 
     private val fakeEnvironmentRepository = FakeEnvironmentRepository()
@@ -403,6 +406,45 @@ class PremiumStateManagerTest {
         val manager = createManager()
         assertFalse(manager.isSelfHosted())
     }
+
+    @Test
+    fun `isSelfHostedFlow should emit false on cloud environment regardless of flag`() = runTest {
+        fakeEnvironmentRepository.environment = Environment.Us
+        val manager = createManager()
+        manager.isSelfHostedFlow.test {
+            assertFalse(awaitItem())
+            mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = true
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `isSelfHostedFlow should emit true on self-hosted environment when flag is disabled`() =
+        runTest {
+            fakeEnvironmentRepository.environment = Environment.SelfHosted(
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+            )
+            val manager = createManager()
+            manager.isSelfHostedFlow.test {
+                assertTrue(awaitItem())
+            }
+        }
+
+    @Test
+    fun `isSelfHostedFlow should re-emit when debug-disable flag toggles on self-hosted env`() =
+        runTest {
+            fakeEnvironmentRepository.environment = Environment.SelfHosted(
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+            )
+            val manager = createManager()
+            manager.isSelfHostedFlow.test {
+                assertTrue(awaitItem())
+                mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = true
+                assertFalse(awaitItem())
+                mutableDebugDisableSelfHostPremiumCheckFlagFlow.value = false
+                assertTrue(awaitItem())
+            }
+        }
 
     @Test
     fun `dismissPremiumUpgradeBanner should store dismissed state for active user`() {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -70,7 +70,7 @@ class PlanViewModelTest : BaseViewModelTest() {
     private var mockIsSelfHosted = false
     private val mockPremiumStateManager: PremiumStateManager = mockk {
         every { subscriptionStatusStateFlow } returns mutableSubscriptionStatusStateFlow
-        every { isSelfHosted() } answers { mockIsSelfHosted }
+        every { isSelfHosted } answers { mockIsSelfHosted }
     }
     private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
     private val mockEnvironmentRepository: EnvironmentRepository = mockk {

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/premium/plan/PlanViewModelTest.kt
@@ -67,8 +67,10 @@ class PlanViewModelTest : BaseViewModelTest() {
     }
     private val mutableSubscriptionStatusStateFlow =
         MutableStateFlow<SubscriptionStatusState>(SubscriptionStatusState.NoSubscription)
+    private var mockIsSelfHosted = false
     private val mockPremiumStateManager: PremiumStateManager = mockk {
         every { subscriptionStatusStateFlow } returns mutableSubscriptionStatusStateFlow
+        every { isSelfHosted() } answers { mockIsSelfHosted }
     }
     private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
     private val mockEnvironmentRepository: EnvironmentRepository = mockk {
@@ -612,6 +614,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `initial state on self-hosted should be Free SelfHosted ViewState`() = runTest {
+        mockIsSelfHosted = true
         mutableEnvironmentFlow.value = Environment.SelfHosted(
             environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
         )
@@ -633,6 +636,7 @@ class PlanViewModelTest : BaseViewModelTest() {
 
     @Test
     fun `initial state on self-hosted should not fetch pricing`() = runTest {
+        mockIsSelfHosted = true
         mutableEnvironmentFlow.value = Environment.SelfHosted(
             environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
         )
@@ -642,6 +646,36 @@ class PlanViewModelTest : BaseViewModelTest() {
             mockBillingRepository.getPremiumPlanPricing()
         }
     }
+
+    @Test
+    fun `self-hosted with debug disable flag enabled should show Free Cloud and fetch pricing`() =
+        runTest {
+            // The PremiumStateManager helper reports false when the debug-disable flag is on,
+            // so the view model treats the self-hosted env as cloud for premium-upgrade purposes.
+            mockIsSelfHosted = false
+            mutableEnvironmentFlow.value = Environment.SelfHosted(
+                environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+            )
+            val viewModel = createViewModel()
+
+            viewModel.stateFlow.test {
+                assertEquals(
+                    PlanState(
+                        planMode = PlanMode.Modal,
+                        viewState = PlanState.ViewState.Free.Cloud(
+                            rate = "$1.67",
+                            checkoutUrl = null,
+                            isAwaitingPremiumStatus = false,
+                        ),
+                        dialogState = null,
+                    ),
+                    awaitItem(),
+                )
+            }
+            coVerify(exactly = 1) {
+                mockBillingRepository.getPremiumPlanPricing()
+            }
+        }
 
     // endregion Self-hosted path
 

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -44,11 +44,13 @@ class SettingsViewModelTest : BaseViewModelTest() {
 
     private val mutablePlanRowEligibleFlow = MutableStateFlow(false)
     private val mutableUpgradedToPremiumCardEligibleFlow = MutableStateFlow(false)
+    private var isSelfHosted = false
     private val premiumStateManager: PremiumStateManager = mockk(relaxed = true) {
         every { isPlanRowEligibleFlow } returns mutablePlanRowEligibleFlow
         every {
             isUpgradedToPremiumCardEligibleFlow
         } returns mutableUpgradedToPremiumCardEligibleFlow
+        every { isSelfHosted() } answers { isSelfHosted }
     }
     private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
     private val environmentRepository: EnvironmentRepository = mockk {
@@ -334,6 +336,7 @@ class SettingsViewModelTest : BaseViewModelTest() {
     @Test
     fun `Plan row should be hidden when environment is self-hosted`() {
         mutablePlanRowEligibleFlow.value = true
+        isSelfHosted = true
         mutableEnvironmentFlow.value = Environment.SelfHosted(
             environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
         )
@@ -353,6 +356,7 @@ class SettingsViewModelTest : BaseViewModelTest() {
                 .contains(Settings.PLAN),
         )
 
+        isSelfHosted = true
         mutableEnvironmentFlow.value = Environment.SelfHosted(
             environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
         )
@@ -361,6 +365,22 @@ class SettingsViewModelTest : BaseViewModelTest() {
                 awaitItem().settingRows.contains(Settings.PLAN),
             )
         }
+    }
+
+    @Test
+    fun `Plan row should be visible when self-hosted but debug disable flag is enabled`() {
+        // PremiumStateManager.isSelfHosted() returns false when the debug-disable flag is on,
+        // so the Plan row remains visible even with a self-hosted environment.
+        mutablePlanRowEligibleFlow.value = true
+        isSelfHosted = false
+        mutableEnvironmentFlow.value = Environment.SelfHosted(
+            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
+        )
+        val viewModel = createViewModel()
+        assertTrue(
+            viewModel.stateFlow.value.settingRows
+                .contains(Settings.PLAN),
+        )
     }
 
     private fun createViewModel(isPreAuth: Boolean = false) = SettingsViewModel(

--- a/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/x8bit/bitwarden/ui/platform/feature/settings/SettingsViewModelTest.kt
@@ -2,14 +2,11 @@ package com.x8bit.bitwarden.ui.platform.feature.settings
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import com.bitwarden.data.datasource.disk.model.EnvironmentUrlDataJson
-import com.bitwarden.data.repository.model.Environment
 import com.bitwarden.ui.platform.base.BaseViewModelTest
 import com.x8bit.bitwarden.data.billing.manager.PremiumStateManager
 import com.x8bit.bitwarden.data.platform.manager.FirstTimeActionManager
 import com.x8bit.bitwarden.data.platform.manager.SpecialCircumstanceManager
 import com.x8bit.bitwarden.data.platform.manager.model.SpecialCircumstance
-import com.x8bit.bitwarden.data.platform.repository.EnvironmentRepository
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -44,18 +41,13 @@ class SettingsViewModelTest : BaseViewModelTest() {
 
     private val mutablePlanRowEligibleFlow = MutableStateFlow(false)
     private val mutableUpgradedToPremiumCardEligibleFlow = MutableStateFlow(false)
-    private var isSelfHosted = false
+    private val mutableIsSelfHostedFlow = MutableStateFlow(false)
     private val premiumStateManager: PremiumStateManager = mockk(relaxed = true) {
         every { isPlanRowEligibleFlow } returns mutablePlanRowEligibleFlow
         every {
             isUpgradedToPremiumCardEligibleFlow
         } returns mutableUpgradedToPremiumCardEligibleFlow
-        every { isSelfHosted() } answers { isSelfHosted }
-    }
-    private val mutableEnvironmentFlow = MutableStateFlow<Environment>(Environment.Us)
-    private val environmentRepository: EnvironmentRepository = mockk {
-        every { environment } answers { mutableEnvironmentFlow.value }
-        every { environmentStateFlow } returns mutableEnvironmentFlow
+        every { isSelfHostedFlow } returns mutableIsSelfHostedFlow
     }
 
     @BeforeEach
@@ -334,12 +326,9 @@ class SettingsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `Plan row should be hidden when environment is self-hosted`() {
+    fun `Plan row should be hidden when self-hosted status flow emits true`() {
         mutablePlanRowEligibleFlow.value = true
-        isSelfHosted = true
-        mutableEnvironmentFlow.value = Environment.SelfHosted(
-            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
-        )
+        mutableIsSelfHostedFlow.value = true
         val viewModel = createViewModel()
         assertFalse(
             viewModel.stateFlow.value.settingRows
@@ -348,7 +337,7 @@ class SettingsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `Plan row should update when environment changes to self-hosted`() = runTest {
+    fun `Plan row should update when self-hosted status flow flips to true`() = runTest {
         mutablePlanRowEligibleFlow.value = true
         val viewModel = createViewModel()
         assertTrue(
@@ -356,10 +345,7 @@ class SettingsViewModelTest : BaseViewModelTest() {
                 .contains(Settings.PLAN),
         )
 
-        isSelfHosted = true
-        mutableEnvironmentFlow.value = Environment.SelfHosted(
-            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
-        )
+        mutableIsSelfHostedFlow.value = true
         viewModel.stateFlow.test {
             assertFalse(
                 awaitItem().settingRows.contains(Settings.PLAN),
@@ -368,25 +354,28 @@ class SettingsViewModelTest : BaseViewModelTest() {
     }
 
     @Test
-    fun `Plan row should be visible when self-hosted but debug disable flag is enabled`() {
-        // PremiumStateManager.isSelfHosted() returns false when the debug-disable flag is on,
-        // so the Plan row remains visible even with a self-hosted environment.
+    fun `Plan row should re-appear when self-hosted status flow flips back to false`() = runTest {
+        // Simulates the debug-disable flag being toggled on while self-hosted: the flow emits
+        // false even though the environment is still self-hosted.
         mutablePlanRowEligibleFlow.value = true
-        isSelfHosted = false
-        mutableEnvironmentFlow.value = Environment.SelfHosted(
-            environmentUrlData = EnvironmentUrlDataJson.DEFAULT_US,
-        )
+        mutableIsSelfHostedFlow.value = true
         val viewModel = createViewModel()
-        assertTrue(
+        assertFalse(
             viewModel.stateFlow.value.settingRows
                 .contains(Settings.PLAN),
         )
+
+        mutableIsSelfHostedFlow.value = false
+        viewModel.stateFlow.test {
+            assertTrue(
+                awaitItem().settingRows.contains(Settings.PLAN),
+            )
+        }
     }
 
     private fun createViewModel(isPreAuth: Boolean = false) = SettingsViewModel(
         firstTimeActionManager = firstTimeManager,
         specialCircumstanceManager = specialCircumstanceManager,
-        environmentRepository = environmentRepository,
         premiumStateManager = premiumStateManager,
         savedStateHandle = SavedStateHandle().apply {
             every { toSettingsArgs() } returns SettingsArgs(isPreAuth = isPreAuth)

--- a/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
+++ b/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt
@@ -45,6 +45,7 @@ sealed class FlagKey<out T : Any> {
                 V2EncryptionPassword,
                 V2EncryptionTde,
                 NewItemTypes,
+                DebugDisableSelfHostPremiumCheck,
             )
         }
     }
@@ -177,6 +178,16 @@ sealed class FlagKey<out T : Any> {
      */
     data object NewItemTypes : FlagKey<Boolean>() {
         override val keyName: String = "pm-32009-new-item-types"
+        override val defaultValue: Boolean = false
+    }
+
+    /**
+     * Debug-only flag that, when enabled, makes self-hosted environments behave as cloud
+     * environments for premium-upgrade gating. Used by QA to test the premium upgrade flow
+     * against internal self-hosted environments.
+     */
+    data object DebugDisableSelfHostPremiumCheck : FlagKey<Boolean>() {
+        override val keyName: String = "debug-disable-self-host-premium-check"
         override val defaultValue: Boolean = false
     }
 

--- a/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
+++ b/ui/src/main/kotlin/com/bitwarden/ui/platform/components/debug/FeatureFlagListItems.kt
@@ -39,6 +39,7 @@ fun <T : Any> FlagKey<T>.ListItemContent(
     FlagKey.V2EncryptionPassword,
     FlagKey.V2EncryptionTde,
     FlagKey.NewItemTypes,
+    FlagKey.DebugDisableSelfHostPremiumCheck,
         -> {
         @Suppress("UNCHECKED_CAST")
         BooleanFlagItem(
@@ -99,4 +100,7 @@ private fun <T : Any> FlagKey<T>.getDisplayLabel(): String = when (this) {
     FlagKey.V2EncryptionPassword -> stringResource(BitwardenString.v2_encryption_password)
     FlagKey.V2EncryptionTde -> stringResource(BitwardenString.v2_encryption_tde)
     FlagKey.NewItemTypes -> stringResource(BitwardenString.new_item_types)
+    FlagKey.DebugDisableSelfHostPremiumCheck -> {
+        stringResource(BitwardenString.debug_disable_self_host_premium_check)
+    }
 }

--- a/ui/src/main/res/values/strings_non_localized.xml
+++ b/ui/src/main/res/values/strings_non_localized.xml
@@ -53,6 +53,7 @@
     <string name="v2_encryption_password">V2 Encryption - Password</string>
     <string name="manage_devices">Manage devices</string>
     <string name="new_item_types">New Item Types</string>
+    <string name="debug_disable_self_host_premium_check">Debug: Disable self-host premium check</string>
 
     <!-- endregion Debug Menu -->
 </resources>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37814

## 📔 Objective

Three Bitwarden internal dev/QA environments — `vault.qa.bitwarden.pw`, `qa-team.sh.bitwarden.pw`, and `vault.usdev.bitwarden.pw` — are classified as self-hosted, which causes the existing Premium Upgrade self-host gating to hide the flow and prevent QA from exercising it on those environments.

This adds a debug-only feature flag (`debug-disable-self-host-premium-check`) that, when enabled in the debug menu, treats self-hosted environments as cloud for premium upgrade purposes. The flag defaults off, only surfaces in builds where the debug menu is available, and leaves cloud environments completely unaffected.

Ports the iOS approach in [bitwarden/ios#2657](https://github.com/bitwarden/ios/pull/2657) for cross-platform parity. Like iOS, the mechanism is pure flag-based — no URL whitelist — so QA can use it against any self-hosted setup they need to test.

The gating decision is exposed as a `StateFlow` on `PremiumStateManager` and observed by Settings, so the Plan row reacts the moment the toggle flips (no environment-switch or screen re-entry required).

## 📸 Screenshots


https://github.com/user-attachments/assets/327afeba-db3b-45cf-a292-ab103fe8811a